### PR TITLE
feat(finance): nâng cấp UX drawer Thu học phí — hub-and-spoke + cây phân cấp + copy CCCD/địa chỉ

### DIFF
--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -603,10 +603,13 @@ async def get_profile_collection(
         profile_code=format_profile_code(profile.id),
         student_name=lead.full_name if lead else None,
         citizen_id_masked=mask_citizen_id(getattr(profile, "citizen_id", None)),
+        # Full CCCD for the drawer's copy button only (display stays masked).
+        citizen_id_full=getattr(profile, "citizen_id", None),
         program_name=_resolved_major.name if _resolved_major else None,
         degree_level=_resolved_degree,
         officer_name=officer.full_name if officer else None,
         phone=lead.phone if lead else None,
+        permanent_address=_format_permanent_address(profile),
     )
     all_invoices = []
     all_payments = []
@@ -959,6 +962,25 @@ def _fee_can_cancel(fee, current_user_role: str = None) -> bool:
     is_terminal = status_value in _FEE_TERMINAL_STATUSES
     is_admin = current_user_role == UserRole.ADMIN
     return not is_terminal and fee.paid_amount == 0 and is_admin
+
+
+def _format_permanent_address(profile) -> Optional[str]:
+    """Join the profile's stored permanent-address parts into ONE readable line
+    (số nhà/đường → tổ/thôn → xã/phường → quận/huyện → tỉnh) for the drawer.
+
+    Displays the stored free-text as-is — no GSO re-resolve (that legacy
+    ward-jump handling belongs to the admissions display, out of scope here).
+    Returns None when nothing is filled.
+    """
+    parts = [
+        getattr(profile, "permanent_street_address", None),
+        getattr(profile, "permanent_residential_group", None),
+        getattr(profile, "permanent_ward", None),
+        getattr(profile, "permanent_district", None),
+        getattr(profile, "permanent_province", None),
+    ]
+    cleaned = [p.strip() for p in parts if p and p.strip()]
+    return ", ".join(cleaned) or None
 
 
 def _build_fee_response(

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -641,9 +641,14 @@ async def get_profile_collection(
                 paid_amount=f.paid_amount,
                 remaining_amount=f.remaining_amount,
                 status=f.status,
-                # Role-aware (route gate): drawer shows "Miễn giảm" only when the
-                # waive route would accept it — never a button that 400/403s.
+                # Role-aware (route gate): drawer shows each fee action only when
+                # the matching route would accept it — never a button that
+                # 400/403s. Same single-source helpers as the detail FeeResponse.
                 can_waive=_fee_can_waive(f, current_user.role),
+                can_recalculate=_fee_can_recalculate(f, current_user.role),
+                can_cancel=_fee_can_cancel(f, current_user.role),
+                # base_amount prefills the drawer's "Tính lại" dialog.
+                base_amount=f.base_amount,
             )
             for f in fees
         ],
@@ -929,6 +934,33 @@ def _fee_can_waive(fee, current_user_role: str = None) -> bool:
     return not is_terminal and fee.remaining_amount > 0 and is_manager_or_admin
 
 
+def _fee_can_recalculate(fee, current_user_role: str = None) -> bool:
+    """Role-aware recalculate capability — SINGLE source for the detail
+    ``FeeResponse`` and the collection drawer's ``FeeSummaryResponse``.
+
+    Mirrors the recalculate route gate (``RequireManager`` → admin/manager):
+    not terminal AND paid == 0 AND role in [admin, manager]. paid == 0 because
+    recomputing the base after money has come in would desync the ledger.
+    """
+    status_value = fee.status.value if hasattr(fee.status, "value") else fee.status
+    is_terminal = status_value in _FEE_TERMINAL_STATUSES
+    is_manager_or_admin = current_user_role in [UserRole.ADMIN, UserRole.MANAGER]
+    return not is_terminal and fee.paid_amount == 0 and is_manager_or_admin
+
+
+def _fee_can_cancel(fee, current_user_role: str = None) -> bool:
+    """Role-aware cancel capability — SINGLE source for the detail
+    ``FeeResponse`` and the collection drawer's ``FeeSummaryResponse``.
+
+    Mirrors the cancel route gate (``RequireAdmin`` → admin only — stricter than
+    waive/recalculate by design): not terminal AND paid == 0 AND role == admin.
+    """
+    status_value = fee.status.value if hasattr(fee.status, "value") else fee.status
+    is_terminal = status_value in _FEE_TERMINAL_STATUSES
+    is_admin = current_user_role == UserRole.ADMIN
+    return not is_terminal and fee.paid_amount == 0 and is_admin
+
+
 def _build_fee_response(
     fee, first_due_date=None, current_user_role: str = None
 ) -> finance_schemas.FeeResponse:
@@ -960,18 +992,12 @@ def _build_fee_response(
             )
         )
 
-    # P1: Compute permission flags based on status, amounts, AND role.
-    # can_waive shares _fee_can_waive with the collection drawer (single source).
-    # can_cancel is admin-only (RequireAdmin); can_recalculate is manager+ — both
-    # kept aligned with their route gate (thin-client: no button the route 403s).
-    status_value = fee.status.value if hasattr(fee.status, "value") else fee.status
-    is_terminal = status_value in _FEE_TERMINAL_STATUSES
-    is_manager_or_admin = current_user_role in [UserRole.ADMIN, UserRole.MANAGER]
-    is_admin = current_user_role == UserRole.ADMIN
-
+    # P1: Compute permission flags based on status, amounts, AND role — all three
+    # share their helper with the collection drawer (single source). Each mirrors
+    # its route gate (thin-client: no button the route 403s).
     can_waive = _fee_can_waive(fee, current_user_role)
-    can_cancel = not is_terminal and fee.paid_amount == 0 and is_admin
-    can_recalculate = not is_terminal and fee.paid_amount == 0 and is_manager_or_admin
+    can_cancel = _fee_can_cancel(fee, current_user_role)
+    can_recalculate = _fee_can_recalculate(fee, current_user_role)
 
     return finance_schemas.FeeResponse(
         id=fee.id,

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -603,7 +603,11 @@ async def get_profile_collection(
         profile_code=format_profile_code(profile.id),
         student_name=lead.full_name if lead else None,
         citizen_id_masked=mask_citizen_id(getattr(profile, "citizen_id", None)),
-        # Full CCCD for the drawer's copy button only (display stays masked).
+        # Full CCCD for the drawer's copy button (display stays masked). DELIBERATE
+        # PII exposure to finance staff INCLUDING accountant — accountant is denied
+        # /api/admissions (PII minimization) but legitimately needs the full buyer
+        # CCCD + address to issue a VAT invoice (hóa đơn GTGT) from the collection
+        # workspace. This is an accepted business need, not an oversight.
         citizen_id_full=getattr(profile, "citizen_id", None),
         program_name=_resolved_major.name if _resolved_major else None,
         degree_level=_resolved_degree,
@@ -645,8 +649,11 @@ async def get_profile_collection(
                 remaining_amount=f.remaining_amount,
                 status=f.status,
                 # Role-aware (route gate): drawer shows each fee action only when
-                # the matching route would accept it — never a button that
-                # 400/403s. Same single-source helpers as the detail FeeResponse.
+                # the matching route would accept it. Same single-source helpers as
+                # the detail FeeResponse. CAVEAT: can_cancel mirrors only the
+                # role + paid==0 gate; cancel_fee ALSO blocks on a pending payment
+                # / active online intent (data not loaded here) — those rare cases
+                # surface as a graceful 400 with a clear message, not a silent fail.
                 can_waive=_fee_can_waive(f, current_user.role),
                 can_recalculate=_fee_can_recalculate(f, current_user.role),
                 can_cancel=_fee_can_cancel(f, current_user.role),

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -980,11 +980,17 @@ class ProfileCollectionIdentity(BaseModel):
     profile_id: int
     profile_code: str                      # "HS-000131"
     student_name: Optional[str] = None
-    citizen_id_masked: Optional[str] = None  # CCCD đã che giữa (PII-safe)
+    citizen_id_masked: Optional[str] = None  # CCCD đã che giữa (display, PII-safe)
+    # CCCD đầy đủ — CHỈ để nút copy của drawer (vai trò tài chính đã xem được hồ
+    # sơ đầy đủ). Hiển thị vẫn dùng bản che ``citizen_id_masked``.
+    citizen_id_full: Optional[str] = None
     program_name: Optional[str] = None     # ngành (snapshot Fee.resolved_major)
     degree_level: Optional[str] = None     # trình độ (snapshot, TEXT name)
-    officer_name: Optional[str] = None     # TVV phụ trách
+    officer_name: Optional[str] = None     # tư vấn viên phụ trách
     phone: Optional[str] = None            # parent phone (accountant lookup)
+    # Địa chỉ thường trú đã ghép 1 dòng đọc được (số nhà → đường → tổ/thôn → xã →
+    # huyện → tỉnh). None khi hồ sơ chưa có địa chỉ.
+    permanent_address: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -322,12 +322,21 @@ class FeeSummaryResponse(BaseModel):
     paid_amount: Decimal
     remaining_amount: Decimal
     status: FeeStatusEnum
-    # Role-aware waive capability (same rule as FeeResponse.can_waive: not
-    # terminal AND remaining > 0 AND role in [admin, manager] — the RequireManager
-    # route gate). Default False so any builder that doesn't set it shows no
-    # waive button rather than a button the route would 403. The collection
-    # drawer populates it per the viewing user.
+    # Role-aware capability flags (same rules as FeeResponse: each mirrors its
+    # route gate so the thin client never shows a button the route would 403).
+    #   can_waive       — not terminal AND remaining > 0 AND role in [admin, manager]
+    #   can_recalculate — not terminal AND paid == 0  AND role in [admin, manager]
+    #   can_cancel      — not terminal AND paid == 0  AND role == admin (RequireAdmin)
+    # All default False so any builder that doesn't set them shows no button.
+    # The collection drawer populates them per the viewing user.
     can_waive: bool = False
+    can_recalculate: bool = False
+    can_cancel: bool = False
+    # Current base amount — only the collection drawer sets it (to prefill the
+    # "Tính lại" dialog). Optional/None elsewhere: other summary builders don't
+    # drive a recalculate dialog, and None makes "not provided" explicit rather
+    # than a misleading 0.
+    base_amount: Optional[Decimal] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -981,8 +981,10 @@ class ProfileCollectionIdentity(BaseModel):
     profile_code: str                      # "HS-000131"
     student_name: Optional[str] = None
     citizen_id_masked: Optional[str] = None  # CCCD đã che giữa (display, PII-safe)
-    # CCCD đầy đủ — CHỈ để nút copy của drawer (vai trò tài chính đã xem được hồ
-    # sơ đầy đủ). Hiển thị vẫn dùng bản che ``citizen_id_masked``.
+    # CCCD đầy đủ — CHỈ cho nút copy của drawer (hiển thị vẫn dùng bản che
+    # ``citizen_id_masked``). LỘ PII CÓ CHỦ ĐÍCH cho nhân viên tài chính (gồm cả
+    # accountant — vốn bị từ chối /api/admissions): kế toán cần CCCD + địa chỉ
+    # người mua đầy đủ để xuất hóa đơn GTGT ngay từ workspace thu học phí.
     citizen_id_full: Optional[str] = None
     program_name: Optional[str] = None     # ngành (snapshot Fee.resolved_major)
     degree_level: Optional[str] = None     # trình độ (snapshot, TEXT name)

--- a/Backend_FastAPI/tests/repositories/test_profile_collection.py
+++ b/Backend_FastAPI/tests/repositories/test_profile_collection.py
@@ -47,6 +47,7 @@ from app.routers.fees import (
     _fee_can_waive,
     _fee_can_recalculate,
     _fee_can_cancel,
+    _format_permanent_address,
     _total_remaining_with_penalty,
 )
 from types import SimpleNamespace
@@ -518,6 +519,39 @@ async def test_fee_can_recalculate_role_and_paid_gate():
     # …and terminal statuses are never recalculable.
     for terminal in ("paid", "cancelled", "waived"):
         assert _fee_can_recalculate(_stub_fee(status=terminal), "admin") is False
+
+
+async def test_format_permanent_address_joins_in_reading_order():
+    """The drawer's địa chỉ thường trú joins stored parts số nhà → tổ → xã →
+    huyện → tỉnh, drops blanks, and is None when nothing is filled."""
+    full = SimpleNamespace(
+        permanent_street_address="Số 12, đường Lê Lợi",
+        permanent_residential_group="Tổ 4",
+        permanent_ward="Phường Tân Hòa",
+        permanent_district="TP Buôn Ma Thuột",
+        permanent_province="Đắk Lắk",
+    )
+    assert _format_permanent_address(full) == (
+        "Số 12, đường Lê Lợi, Tổ 4, Phường Tân Hòa, TP Buôn Ma Thuột, Đắk Lắk"
+    )
+    # Blank / whitespace-only parts are dropped, order preserved.
+    partial = SimpleNamespace(
+        permanent_street_address=None,
+        permanent_residential_group="   ",
+        permanent_ward="Phường Tân Hòa",
+        permanent_district="",
+        permanent_province="Đắk Lắk",
+    )
+    assert _format_permanent_address(partial) == "Phường Tân Hòa, Đắk Lắk"
+    # Nothing filled → None (FE hides the line).
+    empty = SimpleNamespace(
+        permanent_street_address=None,
+        permanent_residential_group=None,
+        permanent_ward=None,
+        permanent_district=None,
+        permanent_province=None,
+    )
+    assert _format_permanent_address(empty) is None
 
 
 async def test_fee_can_cancel_admin_only_and_paid_gate():

--- a/Backend_FastAPI/tests/repositories/test_profile_collection.py
+++ b/Backend_FastAPI/tests/repositories/test_profile_collection.py
@@ -43,7 +43,13 @@ from app.repositories.payment_repository import PaymentRepository
 from app.services.fee_calculation_service import FeeCalculationService
 from app.routers.invoices import _build_invoice_list_item, _invoice_is_overdue
 from app.routers.payments import _build_payment_list_item
-from app.routers.fees import _fee_can_waive, _total_remaining_with_penalty
+from app.routers.fees import (
+    _fee_can_waive,
+    _fee_can_recalculate,
+    _fee_can_cancel,
+    _total_remaining_with_penalty,
+)
+from types import SimpleNamespace
 from app.utils.id_helpers import format_profile_code
 
 pytestmark = pytest.mark.asyncio
@@ -486,6 +492,68 @@ async def test_collection_fee_can_waive_role_aware(db, seeded_collection):
     assert _fee_can_waive(tuition, "accountant") is False
     # …and a fully-paid (terminal) fee is never waivable, even for admin.
     assert _fee_can_waive(application, "admin") is False
+
+
+def _stub_fee(status="invoiced", paid="0", remaining="1000000"):
+    """Lightweight fee for the pure flag-helper truth table (no DB needed)."""
+    return SimpleNamespace(
+        status=status,
+        paid_amount=Decimal(paid),
+        remaining_amount=Decimal(remaining),
+    )
+
+
+async def test_fee_can_recalculate_role_and_paid_gate():
+    """Tính lại mirrors the recalculate route (RequireManager → admin/manager;
+    not terminal; paid == 0). A True flag the route would 403 is a broken button.
+    """
+    fresh = _stub_fee(status="invoiced", paid="0")
+    # admin/manager may recalculate a non-terminal, un-paid fee…
+    assert _fee_can_recalculate(fresh, "admin") is True
+    assert _fee_can_recalculate(fresh, "manager") is True
+    # …accountant may NOT (separation of duties)…
+    assert _fee_can_recalculate(fresh, "accountant") is False
+    # …once any money has come in, recompute is blocked (ledger would desync)…
+    assert _fee_can_recalculate(_stub_fee(paid="200000"), "admin") is False
+    # …and terminal statuses are never recalculable.
+    for terminal in ("paid", "cancelled", "waived"):
+        assert _fee_can_recalculate(_stub_fee(status=terminal), "admin") is False
+
+
+async def test_fee_can_cancel_admin_only_and_paid_gate():
+    """Hủy khoản phí mirrors the cancel route (RequireAdmin → admin ONLY —
+    stricter than waive/recalculate; not terminal; paid == 0)."""
+    fresh = _stub_fee(status="invoiced", paid="0")
+    # admin only…
+    assert _fee_can_cancel(fresh, "admin") is True
+    assert _fee_can_cancel(fresh, "manager") is False
+    assert _fee_can_cancel(fresh, "accountant") is False
+    # …paid fee can't be cancelled…
+    assert _fee_can_cancel(_stub_fee(paid="200000"), "admin") is False
+    # …terminal never.
+    for terminal in ("paid", "cancelled", "waived"):
+        assert _fee_can_cancel(_stub_fee(status=terminal), "admin") is False
+
+
+async def test_collection_fee_recalc_cancel_gates_on_real_fees(db, seeded_collection):
+    """End-to-end on the real seeded ORM fees the router feeds into FeeSummary:
+    the seeded tuition is PARTIAL (paid 200k) so Tính lại / Hủy are paid-gated
+    off even for admin, and the fully-paid application is terminal → off too.
+    (The True/role/terminal matrix is covered by the stub truth-table tests.)"""
+    service = FeeCalculationService(db)
+    profile = await service.get_profile_collection(
+        seeded_collection["prof_a_id"], unit_id=seeded_collection["unit_a"]
+    )
+    by_type = {f.fee_type: f for f in profile.fees}
+    tuition = by_type["tuition"]       # partial, paid 200k
+    application = by_type["application"]  # paid (terminal)
+
+    assert _fee_can_recalculate(tuition, "admin") is False
+    assert _fee_can_cancel(tuition, "admin") is False
+    assert _fee_can_recalculate(application, "admin") is False
+    assert _fee_can_cancel(application, "admin") is False
+    # base_amount the router surfaces for the Tính lại prefill is present.
+    assert tuition.base_amount == Decimal("1000000")
 
 
 # =============================================================================

--- a/frontend/src/app/(dashboard)/finance/accounting/_components/AccountingPeriodClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/accounting/_components/AccountingPeriodClient.tsx
@@ -514,7 +514,10 @@ function ClosePeriodDialog({
             <Lock className="h-5 w-5" />
             Đóng kỳ kế toán
           </AlertDialogTitle>
-          <AlertDialogDescription className="space-y-3">
+          {/* asChild → Description renders AS this <div> so block children
+              (<p>/<div>/<ul>) are valid HTML (no <p>-in-<p> hydration error). */}
+          <AlertDialogDescription asChild>
+          <div className="space-y-3 text-sm text-muted-foreground">
             <p>
               Bạn có chắc chắn muốn đóng kỳ kế toán{" "}
               <strong>{formatPeriodLabel(period.month, period.year)}</strong>?
@@ -534,6 +537,7 @@ function ClosePeriodDialog({
                 </div>
               </div>
             </div>
+          </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
 

--- a/frontend/src/app/(dashboard)/finance/fees/[feeId]/_components/FeeCancelDialog.tsx
+++ b/frontend/src/app/(dashboard)/finance/fees/[feeId]/_components/FeeCancelDialog.tsx
@@ -110,12 +110,13 @@ export function FeeCancelDialog({
             Xác nhận hủy học phí
           </AlertDialogTitle>
           <AlertDialogDescription className="space-y-2">
-            <p>
+            {/* Description renders a <p>; block spans avoid <p>-in-<p>. */}
+            <span className="block">
               Bạn có chắc chắn muốn hủy khoản <strong>{feeType}</strong> này?
-            </p>
-            <p className="text-destructive font-medium">
+            </span>
+            <span className="block text-destructive font-medium">
               Hành động này không thể hoàn tác. Tất cả hóa đơn liên quan sẽ bị hủy theo.
-            </p>
+            </span>
           </AlertDialogDescription>
         </AlertDialogHeader>
 

--- a/frontend/src/app/(dashboard)/finance/fees/[feeId]/_components/FeeDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/fees/[feeId]/_components/FeeDetailClient.tsx
@@ -69,6 +69,15 @@ export function FeeDetailClient({ feeId }: FeeDetailClientProps) {
   // browser-back). Falls back to the Thu học phí workspace.
   const from = searchParams.get("from")
   const back = React.useMemo(() => resolveFinanceReturn(from), [from])
+  // With an explicit ?from we push to the controlled return target (reopens the
+  // right drawer). WITHOUT one — e.g. reached from the admission Tuition tab,
+  // which links here without stamping ?from — fall back to browser history so we
+  // return to where the user actually came from, not the finance workspace.
+  const goBack = React.useCallback(
+    () => (from ? router.push(back.href) : router.back()),
+    [from, back.href, router],
+  )
+  const backLabel = from ? back.label : "Quay lại"
 
   // State for dialogs
   const [waiveDialogOpen, setWaiveDialogOpen] = React.useState(
@@ -101,9 +110,9 @@ export function FeeDetailClient({ feeId }: FeeDetailClientProps) {
   if (error || !fee) {
     return (
       <div className="h-full flex flex-col p-4 sm:p-6">
-        <Button variant="ghost" size="sm" onClick={() => router.push(back.href)} className="w-fit mb-4">
+        <Button variant="ghost" size="sm" onClick={goBack} className="w-fit mb-4">
           <ArrowLeft className="h-4 w-4 mr-2" />
-          {back.label}
+          {backLabel}
         </Button>
         <Card className="border-destructive">
           <CardContent className="p-6 text-center">
@@ -121,9 +130,9 @@ export function FeeDetailClient({ feeId }: FeeDetailClientProps) {
   return (
     <div className="h-full flex flex-col p-4 sm:p-6 space-y-6">
       {/* Back button */}
-      <Button variant="ghost" size="sm" onClick={() => router.push(back.href)} className="w-fit">
+      <Button variant="ghost" size="sm" onClick={goBack} className="w-fit">
         <ArrowLeft className="h-4 w-4 mr-2" />
-        {back.label}
+        {backLabel}
       </Button>
 
       {/* Header */}

--- a/frontend/src/app/(dashboard)/finance/fees/[feeId]/_components/FeeDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/fees/[feeId]/_components/FeeDetailClient.tsx
@@ -37,6 +37,7 @@ import { cn } from "@/lib/utils"
 import { FeeWaiveDialog } from "./FeeWaiveDialog"
 import { FeeCancelDialog } from "./FeeCancelDialog"
 import { FeeRecalculateDialog } from "./FeeRecalculateDialog"
+import { resolveFinanceReturn, withFrom } from "@/lib/finance/nav-context"
 
 // =============================================================================
 // TYPES
@@ -63,6 +64,12 @@ export function FeeDetailClient({ feeId }: FeeDetailClientProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
 
+  // Controlled return target: the workspace stamps `?from=profile:<id>` when it
+  // links here, so "Quay lại" reopens that profile's drawer (never a blind
+  // browser-back). Falls back to the Thu học phí workspace.
+  const from = searchParams.get("from")
+  const back = React.useMemo(() => resolveFinanceReturn(from), [from])
+
   // State for dialogs
   const [waiveDialogOpen, setWaiveDialogOpen] = React.useState(
     searchParams.get("action") === "waive"
@@ -82,9 +89,10 @@ export function FeeDetailClient({ feeId }: FeeDetailClientProps) {
     setWaiveDialogOpen(false)
     setCancelDialogOpen(false)
     setRecalculateDialogOpen(false)
-    // Remove action from URL
-    router.replace(`/finance/fees/${feeId}`)
-  }, [feeId, router])
+    // Drop the `?action=` param but PRESERVE `?from=` so the return context
+    // survives closing a dialog.
+    router.replace(withFrom(`/finance/fees/${feeId}`, from))
+  }, [feeId, router, from])
 
   if (isLoading) {
     return <FeeDetailSkeleton />
@@ -93,9 +101,9 @@ export function FeeDetailClient({ feeId }: FeeDetailClientProps) {
   if (error || !fee) {
     return (
       <div className="h-full flex flex-col p-4 sm:p-6">
-        <Button variant="ghost" size="sm" onClick={() => router.back()} className="w-fit mb-4">
+        <Button variant="ghost" size="sm" onClick={() => router.push(back.href)} className="w-fit mb-4">
           <ArrowLeft className="h-4 w-4 mr-2" />
-          Quay lại
+          {back.label}
         </Button>
         <Card className="border-destructive">
           <CardContent className="p-6 text-center">
@@ -113,9 +121,9 @@ export function FeeDetailClient({ feeId }: FeeDetailClientProps) {
   return (
     <div className="h-full flex flex-col p-4 sm:p-6 space-y-6">
       {/* Back button */}
-      <Button variant="ghost" size="sm" onClick={() => router.back()} className="w-fit">
+      <Button variant="ghost" size="sm" onClick={() => router.push(back.href)} className="w-fit">
         <ArrowLeft className="h-4 w-4 mr-2" />
-        Quay lại
+        {back.label}
       </Button>
 
       {/* Header */}

--- a/frontend/src/app/(dashboard)/finance/fees/[feeId]/_components/FeeDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/fees/[feeId]/_components/FeeDetailClient.tsx
@@ -243,7 +243,7 @@ export function FeeDetailClient({ feeId }: FeeDetailClientProps) {
                     <TableRow
                       key={invoice.id}
                       className="cursor-pointer hover:bg-muted/50"
-                      onClick={() => router.push(`/finance/invoices/${invoice.id}`)}
+                      onClick={() => router.push(withFrom(`/finance/invoices/${invoice.id}`, from))}
                     >
                       <TableCell className="font-mono text-sm">
                         {invoice.invoice_number}

--- a/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceCancelDialog.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceCancelDialog.tsx
@@ -106,12 +106,14 @@ export function InvoiceCancelDialog({
             Xác nhận hủy hóa đơn
           </AlertDialogTitle>
           <AlertDialogDescription className="space-y-2">
-            <p>
+            {/* AlertDialogDescription renders a <p>; use block spans so we don't
+                nest <p> in <p> (invalid HTML → hydration error). */}
+            <span className="block">
               Bạn có chắc chắn muốn hủy hóa đơn <strong className="font-mono">{invoiceNumber}</strong>?
-            </p>
-            <p className="text-destructive font-medium">
+            </span>
+            <span className="block text-destructive font-medium">
               Hành động này không thể hoàn tác.
-            </p>
+            </span>
           </AlertDialogDescription>
         </AlertDialogHeader>
 

--- a/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceDetailClient.tsx
@@ -156,7 +156,7 @@ export function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientProps) {
             Đợt {invoice.installment_no}
             {invoice.fee && (
               <>
-                {" "}• <Link href={`/finance/fees/${invoice.fee.id}`} className="hover:underline">
+                {" "}• <Link href={withFrom(`/finance/fees/${invoice.fee.id}`, from)} className="hover:underline">
                   {FEE_TYPE_LABELS[invoice.fee.fee_type as FeeType] ?? invoice.fee.fee_type}
                 </Link>
               </>
@@ -379,7 +379,7 @@ export function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientProps) {
                 </div>
                 <Separator className="my-2" />
                 <Button variant="outline" size="sm" className="w-full" asChild>
-                  <Link href={`/finance/fees/${invoice.fee.id}`}>
+                  <Link href={withFrom(`/finance/fees/${invoice.fee.id}`, from)}>
                     Xem chi tiết học phí
                   </Link>
                 </Button>

--- a/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceDetailClient.tsx
@@ -71,6 +71,14 @@ export function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientProps) {
   // (never a blind browser-back; falls back to the Thu học phí workspace).
   const from = searchParams.get("from")
   const back = React.useMemo(() => resolveFinanceReturn(from), [from])
+  // With ?from → controlled return target; without → browser history (so entry
+  // points that don't stamp ?from return where the user came from, not the
+  // finance workspace). See FeeDetailClient for the same rationale.
+  const goBack = React.useCallback(
+    () => (from ? router.push(back.href) : router.back()),
+    [from, back.href, router],
+  )
+  const backLabel = from ? back.label : "Quay lại"
 
   // Dialog states
   const [recordPaymentOpen, setRecordPaymentOpen] = React.useState(
@@ -118,9 +126,9 @@ export function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientProps) {
   if (error || !invoice) {
     return (
       <div className="h-full flex flex-col p-4 sm:p-6">
-        <Button variant="ghost" size="sm" onClick={() => router.push(back.href)} className="w-fit mb-4">
+        <Button variant="ghost" size="sm" onClick={goBack} className="w-fit mb-4">
           <ArrowLeft className="h-4 w-4 mr-2" />
-          {back.label}
+          {backLabel}
         </Button>
         <Card className="border-destructive">
           <CardContent className="p-6 text-center">
@@ -138,9 +146,9 @@ export function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientProps) {
   return (
     <div className="h-full flex flex-col p-4 sm:p-6 space-y-6">
       {/* Back button */}
-      <Button variant="ghost" size="sm" onClick={() => router.push(back.href)} className="w-fit">
+      <Button variant="ghost" size="sm" onClick={goBack} className="w-fit">
         <ArrowLeft className="h-4 w-4 mr-2" />
-        {back.label}
+        {backLabel}
       </Button>
 
       {/* Header */}

--- a/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceDetailClient.tsx
@@ -41,6 +41,7 @@ import { InvoiceIssueDialog } from "./InvoiceIssueDialog"
 import { InvoiceCancelDialog } from "./InvoiceCancelDialog"
 import { InvoicePenaltyDialog } from "./InvoicePenaltyDialog"
 import { OnlinePaymentDialog } from "./OnlinePaymentDialog"
+import { resolveFinanceReturn, withFrom } from "@/lib/finance/nav-context"
 
 // =============================================================================
 // TYPES
@@ -65,6 +66,11 @@ interface InvoiceDetailClientProps {
 export function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
+
+  // Controlled return target from the workspace `?from=profile:<id>` context
+  // (never a blind browser-back; falls back to the Thu học phí workspace).
+  const from = searchParams.get("from")
+  const back = React.useMemo(() => resolveFinanceReturn(from), [from])
 
   // Dialog states
   const [recordPaymentOpen, setRecordPaymentOpen] = React.useState(
@@ -101,8 +107,9 @@ export function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientProps) {
     setCancelDialogOpen(false)
     setPenaltyDialogOpen(false)
     setOnlinePaymentOpen(false)
-    router.replace(`/finance/invoices/${invoiceId}`)
-  }, [invoiceId, router])
+    // Drop `?action=` but PRESERVE `?from=` so the return context survives.
+    router.replace(withFrom(`/finance/invoices/${invoiceId}`, from))
+  }, [invoiceId, router, from])
 
   if (isLoading) {
     return <InvoiceDetailSkeleton />
@@ -111,9 +118,9 @@ export function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientProps) {
   if (error || !invoice) {
     return (
       <div className="h-full flex flex-col p-4 sm:p-6">
-        <Button variant="ghost" size="sm" onClick={() => router.back()} className="w-fit mb-4">
+        <Button variant="ghost" size="sm" onClick={() => router.push(back.href)} className="w-fit mb-4">
           <ArrowLeft className="h-4 w-4 mr-2" />
-          Quay lại
+          {back.label}
         </Button>
         <Card className="border-destructive">
           <CardContent className="p-6 text-center">
@@ -131,9 +138,9 @@ export function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientProps) {
   return (
     <div className="h-full flex flex-col p-4 sm:p-6 space-y-6">
       {/* Back button */}
-      <Button variant="ghost" size="sm" onClick={() => router.back()} className="w-fit">
+      <Button variant="ghost" size="sm" onClick={() => router.push(back.href)} className="w-fit">
         <ArrowLeft className="h-4 w-4 mr-2" />
-        Quay lại
+        {back.label}
       </Button>
 
       {/* Header */}

--- a/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceIssueDialog.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceIssueDialog.tsx
@@ -65,12 +65,13 @@ export function InvoiceIssueDialog({
             Xuất hóa đơn
           </AlertDialogTitle>
           <AlertDialogDescription className="space-y-2">
-            <p>
+            {/* Description renders a <p>; block spans avoid <p>-in-<p>. */}
+            <span className="block">
               Bạn có chắc chắn muốn xuất hóa đơn <strong className="font-mono">{invoiceNumber}</strong>?
-            </p>
-            <p>
+            </span>
+            <span className="block">
               Sau khi xuất, hóa đơn sẽ chuyển sang trạng thái &quot;Đã xuất&quot; và có thể ghi nhận thanh toán.
-            </p>
+            </span>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
@@ -28,7 +28,7 @@ import {
   Plus,
   CreditCard,
   FileText,
-  MoreHorizontal,
+  MoreVertical,
   QrCode,
   Ban,
   AlertTriangle,
@@ -39,6 +39,10 @@ import {
   ArrowUpRight,
   Percent,
   RefreshCw,
+  User,
+  Phone,
+  MapPin,
+  Fingerprint,
 } from "lucide-react"
 
 import {
@@ -62,6 +66,7 @@ import { cn } from "@/lib/utils"
 import { formatVND } from "@/lib/zod/finance"
 import { formatDate } from "@/lib/utils/admission-helpers"
 import { profileFrom } from "@/lib/finance/nav-context"
+import { CopyableCell } from "@/components/common/CopyableCell"
 
 import { Monogram } from "@/app/(dashboard)/admissions/_components/roster-parts"
 import {
@@ -222,17 +227,53 @@ function DrawerIdentity({ collection }: { collection: ProfileCollection }) {
     .filter(Boolean)
     .join(" · ")
   return (
-    <div className="flex items-center gap-3 pr-10">
-      <Monogram name={name} className="size-10" />
-      <div className="min-w-0">
+    <div className="flex items-start gap-3 pr-10">
+      <Monogram name={name} className="size-10 shrink-0" />
+      <div className="min-w-0 space-y-1">
         <SheetTitle className="truncate text-base">{name}</SheetTitle>
-        <SheetDescription className="truncate">
-          {sub || "Hồ sơ tài chính"}
-          {identity.officer_name ? ` · TVV ${identity.officer_name}` : ""}
-        </SheetDescription>
-        {identity.citizen_id_masked ? (
-          <p className="truncate text-xs text-muted-foreground">
-            CCCD: {identity.citizen_id_masked}
+        <SheetDescription className="truncate">{sub || "Hồ sơ tài chính"}</SheetDescription>
+
+        {/* Tư vấn viên phụ trách — tên trần, không nhãn "TVV". */}
+        {identity.officer_name ? (
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <User className="size-3.5 shrink-0" aria-hidden="true" />
+            <span className="truncate">{identity.officer_name}</span>
+          </p>
+        ) : null}
+
+        {/* CCCD (hiển thị che, copy đầy đủ) + SĐT (copy) — click-to-copy. */}
+        {(identity.citizen_id_full || identity.citizen_id_masked || identity.phone) ? (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+            {identity.citizen_id_full ? (
+              <CopyableCell
+                value={identity.citizen_id_full}
+                displayValue={identity.citizen_id_masked ?? identity.citizen_id_full}
+                label="CCCD"
+                className="text-muted-foreground"
+                icon={<Fingerprint className="size-3.5 text-muted-foreground" aria-hidden="true" />}
+              />
+            ) : identity.citizen_id_masked ? (
+              <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                <Fingerprint className="size-3.5" aria-hidden="true" />
+                {identity.citizen_id_masked}
+              </span>
+            ) : null}
+            {identity.phone ? (
+              <CopyableCell
+                value={identity.phone}
+                label="Số điện thoại"
+                className="text-muted-foreground"
+                icon={<Phone className="size-3.5 text-muted-foreground" aria-hidden="true" />}
+              />
+            ) : null}
+          </div>
+        ) : null}
+
+        {/* Địa chỉ thường trú (BE ghép 1 dòng). */}
+        {identity.permanent_address ? (
+          <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+            <MapPin className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+            <span className="line-clamp-2">{identity.permanent_address}</span>
           </p>
         ) : null}
       </div>
@@ -403,11 +444,29 @@ function FeeRow({
           {formatVND(fee.final_amount)} · còn {formatVND(fee.remaining_amount)}
         </p>
       </div>
-      <div className="flex shrink-0 items-center gap-1.5">
+      <div className="flex shrink-0 items-center gap-1">
         <FeeStatusBadge status={fee.status} size="sm" />
-        {/* Fee-level actions live in ONE overflow menu (mirrors InvoiceRow) so
-            80% of the work happens in the drawer without leaving — each item is
-            role-gated by a BE flag and raised through the shared dialog host. */}
+        {/* "Chi tiết" = đào sâu (lịch sử / audit / breakdown) — icon-only để gọn,
+            không phải nơi DUY NHẤT để thao tác. Carries `?from=profile` so "Quay
+            lại" reopens THIS drawer (see lib/finance/nav-context). */}
+        {profileId != null && (
+          <Button
+            asChild
+            size="icon"
+            variant="ghost"
+            className="size-8 text-muted-foreground"
+            title="Mở chi tiết khoản phí"
+            aria-label="Mở chi tiết khoản phí"
+          >
+            <Link href={`/finance/fees/${fee.id}?from=${profileFrom(profileId)}`}>
+              <ArrowUpRight className="size-4" aria-hidden="true" />
+            </Link>
+          </Button>
+        )}
+        {/* Fee-level actions in ONE overflow menu at the OUTERMOST edge (vertical
+            3-dots, matching the system's row/card action convention) so 80% of
+            the work happens in the drawer — each item role-gated by a BE flag,
+            raised through the shared dialog host. */}
         {hasMenu && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -417,7 +476,7 @@ function FeeRow({
                 className="size-8"
                 aria-label={`Thao tác cho khoản ${typeLabel}`}
               >
-                <MoreHorizontal className="size-4" aria-hidden="true" />
+                <MoreVertical className="size-4" aria-hidden="true" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -472,23 +531,6 @@ function FeeRow({
               )}
             </DropdownMenuContent>
           </DropdownMenu>
-        )}
-        {/* "Chi tiết" = đào sâu (lịch sử / audit / breakdown), không phải nơi
-            DUY NHẤT để thao tác. Carries `?from=profile` so "Quay lại" reopens
-            THIS drawer (see lib/finance/nav-context). */}
-        {profileId != null && (
-          <Button
-            asChild
-            size="sm"
-            variant="ghost"
-            className="h-8 px-2 text-xs"
-            title="Chi tiết khoản phí"
-          >
-            <Link href={`/finance/fees/${fee.id}?from=${profileFrom(profileId)}`}>
-              Chi tiết
-              <ArrowUpRight className="ml-1 h-3.5 w-3.5" />
-            </Link>
-          </Button>
         )}
       </div>
     </li>
@@ -552,6 +594,13 @@ function InvoiceRow({
     invoice.can_issue || invoice.can_cancel || invoice.can_apply_penalty
   // QR only makes sense once the invoice can actually receive money.
   const canQr = invoice.can_record_payment
+  // Which fee this invoice bills (BE-owned fee_type + semester) — makes the
+  // money-flow spine legible: invoice → its fee, no nesting needed.
+  const feeLabel = invoice.fee_type
+    ? `${FEE_TYPE_LABELS[invoice.fee_type as FeeType] ?? invoice.fee_type}${
+        invoice.semester_no ? ` · HK${invoice.semester_no}` : ""
+      }`
+    : null
 
   return (
     <li
@@ -563,6 +612,9 @@ function InvoiceRow({
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <p className="truncate text-sm font-medium">{invoice.invoice_number}</p>
+          {feeLabel ? (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">{feeLabel}</p>
+          ) : null}
           <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">
             Còn {remainingFormatted}
             {overdueDays > 0 && (
@@ -608,7 +660,7 @@ function InvoiceRow({
                 className="size-8"
                 aria-label={`Thao tác cho hóa đơn ${invoice.invoice_number}`}
               >
-                <MoreHorizontal className="size-4" aria-hidden="true" />
+                <MoreVertical className="size-4" aria-hidden="true" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -696,6 +748,12 @@ function PaymentSection({
   onAction: (d: WorkspaceDialog) => void
 }) {
   const payments = collection.payments
+  // Map invoice_id → số HĐ (từ danh sách hóa đơn đã tải) để mỗi thanh toán nêu
+  // rõ trả cho hóa đơn nào — khép mạch hóa đơn → thanh toán, không cần BE thêm.
+  const invoiceNumberById = React.useMemo(
+    () => new Map(collection.invoices.map((inv) => [inv.id, inv.invoice_number])),
+    [collection.invoices],
+  )
   return (
     <section>
       <SectionHeader
@@ -710,7 +768,12 @@ function PaymentSection({
       ) : (
         <ul className="space-y-2">
           {payments.map((p) => (
-            <PaymentRow key={p.id} payment={p} onAction={onAction} />
+            <PaymentRow
+              key={p.id}
+              payment={p}
+              onAction={onAction}
+              invoiceNumber={invoiceNumberById.get(p.invoice_id) ?? null}
+            />
           ))}
         </ul>
       )}
@@ -727,9 +790,11 @@ const PAYMENT_SOURCE_LABEL: Record<string, string> = {
 function PaymentRow({
   payment,
   onAction,
+  invoiceNumber,
 }: {
   payment: PaymentListItem
   onAction: (d: WorkspaceDialog) => void
+  invoiceNumber?: string | null
 }) {
   const reviewTarget = {
     id: payment.id,
@@ -760,6 +825,11 @@ function PaymentRow({
             {payment.reference_code || `#${payment.id}`}
             {payment.payer_name ? ` · ${payment.payer_name}` : ""}
           </p>
+          {invoiceNumber ? (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              cho HĐ {invoiceNumber}
+            </p>
+          ) : null}
           {detailParts.length > 0 ? (
             <p className="mt-0.5 truncate text-xs text-muted-foreground">
               {detailParts.join(" · ")}

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
@@ -753,7 +753,7 @@ function InvoiceNode({
 
       {/* Thanh toán của hóa đơn (cấp 3) */}
       {payments.length > 0 && (
-        <div className="space-y-1.5 border-t border-border/50 bg-muted/30 px-3 py-2">
+        <div className="space-y-1.5 border-t border-border/50 px-3 py-2">
           {payments.map((p) => (
             <PaymentLeaf key={p.id} payment={p} onAction={onAction} />
           ))}
@@ -795,7 +795,7 @@ function PaymentLeaf({
     payment.verified_by_name ? `Duyệt: ${payment.verified_by_name}` : null,
   ].filter(Boolean)
   return (
-    <div className="rounded-md border border-border/50 bg-card px-2.5 py-1.5">
+    <div className="rounded-md bg-muted/40 px-2.5 py-1.5">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <p className="truncate text-xs font-semibold tabular-nums">

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
@@ -22,6 +22,7 @@
 "use client"
 
 import * as React from "react"
+import Link from "next/link"
 import {
   Receipt,
   Plus,
@@ -35,6 +36,7 @@ import {
   XCircle,
   CircleDollarSign,
   Clock,
+  ArrowUpRight,
 } from "lucide-react"
 
 import {
@@ -57,6 +59,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
 import { formatVND } from "@/lib/zod/finance"
 import { formatDate } from "@/lib/utils/admission-helpers"
+import { profileFrom } from "@/lib/finance/nav-context"
 
 import { Monogram } from "@/app/(dashboard)/admissions/_components/roster-parts"
 import {
@@ -193,7 +196,7 @@ export function FinanceProfileDrawer({
           ) : data ? (
             <div className="space-y-6">
               <DrawerSummary collection={data} onAction={onAction} />
-              <FeeSection collection={data} onAction={onAction} />
+              <FeeSection collection={data} onAction={onAction} profileId={profileId} />
               <InvoiceSection collection={data} onAction={onAction} />
               <PaymentSection collection={data} onAction={onAction} />
             </div>
@@ -335,9 +338,11 @@ function SectionHeader({
 function FeeSection({
   collection,
   onAction,
+  profileId,
 }: {
   collection: ProfileCollection
   onAction: (d: WorkspaceDialog) => void
+  profileId: number | null
 }) {
   const fees = collection.summary.fees
   return (
@@ -354,7 +359,12 @@ function FeeSection({
       ) : (
         <ul className="space-y-2">
           {fees.map((fee) => (
-            <FeeRow key={fee.id} fee={fee} onAction={onAction} />
+            <FeeRow
+              key={fee.id}
+              fee={fee}
+              onAction={onAction}
+              profileId={profileId}
+            />
           ))}
         </ul>
       )}
@@ -365,9 +375,11 @@ function FeeSection({
 function FeeRow({
   fee,
   onAction,
+  profileId,
 }: {
   fee: FeeSummary
   onAction: (d: WorkspaceDialog) => void
+  profileId: number | null
 }) {
   // Backend-owned (role + status + amount, matches the waive route gate) — do
   // NOT re-derive on the client (thin-client; avoids showing a button the route
@@ -403,6 +415,24 @@ function FeeRow({
             }
           >
             Miễn giảm
+          </Button>
+        )}
+        {/* Reachability: a fee with no invoice yet can't be reached via invoice
+            detail — link to the fee page (recalc / huỷ khoản phí live there,
+            role-gated). Carries `?from=profile` so "Quay lại" reopens THIS
+            drawer (see lib/finance/nav-context). */}
+        {profileId != null && (
+          <Button
+            asChild
+            size="sm"
+            variant="ghost"
+            className="h-8 px-2 text-xs"
+            title="Chi tiết khoản phí"
+          >
+            <Link href={`/finance/fees/${fee.id}?from=${profileFrom(profileId)}`}>
+              Chi tiết
+              <ArrowUpRight className="ml-1 h-3.5 w-3.5" />
+            </Link>
           </Button>
         )}
       </div>

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
@@ -24,7 +24,6 @@
 import * as React from "react"
 import Link from "next/link"
 import {
-  Receipt,
   Plus,
   CreditCard,
   FileText,
@@ -203,9 +202,7 @@ export function FinanceProfileDrawer({
           ) : data ? (
             <div className="space-y-6">
               <DrawerSummary collection={data} onAction={onAction} />
-              <FeeSection collection={data} onAction={onAction} profileId={profileId} />
-              <InvoiceSection collection={data} onAction={onAction} />
-              <PaymentSection collection={data} onAction={onAction} />
+              <FeeTree collection={data} onAction={onAction} profileId={profileId} />
             </div>
           ) : null}
         </div>
@@ -378,7 +375,7 @@ function SectionHeader({
   )
 }
 
-function FeeSection({
+function FeeTree({
   collection,
   onAction,
   profileId,
@@ -388,6 +385,32 @@ function FeeSection({
   profileId: number | null
 }) {
   const fees = collection.summary.fees
+  // Build the hierarchy client-side from the link keys already on each row:
+  // fee → its invoices (invoice.fee_id) → their payments (payment.invoice_id).
+  // The nesting itself shows the money flow, so rows no longer need "thuộc khoản
+  // phí / cho HĐ …" cross-reference labels.
+  const invoicesByFee = React.useMemo(() => {
+    const m = new Map<number, InvoiceListItem[]>()
+    for (const inv of collection.invoices) {
+      const arr = m.get(inv.fee_id)
+      if (arr) arr.push(inv)
+      else m.set(inv.fee_id, [inv])
+    }
+    return m
+  }, [collection.invoices])
+  const paymentsByInvoice = React.useMemo(() => {
+    const m = new Map<number, PaymentListItem[]>()
+    for (const p of collection.payments) {
+      const arr = m.get(p.invoice_id)
+      if (arr) arr.push(p)
+      else m.set(p.invoice_id, [p])
+    }
+    return m
+  }, [collection.payments])
+
+  const payerName = collection.identity.student_name ?? undefined
+  const referenceHint = collection.identity.profile_code
+
   return (
     <section>
       <SectionHeader
@@ -400,13 +423,17 @@ function FeeSection({
           Chưa có khoản phí nào. Dùng “Tính phí” để tạo.
         </p>
       ) : (
-        <ul className="space-y-2">
+        <ul className="space-y-2.5">
           {fees.map((fee) => (
-            <FeeRow
+            <FeeGroup
               key={fee.id}
               fee={fee}
+              invoices={invoicesByFee.get(fee.id) ?? []}
+              paymentsByInvoice={paymentsByInvoice}
               onAction={onAction}
               profileId={profileId}
+              payerName={payerName}
+              referenceHint={referenceHint}
             />
           ))}
         </ul>
@@ -415,18 +442,30 @@ function FeeSection({
   )
 }
 
-function FeeRow({
+/**
+ * FeeGroup — cấp 1 của cây: một khoản phí, với các hóa đơn của nó lồng bên trong
+ * (mỗi hóa đơn lại lồng các lần thanh toán). Nesting = mạch "phí → hóa đơn →
+ * thanh toán" hiện rõ bằng phân cấp card-trong-card.
+ */
+function FeeGroup({
   fee,
+  invoices,
+  paymentsByInvoice,
   onAction,
   profileId,
+  payerName,
+  referenceHint,
 }: {
   fee: FeeSummary
+  invoices: InvoiceListItem[]
+  paymentsByInvoice: Map<number, PaymentListItem[]>
   onAction: (d: WorkspaceDialog) => void
   profileId: number | null
+  payerName?: string
+  referenceHint?: string
 }) {
   // Backend-owned (role + status + amount, matches each action's route gate) —
-  // do NOT re-derive on the client (thin-client; avoids showing a button the
-  // route would reject). Tính lại needs base_amount to prefill its dialog.
+  // do NOT re-derive on the client. Tính lại needs base_amount to prefill.
   const canWaive = fee.can_waive ?? false
   const canRecalculate = (fee.can_recalculate ?? false) && fee.base_amount != null
   const canCancel = fee.can_cancel ?? false
@@ -434,156 +473,142 @@ function FeeRow({
   const typeLabel = FEE_TYPE_LABELS[fee.fee_type as FeeType] ?? fee.fee_type
   const semester = fee.semester_no ? ` · HK${fee.semester_no}` : ""
   return (
-    <li className="flex items-center justify-between gap-3 rounded-xl border border-border bg-card px-3 py-2.5">
-      <div className="min-w-0">
-        <p className="truncate text-sm font-medium">
-          {typeLabel}
-          <span className="text-muted-foreground">{semester}</span>
-        </p>
-        <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">
-          {formatVND(fee.final_amount)} · còn {formatVND(fee.remaining_amount)}
-        </p>
-      </div>
-      <div className="flex shrink-0 items-center gap-1">
-        <FeeStatusBadge status={fee.status} size="sm" />
-        {/* "Chi tiết" = đào sâu (lịch sử / audit / breakdown) — icon-only để gọn,
-            không phải nơi DUY NHẤT để thao tác. Carries `?from=profile` so "Quay
-            lại" reopens THIS drawer (see lib/finance/nav-context). */}
-        {profileId != null && (
-          <Button
-            asChild
-            size="icon"
-            variant="ghost"
-            className="size-8 text-muted-foreground"
-            title="Mở chi tiết khoản phí"
-            aria-label="Mở chi tiết khoản phí"
-          >
-            <Link href={`/finance/fees/${fee.id}?from=${profileFrom(profileId)}`}>
-              <ArrowUpRight className="size-4" aria-hidden="true" />
-            </Link>
-          </Button>
-        )}
-        {/* Fee-level actions in ONE overflow menu at the OUTERMOST edge (vertical
-            3-dots, matching the system's row/card action convention) so 80% of
-            the work happens in the drawer — each item role-gated by a BE flag,
-            raised through the shared dialog host. */}
-        {hasMenu && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                size="icon"
-                variant="ghost"
-                className="size-8"
-                aria-label={`Thao tác cho khoản ${typeLabel}`}
-              >
-                <MoreVertical className="size-4" aria-hidden="true" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {canWaive && (
-                <DropdownMenuItem
-                  onClick={() =>
-                    onAction({
-                      type: "waive",
-                      feeId: fee.id,
-                      maxAmount: fee.remaining_amount,
-                      maxAmountFormatted: formatVND(fee.remaining_amount),
-                    })
-                  }
+    <li className="overflow-hidden rounded-xl border border-border bg-card">
+      {/* Khoản phí (cấp 1) */}
+      <div className="flex items-center justify-between gap-3 px-3 py-2.5">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold">
+            {typeLabel}
+            <span className="font-normal text-muted-foreground">{semester}</span>
+          </p>
+          <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">
+            {formatVND(fee.final_amount)} · còn {formatVND(fee.remaining_amount)}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <FeeStatusBadge status={fee.status} size="sm" />
+          {/* "Chi tiết" = đào sâu (lịch sử / audit / breakdown) — icon-only. Carries
+              `?from=profile` so "Quay lại" reopens THIS drawer (nav-context). */}
+          {profileId != null && (
+            <Button
+              asChild
+              size="icon"
+              variant="ghost"
+              className="size-8 text-muted-foreground"
+              title="Mở chi tiết khoản phí"
+              aria-label="Mở chi tiết khoản phí"
+            >
+              <Link href={`/finance/fees/${fee.id}?from=${profileFrom(profileId)}`}>
+                <ArrowUpRight className="size-4" aria-hidden="true" />
+              </Link>
+            </Button>
+          )}
+          {/* Fee-level actions in ONE overflow menu at the OUTERMOST edge (vertical
+              3-dots, system convention) — each item role-gated by a BE flag. */}
+          {hasMenu && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-8"
+                  aria-label={`Thao tác cho khoản ${typeLabel}`}
                 >
-                  <Percent className="size-4" aria-hidden="true" />
-                  Miễn giảm
-                </DropdownMenuItem>
-              )}
-              {canRecalculate && (
-                <DropdownMenuItem
-                  onClick={() =>
-                    onAction({
-                      type: "recalculate",
-                      feeId: fee.id,
-                      feeType: typeLabel,
-                      currentBaseAmount: fee.base_amount as string,
-                      currentBaseAmountFormatted: formatVND(fee.base_amount as string),
-                    })
-                  }
-                >
-                  <RefreshCw className="size-4" aria-hidden="true" />
-                  Tính lại
-                </DropdownMenuItem>
-              )}
-              {canCancel && (
-                <>
-                  <DropdownMenuSeparator />
+                  <MoreVertical className="size-4" aria-hidden="true" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {canWaive && (
                   <DropdownMenuItem
-                    className="text-destructive focus:text-destructive"
                     onClick={() =>
                       onAction({
-                        type: "cancel-fee",
+                        type: "waive",
                         feeId: fee.id,
-                        feeType: typeLabel,
+                        maxAmount: fee.remaining_amount,
+                        maxAmountFormatted: formatVND(fee.remaining_amount),
                       })
                     }
                   >
-                    <Ban className="size-4" aria-hidden="true" />
-                    Hủy khoản phí
+                    <Percent className="size-4" aria-hidden="true" />
+                    Miễn giảm
                   </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+                )}
+                {canRecalculate && (
+                  <DropdownMenuItem
+                    onClick={() =>
+                      onAction({
+                        type: "recalculate",
+                        feeId: fee.id,
+                        feeType: typeLabel,
+                        currentBaseAmount: fee.base_amount as string,
+                        currentBaseAmountFormatted: formatVND(fee.base_amount as string),
+                      })
+                    }
+                  >
+                    <RefreshCw className="size-4" aria-hidden="true" />
+                    Tính lại
+                  </DropdownMenuItem>
+                )}
+                {canCancel && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onClick={() =>
+                        onAction({
+                          type: "cancel-fee",
+                          feeId: fee.id,
+                          feeType: typeLabel,
+                        })
+                      }
+                    >
+                      <Ban className="size-4" aria-hidden="true" />
+                      Hủy khoản phí
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
       </div>
+
+      {/* Hóa đơn của khoản phí (cấp 2) */}
+      {invoices.length > 0 ? (
+        <div className="space-y-2 border-t border-border/60 bg-muted/20 px-3 py-2.5">
+          {invoices.map((inv) => (
+            <InvoiceNode
+              key={inv.id}
+              invoice={inv}
+              payments={paymentsByInvoice.get(inv.id) ?? []}
+              onAction={onAction}
+              payerName={payerName}
+              referenceHint={referenceHint}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="border-t border-border/60 px-3 py-2 text-xs text-muted-foreground">
+          Chưa có hóa đơn cho khoản phí này.
+        </p>
+      )}
     </li>
   )
 }
 
 // =============================================================================
-// HÓA ĐƠN SECTION
+// HÓA ĐƠN NODE (cấp 2) — lồng dưới khoản phí, chứa các lần thanh toán (cấp 3)
 // =============================================================================
 
-function InvoiceSection({
-  collection,
-  onAction,
-}: {
-  collection: ProfileCollection
-  onAction: (d: WorkspaceDialog) => void
-}) {
-  const invoices = collection.invoices
-  return (
-    <section>
-      <SectionHeader
-        icon={<Receipt className="size-4" />}
-        title="Hóa đơn"
-        count={invoices.length}
-      />
-      {invoices.length === 0 ? (
-        <p className="rounded-xl border border-dashed border-border px-3 py-4 text-center text-sm text-muted-foreground">
-          Chưa có hóa đơn nào.
-        </p>
-      ) : (
-        <ul className="space-y-2">
-          {invoices.map((inv) => (
-            <InvoiceRow
-              key={inv.id}
-              invoice={inv}
-              onAction={onAction}
-              payerName={collection.identity.student_name ?? undefined}
-              referenceHint={collection.identity.profile_code}
-            />
-          ))}
-        </ul>
-      )}
-    </section>
-  )
-}
-
-function InvoiceRow({
+function InvoiceNode({
   invoice,
+  payments,
   onAction,
   payerName,
   referenceHint,
 }: {
   invoice: InvoiceListItem
+  payments: PaymentListItem[]
   onAction: (d: WorkspaceDialog) => void
   payerName?: string
   referenceHint?: string
@@ -594,27 +619,18 @@ function InvoiceRow({
     invoice.can_issue || invoice.can_cancel || invoice.can_apply_penalty
   // QR only makes sense once the invoice can actually receive money.
   const canQr = invoice.can_record_payment
-  // Which fee this invoice bills (BE-owned fee_type + semester) — makes the
-  // money-flow spine legible: invoice → its fee, no nesting needed.
-  const feeLabel = invoice.fee_type
-    ? `${FEE_TYPE_LABELS[invoice.fee_type as FeeType] ?? invoice.fee_type}${
-        invoice.semester_no ? ` · HK${invoice.semester_no}` : ""
-      }`
-    : null
+  // Fee reference dropped here: the invoice is nested under its fee already.
 
   return (
-    <li
+    <div
       className={cn(
-        "rounded-xl border bg-card px-3 py-2.5",
-        invoice.is_overdue ? "border-l-2 border-l-error-500 border-border" : "border-border",
+        "rounded-lg border bg-card",
+        invoice.is_overdue ? "border-l-2 border-l-error-500 border-border" : "border-border/70",
       )}
     >
-      <div className="flex items-start justify-between gap-3">
+      <div className="flex items-start justify-between gap-3 px-3 py-2">
         <div className="min-w-0">
           <p className="truncate text-sm font-medium">{invoice.invoice_number}</p>
-          {feeLabel ? (
-            <p className="mt-0.5 truncate text-xs text-muted-foreground">{feeLabel}</p>
-          ) : null}
           <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">
             Còn {remainingFormatted}
             {overdueDays > 0 && (
@@ -630,7 +646,8 @@ function InvoiceRow({
         />
       </div>
 
-      <div className="mt-2 flex items-center justify-end gap-1.5">
+      {(invoice.can_record_payment || hasMenu || canQr) && (
+      <div className="flex items-center justify-end gap-1.5 px-3 pb-2">
         {invoice.can_record_payment && (
           <Button
             size="sm"
@@ -732,52 +749,17 @@ function InvoiceRow({
           </DropdownMenu>
         )}
       </div>
-    </li>
-  )
-}
-
-// =============================================================================
-// THANH TOÁN SECTION
-// =============================================================================
-
-function PaymentSection({
-  collection,
-  onAction,
-}: {
-  collection: ProfileCollection
-  onAction: (d: WorkspaceDialog) => void
-}) {
-  const payments = collection.payments
-  // Map invoice_id → số HĐ (từ danh sách hóa đơn đã tải) để mỗi thanh toán nêu
-  // rõ trả cho hóa đơn nào — khép mạch hóa đơn → thanh toán, không cần BE thêm.
-  const invoiceNumberById = React.useMemo(
-    () => new Map(collection.invoices.map((inv) => [inv.id, inv.invoice_number])),
-    [collection.invoices],
-  )
-  return (
-    <section>
-      <SectionHeader
-        icon={<CreditCard className="size-4" />}
-        title="Thanh toán"
-        count={payments.length}
-      />
-      {payments.length === 0 ? (
-        <p className="rounded-xl border border-dashed border-border px-3 py-4 text-center text-sm text-muted-foreground">
-          Chưa có giao dịch thanh toán nào.
-        </p>
-      ) : (
-        <ul className="space-y-2">
-          {payments.map((p) => (
-            <PaymentRow
-              key={p.id}
-              payment={p}
-              onAction={onAction}
-              invoiceNumber={invoiceNumberById.get(p.invoice_id) ?? null}
-            />
-          ))}
-        </ul>
       )}
-    </section>
+
+      {/* Thanh toán của hóa đơn (cấp 3) */}
+      {payments.length > 0 && (
+        <div className="space-y-1.5 border-t border-border/50 bg-muted/30 px-3 py-2">
+          {payments.map((p) => (
+            <PaymentLeaf key={p.id} payment={p} onAction={onAction} />
+          ))}
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -787,14 +769,12 @@ const PAYMENT_SOURCE_LABEL: Record<string, string> = {
   manual: "Thu tay",
 }
 
-function PaymentRow({
+function PaymentLeaf({
   payment,
   onAction,
-  invoiceNumber,
 }: {
   payment: PaymentListItem
   onAction: (d: WorkspaceDialog) => void
-  invoiceNumber?: string | null
 }) {
   const reviewTarget = {
     id: payment.id,
@@ -815,23 +795,18 @@ function PaymentRow({
     payment.verified_by_name ? `Duyệt: ${payment.verified_by_name}` : null,
   ].filter(Boolean)
   return (
-    <li className="rounded-xl border border-border bg-card px-3 py-2.5">
-      <div className="flex items-start justify-between gap-3">
+    <div className="rounded-md border border-border/50 bg-card px-2.5 py-1.5">
+      <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <p className="truncate text-sm font-medium tabular-nums">
+          <p className="truncate text-xs font-semibold tabular-nums">
             {formatVND(payment.amount)}
           </p>
-          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+          <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
             {payment.reference_code || `#${payment.id}`}
             {payment.payer_name ? ` · ${payment.payer_name}` : ""}
           </p>
-          {invoiceNumber ? (
-            <p className="mt-0.5 truncate text-xs text-muted-foreground">
-              cho HĐ {invoiceNumber}
-            </p>
-          ) : null}
           {detailParts.length > 0 ? (
-            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
               {detailParts.join(" · ")}
             </p>
           ) : null}
@@ -845,14 +820,14 @@ function PaymentRow({
       </div>
 
       {isPending && payment.is_own && (
-        <p className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground" role="note">
+        <p className="mt-1.5 flex items-center gap-1.5 text-[11px] text-muted-foreground" role="note">
           <Clock className="size-3.5 shrink-0" aria-hidden="true" />
           Khoản bạn tạo — cần người khác duyệt
         </p>
       )}
 
       {(payment.can_verify || payment.can_reject) && (
-        <div className="mt-2 flex justify-end gap-1.5">
+        <div className="mt-1.5 flex justify-end gap-1.5">
           {payment.can_verify && (
             <Button
               size="sm"
@@ -876,7 +851,7 @@ function PaymentRow({
           )}
         </div>
       )}
-    </li>
+    </div>
   )
 }
 

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
@@ -37,6 +37,8 @@ import {
   CircleDollarSign,
   Clock,
   ArrowUpRight,
+  Percent,
+  RefreshCw,
 } from "lucide-react"
 
 import {
@@ -381,10 +383,13 @@ function FeeRow({
   onAction: (d: WorkspaceDialog) => void
   profileId: number | null
 }) {
-  // Backend-owned (role + status + amount, matches the waive route gate) — do
-  // NOT re-derive on the client (thin-client; avoids showing a button the route
-  // would reject).
+  // Backend-owned (role + status + amount, matches each action's route gate) —
+  // do NOT re-derive on the client (thin-client; avoids showing a button the
+  // route would reject). Tính lại needs base_amount to prefill its dialog.
   const canWaive = fee.can_waive ?? false
+  const canRecalculate = (fee.can_recalculate ?? false) && fee.base_amount != null
+  const canCancel = fee.can_cancel ?? false
+  const hasMenu = canWaive || canRecalculate || canCancel
   const typeLabel = FEE_TYPE_LABELS[fee.fee_type as FeeType] ?? fee.fee_type
   const semester = fee.semester_no ? ` · HK${fee.semester_no}` : ""
   return (
@@ -398,29 +403,79 @@ function FeeRow({
           {formatVND(fee.final_amount)} · còn {formatVND(fee.remaining_amount)}
         </p>
       </div>
-      <div className="flex shrink-0 items-center gap-2">
+      <div className="flex shrink-0 items-center gap-1.5">
         <FeeStatusBadge status={fee.status} size="sm" />
-        {canWaive && (
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-8 px-2 text-xs"
-            onClick={() =>
-              onAction({
-                type: "waive",
-                feeId: fee.id,
-                maxAmount: fee.remaining_amount,
-                maxAmountFormatted: formatVND(fee.remaining_amount),
-              })
-            }
-          >
-            Miễn giảm
-          </Button>
+        {/* Fee-level actions live in ONE overflow menu (mirrors InvoiceRow) so
+            80% of the work happens in the drawer without leaving — each item is
+            role-gated by a BE flag and raised through the shared dialog host. */}
+        {hasMenu && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="size-8"
+                aria-label={`Thao tác cho khoản ${typeLabel}`}
+              >
+                <MoreHorizontal className="size-4" aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {canWaive && (
+                <DropdownMenuItem
+                  onClick={() =>
+                    onAction({
+                      type: "waive",
+                      feeId: fee.id,
+                      maxAmount: fee.remaining_amount,
+                      maxAmountFormatted: formatVND(fee.remaining_amount),
+                    })
+                  }
+                >
+                  <Percent className="size-4" aria-hidden="true" />
+                  Miễn giảm
+                </DropdownMenuItem>
+              )}
+              {canRecalculate && (
+                <DropdownMenuItem
+                  onClick={() =>
+                    onAction({
+                      type: "recalculate",
+                      feeId: fee.id,
+                      feeType: typeLabel,
+                      currentBaseAmount: fee.base_amount as string,
+                      currentBaseAmountFormatted: formatVND(fee.base_amount as string),
+                    })
+                  }
+                >
+                  <RefreshCw className="size-4" aria-hidden="true" />
+                  Tính lại
+                </DropdownMenuItem>
+              )}
+              {canCancel && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() =>
+                      onAction({
+                        type: "cancel-fee",
+                        feeId: fee.id,
+                        feeType: typeLabel,
+                      })
+                    }
+                  >
+                    <Ban className="size-4" aria-hidden="true" />
+                    Hủy khoản phí
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
-        {/* Reachability: a fee with no invoice yet can't be reached via invoice
-            detail — link to the fee page (recalc / huỷ khoản phí live there,
-            role-gated). Carries `?from=profile` so "Quay lại" reopens THIS
-            drawer (see lib/finance/nav-context). */}
+        {/* "Chi tiết" = đào sâu (lịch sử / audit / breakdown), không phải nơi
+            DUY NHẤT để thao tác. Carries `?from=profile` so "Quay lại" reopens
+            THIS drawer (see lib/finance/nav-context). */}
         {profileId != null && (
           <Button
             asChild

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
@@ -64,7 +64,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
 import { formatVND } from "@/lib/zod/finance"
 import { formatDate } from "@/lib/utils/admission-helpers"
-import { profileFrom } from "@/lib/finance/nav-context"
+import { profileFrom, withFrom } from "@/lib/finance/nav-context"
 import { CopyableCell } from "@/components/common/CopyableCell"
 
 import { Monogram } from "@/app/(dashboard)/admissions/_components/roster-parts"
@@ -353,25 +353,14 @@ function DrawerSummary({
 // PHÍ SECTION
 // =============================================================================
 
-function SectionHeader({
-  icon,
-  title,
-  count,
-}: {
-  icon: React.ReactNode
-  title: string
-  count: number
-}) {
+/** Shared 3-dot overflow-menu trigger (vertical, the system row/card convention). */
+function OverflowMenuTrigger({ label }: { label: string }) {
   return (
-    <div className="mb-2 flex items-center gap-2">
-      <span className="text-muted-foreground" aria-hidden="true">
-        {icon}
-      </span>
-      <h3 className="text-sm font-semibold">{title}</h3>
-      <span className="rounded-full bg-muted px-1.5 py-0.5 text-2xs tabular-nums text-muted-foreground">
-        {count}
-      </span>
-    </div>
+    <DropdownMenuTrigger asChild>
+      <Button size="icon" variant="ghost" className="size-8" aria-label={label}>
+        <MoreVertical className="size-4" aria-hidden="true" />
+      </Button>
+    </DropdownMenuTrigger>
   )
 }
 
@@ -408,35 +397,98 @@ function FeeTree({
     return m
   }, [collection.payments])
 
+  // Surface the most urgent fee first — overdue, then still-owing, then settled
+  // (stable sort keeps the backend order within each bucket). Restores the
+  // actionable-first signal the old flat invoice list carried.
+  const orderedFees = React.useMemo(() => {
+    const rank = (fee: FeeSummary) => {
+      const invs = invoicesByFee.get(fee.id) ?? []
+      if (invs.some((i) => i.is_overdue)) return 0
+      if (Number(fee.remaining_amount) > 0) return 1
+      return 2
+    }
+    return [...fees].sort((a, b) => rank(a) - rank(b))
+  }, [fees, invoicesByFee])
+
+  // Defensive: anything the backend sent that doesn't fit the fee→invoice→payment
+  // tree (impossible by today's collection contract, but a future overpayment /
+  // unallocated row could) is shown in a "Khác" bucket, never silently dropped.
+  const feeIds = React.useMemo(() => new Set(fees.map((f) => f.id)), [fees])
+  const invoiceIds = React.useMemo(
+    () => new Set(collection.invoices.map((i) => i.id)),
+    [collection.invoices],
+  )
+  const orphanInvoices = collection.invoices.filter((i) => !feeIds.has(i.fee_id))
+  const orphanPayments = collection.payments.filter((p) => !invoiceIds.has(p.invoice_id))
+
   const payerName = collection.identity.student_name ?? undefined
   const referenceHint = collection.identity.profile_code
 
   return (
     <section>
-      <SectionHeader
-        icon={<CircleDollarSign className="size-4" />}
-        title="Khoản phí"
-        count={fees.length}
-      />
+      <div className="mb-2 flex items-center gap-2">
+        <CircleDollarSign className="size-4 text-muted-foreground" aria-hidden="true" />
+        <h3 className="text-sm font-semibold">Khoản phí</h3>
+        <span className="rounded-full bg-muted px-1.5 py-0.5 text-2xs tabular-nums text-muted-foreground">
+          {fees.length}
+        </span>
+      </div>
+
       {fees.length === 0 ? (
         <p className="rounded-xl border border-dashed border-border px-3 py-4 text-center text-sm text-muted-foreground">
           Chưa có khoản phí nào. Dùng “Tính phí” để tạo.
         </p>
       ) : (
-        <ul className="space-y-2.5">
-          {fees.map((fee) => (
-            <FeeGroup
-              key={fee.id}
-              fee={fee}
-              invoices={invoicesByFee.get(fee.id) ?? []}
-              paymentsByInvoice={paymentsByInvoice}
-              onAction={onAction}
-              profileId={profileId}
-              payerName={payerName}
-              referenceHint={referenceHint}
-            />
-          ))}
-        </ul>
+        <>
+          {/* At-a-glance totals (restored — lost when the 3 section headers
+              collapsed into one). */}
+          <p className="-mt-1 mb-2 text-xs text-muted-foreground tabular-nums">
+            {collection.invoices.length} hóa đơn · {collection.payments.length} thanh toán
+          </p>
+          <ul className="space-y-2.5">
+            {orderedFees.map((fee) => (
+              <FeeGroup
+                key={fee.id}
+                fee={fee}
+                invoices={invoicesByFee.get(fee.id) ?? []}
+                paymentsByInvoice={paymentsByInvoice}
+                onAction={onAction}
+                profileId={profileId}
+                payerName={payerName}
+                referenceHint={referenceHint}
+              />
+            ))}
+          </ul>
+        </>
+      )}
+
+      {(orphanInvoices.length > 0 || orphanPayments.length > 0) && (
+        <div className="mt-3 rounded-xl border border-dashed border-border bg-muted/20 px-3 py-2.5">
+          <p className="mb-2 text-xs font-medium text-muted-foreground">
+            Khác (chưa gắn khoản phí)
+          </p>
+          {orphanInvoices.length > 0 && (
+            <ul className="space-y-2">
+              {orphanInvoices.map((inv) => (
+                <InvoiceNode
+                  key={inv.id}
+                  invoice={inv}
+                  payments={paymentsByInvoice.get(inv.id) ?? []}
+                  onAction={onAction}
+                  payerName={payerName}
+                  referenceHint={referenceHint}
+                />
+              ))}
+            </ul>
+          )}
+          {orphanPayments.length > 0 && (
+            <ul className="mt-2 space-y-1.5">
+              {orphanPayments.map((p) => (
+                <PaymentLeaf key={p.id} payment={p} onAction={onAction} />
+              ))}
+            </ul>
+          )}
+        </div>
       )}
     </section>
   )
@@ -466,8 +518,10 @@ function FeeGroup({
 }) {
   // Backend-owned (role + status + amount, matches each action's route gate) —
   // do NOT re-derive on the client. Tính lại needs base_amount to prefill.
+  // Trust the backend capability flags (thin-client); base_amount only prefills
+  // the Tính lại dialog and degrades to 0 if ever absent.
   const canWaive = fee.can_waive ?? false
-  const canRecalculate = (fee.can_recalculate ?? false) && fee.base_amount != null
+  const canRecalculate = fee.can_recalculate ?? false
   const canCancel = fee.can_cancel ?? false
   const hasMenu = canWaive || canRecalculate || canCancel
   const typeLabel = FEE_TYPE_LABELS[fee.fee_type as FeeType] ?? fee.fee_type
@@ -498,7 +552,7 @@ function FeeGroup({
               title="Mở chi tiết khoản phí"
               aria-label="Mở chi tiết khoản phí"
             >
-              <Link href={`/finance/fees/${fee.id}?from=${profileFrom(profileId)}`}>
+              <Link href={withFrom(`/finance/fees/${fee.id}`, profileFrom(profileId))}>
                 <ArrowUpRight className="size-4" aria-hidden="true" />
               </Link>
             </Button>
@@ -507,16 +561,7 @@ function FeeGroup({
               3-dots, system convention) — each item role-gated by a BE flag. */}
           {hasMenu && (
             <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="size-8"
-                  aria-label={`Thao tác cho khoản ${typeLabel}`}
-                >
-                  <MoreVertical className="size-4" aria-hidden="true" />
-                </Button>
-              </DropdownMenuTrigger>
+              <OverflowMenuTrigger label={`Thao tác cho khoản ${typeLabel}`} />
               <DropdownMenuContent align="end">
                 {canWaive && (
                   <DropdownMenuItem
@@ -540,8 +585,8 @@ function FeeGroup({
                         type: "recalculate",
                         feeId: fee.id,
                         feeType: typeLabel,
-                        currentBaseAmount: fee.base_amount as string,
-                        currentBaseAmountFormatted: formatVND(fee.base_amount as string),
+                        currentBaseAmount: fee.base_amount ?? "0",
+                        currentBaseAmountFormatted: formatVND(fee.base_amount ?? "0"),
                       })
                     }
                   >
@@ -575,7 +620,7 @@ function FeeGroup({
 
       {/* Hóa đơn của khoản phí (cấp 2) */}
       {invoices.length > 0 ? (
-        <div className="space-y-2 border-t border-border/60 bg-muted/20 px-3 py-2.5">
+        <ul className="space-y-2 border-t border-border/60 bg-muted/20 px-3 py-2.5">
           {invoices.map((inv) => (
             <InvoiceNode
               key={inv.id}
@@ -586,7 +631,7 @@ function FeeGroup({
               referenceHint={referenceHint}
             />
           ))}
-        </div>
+        </ul>
       ) : (
         <p className="border-t border-border/60 px-3 py-2 text-xs text-muted-foreground">
           Chưa có hóa đơn cho khoản phí này.
@@ -622,7 +667,7 @@ function InvoiceNode({
   // Fee reference dropped here: the invoice is nested under its fee already.
 
   return (
-    <div
+    <li
       className={cn(
         "rounded-lg border bg-card",
         invoice.is_overdue ? "border-l-2 border-l-error-500 border-border" : "border-border/70",
@@ -646,7 +691,7 @@ function InvoiceNode({
         />
       </div>
 
-      {(invoice.can_record_payment || hasMenu || canQr) && (
+      {(invoice.can_record_payment || hasMenu) && (
       <div className="flex items-center justify-end gap-1.5 px-3 pb-2">
         {invoice.can_record_payment && (
           <Button
@@ -670,16 +715,7 @@ function InvoiceNode({
         )}
         {(hasMenu || canQr) && (
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                size="icon"
-                variant="ghost"
-                className="size-8"
-                aria-label={`Thao tác cho hóa đơn ${invoice.invoice_number}`}
-              >
-                <MoreVertical className="size-4" aria-hidden="true" />
-              </Button>
-            </DropdownMenuTrigger>
+            <OverflowMenuTrigger label={`Thao tác cho hóa đơn ${invoice.invoice_number}`} />
             <DropdownMenuContent align="end">
               {canQr && (
                 <DropdownMenuItem
@@ -752,14 +788,18 @@ function InvoiceNode({
       )}
 
       {/* Thanh toán của hóa đơn (cấp 3) */}
-      {payments.length > 0 && (
-        <div className="space-y-1.5 border-t border-border/50 px-3 py-2">
+      {payments.length > 0 ? (
+        <ul className="space-y-1.5 border-t border-border/50 px-3 py-2">
           {payments.map((p) => (
             <PaymentLeaf key={p.id} payment={p} onAction={onAction} />
           ))}
-        </div>
-      )}
-    </div>
+        </ul>
+      ) : invoice.can_record_payment ? (
+        <p className="border-t border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
+          Chưa có lần thu nào.
+        </p>
+      ) : null}
+    </li>
   )
 }
 
@@ -795,7 +835,7 @@ function PaymentLeaf({
     payment.verified_by_name ? `Duyệt: ${payment.verified_by_name}` : null,
   ].filter(Boolean)
   return (
-    <div className="rounded-md bg-muted/40 px-2.5 py-1.5">
+    <li className="rounded-md bg-muted/40 px-2.5 py-1.5">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <p className="truncate text-xs font-semibold tabular-nums">
@@ -851,7 +891,7 @@ function PaymentLeaf({
           )}
         </div>
       )}
-    </div>
+    </li>
   )
 }
 

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/WorkspaceActionDialogs.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/WorkspaceActionDialogs.tsx
@@ -44,6 +44,8 @@ import { InvoiceIssueDialog } from "../[invoiceId]/_components/InvoiceIssueDialo
 import { InvoiceCancelDialog } from "../[invoiceId]/_components/InvoiceCancelDialog"
 import { InvoicePenaltyDialog } from "../[invoiceId]/_components/InvoicePenaltyDialog"
 import { FeeWaiveDialog } from "../../fees/[feeId]/_components/FeeWaiveDialog"
+import { FeeRecalculateDialog } from "../../fees/[feeId]/_components/FeeRecalculateDialog"
+import { FeeCancelDialog } from "../../fees/[feeId]/_components/FeeCancelDialog"
 import { CalculateFeeDialog } from "@/components/admissions/CalculateFeeDialog"
 
 // =============================================================================
@@ -79,6 +81,14 @@ export type WorkspaceDialog =
       daysOverdue: number
     }
   | { type: "waive"; feeId: number; maxAmount: string; maxAmountFormatted: string }
+  | {
+      type: "recalculate"
+      feeId: number
+      feeType: string
+      currentBaseAmount: string
+      currentBaseAmountFormatted: string
+    }
+  | { type: "cancel-fee"; feeId: number; feeType: string }
   | { type: "verify"; payment: PaymentReviewTarget }
   | { type: "reject"; payment: PaymentReviewTarget }
   | { type: "qr"; invoiceId: number; invoiceNumber: string }
@@ -151,6 +161,26 @@ export function WorkspaceActionDialogs({ dialog, onClose, onCalculated }: Worksp
           feeId={dialog.feeId}
           maxAmount={dialog.maxAmount}
           maxAmountFormatted={dialog.maxAmountFormatted}
+        />
+      )}
+
+      {dialog?.type === "recalculate" && (
+        <FeeRecalculateDialog
+          open
+          onOpenChange={handleOpenChange}
+          feeId={dialog.feeId}
+          feeType={dialog.feeType}
+          currentBaseAmount={dialog.currentBaseAmount}
+          currentBaseAmountFormatted={dialog.currentBaseAmountFormatted}
+        />
+      )}
+
+      {dialog?.type === "cancel-fee" && (
+        <FeeCancelDialog
+          open
+          onOpenChange={handleOpenChange}
+          feeId={dialog.feeId}
+          feeType={dialog.feeType}
         />
       )}
 

--- a/frontend/src/lib/finance/nav-context.ts
+++ b/frontend/src/lib/finance/nav-context.ts
@@ -47,5 +47,9 @@ export function resolveFinanceReturn(from: string | null | undefined): {
  * dialog (which strips the `?action=` param) does NOT lose the return context.
  */
 export function withFrom(path: string, from: string | null | undefined): string {
-  return from ? `${path}?from=${encodeURIComponent(from)}` : path
+  if (!from) return path
+  // Use `&` if the path already carries a query string so we never emit a
+  // malformed double-`?` (which would fold `from` into the previous param).
+  const sep = path.includes("?") ? "&" : "?"
+  return `${path}${sep}from=${encodeURIComponent(from)}`
 }

--- a/frontend/src/lib/finance/nav-context.ts
+++ b/frontend/src/lib/finance/nav-context.ts
@@ -1,0 +1,51 @@
+// src/lib/finance/nav-context.ts
+/**
+ * Finance navigation context.
+ *
+ * The "Thu học phí" workspace (/finance/invoices) is the hub; fee & invoice
+ * detail pages are spokes. When the workspace links into a detail page it stamps
+ * a `?from=` context so the detail page's "Quay lại" returns to EXACTLY where the
+ * user came from (reopening the right profile drawer) instead of a blind
+ * browser-back. If no context is present we fall back to the workspace, never a
+ * dead-end.
+ *
+ * Only internal finance targets are ever produced (no open-redirect surface):
+ * `from` is parsed, validated, and mapped to a fixed route shape here.
+ */
+
+/** Workspace hub — the safe finance landing when there's no return context. */
+const FINANCE_WORKSPACE = "/finance/invoices"
+
+/** `?from` value the workspace stamps on a link into a profile's detail page. */
+export function profileFrom(profileId: number): string {
+  return `profile:${profileId}`
+}
+
+/**
+ * Resolve the controlled return target for a finance detail page from its
+ * `?from` param. Returns the href to navigate to and a human label naming the
+ * destination (so the back control says where it goes, not a generic "back").
+ */
+export function resolveFinanceReturn(from: string | null | undefined): {
+  href: string
+  label: string
+} {
+  if (from) {
+    const [kind, raw] = from.split(":")
+    if (kind === "profile" && raw && /^\d+$/.test(raw)) {
+      return {
+        href: `${FINANCE_WORKSPACE}?profile=${raw}`,
+        label: "Quay lại hồ sơ",
+      }
+    }
+  }
+  return { href: FINANCE_WORKSPACE, label: "Quay lại Thu học phí" }
+}
+
+/**
+ * Append the current `?from` to a same-page replace target so closing an action
+ * dialog (which strips the `?action=` param) does NOT lose the return context.
+ */
+export function withFrom(path: string, from: string | null | undefined): string {
+  return from ? `${path}?from=${encodeURIComponent(from)}` : path
+}

--- a/frontend/src/lib/navigation/routes.ts
+++ b/frontend/src/lib/navigation/routes.ts
@@ -86,6 +86,28 @@ export const routes: Record<string, RouteConfig> = {
     label: "Notifications",
     parent: "dashboard",
   },
+
+  // Finance — hub & spoke quanh "Thu học phí"
+  // Workspace /finance/invoices là hub (có trong sidebar); trang chi tiết khoản
+  // phí / hóa đơn là spoke. Khai báo tường minh để breadcrumb đi qua hub thật,
+  // KHÔNG rơi vào auto-generation trỏ /finance/fees (trang redirect, mồ côi nav).
+  // Lưu ý: nút "Quay lại hồ sơ" trên trang chi tiết mới là đường về đúng drawer
+  // (?from=profile:<id>); breadcrumb chỉ đưa về hub workspace.
+  financeWorkspace: {
+    path: "/finance/invoices",
+    label: "Thu học phí",
+    parent: "dashboard",
+  },
+  financeFeeDetail: {
+    path: "/finance/fees/[feeId]",
+    label: "Chi tiết khoản phí",
+    parent: "financeWorkspace",
+  },
+  financeInvoiceDetail: {
+    path: "/finance/invoices/[invoiceId]",
+    label: "Chi tiết hóa đơn",
+    parent: "financeWorkspace",
+  },
 };
 
 /**

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -484,12 +484,17 @@ export interface ProfileCollectionIdentity {
   profile_id: number
   profile_code: string
   student_name: string | null
-  // CCCD đã che giữa (PII-safe). Ngành/trình độ từ snapshot Fee.resolved_*.
+  // CCCD đã che giữa (PII-safe, dùng để HIỂN THỊ). Ngành/trình độ từ snapshot
+  // Fee.resolved_*.
   citizen_id_masked: string | null
+  // CCCD đầy đủ — CHỈ cho nút copy (vai trò tài chính đã xem được hồ sơ đầy đủ).
+  citizen_id_full: string | null
   program_name: string | null
   degree_level: string | null
   officer_name: string | null
   phone: string | null
+  // Địa chỉ thường trú đã ghép 1 dòng (BE-owned). Null khi chưa có.
+  permanent_address: string | null
 }
 
 export interface ProfileCollection {

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -135,10 +135,15 @@ export interface FeeSummary {
   paid_amount: string
   remaining_amount: string
   status: FeeStatus
-  // Role-aware waive capability (backend-owned, matches the RequireManager
-  // route gate). Optional: only the collection drawer populates it; other
-  // FeeSummary sources leave it falsy → no waive button (safe default).
+  // Role-aware capability flags (backend-owned, each mirrors its route gate).
+  // Optional: only the collection drawer populates them; other FeeSummary
+  // sources leave them falsy → no action button (safe default).
   can_waive?: boolean
+  can_recalculate?: boolean
+  can_cancel?: boolean
+  // Current base amount — only the drawer sets it (prefills the "Tính lại"
+  // dialog). Absent elsewhere (no recalculate button there).
+  base_amount?: string
 }
 
 export interface FeeDetail extends Fee {

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -487,7 +487,8 @@ export interface ProfileCollectionIdentity {
   // CCCD đã che giữa (PII-safe, dùng để HIỂN THỊ). Ngành/trình độ từ snapshot
   // Fee.resolved_*.
   citizen_id_masked: string | null
-  // CCCD đầy đủ — CHỈ cho nút copy (vai trò tài chính đã xem được hồ sơ đầy đủ).
+  // CCCD đầy đủ — CHỈ cho nút copy (kế toán cần để xuất hóa đơn GTGT; lộ PII có
+  // chủ đích cho nhân viên tài chính). Hiển thị vẫn dùng bản che bên trên.
   citizen_id_full: string | null
   program_name: string | null
   degree_level: string | null


### PR DESCRIPTION
## Tóm tắt
Nâng cấp toàn diện trải nghiệm điều hướng & bố cục **drawer "Thu học phí"** (FinanceProfileDrawer) cùng các trang chi tiết fee/invoice. 9 commit, FE-trọng-tâm + bổ sung nhỏ BE contract.

## Thay đổi chính
**Điều hướng (hub-and-spoke):**
- Drawer = hub; trang fee/invoice detail = spoke. Link mang `?from=profile:{id}` → "Quay lại hồ sơ" mở lại đúng drawer; không có `from` thì fallback `router.back()` (về đúng nơi xuất phát, vd tab Học phí của hồ sơ tuyển sinh).
- Breadcrumb hub-and-spoke (route config tường minh), hết trỏ trang mồ côi `/finance/fees`.
- `nav-context.ts`: helper `resolveFinanceReturn`/`withFrom`/`profileFrom` (validate, không open-redirect; `withFrom` xử lý query sẵn có).

**Drawer:**
- **Cây phân cấp** Khoản phí → Hóa đơn của nó → Thanh toán của nó (card-trong-card), sort fee theo độ khẩn (quá-hạn → còn-nợ → đã-đủ).
- Đưa **Tính lại / Hủy khoản phí / Miễn giảm** vào menu ⋮ ngay trong drawer (tái dùng dialog; mutation invalidate → refresh tại chỗ).
- Header: **copy CCCD** (hiện che, copy đầy đủ) + copy SĐT + **địa chỉ thường trú**; bỏ nhãn "TVV".
- Số đếm "X hóa đơn · Y thanh toán", empty-state, mục "Khác (chưa gắn khoản phí)" phòng thủ.

**Backend (đổi contract — KHÔNG migration, KHÔNG Casbin):**
- `FeeSummaryResponse` +`can_recalculate`/`can_cancel`/`base_amount`; helper single-source `_fee_can_recalculate`/`_fee_can_cancel` khớp route gate.
- `ProfileCollectionIdentity` +`citizen_id_full` (cho nút copy) + `permanent_address` (helper ghép). ⚠️ `citizen_id_full` **lộ PII có chủ đích** cho nhân viên tài chính (gồm accountant) để **xuất hóa đơn GTGT** — đã ghi rõ ở comment.

**Sửa lỗi kèm theo:**
- Hết hydration `<p>` lồng `<p>` ở 4 dialog xác nhận (InvoiceCancel/FeeCancel/InvoiceIssue + AccountingPeriod dùng `asChild`).

## /code-review max
Đã chạy 10 angle + verify + sweep; xử lý #1–#15: #1 PII (chấp nhận, ghi rõ ý đồ), #2 cancel_fee 400 (sửa comment over-claim — guard pending/intent ở #442 không model được phía flag), #3 back-nav, #4 sort, #5 dialog, #6–#15 cleanup.

## Kiểm thử
- FE type-check + lint: **0 error**.
- pytest `test_profile_collection`: **19/19 pass** (gồm test `_format_permanent_address` + flag recalc/cancel).
- Smoke dev (admin): điều hướng round-trip, cây 3 cấp, copy CCCD ra đầy đủ, breadcrumb, sort, console sạch (0 DOM-nesting).

## Deploy
Code-only + **restart backend** (nhận schema mới). KHÔNG migration, KHÔNG Casbin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)