### PR TITLE
fix(finance): vá 5 edge case Thu học phí + hardening (audit 2026-06-29)

### DIFF
--- a/Backend_FastAPI/app/models/finance/installment_plan.py
+++ b/Backend_FastAPI/app/models/finance/installment_plan.py
@@ -184,4 +184,13 @@ class InstallmentPlan(Base):
                 entry["due_date"] = (anchor_date + timedelta(days=offset)).isoformat()
             result.append(entry)
 
+        # Defense-in-depth: tổng % các đợt vượt 100 → đợt cuối (remainder-to-last)
+        # ra ÂM → Invoice amount âm. Schema validate sum==100 ở biên API, nhưng
+        # plan dị dạng (sửa JSONB/seed tay) có thể lọt vào runtime — fail-fast.
+        if any(e["amount"] < 0 for e in result):
+            raise ValueError(
+                f"Lịch trả góp lỗi (plan id={self.id}): tổng phần trăm các đợt "
+                "vượt 100% khiến đợt cuối âm."
+            )
+
         return result

--- a/Backend_FastAPI/app/models/finance/installment_plan.py
+++ b/Backend_FastAPI/app/models/finance/installment_plan.py
@@ -187,8 +187,12 @@ class InstallmentPlan(Base):
         # Defense-in-depth: tổng % các đợt vượt 100 → đợt cuối (remainder-to-last)
         # ra ÂM → Invoice amount âm. Schema validate sum==100 ở biên API, nhưng
         # plan dị dạng (sửa JSONB/seed tay) có thể lọt vào runtime — fail-fast.
+        # Domain exception (→400) thay vì ValueError (→500 không bắt) để caller
+        # (generate_invoices_for_fee / recalculate_fee) trả lỗi sạch.
         if any(e["amount"] < 0 for e in result):
-            raise ValueError(
+            from app.utils.exceptions import BusinessRuleViolation
+
+            raise BusinessRuleViolation(
                 f"Lịch trả góp lỗi (plan id={self.id}): tổng phần trăm các đợt "
                 "vượt 100% khiến đợt cuối âm."
             )

--- a/Backend_FastAPI/app/routers/invoices.py
+++ b/Backend_FastAPI/app/routers/invoices.py
@@ -596,9 +596,10 @@ async def create_invoice(
 async def apply_penalty(
     request: Request,
     invoice_id: int,
-    penalty_amount: Optional[Decimal] = Query(
-        None, gt=0, description="Penalty amount (auto-calculated if not provided)"
+    penalty_amount: Decimal = Query(
+        ..., gt=0, le=finance_schemas.MAX_AMOUNT, description="Số tiền phạt (VND, bắt buộc)"
     ),
+    reason: str = Query(..., min_length=1, max_length=500, description="Lý do áp phạt"),
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = RequireManager,
 ):
@@ -606,8 +607,8 @@ async def apply_penalty(
     Apply late payment penalty to an overdue invoice.
 
     **Business Rules:**
-    - Only applies to overdue invoices
-    - If penalty_amount not provided, calculated based on installment plan penalty_rate
+    - ``penalty_amount`` bắt buộc (> 0); tổng phạt không vượt số tiền hóa đơn.
+    - Không áp phạt cho hóa đơn đã thanh toán / đã hủy.
     - Requires manager or admin role
 
     **Security:**
@@ -621,6 +622,7 @@ async def apply_penalty(
         invoice, _ = await invoice_service.apply_penalty(
             invoice_id=invoice_id,
             penalty_amount=penalty_amount,
+            reason=reason,
             user_id=current_user.id,
             unit_id=unit_id,
         )

--- a/Backend_FastAPI/app/routers/invoices.py
+++ b/Backend_FastAPI/app/routers/invoices.py
@@ -668,7 +668,8 @@ def _compute_invoice_permissions(
       (POST /api/payments → ACCOUNTANT_TEMPLATE; manager lacks it)
     - can_cancel: status not terminal AND paid == 0 AND role in [admin, manager]
       (PUT /api/invoices/{id}/cancel → RequireManager; accountant excluded)
-    - can_apply_penalty: status == 'overdue' AND role in [admin, manager]
+    - can_apply_penalty: derived-overdue (issued/partial/overdue đã quá due_date)
+      AND role in [admin, manager]
       (POST /api/invoices/{id}/apply-penalty → RequireManager; accountant excluded)
     """
     status_value = (
@@ -688,7 +689,10 @@ def _compute_invoice_permissions(
             and invoice.remaining_amount > 0
             and is_accountant_or_admin
         ),
-        "can_apply_penalty": status_value == "overdue" and is_manager_or_admin,
+        # Derived-overdue (issued/partial/overdue ĐÃ quá due_date), KHÔNG dùng enum
+        # 'overdue' (lag theo beat job) → nút hiện đúng khi service apply_penalty
+        # chấp nhận (service cũng gate ``invoice.is_overdue``).
+        "can_apply_penalty": _invoice_is_overdue(invoice) and is_manager_or_admin,
     }
 
 

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -839,10 +839,27 @@ class FeeCalculationService:
         draft_invoices = [
             inv for inv in fee_invoices if inv.status == "draft"
         ]
-        if draft_invoices and fee.installment_plan:
+        if len(draft_invoices) == 1:
+            # 1 đợt draft (FULL plan, hoặc multi-plan còn đúng 1 đợt sau khi hủy) →
+            # toàn bộ final vào đó, giữ sum(invoice)==final.
+            await self.db.execute(
+                sa.update(Invoice)
+                .where(Invoice.id == draft_invoices[0].id)
+                .values(amount=fee.final_amount)
+            )
+        elif draft_invoices and fee.installment_plan:
             new_schedule = fee.installment_plan.get_installment_schedule(
                 fee.final_amount
             )
+            # zip theo VỊ TRÍ → chỉ đúng khi số HĐ draft KHỚP số đợt kế hoạch. Nếu
+            # lệch (vd 1 đợt giữa chừng đã hủy, cancelled không bị block ở trên) →
+            # gán lệch số tiền → fee↔invoice lệch (undercharge). Chặn an toàn thay
+            # vì rewrite mù.
+            if len(draft_invoices) != len(new_schedule):
+                raise BusinessRuleViolation(
+                    "Bộ hóa đơn không khớp kế hoạch trả góp (có đợt đã hủy) — hãy "
+                    "hủy các hóa đơn còn lại rồi phát hành lại để tính lại phí."
+                )
             for inv, sched in zip(
                 sorted(draft_invoices, key=lambda x: x.installment_no),
                 new_schedule,
@@ -852,12 +869,6 @@ class FeeCalculationService:
                     .where(Invoice.id == inv.id)
                     .values(amount=sched["amount"])
                 )
-        elif len(draft_invoices) == 1:
-            await self.db.execute(
-                sa.update(Invoice)
-                .where(Invoice.id == draft_invoices[0].id)
-                .values(amount=fee.final_amount)
-            )
 
         await self.db.flush()
 

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -847,22 +847,30 @@ class FeeCalculationService:
                 .where(Invoice.id == draft_invoices[0].id)
                 .values(amount=fee.final_amount)
             )
-        elif draft_invoices and fee.installment_plan:
-            new_schedule = fee.installment_plan.get_installment_schedule(
-                fee.final_amount
+        elif len(draft_invoices) >= 2:
+            # ≥2 HĐ draft: chỉ rewrite AN TOÀN khi có installment_plan VÀ số HĐ
+            # draft KHỚP số đợt kế hoạch. Lệch vì: (a) 1 đợt giữa kế hoạch đã hủy
+            # (cancelled không bị block ở trên), HOẶC (b) fee KHÔNG có plan nhưng bị
+            # tạo thêm HĐ draft qua POST /api/invoices (create_single_invoice). Cả 2
+            # trường hợp: zip theo vị trí sẽ gán lệch số tiền → fee↔invoice lệch
+            # (thu thiếu/dư) — đúng kiểu sai tiền #2 định chặn. KHÔNG rewrite mù →
+            # chặn, yêu cầu hủy & phát hành lại.
+            new_schedule = (
+                fee.installment_plan.get_installment_schedule(fee.final_amount)
+                if fee.installment_plan
+                else None
             )
-            # zip theo VỊ TRÍ → chỉ đúng khi số HĐ draft KHỚP số đợt kế hoạch. Nếu
-            # lệch (vd 1 đợt giữa chừng đã hủy, cancelled không bị block ở trên) →
-            # gán lệch số tiền → fee↔invoice lệch (undercharge). Chặn an toàn thay
-            # vì rewrite mù.
-            if len(draft_invoices) != len(new_schedule):
+            if new_schedule is None or len(draft_invoices) != len(new_schedule):
                 raise BusinessRuleViolation(
-                    "Bộ hóa đơn không khớp kế hoạch trả góp (có đợt đã hủy) — hãy "
-                    "hủy các hóa đơn còn lại rồi phát hành lại để tính lại phí."
+                    "Bộ hóa đơn không khớp kế hoạch trả góp (đợt đã hủy hoặc không "
+                    "có kế hoạch trả góp) — hãy hủy các hóa đơn còn lại rồi phát "
+                    "hành lại để tính lại phí."
                 )
+            # Sort CẢ HAI theo installment_no để ghép ĐÚNG đợt (schedule JSONB có
+            # thể lưu lệch thứ tự, remainder rơi vào phần tử cuối list).
             for inv, sched in zip(
                 sorted(draft_invoices, key=lambda x: x.installment_no),
-                new_schedule,
+                sorted(new_schedule, key=lambda s: s["installment_no"]),
             ):
                 await self.db.execute(
                     sa.update(Invoice)
@@ -1591,6 +1599,23 @@ async def recalculate_fees_for_semester_tuition_change(
                 )
                 continue
 
+        # ≥2 HĐ draft KHÔNG khớp kế hoạch trả góp (không có plan, hoặc số HĐ ≠ số
+        # đợt) → KHÔNG rewrite an toàn bằng zip vị trí được → SKIP fee này TRƯỚC khi
+        # đổi base (tránh fee↔invoice lệch im lặng — cùng invariant recalculate_fee
+        # #1). Tới đây mọi HĐ đều draft (non-draft đã skip ở trên).
+        draft_count = sum(1 for inv in fee.invoices if inv.status == "draft")
+        if draft_count >= 2 and (
+            fee.installment_plan is None
+            or draft_count != fee.installment_plan.installment_count
+        ):
+            log.info(
+                "fee_recalc_skipped_unmappable_invoices",
+                fee_id=fee.id,
+                semester_no=fee.semester_no,
+                draft_count=draft_count,
+            )
+            continue
+
         # Look up new semester tuition amount
         sem_result = await db.execute(
             select(models.OfferingSemesterTuition.amount).where(
@@ -1630,9 +1655,11 @@ async def recalculate_fees_for_semester_tuition_change(
             new_schedule = fee.installment_plan.get_installment_schedule(
                 fee.final_amount
             )
+            # Sort CẢ HAI theo installment_no để ghép ĐÚNG đợt (schedule JSONB có
+            # thể lưu lệch thứ tự, remainder rơi vào phần tử cuối list).
             for inv, sched in zip(
                 sorted(fee.invoices, key=lambda x: x.installment_no),
-                new_schedule,
+                sorted(new_schedule, key=lambda s: s["installment_no"]),
             ):
                 await db.execute(
                     sa.update(Invoice)

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -765,6 +765,32 @@ class FeeCalculationService:
                 f"Paid amount: {fee.paid_amount} VND"
             )
 
+        # Block when any non-cancelled invoice is beyond draft. Recalc đổi
+        # ``fee.final_amount`` nhưng payment thu theo ``invoice.amount`` (KHÔNG
+        # đọc fee) → fee 10tr/HĐ issued 10tr, recalc 8tr ⇒ vẫn thu 10tr (dư 2tr);
+        # ngược lại tăng giá ⇒ thu thiếu. Đối xứng
+        # ``recalculate_fees_for_semester_tuition_change`` (chỉ recalc khi mọi HĐ
+        # còn draft). Muốn đổi phí đã phát hành: hủy hóa đơn rồi tính lại.
+        # Query invoices TƯƠI (không dựa ``fee.invoices`` relationship — có thể
+        # stale dưới session tái dùng; prod mỗi request session mới nhưng đây là
+        # tiền lõi nên load tường minh).
+        fee_invoices = list(
+            (
+                await self.db.execute(
+                    select(Invoice).where(Invoice.fee_id == fee_id)
+                )
+            ).scalars().all()
+        )
+        active_invoices = [
+            inv for inv in fee_invoices if inv.status != "cancelled"
+        ]
+        if any(inv.status != "draft" for inv in active_invoices):
+            raise BusinessRuleViolation(
+                "Không thể tính lại phí khi đã phát hành hóa đơn "
+                "(issued/partial/paid). Hãy hủy hóa đơn liên quan trước rồi "
+                "tính lại."
+            )
+
         # Get existing discount policy IDs
         existing_policy_ids = [
             ad.policy_id for ad in fee.applied_discounts if ad.policy_id
@@ -786,6 +812,32 @@ class FeeCalculationService:
         fee.notes = f"{fee.notes or ''}\n[{datetime.now(timezone.utc).isoformat()}] " \
                     f"Recalculated by user {user_id}: {old_base} → {new_base_amount}. " \
                     f"Reason: {reason}"
+
+        # Đồng bộ hóa đơn DRAFT (nếu có) theo final mới để fee↔invoice không lệch
+        # — chỉ tới đây khi mọi HĐ còn draft (guard non-draft ở trên). Mirror
+        # recalculate_fees_for_semester_tuition_change.
+        draft_invoices = [
+            inv for inv in fee_invoices if inv.status == "draft"
+        ]
+        if draft_invoices and fee.installment_plan:
+            new_schedule = fee.installment_plan.get_installment_schedule(
+                fee.final_amount
+            )
+            for inv, sched in zip(
+                sorted(draft_invoices, key=lambda x: x.installment_no),
+                new_schedule,
+            ):
+                await self.db.execute(
+                    sa.update(Invoice)
+                    .where(Invoice.id == inv.id)
+                    .values(amount=sched["amount"])
+                )
+        elif len(draft_invoices) == 1:
+            await self.db.execute(
+                sa.update(Invoice)
+                .where(Invoice.id == draft_invoices[0].id)
+                .values(amount=fee.final_amount)
+            )
 
         await self.db.flush()
 

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -378,6 +378,26 @@ async def resnapshot_fee_academic_info_for_profile(
         return 0
 
     for fee in fees:
+        # E2 hardening (audit 29-06): fee đã gắn ngành (resolved_ai cũ) mà nay
+        # resolve ra ngành KHÁC → cấu hình AdmissionPath/academic_info có thể đã bị
+        # sửa SAU khi tính phí; ``final_amount`` (đóng băng theo ngành cũ) có thể
+        # KHÔNG còn khớp ngành mới. Snapshot vẫn cập nhật để display khớp ngành
+        # hiện tại, nhưng phát log.warning để kế-toán/admin soát tiền (biến vi phạm
+        # invariant thành tín hiệu quan sát được thay vì ghi đè im lặng).
+        prior_ai = fee.resolved_academic_info_id
+        if (
+            resolved_ai_id is not None
+            and prior_ai is not None
+            and prior_ai != resolved_ai_id
+        ):
+            log.warning(
+                "fee_resolved_major_drift",
+                fee_id=fee.id,
+                profile_id=profile_id,
+                prior_academic_info_id=prior_ai,
+                new_academic_info_id=resolved_ai_id,
+                fee_final_amount=str(fee.final_amount),
+            )
         fee.resolved_academic_info_id = resolved_ai_id
         fee.resolved_major_id = resolved_major_id
         fee.resolved_degree_level = resolved_degree_level

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -675,18 +675,28 @@ class InvoiceService:
         if not invoice:
             raise ResourceNotFoundError("Invoice not found")
 
+        # (1) Input: ``is None`` guard cho direct caller (route đã ép required gt=0;
+        # HTTP không gửi None được nữa, nhưng service là business boundary → tự bảo
+        # vệ khỏi None→TypeError).
+        if penalty_amount is None or penalty_amount <= 0:
+            raise BadRequest("Penalty amount must be positive")
+
+        # (2) Trạng thái: không áp phạt hóa đơn đã thanh toán / đã hủy.
         if invoice.status in [InvoiceStatusEnum.paid.value, InvoiceStatusEnum.cancelled.value]:
             raise BusinessRuleViolation(
                 f"Cannot apply penalty to {invoice.status} invoice"
             )
 
-        # ``is None`` guard cho direct caller (route đã ép required gt=0; HTTP
-        # không thể gửi None nữa, nhưng service là business boundary → tự bảo vệ
-        # khỏi None→TypeError).
-        if penalty_amount is None or penalty_amount <= 0:
-            raise BadRequest("Penalty amount must be positive")
+        # (3) CHỈ áp phạt khi ĐÃ QUÁ HẠN (phí TRỄ hạn): quá ngày đến hạn + chưa thu
+        # đủ. Dùng ``is_overdue`` (derived: today > due_date) nên bắt cả HĐ quá hạn
+        # mà beat job chưa kịp lật status='overdue'; đồng thời CHẶN áp phạt HĐ chưa
+        # tới hạn (issued, due tương lai) — khớp cờ FE can_apply_penalty.
+        if not invoice.is_overdue:
+            raise BusinessRuleViolation(
+                "Chỉ áp phạt cho hóa đơn ĐÃ QUÁ HẠN (quá ngày đến hạn, chưa thu đủ)."
+            )
 
-        # Trần: tổng phạt cộng dồn không vượt số tiền hóa đơn (chống áp phạt lặp
+        # (4) Trần: tổng phạt cộng dồn không vượt số tiền hóa đơn (chống áp phạt lặp
         # nhiều lần đẩy nợ vô lý).
         if invoice.penalty_amount + penalty_amount > invoice.amount:
             raise BusinessRuleViolation(

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -37,6 +37,7 @@ from app.models.finance import (
     Fee, Invoice, InstallmentPlan,
     FeeStatusEnum, InvoiceStatusEnum,
 )
+from app.models.finance.invoice import OVERDUE_DERIVED_STATUSES
 from app.repositories.fee_repository import FeeRepository, InvoiceRepository
 from app.utils.exceptions import (
     ResourceNotFoundError,
@@ -687,15 +688,17 @@ class InvoiceService:
                 f"Cannot apply penalty to {invoice.status} invoice"
             )
 
-        # (3) CHỈ áp phạt khi ĐÃ QUÁ HẠN (phí TRỄ hạn): quá ngày đến hạn + chưa thu
-        # đủ. Dùng ``is_overdue`` (derived: today > due_date) nên bắt cả HĐ quá hạn
-        # mà beat job chưa kịp lật status='overdue'; đồng thời CHẶN áp phạt HĐ chưa
-        # tới hạn (issued, due tương lai). Cờ FE ``can_apply_penalty`` cũng tính
-        # theo derived-overdue (``_invoice_is_overdue``) nên nút chỉ hiện đúng khi
-        # service chấp nhận (không lệch enum 'overdue' lag theo beat job).
-        if not invoice.is_overdue:
+        # (3) CHỈ áp phạt HĐ ĐÃ PHÁT HÀNH và ĐÃ QUÁ HẠN. Khớp ĐÚNG cờ FE
+        # ``can_apply_penalty`` = ``_invoice_is_overdue`` (status ∈ issued/partial/
+        # overdue ∧ quá due_date). LƯU Ý: ``invoice.is_overdue`` (model) KHÔNG check
+        # status nên một mình nó cho áp phạt cả HĐ **draft** quá hạn (FE đã ẩn nút)
+        # → phải kèm gate status ``OVERDUE_DERIVED_STATUSES`` để chặn HĐ chưa phát
+        # hành + giữ service KHÔNG rộng hơn cờ FE. ``is_overdue`` bổ sung điều kiện
+        # quá-hạn (bắt cả HĐ issued quá hạn mà beat job chưa lật status='overdue').
+        if invoice.status not in OVERDUE_DERIVED_STATUSES or not invoice.is_overdue:
             raise BusinessRuleViolation(
-                "Chỉ áp phạt cho hóa đơn ĐÃ QUÁ HẠN (quá ngày đến hạn, chưa thu đủ)."
+                "Chỉ áp phạt cho hóa đơn ĐÃ PHÁT HÀNH và ĐÃ QUÁ HẠN "
+                "(quá ngày đến hạn, chưa thu đủ)."
             )
 
         # (4) Trần: tổng phạt cộng dồn không vượt số tiền hóa đơn (chống áp phạt lặp

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -690,7 +690,9 @@ class InvoiceService:
         # (3) CHỈ áp phạt khi ĐÃ QUÁ HẠN (phí TRỄ hạn): quá ngày đến hạn + chưa thu
         # đủ. Dùng ``is_overdue`` (derived: today > due_date) nên bắt cả HĐ quá hạn
         # mà beat job chưa kịp lật status='overdue'; đồng thời CHẶN áp phạt HĐ chưa
-        # tới hạn (issued, due tương lai) — khớp cờ FE can_apply_penalty.
+        # tới hạn (issued, due tương lai). Cờ FE ``can_apply_penalty`` cũng tính
+        # theo derived-overdue (``_invoice_is_overdue``) nên nút chỉ hiện đúng khi
+        # service chấp nhận (không lệch enum 'overdue' lag theo beat job).
         if not invoice.is_overdue:
             raise BusinessRuleViolation(
                 "Chỉ áp phạt cho hóa đơn ĐÃ QUÁ HẠN (quá ngày đến hạn, chưa thu đủ)."

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -135,6 +135,14 @@ class InvoiceService:
 
         # Get installment schedule
         if fee.installment_plan:
+            # Chặn dùng plan đã NGỪNG hoạt động: lúc gắn plan đã lọc is_active
+            # (fee_calculation_service), nhưng admin có thể tắt plan SAU đó →
+            # không được tiếp tục sinh hóa đơn theo schedule của plan đã tắt.
+            if not getattr(fee.installment_plan, "is_active", True):
+                raise BusinessRuleViolation(
+                    f"Kế hoạch thanh toán '{fee.installment_plan.code}' đã ngừng "
+                    "hoạt động — không thể sinh hóa đơn."
+                )
             # Use plan's schedule with proper due_days_offset per installment
             installment_schedule = fee.installment_plan.get_installment_schedule(
                 amount_to_invoice, anchor_date=anchor_date
@@ -672,8 +680,19 @@ class InvoiceService:
                 f"Cannot apply penalty to {invoice.status} invoice"
             )
 
-        if penalty_amount <= 0:
+        # ``is None`` guard cho direct caller (route đã ép required gt=0; HTTP
+        # không thể gửi None nữa, nhưng service là business boundary → tự bảo vệ
+        # khỏi None→TypeError).
+        if penalty_amount is None or penalty_amount <= 0:
             raise BadRequest("Penalty amount must be positive")
+
+        # Trần: tổng phạt cộng dồn không vượt số tiền hóa đơn (chống áp phạt lặp
+        # nhiều lần đẩy nợ vô lý).
+        if invoice.penalty_amount + penalty_amount > invoice.amount:
+            raise BusinessRuleViolation(
+                f"Tổng phạt ({invoice.penalty_amount + penalty_amount}) vượt số "
+                f"tiền hóa đơn ({invoice.amount})."
+            )
 
         old_penalty = invoice.penalty_amount
         invoice.penalty_amount = invoice.penalty_amount + penalty_amount

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -412,6 +412,39 @@ async def resolve_and_validate(
     no_payable_fee_ids = [fid for fid in fee_ids if fid not in invoices_by_fee]
     invoice_statuses = await _fetch_invoice_status_sets(db, no_payable_fee_ids)
 
+    # #6 — nghi TRÙNG GIAO DỊCH (re-import sao kê chồng ngày → tạo Payment thứ 2
+    # cho cùng giao dịch khi hồ sơ còn nợ). reference_code là FREE-TEXT (phiếu thu
+    # PT-/mã hồ sơ HS-/cash), TÁI DÙNG hợp lệ được ở thu góp KHÁC số tiền → KHÔNG
+    # đặt unique. Tín hiệu re-import = tổng payment verified đã ghi cho (hồ sơ, ref)
+    # KHỚP số tiền dòng. Prefetch 1 query group; bỏ ref rỗng/synthetic. CẢNH BÁO
+    # mềm (không chặn — kế toán quyết).
+    existing_ref_sums: Dict[Tuple[int, str], Decimal] = {}
+    _prof_ids = [p.id for p in profiles.values()]
+    if _prof_ids:
+        for pid, ref, total in (
+            await db.execute(
+                select(
+                    models.AdmissionProfile.id,
+                    Payment.reference_code,
+                    func.sum(Payment.amount),
+                )
+                .join(Invoice, Invoice.id == Payment.invoice_id)
+                .join(Fee, Fee.id == Invoice.fee_id)
+                .join(
+                    models.AdmissionProfile,
+                    models.AdmissionProfile.id == Fee.admission_profile_id,
+                )
+                .where(
+                    models.AdmissionProfile.id.in_(_prof_ids),
+                    Payment.status == PaymentStatusEnum.verified.value,
+                    Payment.reference_code.isnot(None),
+                    Payment.reference_code != "",
+                )
+                .group_by(models.AdmissionProfile.id, Payment.reference_code)
+            )
+        ).all():
+            existing_ref_sums[(pid, _norm(ref))] = total
+
     # G2 — code hình thức ĐANG hoạt động (mirror commit:1017). Parser đã loại method
     # text lạ (:346); đây bắt method map-OK nhưng PaymentMethod inactive/missing → ERROR
     # ngay ở preview (đối xứng commit, hết "khớp giả" rồi commit fail).
@@ -554,6 +587,19 @@ async def resolve_and_validate(
                 warnings.append(
                     f"CCCD xuất hiện {dup_n} dòng trong file — kiểm tra trùng "
                     "(nếu thu nhiều đợt thì bỏ qua)"
+                )
+
+        # (#6) nghi TRÙNG GIAO DỊCH với payment ĐÃ GHI (re-import) — prefetch ở trên.
+        # Khớp (hồ sơ, mã tham chiếu, tổng đã ghi == số tiền dòng): thu góp hợp lệ
+        # khác số tiền nên KHÔNG dính. Bỏ ref rỗng/synthetic (không dedup được).
+        _ref = _norm(d.reference or "")
+        if _ref and not _ref.startswith(("BULK-", "PAY-")):
+            _prior = existing_ref_sums.get((profile.id, _ref))
+            if _prior is not None and _prior == d.amount:
+                warnings.append(
+                    f"nghi trùng giao dịch: mã tham chiếu '{_ref}' + số tiền "
+                    f"{_money(d.amount)} đã ghi nhận cho hồ sơ này — kiểm tra "
+                    "trước khi thu lại (re-import?)"
                 )
 
         # FIFO allocate

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -30,7 +30,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 import pandas as pd
 import structlog
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -1023,6 +1023,54 @@ async def _load_profile_with_lead(
     ).scalar_one_or_none()
 
 
+async def _lead_has_other_settled_hk1(
+    db: AsyncSession, profile_id: int, exclude_fee_ids: "set[int]"
+) -> bool:
+    """LEAD này (qua MỌI hồ sơ) còn HK1 tuition fee đã SETTLED nào KHÁC không
+    (loại trừ các fee đang void trong lô)?
+
+    Void 1 fee HK1 chỉ nên lùi lead khỏi sts10 khi lead KHÔNG còn HK1 settled ở
+    bất kỳ hồ sơ/năm nào khác — nếu không sẽ tụt nhãn oan (lead multi-profile/
+    multi-year, forward sync chỉ fire 1 lần). Settled = mirror ``is_hk1_settled``
+    (paid/waived HOẶC remaining<=0), trừ cancelled.
+    """
+    lead_id = (
+        await db.execute(
+            select(models.AdmissionProfile.lead_id).where(
+                models.AdmissionProfile.id == profile_id
+            )
+        )
+    ).scalar_one_or_none()
+    if lead_id is None:
+        return False
+
+    conditions = [
+        models.AdmissionProfile.lead_id == lead_id,
+        Fee.fee_type == "tuition",
+        Fee.semester_no == 1,
+        Fee.status != FeeStatusEnum.cancelled.value,
+        or_(
+            Fee.status.in_(
+                [FeeStatusEnum.paid.value, FeeStatusEnum.waived.value]
+            ),
+            (Fee.final_amount - Fee.paid_amount - Fee.waived_amount) <= 0,
+        ),
+    ]
+    if exclude_fee_ids:
+        conditions.append(~Fee.id.in_(exclude_fee_ids))
+
+    stmt = (
+        select(Fee.id)
+        .join(
+            models.AdmissionProfile,
+            models.AdmissionProfile.id == Fee.admission_profile_id,
+        )
+        .where(*conditions)
+        .limit(1)
+    )
+    return (await db.execute(stmt)).first() is not None
+
+
 @dataclass
 class CommitResult:
     batch_id: int
@@ -1556,11 +1604,18 @@ async def void_batch(
     from app.services.lead_admission_sync import revert_lead_tuition_paid
 
     reverted_leads = 0
+    _voided_fee_ids = set(fee_by_id.keys())
     for fee in fee_by_id.values():
         if fee.fee_type != "tuition" or fee.semester_no != 1:
             continue  # chỉ HK1 đụng pipeline lead
         if is_hk1_settled_fee(fee):
-            continue  # HK1 vẫn settled (nguồn thu khác) → giữ lead ở sts10
+            continue  # HK1 fee NÀY vẫn settled (nguồn thu khác) → giữ lead sts10
+        # (#4) Lead-level: lead còn HK1 settled ở hồ-sơ/năm KHÁC (ngoài lô đang
+        # void) → KHÔNG lùi nhãn (tránh tụt sts10 oan khi multi-profile/year).
+        if await _lead_has_other_settled_hk1(
+            db, fee.admission_profile_id, _voided_fee_ids
+        ):
+            continue
         try:
             async with db.begin_nested():
                 profile = await _load_profile_with_lead(db, fee.admission_profile_id)

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -421,6 +421,10 @@ async def resolve_and_validate(
     existing_ref_sums: Dict[Tuple[int, str], Decimal] = {}
     _prof_ids = [p.id for p in profiles.values()]
     if _prof_ids:
+        # Scope ĐÚNG fee mà dòng import sẽ áp (tuition + ĐÚNG học kỳ S): nếu gộp mọi
+        # loại phí/kỳ, ref chung (vd lệ phí 500k cùng ref 'TIENMAT' với học phí 500k)
+        # sẽ false-positive "nghi trùng". sum-on-collision phòng 2 ref raw _norm về
+        # cùng key.
         for pid, ref, total in (
             await db.execute(
                 select(
@@ -436,6 +440,8 @@ async def resolve_and_validate(
                 )
                 .where(
                     models.AdmissionProfile.id.in_(_prof_ids),
+                    Fee.fee_type == "tuition",
+                    Fee.semester_no == semester_no,
                     Payment.status == PaymentStatusEnum.verified.value,
                     Payment.reference_code.isnot(None),
                     Payment.reference_code != "",
@@ -443,7 +449,8 @@ async def resolve_and_validate(
                 .group_by(models.AdmissionProfile.id, Payment.reference_code)
             )
         ).all():
-            existing_ref_sums[(pid, _norm(ref))] = total
+            _k = (pid, _norm(ref))
+            existing_ref_sums[_k] = existing_ref_sums.get(_k, Decimal("0")) + total
 
     # G2 — code hình thức ĐANG hoạt động (mirror commit:1017). Parser đã loại method
     # text lạ (:346); đây bắt method map-OK nhưng PaymentMethod inactive/missing → ERROR

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -838,7 +838,7 @@ async def test_accountant_denied_heavy_finance_mutations(
 
     penalty = await client.post(
         "/api/invoices/1/apply-penalty",
-        params={"penalty_amount": "1000"},
+        params={"penalty_amount": "1000", "reason": "trễ hạn"},
         headers=ah,
     )
     assert penalty.status_code == 403, f"penalty: {penalty.text[:200]}"

--- a/Backend_FastAPI/tests/services/test_invoice_service.py
+++ b/Backend_FastAPI/tests/services/test_invoice_service.py
@@ -956,6 +956,38 @@ class TestRecalculateInvoiceSync:
         assert fee2.final_amount == Decimal("700000")
         assert invs[0].amount == Decimal("700000"), "HĐ draft phải đồng bộ final mới"
 
+    async def test_recalculate_blocked_when_multiple_drafts_no_plan(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Review #1: fee KHÔNG có installment_plan nhưng có ≥2 HĐ draft (vd HĐ bổ
+        sung qua POST /api/invoices) → recalc CHẶN (không rewrite mù → tránh
+        fee↔invoice lệch im lặng)."""
+        inv_service = InvoiceService(db)
+        fee = invoice_fixtures["fee"]  # application 900k, KHÔNG có installment_plan
+        unit_id = invoice_fixtures["unit_id"]
+        invs, _ = await inv_service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=unit_id, auto_issue=False,
+        )
+        await db.commit()
+        # Thêm 1 HĐ draft thứ 2 trực tiếp (mô phỏng create_single_invoice no-plan).
+        db.add(Invoice(
+            fee_id=fee.id, invoice_number=f"INV-T-EXTRA-{fee.id}", installment_no=2,
+            amount=Decimal("100000"), paid_amount=Decimal("0"),
+            penalty_amount=Decimal("0"), status="draft",
+            due_date=date.today() + timedelta(days=30),
+        ))
+        await db.commit()
+        assert fee.installment_plan_id is None
+
+        fee_service = FeeCalculationService(db)
+        with pytest.raises(BusinessRuleViolation):
+            await fee_service.recalculate_fee(
+                fee_id=fee.id, new_base_amount=Decimal("1200000"),
+                reason="Điều chỉnh fee không có kế hoạch, nhiều HĐ",
+                user_id=admin_user.id, unit_id=unit_id,
+            )
+
     async def test_recalculate_blocked_when_draft_count_mismatches_plan(
         self, db, invoice_fixtures, admin_user
     ):
@@ -1047,6 +1079,28 @@ class TestApplyPenaltyGuards:
             await service.apply_penalty(
                 invoice_id=inv.id, penalty_amount=Decimal("50000"), reason="phạt sớm",
                 user_id=admin_user.id, unit_id=invoice_fixtures["unit_id"],
+            )
+
+    async def test_penalty_blocked_on_draft_invoice(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Review #2: HĐ DRAFT (chưa phát hành) DÙ quá due_date → KHÔNG áp phạt —
+        service gate status ∈ OVERDUE_DERIVED_STATUSES, khớp ĐÚNG cờ FE
+        can_apply_penalty (trước đây is_overdue 1 mình cho áp phạt cả draft)."""
+        inv_service = InvoiceService(db)
+        invs, _ = await inv_service.generate_invoices_for_fee(
+            fee_id=invoice_fixtures["fee"].id,
+            due_date_base=date.today() - timedelta(days=5),  # quá hạn
+            user_id=admin_user.id, unit_id=invoice_fixtures["unit_id"],
+            auto_issue=False,  # draft (chưa phát hành)
+        )
+        await db.commit()
+        assert invs[0].status == InvoiceStatusEnum.draft.value
+        with pytest.raises(BusinessRuleViolation):
+            await inv_service.apply_penalty(
+                invoice_id=invs[0].id, penalty_amount=Decimal("50000"),
+                reason="phạt HĐ draft", user_id=admin_user.id,
+                unit_id=invoice_fixtures["unit_id"],
             )
 
 

--- a/Backend_FastAPI/tests/services/test_invoice_service.py
+++ b/Backend_FastAPI/tests/services/test_invoice_service.py
@@ -462,13 +462,13 @@ class TestInvoiceLifecycle:
         assert "already cancelled" in str(exc_info.value).lower()
 
     async def test_apply_penalty(self, db, invoice_fixtures, admin_user):
-        """Penalty increases penalty_amount."""
+        """Penalty increases penalty_amount (hóa đơn ĐÃ QUÁ HẠN)."""
         service = InvoiceService(db)
         fee = invoice_fixtures["fee"]
 
         invoices, _ = await service.generate_invoices_for_fee(
             fee_id=fee.id,
-            due_date_base=date.today() + timedelta(days=30),
+            due_date_base=date.today() - timedelta(days=5),  # quá hạn → áp phạt được
             user_id=admin_user.id,
             unit_id=invoice_fixtures["unit_id"],
             auto_issue=True,
@@ -960,11 +960,16 @@ class TestRecalculateInvoiceSync:
 class TestApplyPenaltyGuards:
     """#8 — penalty: None→reject (không 500), trần ≤ amount, happy-path."""
 
-    async def _issued_invoice(self, db, invoice_fixtures, admin_user):
+    async def _issued_invoice(self, db, invoice_fixtures, admin_user, *, overdue=True):
         inv_service = InvoiceService(db)
+        due = (
+            date.today() - timedelta(days=5)  # quá hạn → áp phạt được
+            if overdue
+            else date.today() + timedelta(days=30)  # chưa tới hạn
+        )
         invs, _ = await inv_service.generate_invoices_for_fee(
             fee_id=invoice_fixtures["fee"].id,
-            due_date_base=date.today() + timedelta(days=30),
+            due_date_base=due,
             user_id=admin_user.id, unit_id=invoice_fixtures["unit_id"], auto_issue=True,
         )
         await db.commit()
@@ -995,7 +1000,7 @@ class TestApplyPenaltyGuards:
             )
 
     async def test_penalty_within_cap_ok(self, db, invoice_fixtures, admin_user):
-        """Phạt trong trần → cộng vào penalty_amount."""
+        """Phạt trong trần (HĐ quá hạn) → cộng vào penalty_amount."""
         inv = await self._issued_invoice(db, invoice_fixtures, admin_user)
         service = InvoiceService(db)
         out, _ = await service.apply_penalty(
@@ -1004,6 +1009,20 @@ class TestApplyPenaltyGuards:
         )
         await db.commit()
         assert out.penalty_amount == Decimal("100000")
+
+    async def test_penalty_blocked_when_not_overdue(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """#8-B: HĐ issued CHƯA tới hạn (due tương lai) → KHÔNG được áp phạt."""
+        inv = await self._issued_invoice(
+            db, invoice_fixtures, admin_user, overdue=False
+        )
+        service = InvoiceService(db)
+        with pytest.raises(BusinessRuleViolation):
+            await service.apply_penalty(
+                invoice_id=inv.id, penalty_amount=Decimal("50000"), reason="phạt sớm",
+                user_id=admin_user.id, unit_id=invoice_fixtures["unit_id"],
+            )
 
 
 class TestInstallmentScheduleGuard:

--- a/Backend_FastAPI/tests/services/test_invoice_service.py
+++ b/Backend_FastAPI/tests/services/test_invoice_service.py
@@ -956,6 +956,31 @@ class TestRecalculateInvoiceSync:
         assert fee2.final_amount == Decimal("700000")
         assert invs[0].amount == Decimal("700000"), "HĐ draft phải đồng bộ final mới"
 
+    async def test_recalculate_blocked_when_draft_count_mismatches_plan(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """F1: hủy 1 đợt GIỮA kế hoạch trả góp (3 đợt) → còn 2 HĐ draft ≠ 3 đợt →
+        recalc CHẶN (tránh zip gán lệch số tiền → fee↔invoice lệch)."""
+        inv_service = InvoiceService(db)
+        fee = invoice_fixtures["fee_with_plan"]  # plan 3 đợt
+        unit_id = invoice_fixtures["unit_id"]
+        invs, _ = await inv_service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=unit_id, auto_issue=False,
+        )
+        await db.commit()
+        assert len(invs) == 3
+        await inv_service.cancel_invoice(invs[0].id, "hủy đợt 1", admin_user.id, unit_id)
+        await db.commit()
+
+        fee_service = FeeCalculationService(db)
+        with pytest.raises(BusinessRuleViolation):
+            await fee_service.recalculate_fee(
+                fee_id=fee.id, new_base_amount=Decimal("8000000"),
+                reason="Điều chỉnh sau khi hủy 1 đợt giữa kế hoạch",
+                user_id=admin_user.id, unit_id=unit_id,
+            )
+
 
 class TestApplyPenaltyGuards:
     """#8 — penalty: None→reject (không 500), trần ≤ amount, happy-path."""
@@ -1039,7 +1064,7 @@ class TestInstallmentScheduleGuard:
             ],
             is_active=True,
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(BusinessRuleViolation):
             plan.get_installment_schedule(Decimal("1000000"))
 
     async def test_generate_inactive_plan_raises(

--- a/Backend_FastAPI/tests/services/test_invoice_service.py
+++ b/Backend_FastAPI/tests/services/test_invoice_service.py
@@ -898,3 +898,143 @@ class TestFeeRecomputeOnCancelPRB:
 
         with pytest.raises(BusinessRuleViolation):
             await service.cancel_invoice(invs[0].id, "x", admin_user.id, unit_id)
+
+
+# =============================================================================
+# FINANCE EDGE-CASE FIXES (audit 2026-06-29)
+# =============================================================================
+
+
+class TestRecalculateInvoiceSync:
+    """#2 — recalculate phải chặn khi HĐ đã phát hành + đồng bộ HĐ draft."""
+
+    async def test_recalculate_blocked_when_invoice_issued(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Fee có HĐ issued (paid=0) → recalc raise BusinessRuleViolation (tránh
+        fee.final lệch invoice.amount → thu dư/thiếu vì payment thu theo HĐ)."""
+        inv_service = InvoiceService(db)
+        fee = invoice_fixtures["fee"]
+        unit_id = invoice_fixtures["unit_id"]
+        await inv_service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=unit_id, auto_issue=True,
+        )
+        await db.commit()
+
+        fee_service = FeeCalculationService(db)
+        with pytest.raises(BusinessRuleViolation):
+            await fee_service.recalculate_fee(
+                fee_id=fee.id, new_base_amount=Decimal("800000"),
+                reason="Điều chỉnh giảm sau khi đã phát hành HĐ", user_id=admin_user.id,
+                unit_id=unit_id,
+            )
+
+    async def test_recalculate_rewrites_draft_invoice(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Fee chỉ có HĐ draft → recalc OK + rewrite amount HĐ draft theo final
+        mới (fee↔invoice không lệch)."""
+        inv_service = InvoiceService(db)
+        fee = invoice_fixtures["fee"]  # application 900,000, paid 0
+        unit_id = invoice_fixtures["unit_id"]
+        invs, _ = await inv_service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=unit_id, auto_issue=False,  # draft
+        )
+        await db.commit()
+        assert invs[0].status == InvoiceStatusEnum.draft.value
+
+        fee_service = FeeCalculationService(db)
+        fee2, _ = await fee_service.recalculate_fee(
+            fee_id=fee.id, new_base_amount=Decimal("700000"),
+            reason="Điều chỉnh mức phí gốc xuống", user_id=admin_user.id,
+            unit_id=unit_id,
+        )
+        await db.commit()
+        await db.refresh(invs[0])
+        assert fee2.final_amount == Decimal("700000")
+        assert invs[0].amount == Decimal("700000"), "HĐ draft phải đồng bộ final mới"
+
+
+class TestApplyPenaltyGuards:
+    """#8 — penalty: None→reject (không 500), trần ≤ amount, happy-path."""
+
+    async def _issued_invoice(self, db, invoice_fixtures, admin_user):
+        inv_service = InvoiceService(db)
+        invs, _ = await inv_service.generate_invoices_for_fee(
+            fee_id=invoice_fixtures["fee"].id,
+            due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=invoice_fixtures["unit_id"], auto_issue=True,
+        )
+        await db.commit()
+        return invs[0]
+
+    async def test_penalty_none_rejected_not_500(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Direct caller truyền None → BadRequest (không TypeError/500)."""
+        inv = await self._issued_invoice(db, invoice_fixtures, admin_user)
+        service = InvoiceService(db)
+        with pytest.raises(BadRequest):
+            await service.apply_penalty(
+                invoice_id=inv.id, penalty_amount=None, reason="late",
+                user_id=admin_user.id, unit_id=invoice_fixtures["unit_id"],
+            )
+
+    async def test_penalty_exceeds_amount_rejected(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Tổng phạt > số tiền HĐ (900,000) → BusinessRuleViolation."""
+        inv = await self._issued_invoice(db, invoice_fixtures, admin_user)
+        service = InvoiceService(db)
+        with pytest.raises(BusinessRuleViolation):
+            await service.apply_penalty(
+                invoice_id=inv.id, penalty_amount=Decimal("1000000"), reason="late",
+                user_id=admin_user.id, unit_id=invoice_fixtures["unit_id"],
+            )
+
+    async def test_penalty_within_cap_ok(self, db, invoice_fixtures, admin_user):
+        """Phạt trong trần → cộng vào penalty_amount."""
+        inv = await self._issued_invoice(db, invoice_fixtures, admin_user)
+        service = InvoiceService(db)
+        out, _ = await service.apply_penalty(
+            invoice_id=inv.id, penalty_amount=Decimal("100000"), reason="trễ hạn 5 ngày",
+            user_id=admin_user.id, unit_id=invoice_fixtures["unit_id"],
+        )
+        await db.commit()
+        assert out.penalty_amount == Decimal("100000")
+
+
+class TestInstallmentScheduleGuard:
+    """#9 — schedule defense-in-depth + chặn plan inactive khi sinh HĐ."""
+
+    async def test_schedule_over_100_percent_raises(self):
+        """Plan dị dạng (đợt đầu cộng >100%) → đợt cuối âm → ValueError."""
+        plan = InstallmentPlan(
+            code="BAD_OVER100", name="Bad", installment_count=3,
+            schedule=[
+                {"installment_no": 1, "due_days_offset": 0, "percent": 60.0},
+                {"installment_no": 2, "due_days_offset": 30, "percent": 60.0},
+                {"installment_no": 3, "due_days_offset": 60, "percent": 60.0},
+            ],
+            is_active=True,
+        )
+        with pytest.raises(ValueError):
+            plan.get_installment_schedule(Decimal("1000000"))
+
+    async def test_generate_inactive_plan_raises(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Plan bị tắt SAU khi gắn fee → generate raise (không sinh HĐ schedule chết)."""
+        plan = invoice_fixtures["installment_plan"]
+        plan.is_active = False
+        await db.flush()
+
+        service = InvoiceService(db)
+        with pytest.raises(BusinessRuleViolation):
+            await service.generate_invoices_for_fee(
+                fee_id=invoice_fixtures["fee_with_plan"].id,
+                due_date_base=date.today() + timedelta(days=30),
+                user_id=admin_user.id, unit_id=invoice_fixtures["unit_id"],
+            )

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -2543,3 +2543,65 @@ class TestMultiCollectionTimeline:
         )
         assert res.rows[0].status == WARNED
         assert len(res.rows[0].allocations) == 2  # 2.5tr đợt1 + 2.5tr đợt2
+
+
+# =============================================================================
+# #4 — void lead-level: giữ sts10 khi lead còn HK1 settled ở hồ sơ/năm KHÁC
+# =============================================================================
+class TestLeadHasOtherSettledHk1:
+    """Audit 2026-06-29 #4 — ``_lead_has_other_settled_hk1`` (chống tụt nhãn
+    lead khỏi sts10 oan khi void 1 fee HK1 của lead multi-profile/multi-year)."""
+
+    async def _two_profile_lead(self, db, deps):
+        lead = models.Lead(
+            full_name="Multi Hồ Sơ",
+            phone=f"09{next(_phone_seq):08d}",
+            source="bulk_test",
+            unit_id=deps["unit_id"],
+            consultation_status_id=deps["initial_status_id"],
+        )
+        db.add(lead)
+        await db.flush()
+        out = []
+        for yr in (2025, 2026):
+            prof = models.AdmissionProfile(
+                lead_id=lead.id, status="submitted", academic_year=yr, applied_rules={},
+            )
+            db.add(prof)
+            await db.flush()
+            fee = Fee(
+                admission_profile_id=prof.id, fee_type="tuition", academic_year=yr,
+                semester_no=1, base_amount=Decimal("7000000"),
+                final_amount=Decimal("7000000"), paid_amount=Decimal("7000000"),
+                status="paid",
+            )
+            db.add(fee)
+            await db.flush()
+            out.append((prof, fee))
+        return out
+
+    async def test_other_settled_hk1_keeps_sts10(self, db, seeded_dependencies):
+        """Void feeB → feeA (HK1, paid, hồ sơ khác) vẫn settled → True (giữ sts10)."""
+        (profA, feeA), (profB, feeB) = await self._two_profile_lead(
+            db, seeded_dependencies
+        )
+        assert await pis._lead_has_other_settled_hk1(db, profB.id, {feeB.id}) is True
+
+    async def test_no_other_settled_when_all_excluded(self, db, seeded_dependencies):
+        """Void CẢ HAI → không còn HK1 settled khác → False (cho phép lùi lead)."""
+        (profA, feeA), (profB, feeB) = await self._two_profile_lead(
+            db, seeded_dependencies
+        )
+        assert (
+            await pis._lead_has_other_settled_hk1(db, profB.id, {feeA.id, feeB.id})
+            is False
+        )
+
+    async def test_cancelled_other_fee_not_counted(self, db, seeded_dependencies):
+        """feeA cancelled → KHÔNG tính là settled → False."""
+        (profA, feeA), (profB, feeB) = await self._two_profile_lead(
+            db, seeded_dependencies
+        )
+        feeA.status = "cancelled"
+        await db.flush()
+        assert await pis._lead_has_other_settled_hk1(db, profB.id, {feeB.id}) is False

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -2605,3 +2605,64 @@ class TestLeadHasOtherSettledHk1:
         feeA.status = "cancelled"
         await db.flush()
         assert await pis._lead_has_other_settled_hk1(db, profB.id, {feeB.id}) is False
+
+
+# =============================================================================
+# #6 — cảnh báo mềm nghi TRÙNG GIAO DỊCH khi re-import (cùng hồ sơ+ref+số tiền)
+# =============================================================================
+class TestDuplicateTransactionWarning:
+    """Audit 2026-06-29 #6 — re-import sao kê chồng ngày (cùng Mã tham chiếu +
+    số tiền cho hồ sơ CÒN NỢ) → preview WARNED (không chặn). Thu góp KHÁC số
+    tiền cùng ref → KHÔNG cảnh báo."""
+
+    async def _commit_partial(self, db, deps, admin_user, *, cccd, ref, amount):
+        """Seed hồ sơ + HĐ issued 10tr, import 1 dòng (ref, amount) rồi commit →
+        có Payment verified(ref, amount); HĐ còn nợ (partial)."""
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        await _seed_tuition(
+            db, deps, citizen_id=cccd, lead_name="Re Import",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        content = _csv_bytes([
+            pis.TEMPLATE_COLS,
+            [cccd, "Re Import", amount, "05/09/2026", "TM", ref, ""],
+        ])
+        batch, _ = await pis.preview_import(
+            db, content=content, filename="dot1.csv", academic_year=2026,
+            semester_no=1, created_by_id=admin_user.id, unit_id=None,
+        )
+        bid = batch.id
+        await db.commit()
+        await pis.commit_batch(db, batch_id=bid, importer_id=admin_user.id, unit_id=None)
+        await db.commit()
+
+    async def test_reimport_same_ref_amount_warns(
+        self, db, seeded_dependencies, admin_user
+    ):
+        cccd = "077200000001"
+        # Commit 4tr (HĐ 10tr → còn nợ 6tr). Re-import CÙNG ref + CÙNG 4tr: 4tr ≤
+        # 6tr còn nợ → KHÔNG dính guard "vượt nợ gốc" → tới dup-check → nghi trùng.
+        # (Re-import > nợ còn lại thì guard nợ-gốc đã chặn rồi.)
+        await self._commit_partial(
+            db, seeded_dependencies, admin_user, cccd=cccd, ref="PT-DUP-1", amount="4.000.000"
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft(cccd, "4000000", reference="PT-DUP-1")], 2026, 1, None
+        )
+        assert res.rows[0].status == WARNED, res.rows[0].message
+        assert "nghi trùng giao dịch" in res.rows[0].message, res.rows[0].message
+
+    async def test_legit_partial_different_amount_no_dup_warn(
+        self, db, seeded_dependencies, admin_user
+    ):
+        cccd = "077200000002"
+        # Commit 4tr (còn nợ 6tr). Thu góp tiếp 5tr (cùng ref nhưng KHÁC số tiền,
+        # 5tr ≤ 6tr) → tới dup-check nhưng tổng đã ghi 4tr ≠ 5tr → KHÔNG cảnh báo.
+        await self._commit_partial(
+            db, seeded_dependencies, admin_user, cccd=cccd, ref="PT-DUP-1", amount="4.000.000"
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft(cccd, "5000000", reference="PT-DUP-1")], 2026, 1, None
+        )
+        assert "nghi trùng giao dịch" not in (res.rows[0].message or ""), res.rows[0].message

--- a/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoicePenaltyDialog.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoicePenaltyDialog.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/form"
 import { Button } from "@/components/ui/button"
 import { CurrencyInput } from "@/components/ui/currency-input"
+import { Textarea } from "@/components/ui/textarea"
 import { AlertTriangle, Loader2 } from "lucide-react"
 import { useApplyPenalty } from "@/hooks/finance/useInvoices"
 import { toast } from "sonner"
@@ -32,6 +33,11 @@ const penaltyFormSchema = z.object({
   penalty_amount: z
     .number({ message: "Vui lòng nhập số tiền phạt" })
     .positive("Số tiền phải lớn hơn 0"),
+  // Backend route apply-penalty yêu cầu reason (1..500). Không gửi → 422.
+  reason: z
+    .string()
+    .min(1, "Vui lòng nhập lý do áp phạt")
+    .max(500, "Lý do không được quá 500 ký tự"),
 })
 
 type PenaltyFormValues = z.infer<typeof penaltyFormSchema>
@@ -59,6 +65,7 @@ export function InvoicePenaltyDialog({
     resolver: zodResolver(penaltyFormSchema),
     defaultValues: {
       penalty_amount: undefined,
+      reason: "",
     },
   })
 
@@ -69,6 +76,7 @@ export function InvoicePenaltyDialog({
         feeId,
         data: {
           penalty_amount: values.penalty_amount.toString(),
+          reason: values.reason.trim(),
         },
       })
       toast.success("Đã áp dụng phí trễ hạn thành công")
@@ -119,7 +127,29 @@ export function InvoicePenaltyDialog({
                       className="h-11"
                     />
                   </FormControl>
-                  <FormDescription>Số tiền phạt sẽ được cộng vào tổng tiền hóa đơn</FormDescription>
+                  <FormDescription>Số tiền phạt sẽ được cộng vào tổng tiền hóa đơn (không vượt số tiền hóa đơn)</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="reason"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Lý do <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      placeholder="Ví dụ: Phạt trễ hạn theo quy định..."
+                      rows={2}
+                      maxLength={500}
+                      className="resize-none"
+                    />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )}

--- a/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoicePenaltyDialog.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoicePenaltyDialog.tsx
@@ -34,8 +34,11 @@ const penaltyFormSchema = z.object({
     .number({ message: "Vui lòng nhập số tiền phạt" })
     .positive("Số tiền phải lớn hơn 0"),
   // Backend route apply-penalty yêu cầu reason (1..500). Không gửi → 422.
+  // .trim() trước min(1): chuỗi toàn khoảng trắng → invalid ngay ở FE (tránh gửi
+  // reason='' sau trim → backend 422 với toast lỗi chung).
   reason: z
     .string()
+    .trim()
     .min(1, "Vui lòng nhập lý do áp phạt")
     .max(500, "Lý do không được quá 500 ký tự"),
 })

--- a/frontend/src/hooks/finance/useInvoices.test.tsx
+++ b/frontend/src/hooks/finance/useInvoices.test.tsx
@@ -270,9 +270,15 @@ describe("useInvoices Hooks", () => {
           http.post(`${API_BASE_URL}/api/invoices/:invoiceId/apply-penalty`, ({ request }) => {
             const url = new URL(request.url);
             const penaltyAmount = url.searchParams.get("penalty_amount");
+            const reason = url.searchParams.get("reason");
 
             if (!penaltyAmount) {
               return HttpResponse.json({ detail: "Penalty amount is required" }, { status: 400 });
+            }
+            // Guard regression #8-A: route mới yêu cầu reason; nếu FE bỏ gửi reason
+            // thì handler trả 400 → isSuccess không true → test fail.
+            if (!reason) {
+              return HttpResponse.json({ detail: "Reason is required" }, { status: 400 });
             }
 
             return HttpResponse.json({

--- a/frontend/src/hooks/finance/useInvoices.test.tsx
+++ b/frontend/src/hooks/finance/useInvoices.test.tsx
@@ -297,6 +297,7 @@ describe("useInvoices Hooks", () => {
 
         const penaltyData: InvoicePenaltyRequest = {
           penalty_amount: "500000",
+          reason: "Phạt trễ hạn",
         };
 
         const { result } = renderHook(() => useApplyPenalty(), {
@@ -332,7 +333,7 @@ describe("useInvoices Hooks", () => {
         result.current.mutate({
           invoiceId: 2,
           feeId: 2,
-          data: { penalty_amount: "100000" },
+          data: { penalty_amount: "100000", reason: "Phạt trễ hạn" },
         });
 
         await waitFor(() => expect(result.current.isError).toBe(true));

--- a/frontend/src/lib/api/invoices.ts
+++ b/frontend/src/lib/api/invoices.ts
@@ -161,7 +161,7 @@ export async function cancelInvoice(invoiceId: number, reason: string): Promise<
  */
 export async function applyPenalty(invoiceId: number, data: InvoicePenaltyRequest): Promise<Invoice> {
   const response = await api.post<Invoice>(API_ENDPOINTS.FINANCE.INVOICES.PENALTY(invoiceId), undefined, {
-    params: { penalty_amount: data.penalty_amount },
+    params: { penalty_amount: data.penalty_amount, reason: data.reason },
   })
   return response.data
 }

--- a/frontend/src/lib/zod/finance.ts
+++ b/frontend/src/lib/zod/finance.ts
@@ -655,6 +655,12 @@ export const invoicePenaltyRequestSchema = z.object({
     .string()
     .min(1, "Vui lòng nhập số tiền phạt")
     .regex(/^\d+(\.\d{1,2})?$/, "Số tiền không hợp lệ"),
+  // Backend route apply-penalty yêu cầu reason (1..500) — mirror để không lệch.
+  reason: z
+    .string()
+    .trim()
+    .min(1, "Vui lòng nhập lý do áp phạt")
+    .max(500, "Lý do không được quá 500 ký tự"),
 })
 
 export type InvoicePenaltyRequest = z.infer<typeof invoicePenaltyRequestSchema>

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -615,6 +615,7 @@ export interface PaymentRejectRequest {
 
 export interface InvoicePenaltyRequest {
   penalty_amount: string
+  reason: string // bắt buộc — backend route apply-penalty yêu cầu lý do
 }
 
 export interface OverpaymentApplyRequest {


### PR DESCRIPTION
## Bối cảnh
Audit code-verified toàn bộ nghiệp vụ **Thu học phí** (6 finder + 5 verifier + sweep) phát hiện 5 bug CONFIRMED (1 P0 sai tiền) + hardening. Tất cả PRE-EXISTING, độc lập feature manual-tuition. **code-only, KHÔNG migration.**

## Các fix
- **#2 (P0 sai tiền)** `recalculate_fee`: chặn tính lại khi HĐ đã phát hành (issued/partial/paid) + đồng bộ amount HĐ draft theo final mới (query invoices tươi). Trước đây chỉ chặn `paid>0` nhưng payment thu theo `invoice.amount` → fee↔HĐ lệch → thu dư/thiếu. +guard count-mismatch khi 1 đợt giữa kế hoạch trả góp đã hủy (zip lệch vị trí).
- **#8 penalty**: route `apply-penalty` thêm `reason` (bắt buộc) + `penalty_amount` required (vá bug route KHÔNG truyền reason → TypeError mọi lần gọi); service guard None + **chỉ áp phạt khi `invoice.is_overdue`** (chặn áp phạt HĐ chưa tới hạn — money) + **trần tổng phạt ≤ số tiền HĐ**. FE: `InvoicePenaltyDialog` thêm ô "Lý do" + `applyPenalty` gửi reason (trước thiếu → 422). Cờ `can_apply_penalty` align derived-overdue.
- **#9**: chặn sinh HĐ khi `installment_plan.is_active=False` (tắt sau khi gắn); `get_installment_schedule` raise `BusinessRuleViolation` (→400) khi đợt cuối âm (tổng % >100).
- **#4 (nhãn lead)** `void_batch`: thêm check lead-level `_lead_has_other_settled_hk1` — void 1 fee HK1 KHÔNG lùi nhãn lead khỏi sts10 nếu lead còn HK1 settled ở hồ sơ/năm KHÁC (chống tụt nhãn oan multi-profile).
- **#6**: cảnh báo mềm nghi trùng giao dịch khi re-import (cùng hồ sơ + reference_code + số tiền), scope tuition + đúng học kỳ. Khảo sát qlts_dev: reference_code là free-text (PT-/HS-/cash) → KHÔNG unique được; chỉ WARN, không chặn.
- **#5-E2 hardening**: `resnapshot` phát `log.warning fee_resolved_major_drift` khi ngành resolve khác ngành đã định giá.

## Test
- BE: **149 pass** (test_invoice_service 38 + test_payment_import_service 111) — gồm penalty overdue-gate + recalc zip-guard + import-dup warn + lead-level void + schedule-negative. one-off container.
- FE: type-check sạch + useInvoices 16 pass.
- ✅ /code-review max (6 fix đã áp) + **Chrome smoke dev FULL** (admin): #8 penalty end-to-end POST 200 + persisted, #8 negative no-button, #2 recalc block POST 400, workspace/payments/picker sạch (0 console/500/422).

## Deploy
**code-only, KHÔNG migration, KHÔNG Casbin.** Deploy = cập nhật code + restart backend thường lệ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)