### PR TITLE
feat(finance): lịch thu "đóng trước" tại Tính phí (giữ nguyên tổng học phí)

### DIFF
--- a/Backend_FastAPI/alembic/versions/mta20260628001_casbin_tuition_preview_grant.py
+++ b/Backend_FastAPI/alembic/versions/mta20260628001_casbin_tuition_preview_grant.py
@@ -1,0 +1,83 @@
+"""Manual-tuition-amount: Casbin grant cho GET /api/fees/tuition-preview.
+
+Seeds GET /api/fees/tuition-preview cho officer + accountant — endpoint preview
+giá chuẩn học phí (read-only) của add-on "Nhập học phí thủ công" trong dialog
+Tính phí. Mirror đúng pattern grant /api/fees/calculate (officer + accountant
+trong template; manager kế thừa officer qua edge g; admin qua wildcard).
+
+Không có migration này, entrypoint deploy không sync grant template mới →
+enforcer 403 officer/accountant trên endpoint preview (toggle nhập tay sẽ không
+thấy được giá chuẩn / giảm giá / dự kiến phải thu).
+
+Idempotent (INSERT WHERE NOT EXISTS) — cùng kiểu feepicker_casbin_20260621.
+
+Revision ID: mta20260628001
+Revises: feecancel20260628001
+Create Date: 2026-06-28
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "mta20260628001"
+down_revision: Union[str, None] = "feecancel20260628001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# (v0=sub, v1=obj, v2=act, v3=eft) — eft MUST be present (NULL v3 crashes load).
+# officer + accountant chỉ — manager kế thừa officer (edge g, role:manager,
+# role:officer), admin qua wildcard /*.*. Cùng tập với /api/fees/calculate.
+_POLICIES = [
+    ("role:officer", "/api/fees/tuition-preview", "GET", "allow"),
+    ("role:accountant", "/api/fees/tuition-preview", "GET", "allow"),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for v0, v1, v2, v3 in _POLICIES:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO casbin_rule
+                    (ptype, v0, v1, v2, v3, template_id, applied_at)
+                SELECT 'p',
+                       CAST(:v0 AS VARCHAR),
+                       CAST(:v1 AS VARCHAR),
+                       CAST(:v2 AS VARCHAR),
+                       CAST(:v3 AS VARCHAR),
+                       '_mta20260628001',
+                       NOW()
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM casbin_rule
+                    WHERE ptype='p'
+                      AND v0=CAST(:v0 AS VARCHAR)
+                      AND v1=CAST(:v1 AS VARCHAR)
+                      AND v2=CAST(:v2 AS VARCHAR)
+                      AND v3=CAST(:v3 AS VARCHAR)
+                )
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for v0, v1, v2, v3 in _POLICIES:
+        conn.execute(
+            sa.text(
+                """
+                DELETE FROM casbin_rule
+                WHERE ptype='p'
+                  AND v0=CAST(:v0 AS VARCHAR)
+                  AND v1=CAST(:v1 AS VARCHAR)
+                  AND v2=CAST(:v2 AS VARCHAR)
+                  AND v3=CAST(:v3 AS VARCHAR)
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )

--- a/Backend_FastAPI/alembic/versions/mta20260628001_casbin_tuition_preview_grant.py
+++ b/Backend_FastAPI/alembic/versions/mta20260628001_casbin_tuition_preview_grant.py
@@ -1,13 +1,14 @@
-"""Manual-tuition-amount: Casbin grant cho GET /api/fees/tuition-preview.
+"""Casbin grant cho GET /api/fees/tuition-preview.
 
 Seeds GET /api/fees/tuition-preview cho officer + accountant — endpoint preview
-giá chuẩn học phí (read-only) của add-on "Nhập học phí thủ công" trong dialog
-Tính phí. Mirror đúng pattern grant /api/fees/calculate (officer + accountant
-trong template; manager kế thừa officer qua edge g; admin qua wildcard).
+giá chuẩn học phí (read-only) của dialog "Tính phí" (hiển base / giảm giá / dự
+kiến phải thu để đối chiếu khi chọn lịch thu). Mirror đúng pattern grant
+/api/fees/calculate (officer + accountant trong template; manager kế thừa officer
+qua edge g; admin qua wildcard).
 
 Không có migration này, entrypoint deploy không sync grant template mới →
-enforcer 403 officer/accountant trên endpoint preview (toggle nhập tay sẽ không
-thấy được giá chuẩn / giảm giá / dự kiến phải thu).
+enforcer 403 officer/accountant trên endpoint preview (không thấy được giá chuẩn
+/ giảm giá / dự kiến phải thu).
 
 Idempotent (INSERT WHERE NOT EXISTS) — cùng kiểu feepicker_casbin_20260621.
 

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -241,6 +241,11 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         # _compute_permissions narrow the scope to the owning officer on a
         # profile in approved/confirmed/enrolled status.
         {"subject": "{role}", "object": "/api/fees/calculate", "action": "POST"},
+        # Manual tuition override — preview giá chuẩn (read-only) cho add-on
+        # "Nhập học phí thủ công" của dialog Tính phí. IDOR-scoped trong route
+        # bằng _fee_calc_authorized (cùng officer-assigned scope như calculate).
+        # Manager kế thừa officer; admin qua wildcard.
+        {"subject": "{role}", "object": "/api/fees/tuition-preview", "action": "GET"},
         # PR #7 review — CalculateFeeDialog populates the installment-plan
         # Select from /api/installment-plans so the UI reflects the real
         # seed (FULL / TWO_TERM / QUARTERLY) rather than guessing codes.
@@ -366,6 +371,9 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         # design, so the workspace fee picker uses this finance-scoped lookup.
         {"subject": "{role}", "object": "/api/fees/calculable-profiles", "action": "GET"},
         {"subject": "{role}", "object": "/api/fees/calculate", "action": "POST"},
+        # Manual tuition override — preview giá chuẩn (read-only) cho add-on
+        # "Nhập học phí thủ công"; accountant tính phí toàn hệ thống nên cũng cần.
+        {"subject": "{role}", "object": "/api/fees/tuition-preview", "action": "GET"},
         # waive / recalculate are admin/manager only (route gate RequireManager
         # excludes accountant — separation of duties). NOT granted to accountant:
         # the grant would be DEAD (route rejects before Casbin) and a foot-gun if

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -241,10 +241,10 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         # _compute_permissions narrow the scope to the owning officer on a
         # profile in approved/confirmed/enrolled status.
         {"subject": "{role}", "object": "/api/fees/calculate", "action": "POST"},
-        # Manual tuition override — preview giá chuẩn (read-only) cho add-on
-        # "Nhập học phí thủ công" của dialog Tính phí. IDOR-scoped trong route
-        # bằng _fee_calc_authorized (cùng officer-assigned scope như calculate).
-        # Manager kế thừa officer; admin qua wildcard.
+        # Preview giá chuẩn học phí (read-only) cho dialog "Tính phí" — hiển base
+        # / giảm giá / dự kiến phải thu để đối chiếu khi chọn lịch thu. IDOR-scoped
+        # trong route bằng _fee_calc_authorized (cùng officer-assigned scope như
+        # calculate). Manager kế thừa officer; admin qua wildcard.
         {"subject": "{role}", "object": "/api/fees/tuition-preview", "action": "GET"},
         # PR #7 review — CalculateFeeDialog populates the installment-plan
         # Select from /api/installment-plans so the UI reflects the real
@@ -371,8 +371,8 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         # design, so the workspace fee picker uses this finance-scoped lookup.
         {"subject": "{role}", "object": "/api/fees/calculable-profiles", "action": "GET"},
         {"subject": "{role}", "object": "/api/fees/calculate", "action": "POST"},
-        # Manual tuition override — preview giá chuẩn (read-only) cho add-on
-        # "Nhập học phí thủ công"; accountant tính phí toàn hệ thống nên cũng cần.
+        # Preview giá chuẩn học phí (read-only) cho dialog "Tính phí"; accountant
+        # tính phí toàn hệ thống nên cũng cần.
         {"subject": "{role}", "object": "/api/fees/tuition-preview", "action": "GET"},
         # waive / recalculate are admin/manager only (route gate RequireManager
         # excludes accountant — separation of duties). NOT granted to accountant:

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -260,23 +260,29 @@ async def calculate_fee(
             # 404 not 403: no existence leak beyond scope, same as other IDOR sites.
             raise ResourceNotFoundError("Admission profile not found")
 
-        # Get installment plan by code. PR #7 review: reject unknown or
-        # inactive codes explicitly instead of falling through to plan_id=None
-        # (which InvoiceService silently downgrades to a single-payment
-        # invoice). Previously the dialog could post INSTALLMENT (not a real
-        # seed code) and the user would still see the fee created but with a
-        # single-installment schedule — actively misleading.
-        plan = await fee_service.fee_repo.get_installment_plan_by_code(data.installment_plan_code)
-        if plan is None:
-            raise BadRequest(
-                f"Kế hoạch thanh toán '{data.installment_plan_code}' không tồn tại "
-                "hoặc không còn hoạt động."
-            )
-        if getattr(plan, "is_active", True) is False:
-            raise BadRequest(
-                f"Kế hoạch thanh toán '{data.installment_plan_code}' đã ngừng hoạt động."
-            )
-        plan_id = plan.id
+        # Lịch thu "đóng trước" (Pha 1): KHÔNG gắn kế hoạch trả góp — hóa đơn do
+        # generate_invoices_for_fee tạo theo 2 đợt tùy chỉnh (đợt đầu + còn lại).
+        # plan_id=None để fee không gắn plan (tránh lệch "plan 1 đợt nhưng 2 HĐ").
+        if data.collection_schedule_mode == "down_payment":
+            plan_id = None
+        else:
+            # Get installment plan by code. PR #7 review: reject unknown or
+            # inactive codes explicitly instead of falling through to plan_id=None
+            # (which InvoiceService silently downgrades to a single-payment
+            # invoice). Previously the dialog could post INSTALLMENT (not a real
+            # seed code) and the user would still see the fee created but with a
+            # single-installment schedule — actively misleading.
+            plan = await fee_service.fee_repo.get_installment_plan_by_code(data.installment_plan_code)
+            if plan is None:
+                raise BadRequest(
+                    f"Kế hoạch thanh toán '{data.installment_plan_code}' không tồn tại "
+                    "hoặc không còn hoạt động."
+                )
+            if getattr(plan, "is_active", True) is False:
+                raise BadRequest(
+                    f"Kế hoạch thanh toán '{data.installment_plan_code}' đã ngừng hoạt động."
+                )
+            plan_id = plan.id
 
         # Service-layer unit_id kept for downstream IDOR inside
         # calculate_fee / generate_invoices_for_fee — admin skips, everyone
@@ -291,12 +297,6 @@ async def calculate_fee(
         # resolve here (no double resolve) and closing the race where the router
         # resolved discount pre-lock while the service resolved amount post-lock
         # (a concurrent waitlist-promote could have mismatched the two ngành).
-        # Manual tuition override (accountant/officer nhập học phí đặc biệt). Số
-        # gõ = BASE; service VẪN áp discount → invoice khớp final. Guard kép:
-        # schema model_validator (422) + service-side guard (400) cho direct
-        # caller. base_amount vẫn None để service tự resolve giá chuẩn (làm audit
-        # + mặc định); manual_base_amount nới riêng cho tuition. Audit log riêng
-        # do service phát (``fee_calculated_manual``) — router giữ "dumb".
         fee, post_commit = await fee_service.calculate_fee(
             admission_profile_id=data.admission_profile_id,
             fee_type=data.fee_type,
@@ -307,8 +307,6 @@ async def calculate_fee(
             user_id=current_user.id,
             unit_id=unit_id,
             semester_no=data.semester_no,
-            manual_base_amount=data.manual_base_amount,
-            manual_reason=data.manual_reason,
         )
 
         # Generate invoices based on installment plan.
@@ -329,6 +327,9 @@ async def calculate_fee(
         # flow. CAPTURE invoice_cb (was discarded with `_`): the issue path
         # builds an INVOICE_ISSUED post-commit fanout that must be awaited,
         # otherwise the invoice is issued silently with no notification/sync.
+        # Lịch thu "đóng trước" (Pha 1): truyền 2 đợt tùy chỉnh xuống service —
+        # GIỮ nghĩa vụ (final), chỉ chia thành đợt đầu + còn lại; cả hai auto-issue
+        # (tuition) → công nợ đợt 2 có hạn cụ thể. None = luồng kế hoạch như cũ.
         invoices, invoice_cb = await invoice_service.generate_invoices_for_fee(
             fee_id=fee.id,
             due_date_base=date.today() + timedelta(days=30),
@@ -336,6 +337,9 @@ async def calculate_fee(
             unit_id=unit_id,
             auto_issue=(data.fee_type == FeeTypeEnum.tuition),
             anchor_date=invoice_anchor,
+            down_payment=data.down_payment,
+            down_payment_due=data.down_payment_due,
+            remainder_due=data.remainder_due,
         )
 
         await db.commit()
@@ -414,7 +418,7 @@ async def list_calculable_profiles(
 @router.get(
     "/tuition-preview",
     response_model=finance_schemas.TuitionPreviewResponse,
-    summary="Preview giá chuẩn học phí (cho add-on nhập học phí thủ công)",
+    summary="Preview giá chuẩn học phí (base / giảm giá / dự kiến phải thu)",
 )
 async def preview_tuition(
     request: Request,
@@ -426,7 +430,8 @@ async def preview_tuition(
     current_user: models.User = CasbinAuth,
 ):
     """Giá chuẩn học phí (base / giảm giá / dự kiến phải thu) cho dialog "Tính
-    phí" khi bật toggle nhập học phí thủ công. Read-only, KHÔNG ghi DB.
+    phí" — hiển để đối chiếu khi chọn lịch thu (vd "đóng trước + còn lại").
+    Read-only, KHÔNG ghi DB.
 
     Auth giống ``POST /api/fees/calculate``: ``_get_profile`` unscoped rồi
     ``_fee_calc_authorized`` → 404 nếu ngoài scope (không leak existence). Khai

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -291,6 +291,12 @@ async def calculate_fee(
         # resolve here (no double resolve) and closing the race where the router
         # resolved discount pre-lock while the service resolved amount post-lock
         # (a concurrent waitlist-promote could have mismatched the two ngành).
+        # Manual tuition override (accountant/officer nhập học phí đặc biệt). Số
+        # gõ = BASE; service VẪN áp discount → invoice khớp final. Guard kép:
+        # schema model_validator (422) + service-side guard (400) cho direct
+        # caller. base_amount vẫn None để service tự resolve giá chuẩn (làm audit
+        # + mặc định); manual_base_amount nới riêng cho tuition. Audit log riêng
+        # do service phát (``fee_calculated_manual``) — router giữ "dumb".
         fee, post_commit = await fee_service.calculate_fee(
             admission_profile_id=data.admission_profile_id,
             fee_type=data.fee_type,
@@ -301,6 +307,8 @@ async def calculate_fee(
             user_id=current_user.id,
             unit_id=unit_id,
             semester_no=data.semester_no,
+            manual_base_amount=data.manual_base_amount,
+            manual_reason=data.manual_reason,
         )
 
         # Generate invoices based on installment plan.
@@ -400,6 +408,55 @@ async def list_calculable_profiles(
             for p in profiles
         ]
     )
+
+
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "/tuition-preview",
+    response_model=finance_schemas.TuitionPreviewResponse,
+    summary="Preview giá chuẩn học phí (cho add-on nhập học phí thủ công)",
+)
+async def preview_tuition(
+    request: Request,
+    admission_profile_id: int = Query(..., gt=0, description="ID hồ sơ tuyển sinh"),
+    # le=12: chặn semester_no ngoài int32 → asyncpg DataError → 500 (cùng lớp
+    # int32-guard codebase đã áp ở các route khác). HK thực tế ≤ 12.
+    semester_no: int = Query(1, ge=1, le=12, description="Số học kỳ (HK1=1)"),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    """Giá chuẩn học phí (base / giảm giá / dự kiến phải thu) cho dialog "Tính
+    phí" khi bật toggle nhập học phí thủ công. Read-only, KHÔNG ghi DB.
+
+    Auth giống ``POST /api/fees/calculate``: ``_get_profile`` unscoped rồi
+    ``_fee_calc_authorized`` → 404 nếu ngoài scope (không leak existence). Khai
+    báo literal ``/tuition-preview`` TRƯỚC ``/{fee_id}`` để route match đúng (một
+    segment đặt sau ``/{fee_id}`` sẽ bị nuốt thành ``fee_id`` → 422). Cùng quy
+    ước với ``/calculable-profiles``.
+    """
+    fee_service = FeeCalculationService(db)
+
+    try:
+        profile = await fee_service._get_profile(admission_profile_id, unit_id=None)
+        if not profile or not _fee_calc_authorized(profile, current_user):
+            # 404 not 403: no existence leak beyond scope (same as calculate_fee).
+            raise ResourceNotFoundError("Admission profile not found")
+
+        base_amount, total_discount, final_amount = await fee_service.preview_tuition(
+            profile, semester_no
+        )
+        return finance_schemas.TuitionPreviewResponse(
+            base_amount=base_amount,
+            total_discount=total_discount,
+            final_amount=final_amount,
+            semester_no=semester_no,
+        )
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except BadRequest as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except BusinessRuleViolation as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 # ==============================================================================

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -15,7 +15,7 @@ Architecture Compliance:
 
 from datetime import datetime, date
 from decimal import Decimal
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Literal
 import html
 
 from pydantic import BaseModel, Field, field_validator, model_validator, ConfigDict
@@ -264,24 +264,21 @@ class FeeCalculateRequest(BaseModel):
         None, ge=1, le=12,
         description="Số học kỳ (HK1=1). Mặc định 1 cho tuition, None cho non-tuition."
     )
-    # Manual tuition override (accountant/officer nhập học phí đặc biệt — học
-    # bổng / chuyển trường / theo quyết định riêng). Số gõ là BASE (TRƯỚC giảm
-    # giá): service vẫn áp discount hiện hành → final = manual − total_discount,
-    # invoice khớp final (≠ số gõ nếu có giảm). CHỈ áp dụng cho fee_type=tuition.
-    # None = luồng cũ (lấy giá chuẩn từ offering_semester_tuition).
-    manual_base_amount: Optional[Decimal] = Field(None, gt=0, le=MAX_AMOUNT)
-    manual_reason: Optional[str] = Field(None, max_length=500)
-
-    @field_validator("manual_reason")
-    @classmethod
-    def strip_manual_reason(cls, v: Optional[str]) -> Optional[str]:
-        # CHỈ strip — KHÔNG escape ở đây. Độ dài ≥10 phải đo trên chuỗi GỐC:
-        # ``html.escape`` chỉ làm DÀI thêm ('<'→'&lt;') nên reason rác vài ký tự
-        # đặc biệt ('<<<<' → 16 ký tự) sẽ lọt cửa ≥10, làm rỗng kiểm soát audit.
-        # Escape lùi xuống ``validate_manual_tuition`` SAU khi đã check độ dài raw.
-        if v is None:
-            return v
-        return v.strip()
+    # Lịch thu tùy chỉnh — Pha 1: "đóng trước + phần còn lại" (2 đợt). KHÔNG đổi
+    # NGHĨA VỤ (base_amount/final_amount giữ giá chuẩn) — chỉ chia final thành 2
+    # hóa đơn. mode="standard" = theo kế hoạch trả góp như cũ. CHỈ cho tuition.
+    # (Mở rộng sau: thêm mode "custom" cho N đợt.)
+    collection_schedule_mode: Literal["standard", "down_payment"] = "standard"
+    down_payment: Optional[Decimal] = Field(
+        None, gt=0, le=MAX_AMOUNT,
+        description="Số tiền đóng trước (đợt 1) — chỉ khi mode='down_payment'.",
+    )
+    down_payment_due: Optional[date] = Field(
+        None, description="Hạn đóng đợt 1 (down_payment)."
+    )
+    remainder_due: Optional[date] = Field(
+        None, description="Hạn đóng đợt 2 (phần còn lại)."
+    )
 
     @model_validator(mode="after")
     def default_semester_for_tuition(self):
@@ -290,28 +287,37 @@ class FeeCalculateRequest(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def validate_manual_tuition(self):
-        """Manual override invariant (HTTP layer → 422 on violation).
-
-        Mirror lớp guard service-side (``calculate_fee``) — defense-in-depth cho
-        tiền lõi: schema bắt caller HTTP, service guard bắt direct/test caller.
-        Độ dài reason đo trên chuỗi RAW (đã strip, CHƯA escape); chỉ escape SAU
-        khi hợp lệ để lưu/audit an toàn.
+    def validate_collection_schedule(self):
+        """Lịch thu 'đóng trước' (HTTP layer → 422). CHỈ kiểm cấu trúc lịch —
+        KHÔNG đụng số tiền nghĩa vụ. Ràng buộc ``down_payment < final`` đo ở
+        service (final chỉ biết sau khi resolve giá chuẩn HK).
         """
-        if self.manual_base_amount is not None:
+        if self.collection_schedule_mode == "down_payment":
             if self.fee_type != FeeTypeEnum.tuition:
                 raise ValueError(
-                    "Nhập học phí thủ công chỉ áp dụng cho loại phí học phí (tuition)."
+                    "Lịch thu 'đóng trước' chỉ áp dụng cho học phí (tuition)."
                 )
-            if not self.manual_reason or len(self.manual_reason) < 10:
+            if (
+                self.down_payment is None
+                or self.down_payment_due is None
+                or self.remainder_due is None
+            ):
                 raise ValueError(
-                    "Cần nhập lý do nhập học phí thủ công (tối thiểu 10 ký tự)."
+                    "Lịch 'đóng trước' cần: số đóng trước, hạn đợt 1 và hạn đợt 2."
                 )
-            # Độ dài đã đo trên RAW → giờ mới escape để lưu vào Fee.notes an toàn.
-            self.manual_reason = html.escape(self.manual_reason)
-        elif self.manual_reason:
+            if self.remainder_due < self.down_payment_due:
+                raise ValueError(
+                    "Hạn đợt còn lại phải >= hạn đợt đóng trước."
+                )
+        elif (
+            self.down_payment is not None
+            or self.down_payment_due is not None
+            or self.remainder_due is not None
+        ):
+            # mode="standard" mà vẫn gửi field down_payment → từ chối (tránh dữ
+            # liệu lạc bị bỏ thầm).
             raise ValueError(
-                "Có lý do nhập tay nhưng thiếu mức học phí thủ công."
+                "Chỉ truyền down_payment khi collection_schedule_mode='down_payment'."
             )
         return self
 
@@ -1017,13 +1023,13 @@ class CalculableProfilesResponse(BaseModel):
 
 
 class TuitionPreviewResponse(BaseModel):
-    """Giá chuẩn học phí (read-only) cho add-on "Nhập học phí thủ công" của dialog
-    Tính phí (GET /api/fees/tuition-preview).
+    """Giá chuẩn học phí (read-only) cho dialog "Tính phí"
+    (GET /api/fees/tuition-preview).
 
-    Trả về 3 con số để dialog hiển khi accountant/officer bật toggle nhập tay:
-    so sánh số gõ với giá chuẩn (``base_amount``), thấy giảm giá hiện hành
-    (``total_discount``) và dự kiến phải thu (``final_amount`` = base − discount).
-    KHÔNG persist gì — chỉ tái dùng resolver giá + discount như ``calculate_fee``.
+    Trả về 3 con số để dialog đối chiếu khi chọn lịch thu: giá chuẩn
+    (``base_amount``), giảm giá hiện hành (``total_discount``) và dự kiến phải thu
+    (``final_amount`` = base − discount). KHÔNG persist — chỉ tái dùng resolver
+    giá + discount như ``calculate_fee``.
     """
     base_amount: Decimal
     total_discount: Decimal

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -261,11 +261,55 @@ class FeeCalculateRequest(BaseModel):
         None, ge=1,
         description="Số học kỳ (HK1=1). Mặc định 1 cho tuition, None cho non-tuition."
     )
+    # Manual tuition override (accountant/officer nhập học phí đặc biệt — học
+    # bổng / chuyển trường / theo quyết định riêng). Số gõ là BASE (TRƯỚC giảm
+    # giá): service vẫn áp discount hiện hành → final = manual − total_discount,
+    # invoice khớp final (≠ số gõ nếu có giảm). CHỈ áp dụng cho fee_type=tuition.
+    # None = luồng cũ (lấy giá chuẩn từ offering_semester_tuition).
+    manual_base_amount: Optional[Decimal] = Field(None, gt=0, le=MAX_AMOUNT)
+    manual_reason: Optional[str] = Field(None, max_length=500)
+
+    @field_validator("manual_reason")
+    @classmethod
+    def strip_manual_reason(cls, v: Optional[str]) -> Optional[str]:
+        # CHỈ strip — KHÔNG escape ở đây. Độ dài ≥10 phải đo trên chuỗi GỐC:
+        # ``html.escape`` chỉ làm DÀI thêm ('<'→'&lt;') nên reason rác vài ký tự
+        # đặc biệt ('<<<<' → 16 ký tự) sẽ lọt cửa ≥10, làm rỗng kiểm soát audit.
+        # Escape lùi xuống ``validate_manual_tuition`` SAU khi đã check độ dài raw.
+        if v is None:
+            return v
+        return v.strip()
 
     @model_validator(mode="after")
     def default_semester_for_tuition(self):
         if self.fee_type == FeeTypeEnum.tuition and self.semester_no is None:
             self.semester_no = 1
+        return self
+
+    @model_validator(mode="after")
+    def validate_manual_tuition(self):
+        """Manual override invariant (HTTP layer → 422 on violation).
+
+        Mirror lớp guard service-side (``calculate_fee``) — defense-in-depth cho
+        tiền lõi: schema bắt caller HTTP, service guard bắt direct/test caller.
+        Độ dài reason đo trên chuỗi RAW (đã strip, CHƯA escape); chỉ escape SAU
+        khi hợp lệ để lưu/audit an toàn.
+        """
+        if self.manual_base_amount is not None:
+            if self.fee_type != FeeTypeEnum.tuition:
+                raise ValueError(
+                    "Nhập học phí thủ công chỉ áp dụng cho loại phí học phí (tuition)."
+                )
+            if not self.manual_reason or len(self.manual_reason) < 10:
+                raise ValueError(
+                    "Cần nhập lý do nhập học phí thủ công (tối thiểu 10 ký tự)."
+                )
+            # Độ dài đã đo trên RAW → giờ mới escape để lưu vào Fee.notes an toàn.
+            self.manual_reason = html.escape(self.manual_reason)
+        elif self.manual_reason:
+            raise ValueError(
+                "Có lý do nhập tay nhưng thiếu mức học phí thủ công."
+            )
         return self
 
     model_config = ConfigDict(from_attributes=True)
@@ -967,6 +1011,21 @@ class CalculableProfilesResponse(BaseModel):
     Finance-scoped so accountant — denied /api/admissions by design — can still
     pick a profile to calculate a fee for."""
     profiles: List[CalculableProfileItem]
+
+
+class TuitionPreviewResponse(BaseModel):
+    """Giá chuẩn học phí (read-only) cho add-on "Nhập học phí thủ công" của dialog
+    Tính phí (GET /api/fees/tuition-preview).
+
+    Trả về 3 con số để dialog hiển khi accountant/officer bật toggle nhập tay:
+    so sánh số gõ với giá chuẩn (``base_amount``), thấy giảm giá hiện hành
+    (``total_discount``) và dự kiến phải thu (``final_amount`` = base − discount).
+    KHÔNG persist gì — chỉ tái dùng resolver giá + discount như ``calculate_fee``.
+    """
+    base_amount: Decimal
+    total_discount: Decimal
+    final_amount: Decimal
+    semester_no: int
 
 
 class ProfileCollectionIdentity(BaseModel):

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -257,8 +257,11 @@ class FeeCalculateRequest(BaseModel):
     admission_profile_id: int
     fee_type: FeeTypeEnum = FeeTypeEnum.tuition
     installment_plan_code: str = Field(default="FULL", max_length=50)
+    # le=12: chặn semester_no ngoài int32 → asyncpg DataError → 500 (cùng lớp
+    # int32-guard codebase đã áp). Mirror route GET /api/fees/tuition-preview
+    # (semester_no Query le=12). HK thực tế ≤ 12.
     semester_no: Optional[int] = Field(
-        None, ge=1,
+        None, ge=1, le=12,
         description="Số học kỳ (HK1=1). Mặc định 1 cho tuition, None cho non-tuition."
     )
     # Manual tuition override (accountant/officer nhập học phí đặc biệt — học

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -485,6 +485,8 @@ class FeeCalculationService:
         user_id: Optional[int] = None,
         unit_id: Optional[int] = None,
         semester_no: Optional[int] = None,
+        manual_base_amount: Optional[Decimal] = None,
+        manual_reason: Optional[str] = None,
     ) -> Tuple[Fee, Optional[Callable]]:
         """
         Calculate fee for an admission profile.
@@ -523,6 +525,30 @@ class FeeCalculationService:
             ResourceNotFoundError: If profile not found
             BadRequest: If fee already exists or semester tuition not configured
         """
+        # 🔴 GUARD SERVICE-SIDE (manual tuition override) — đặt TRƯỚC mọi resolve
+        # giá / DB. ``calculate_fee`` là business boundary có direct/test caller
+        # KHÔNG đi qua schema ``model_validator`` (lo HTTP→422), nên tự bảo vệ
+        # invariant cho con số tài chính lõi: nhập tay chỉ cho tuition + lý do
+        # ≥10. Domain error (BadRequest ⊂ ValidationError → 400). Hai lớp bổ trợ,
+        # không trùng path (schema 422 cho HTTP, guard này cho direct caller).
+        if manual_base_amount is not None:
+            if fee_type != FeeTypeEnum.tuition:
+                raise BadRequest("Nhập học phí thủ công chỉ áp dụng cho học phí (tuition).")
+            if not manual_reason or len(manual_reason.strip()) < 10:
+                raise BadRequest("Cần lý do nhập học phí thủ công (tối thiểu 10 ký tự).")
+            # Manual override CHỈ chạy ở nhánh service-resolve (base_amount=None,
+            # đường router). Nếu caller truyền KÈM base_amount tường minh thì nhánh
+            # ``elif fee_type == tuition`` ép giá chuẩn → manual bị BỎ THẦM +
+            # audit note "chuẩn None". Chặn combo mâu thuẫn fail-fast (đối xứng
+            # guard base_amount/discount_policy_ids ngay dưới).
+            if base_amount is not None:
+                raise BadRequest(
+                    "Nhập học phí thủ công cần chế độ service-resolve "
+                    "(base_amount=None) — không truyền kèm base_amount tường minh."
+                )
+        elif manual_reason:  # lý do có nhưng thiếu mức học phí → vô nghĩa
+            raise BadRequest("Có lý do nhập tay nhưng thiếu mức học phí thủ công.")
+
         # Normalize semester_no: tuition defaults to HK1, non-tuition
         # MUST be None (the DB CHECK chk_fee_nontuition_semester_no_null
         # rejects non-tuition rows with a non-NULL semester_no). Lives in
@@ -585,6 +611,9 @@ class FeeCalculationService:
         # removing the double resolve. Direct/test callers pass an explicit
         # base_amount → their values are used as-is; a ``discount_policy_ids`` of
         # None then keeps the legacy "no discount" meaning (NOT auto-derive).
+        # Audit: giá chuẩn HK resolve được — ghi vào notes khi nhập tay để so
+        # sánh chuẩn → tay. None khi không nhập tay (luồng cũ, không cần).
+        canonical_tuition_amount: Optional[Decimal] = None
         if base_amount is None:
             academic_info = await resolve_fee_academic_info(self.db, profile)
             if discount_policy_ids is None:
@@ -592,9 +621,30 @@ class FeeCalculationService:
                     academic_info.applied_discount_policy_ids or []
                 )
             if fee_type == FeeTypeEnum.tuition:
-                base_amount = await self._semester_tuition_amount_for_ai(
-                    academic_info.id, semester_no
-                )
+                if manual_base_amount is not None:
+                    # Số gõ là BASE (đã qua guard tuition + reason ≥10); discount
+                    # VẪN áp như cũ ở dưới → final = manual − discount, invoice
+                    # khớp final. Giá chuẩn chỉ để AUDIT (best-effort): hồ sơ học
+                    # bổng / chuyển trường có thể CHƯA cấu hình học phí chuẩn HK —
+                    # không được chặn override vì lý do đó (canonical=None → note
+                    # ghi "chưa cấu hình").
+                    try:
+                        canonical_tuition_amount = (
+                            await self._semester_tuition_amount_for_ai(
+                                academic_info.id, semester_no
+                            )
+                        )
+                    except BadRequest:
+                        canonical_tuition_amount = None
+                    base_amount = manual_base_amount
+                else:
+                    # Luồng cũ: giá chuẩn là BASE (bắt buộc có cấu hình HK).
+                    canonical_tuition_amount = (
+                        await self._semester_tuition_amount_for_ai(
+                            academic_info.id, semester_no
+                        )
+                    )
+                    base_amount = canonical_tuition_amount
             else:
                 base_amount = academic_info.tuition_fee_per_year or Decimal("0")
                 if base_amount <= 0:
@@ -643,6 +693,23 @@ class FeeCalculationService:
         else:
             academic_year_int = academic_year
 
+        # Audit note khi nhập học phí thủ công — mirror format ``recalculate_fee``
+        # ("chuẩn {canonical} → {manual}. Lý do: {reason}") để lưu vết kiểm soát
+        # (officer/accountant tự đặt học phí đặc biệt). None khi luồng cũ.
+        manual_note: Optional[str] = None
+        if manual_base_amount is not None:
+            _canonical_str = (
+                str(canonical_tuition_amount)
+                if canonical_tuition_amount is not None
+                else "chưa cấu hình"
+            )
+            manual_note = (
+                f"[{datetime.now(timezone.utc).isoformat()}] "
+                f"Học phí nhập tay bởi user {user_id}: "
+                f"chuẩn {_canonical_str} → {base_amount}. "
+                f"Lý do: {manual_reason}"
+            )
+
         # Create fee record. semester_no is set from the service-level
         # default or caller-provided value (tuition) / None (non-tuition).
         fee = Fee(
@@ -659,6 +726,7 @@ class FeeCalculationService:
             status=FeeStatusEnum.calculated.value,
             calculated_by_id=user_id,
             calculated_at=datetime.now(timezone.utc),
+            notes=manual_note,
             version=1,
         )
 
@@ -697,6 +765,20 @@ class FeeCalculationService:
             final_amount=str(final_amount),
             user_id=user_id,
         )
+
+        # Audit log riêng cho học phí nhập tay — surface trong lead-fraud monitor
+        # (officer tự đặt học phí hồ sơ mình phụ trách). Chỉ fire khi override.
+        if manual_base_amount is not None:
+            log.info(
+                "fee_calculated_manual",
+                fee_id=fee.id,
+                profile_id=admission_profile_id,
+                semester_no=semester_no,
+                canonical_amount=str(canonical_tuition_amount),
+                manual_base_amount=str(base_amount),
+                final_amount=str(final_amount),
+                user_id=user_id,
+            )
 
         # ADR-002 PR 5: Only HK1 fee creation projects into admission pipeline.
         # PR #8 — capture pipeline stage around the sync call so the closure
@@ -746,6 +828,37 @@ class FeeCalculationService:
             )
 
         return fee, post_commit
+
+    async def preview_tuition(
+        self,
+        profile: "models.AdmissionProfile",
+        semester_no: int,
+    ) -> Tuple[Decimal, Decimal, Decimal]:
+        """Giá chuẩn học phí (read-only, KHÔNG persist) cho add-on "Nhập học phí
+        thủ công" của dialog Tính phí.
+
+        Tái dùng ĐÚNG resolver giá + discount như ``calculate_fee`` (cùng nguồn
+        sự thật ``resolve_fee_academic_info`` + ``_semester_tuition_amount_for_ai``
+        + ``_calculate_discounts``) nên số preview khớp với số luồng cũ tạo ra.
+        Router lo IDOR (``_fee_calc_authorized``) trước khi gọi — service chỉ tính.
+
+        Returns:
+            (base_amount, total_discount, final_amount) cho HK ``semester_no``.
+
+        Raises:
+            BadRequest: ngành chưa xác định (multi-NV chưa công bố) / chưa cấu
+                hình học phí HK.
+        """
+        academic_info = await resolve_fee_academic_info(self.db, profile)
+        base_amount = await self._semester_tuition_amount_for_ai(
+            academic_info.id, semester_no
+        )
+        discount_policy_ids = list(academic_info.applied_discount_policy_ids or [])
+        total_discount, _ = await self._calculate_discounts(
+            base_amount, discount_policy_ids
+        )
+        final_amount = max(Decimal("0"), base_amount - total_discount)
+        return base_amount, total_discount, final_amount
 
     async def recalculate_fee(
         self,

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -485,8 +485,6 @@ class FeeCalculationService:
         user_id: Optional[int] = None,
         unit_id: Optional[int] = None,
         semester_no: Optional[int] = None,
-        manual_base_amount: Optional[Decimal] = None,
-        manual_reason: Optional[str] = None,
     ) -> Tuple[Fee, Optional[Callable]]:
         """
         Calculate fee for an admission profile.
@@ -525,30 +523,6 @@ class FeeCalculationService:
             ResourceNotFoundError: If profile not found
             BadRequest: If fee already exists or semester tuition not configured
         """
-        # 🔴 GUARD SERVICE-SIDE (manual tuition override) — đặt TRƯỚC mọi resolve
-        # giá / DB. ``calculate_fee`` là business boundary có direct/test caller
-        # KHÔNG đi qua schema ``model_validator`` (lo HTTP→422), nên tự bảo vệ
-        # invariant cho con số tài chính lõi: nhập tay chỉ cho tuition + lý do
-        # ≥10. Domain error (BadRequest ⊂ ValidationError → 400). Hai lớp bổ trợ,
-        # không trùng path (schema 422 cho HTTP, guard này cho direct caller).
-        if manual_base_amount is not None:
-            if fee_type != FeeTypeEnum.tuition:
-                raise BadRequest("Nhập học phí thủ công chỉ áp dụng cho học phí (tuition).")
-            if not manual_reason or len(manual_reason.strip()) < 10:
-                raise BadRequest("Cần lý do nhập học phí thủ công (tối thiểu 10 ký tự).")
-            # Manual override CHỈ chạy ở nhánh service-resolve (base_amount=None,
-            # đường router). Nếu caller truyền KÈM base_amount tường minh thì nhánh
-            # ``elif fee_type == tuition`` ép giá chuẩn → manual bị BỎ THẦM +
-            # audit note "chuẩn None". Chặn combo mâu thuẫn fail-fast (đối xứng
-            # guard base_amount/discount_policy_ids ngay dưới).
-            if base_amount is not None:
-                raise BadRequest(
-                    "Nhập học phí thủ công cần chế độ service-resolve "
-                    "(base_amount=None) — không truyền kèm base_amount tường minh."
-                )
-        elif manual_reason:  # lý do có nhưng thiếu mức học phí → vô nghĩa
-            raise BadRequest("Có lý do nhập tay nhưng thiếu mức học phí thủ công.")
-
         # Normalize semester_no: tuition defaults to HK1, non-tuition
         # MUST be None (the DB CHECK chk_fee_nontuition_semester_no_null
         # rejects non-tuition rows with a non-NULL semester_no). Lives in
@@ -611,9 +585,6 @@ class FeeCalculationService:
         # removing the double resolve. Direct/test callers pass an explicit
         # base_amount → their values are used as-is; a ``discount_policy_ids`` of
         # None then keeps the legacy "no discount" meaning (NOT auto-derive).
-        # Audit: giá chuẩn HK resolve được — ghi vào notes khi nhập tay để so
-        # sánh chuẩn → tay. None khi không nhập tay (luồng cũ, không cần).
-        canonical_tuition_amount: Optional[Decimal] = None
         if base_amount is None:
             academic_info = await resolve_fee_academic_info(self.db, profile)
             if discount_policy_ids is None:
@@ -621,30 +592,12 @@ class FeeCalculationService:
                     academic_info.applied_discount_policy_ids or []
                 )
             if fee_type == FeeTypeEnum.tuition:
-                if manual_base_amount is not None:
-                    # Số gõ là BASE (đã qua guard tuition + reason ≥10); discount
-                    # VẪN áp như cũ ở dưới → final = manual − discount, invoice
-                    # khớp final. Giá chuẩn chỉ để AUDIT (best-effort): hồ sơ học
-                    # bổng / chuyển trường có thể CHƯA cấu hình học phí chuẩn HK —
-                    # không được chặn override vì lý do đó (canonical=None → note
-                    # ghi "chưa cấu hình").
-                    try:
-                        canonical_tuition_amount = (
-                            await self._semester_tuition_amount_for_ai(
-                                academic_info.id, semester_no
-                            )
-                        )
-                    except BadRequest:
-                        canonical_tuition_amount = None
-                    base_amount = manual_base_amount
-                else:
-                    # Luồng cũ: giá chuẩn là BASE (bắt buộc có cấu hình HK).
-                    canonical_tuition_amount = (
-                        await self._semester_tuition_amount_for_ai(
-                            academic_info.id, semester_no
-                        )
-                    )
-                    base_amount = canonical_tuition_amount
+                # Giá chuẩn HK từ offering_semester_tuition là BASE (bắt buộc có
+                # cấu hình HK). Số tiền nghĩa vụ KHÔNG do người dùng nhập tay —
+                # mọi tuỳ chỉnh (giãn lịch) nằm ở tầng hoá đơn, không đổi base.
+                base_amount = await self._semester_tuition_amount_for_ai(
+                    academic_info.id, semester_no
+                )
             else:
                 base_amount = academic_info.tuition_fee_per_year or Decimal("0")
                 if base_amount <= 0:
@@ -693,23 +646,6 @@ class FeeCalculationService:
         else:
             academic_year_int = academic_year
 
-        # Audit note khi nhập học phí thủ công — mirror format ``recalculate_fee``
-        # ("chuẩn {canonical} → {manual}. Lý do: {reason}") để lưu vết kiểm soát
-        # (officer/accountant tự đặt học phí đặc biệt). None khi luồng cũ.
-        manual_note: Optional[str] = None
-        if manual_base_amount is not None:
-            _canonical_str = (
-                str(canonical_tuition_amount)
-                if canonical_tuition_amount is not None
-                else "chưa cấu hình"
-            )
-            manual_note = (
-                f"[{datetime.now(timezone.utc).isoformat()}] "
-                f"Học phí nhập tay bởi user {user_id}: "
-                f"chuẩn {_canonical_str} → {base_amount}. "
-                f"Lý do: {manual_reason}"
-            )
-
         # Create fee record. semester_no is set from the service-level
         # default or caller-provided value (tuition) / None (non-tuition).
         fee = Fee(
@@ -726,7 +662,6 @@ class FeeCalculationService:
             status=FeeStatusEnum.calculated.value,
             calculated_by_id=user_id,
             calculated_at=datetime.now(timezone.utc),
-            notes=manual_note,
             version=1,
         )
 
@@ -765,20 +700,6 @@ class FeeCalculationService:
             final_amount=str(final_amount),
             user_id=user_id,
         )
-
-        # Audit log riêng cho học phí nhập tay — surface trong lead-fraud monitor
-        # (officer tự đặt học phí hồ sơ mình phụ trách). Chỉ fire khi override.
-        if manual_base_amount is not None:
-            log.info(
-                "fee_calculated_manual",
-                fee_id=fee.id,
-                profile_id=admission_profile_id,
-                semester_no=semester_no,
-                canonical_amount=str(canonical_tuition_amount),
-                manual_base_amount=str(base_amount),
-                final_amount=str(final_amount),
-                user_id=user_id,
-            )
 
         # ADR-002 PR 5: Only HK1 fee creation projects into admission pipeline.
         # PR #8 — capture pipeline stage around the sync call so the closure
@@ -834,8 +755,9 @@ class FeeCalculationService:
         profile: "models.AdmissionProfile",
         semester_no: int,
     ) -> Tuple[Decimal, Decimal, Decimal]:
-        """Giá chuẩn học phí (read-only, KHÔNG persist) cho add-on "Nhập học phí
-        thủ công" của dialog Tính phí.
+        """Giá chuẩn học phí (read-only, KHÔNG persist) cho dialog "Tính phí" —
+        hiển base / giảm giá / dự kiến phải thu để người dùng đối chiếu khi chọn
+        lịch thu (vd chia "đóng trước + còn lại").
 
         Tái dùng ĐÚNG resolver giá + discount như ``calculate_fee`` (cùng nguồn
         sự thật ``resolve_fee_academic_info`` + ``_semester_tuition_amount_for_ai``

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -80,6 +80,9 @@ class InvoiceService:
         unit_id: Optional[int] = None,
         auto_issue: bool = False,
         anchor_date: Optional[date] = None,
+        down_payment: Optional[Decimal] = None,
+        down_payment_due: Optional[date] = None,
+        remainder_due: Optional[date] = None,
     ) -> Tuple[List[Invoice], Optional[Callable]]:
         """
         Generate all invoices for a fee based on its installment plan.
@@ -135,10 +138,40 @@ class InvoiceService:
             raise BadRequest("No amount to invoice (fee fully waived)")
 
         # Get installment schedule
-        if fee.installment_plan:
-            # Chặn dùng plan đã NGỪNG hoạt động: lúc gắn plan đã lọc is_active
-            # (fee_calculation_service), nhưng admin có thể tắt plan SAU đó →
-            # không được tiếp tục sinh hóa đơn theo schedule của plan đã tắt.
+        if down_payment is not None:
+            # Pha 1 — lịch thu "đóng trước + phần còn lại" (2 đợt). KHÔNG đụng
+            # NGHĨA VỤ (final/waived) — chỉ chia ``amount_to_invoice`` (= final −
+            # waived) thành 2 hóa đơn. Bất biến: Σ HĐ = amount_to_invoice. Yêu cầu
+            # 0 < down_payment < amount_to_invoice (remainder > 0).
+            if down_payment <= 0:
+                raise BadRequest("Số đóng trước phải lớn hơn 0.")
+            if down_payment >= amount_to_invoice:
+                raise BadRequest(
+                    f"Số đóng trước ({down_payment}) phải nhỏ hơn tổng phải thu "
+                    f"({amount_to_invoice}). Nếu đóng đủ, dùng kế hoạch trả góp thường."
+                )
+            if down_payment_due is None or remainder_due is None:
+                raise BadRequest("Lịch 'đóng trước' cần hạn của cả hai đợt.")
+            if remainder_due < down_payment_due:
+                raise BadRequest("Hạn đợt còn lại phải >= hạn đợt đóng trước.")
+            installment_schedule = [
+                {
+                    "installment_no": 1,
+                    "amount": down_payment,
+                    "due_days_offset": 0,
+                    "due_date": down_payment_due.isoformat(),
+                },
+                {
+                    "installment_no": 2,
+                    "amount": amount_to_invoice - down_payment,
+                    "due_days_offset": 0,
+                    "due_date": remainder_due.isoformat(),
+                },
+            ]
+        elif fee.installment_plan:
+            # Chặn dùng plan đã NGỪNG hoạt động (#445): lúc gắn plan đã lọc
+            # is_active (fee_calculation_service), nhưng admin có thể tắt plan SAU
+            # đó → không được tiếp tục sinh hóa đơn theo schedule của plan đã tắt.
             if not getattr(fee.installment_plan, "is_active", True):
                 raise BusinessRuleViolation(
                     f"Kế hoạch thanh toán '{fee.installment_plan.code}' đã ngừng "

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -1213,3 +1213,414 @@ async def test_calculate_tuition_auto_derives_discount_from_academic_info(
     # under the lock from the resolved academic_info).
     assert Decimal(str(body["total_discount"])) == Decimal("500000"), body
     assert Decimal(str(body["final_amount"])) == Decimal("4500000"), body
+
+
+# ==============================================================================
+# Manual tuition override (2026-06-28) — accountant/officer nhập học phí thủ công
+# ==============================================================================
+#
+# Số gõ là BASE (TRƯỚC giảm giá): service VẪN áp discount → final = manual −
+# discount; invoice khớp final (≠ số gõ nếu có giảm). Guard kép: schema
+# model_validator (HTTP→422) + service-side guard (direct caller→400/BadRequest).
+# Canonical HK1 trong fee_calc_config = 5,000,000.
+
+
+async def _link_fixed_discount(cfg: dict, amount: str = "500000") -> int:
+    """Gắn 1 discount fixed cho academic_info của offering (mirror
+    test_calculate_tuition_auto_derives_discount_from_academic_info). Trả policy id."""
+    from app.models.tuition_discount_policy import TuitionDiscountPolicy
+    from sqlalchemy import update as sa_update
+
+    ts = str(int(datetime.now().timestamp() * 1000) % 10**9)
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            policy = TuitionDiscountPolicy(
+                code=f"MAN_{ts}"[:50],
+                name=f"Manual test discount {ts}",
+                discount_type="amount",
+                discount_value=Decimal(amount),
+                is_active=True,
+                applicable_scope={},
+                target_criteria={},
+            )
+            s.add(policy)
+            await s.flush()
+            pid = policy.id
+            ai_id = (await s.execute(
+                select(models.OfferingAcademicInfo.id).where(
+                    models.OfferingAcademicInfo.offering_id == cfg["offering_id"]
+                )
+            )).scalar_one()
+            await s.execute(
+                sa_update(models.OfferingAcademicInfo)
+                .where(models.OfferingAcademicInfo.id == ai_id)
+                .values(applied_discount_policy_ids=[pid])
+            )
+    return pid
+
+
+@pytest.mark.asyncio
+async def test_manual_tuition_honored_no_discount(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Owning officer nhập học phí thủ công (không discount): base_amount = số gõ
+    (9,000,000 ≠ canonical 5,000,000), final = base, notes có dòng audit, invoice
+    khớp final."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Manual NoDiscount",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+            "manual_base_amount": "9000000",
+            "manual_reason": "Học phí theo quyết định riêng của nhà trường",
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert Decimal(str(body["base_amount"])) == Decimal("9000000"), body
+    assert Decimal(str(body["total_discount"])) == Decimal("0"), body
+    assert Decimal(str(body["final_amount"])) == Decimal("9000000"), body
+    # Audit note lưu vết nhập tay + giá chuẩn → tay.
+    assert "Học phí nhập tay" in (body.get("notes") or ""), body.get("notes")
+    # Invoice khớp final (FULL = 1 installment 100%).
+    invoices = body.get("invoices") or []
+    assert invoices, body
+    assert sum(Decimal(str(inv["amount"])) for inv in invoices) == Decimal("9000000"), invoices
+
+
+@pytest.mark.asyncio
+async def test_manual_tuition_applies_existing_discount(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Số gõ = BASE, discount VẪN áp: manual 8,000,000 − fixed 500,000 =
+    7,500,000 (final). Invoice khớp final, KHÔNG bằng số gõ."""
+    await _link_fixed_discount(fee_calc_config, amount="500000")
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Manual WithDiscount",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+            "manual_base_amount": "8000000",
+            "manual_reason": "Học bổng đặc biệt theo quyết định khen thưởng",
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert Decimal(str(body["base_amount"])) == Decimal("8000000"), body
+    assert Decimal(str(body["total_discount"])) == Decimal("500000"), body
+    assert Decimal(str(body["final_amount"])) == Decimal("7500000"), body
+    invoices = body.get("invoices") or []
+    assert sum(Decimal(str(inv["amount"])) for inv in invoices) == Decimal("7500000"), invoices
+
+
+@pytest.mark.asyncio
+async def test_manual_tuition_unconfigured_semester_ok(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Mục đích của tính năng: nhập tay học bổng/chuyển trường cho hồ sơ CHƯA cấu
+    hình học phí chuẩn HK. fixture chỉ seed HK1 → nhập tay HK2 (không có cấu hình)
+    vẫn phải tạo được (canonical best-effort = None, base = số gõ, note ghi 'chưa
+    cấu hình'). Trước fix: 400 'Chưa cấu hình học phí cho HK2'."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Manual NoConfigHK",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 2,  # KHÔNG có offering_semester_tuition cho HK2
+            "manual_base_amount": "7000000",
+            "manual_reason": "Học phí học kỳ 2 theo quyết định riêng",
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert Decimal(str(body["base_amount"])) == Decimal("7000000"), body
+    assert Decimal(str(body["final_amount"])) == Decimal("7000000"), body
+    assert "chưa cấu hình" in (body.get("notes") or ""), body.get("notes")
+
+
+@pytest.mark.asyncio
+async def test_manual_reason_special_chars_short_422(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Bypass-guard: reason '<<<<' (4 ký tự raw) escape thành 16 ký tự — KHÔNG
+    được lọt cửa ≥10. Độ dài phải đo trên chuỗi GỐC → 422."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Manual SpecialShort",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+            "manual_base_amount": "9000000",
+            "manual_reason": "<<<<",
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_manual_tuition_reason_too_short_422(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Lý do <10 ký tự → schema model_validator → 422 (RequestValidationError)."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Manual ShortReason",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+            "manual_base_amount": "9000000",
+            "manual_reason": "ngắn",
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_manual_amount_on_nontuition_422(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """manual_base_amount kèm non-tuition → schema model_validator → 422."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Manual NonTuition",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "application",
+            "installment_plan_code": "FULL",
+            "manual_base_amount": "9000000",
+            "manual_reason": "Lý do hợp lệ đủ mười ký tự trở lên",
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_accountant_can_manual_tuition(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    accountant_same_unit: dict,
+    fee_calc_config: dict,
+):
+    """Accountant cũng nhập học phí thủ công được (vai trò tài chính trung tâm)."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Manual Accountant", approve=False,
+    )
+    ah = await _login(
+        client, accountant_same_unit["username"], accountant_same_unit["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+            "manual_base_amount": "12000000",
+            "manual_reason": "Điều chỉnh học phí theo trường hợp đặc biệt",
+        },
+        headers=ah,
+    )
+    assert resp.status_code == 201, resp.text
+    assert Decimal(str(resp.json()["base_amount"])) == Decimal("12000000")
+
+
+@pytest.mark.asyncio
+async def test_tuition_preview_returns_canonical(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """GET /api/fees/tuition-preview trả giá chuẩn HK1 (5,000,000) cho owning
+    officer; ngoài scope → 404."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Preview Canonical",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.get(
+        "/api/fees/tuition-preview",
+        params={"admission_profile_id": pid, "semester_no": 1},
+        headers=oh,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert Decimal(str(body["base_amount"])) == Decimal("5000000"), body
+    assert Decimal(str(body["total_discount"])) == Decimal("0"), body
+    assert Decimal(str(body["final_amount"])) == Decimal("5000000"), body
+    assert body["semester_no"] == 1, body
+
+    # Ngoài scope → 404 (profile không tồn tại).
+    miss = await client.get(
+        "/api/fees/tuition-preview",
+        params={"admission_profile_id": 999999, "semester_no": 1},
+        headers=oh,
+    )
+    assert miss.status_code == 404, miss.text
+
+
+@pytest.mark.asyncio
+async def test_tuition_preview_reflects_discount(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Preview phản ánh discount hiện hành: base 5,000,000 − 500,000 = 4,500,000."""
+    await _link_fixed_discount(fee_calc_config, amount="500000")
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Preview WithDiscount",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.get(
+        "/api/fees/tuition-preview",
+        params={"admission_profile_id": pid, "semester_no": 1},
+        headers=oh,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert Decimal(str(body["base_amount"])) == Decimal("5000000"), body
+    assert Decimal(str(body["total_discount"])) == Decimal("500000"), body
+    assert Decimal(str(body["final_amount"])) == Decimal("4500000"), body
+
+
+@pytest.mark.asyncio
+async def test_service_guard_rejects_invalid_manual_before_resolve():
+    """🔴 REVISIONS #7 — guard TẦNG SERVICE: gọi thẳng calculate_fee() với manual
+    params invalid raise domain error (BadRequest) TRƯỚC mọi resolve giá / DB.
+
+    Dùng profile_id không tồn tại: nếu guard KHÔNG fire trước, hàm sẽ chạy tới
+    lookup profile rồi raise ResourceNotFoundError (404) thay vì BadRequest (400)
+    — test này khóa thứ tự guard-trước-resolve cho direct/test caller (lớp ngoài
+    HTTP 422)."""
+    from app.services.fee_calculation_service import FeeCalculationService
+    from app.utils.exceptions import BadRequest
+    from app.models.finance import FeeTypeEnum
+
+    GHOST = 99999999
+    async with AsyncSessionLocal() as s:
+        svc = FeeCalculationService(s)
+
+        # (a) non-tuition + manual
+        with pytest.raises(BadRequest):
+            await svc.calculate_fee(
+                admission_profile_id=GHOST,
+                fee_type=FeeTypeEnum.application,
+                base_amount=None,
+                academic_year="2026",
+                manual_base_amount=Decimal("5000000"),
+                manual_reason="Lý do hợp lệ đủ mười ký tự",
+            )
+
+        # (b) reason <10
+        with pytest.raises(BadRequest):
+            await svc.calculate_fee(
+                admission_profile_id=GHOST,
+                fee_type=FeeTypeEnum.tuition,
+                base_amount=None,
+                academic_year="2026",
+                manual_base_amount=Decimal("5000000"),
+                manual_reason="ngắn",
+            )
+
+        # (c) reason nhưng thiếu mức học phí
+        with pytest.raises(BadRequest):
+            await svc.calculate_fee(
+                admission_profile_id=GHOST,
+                fee_type=FeeTypeEnum.tuition,
+                base_amount=None,
+                academic_year="2026",
+                manual_base_amount=None,
+                manual_reason="Lý do hợp lệ đủ mười ký tự",
+            )
+
+        # (d) manual_base_amount kèm base_amount tường minh → combo mâu thuẫn
+        # (nhánh ép giá chuẩn sẽ bỏ thầm manual). Phải raise TRƯỚC resolve.
+        with pytest.raises(BadRequest):
+            await svc.calculate_fee(
+                admission_profile_id=GHOST,
+                fee_type=FeeTypeEnum.tuition,
+                base_amount=Decimal("5000000"),
+                academic_year="2026",
+                manual_base_amount=Decimal("9000000"),
+                manual_reason="Lý do hợp lệ đủ mười ký tự",
+            )

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -1216,12 +1216,11 @@ async def test_calculate_tuition_auto_derives_discount_from_academic_info(
 
 
 # ==============================================================================
-# Manual tuition override (2026-06-28) — accountant/officer nhập học phí thủ công
+# Lịch thu "đóng trước" (Pha 1, 2026-06-29) — giãn lịch, GIỮ nguyên tổng học phí
 # ==============================================================================
 #
-# Số gõ là BASE (TRƯỚC giảm giá): service VẪN áp discount → final = manual −
-# discount; invoice khớp final (≠ số gõ nếu có giảm). Guard kép: schema
-# model_validator (HTTP→422) + service-side guard (direct caller→400/BadRequest).
+# collection_schedule_mode="down_payment": chia số PHẢI THU (final − waived)
+# thành 2 hóa đơn (đợt đầu + phần còn lại) — KHÔNG đụng base_amount/final_amount.
 # Canonical HK1 trong fee_calc_config = 5,000,000.
 
 
@@ -1257,245 +1256,6 @@ async def _link_fixed_discount(cfg: dict, amount: str = "500000") -> int:
                 .values(applied_discount_policy_ids=[pid])
             )
     return pid
-
-
-@pytest.mark.asyncio
-async def test_manual_tuition_honored_no_discount(
-    client: AsyncClient,
-    admin_token_headers: dict,
-    officer_user_in_db: dict,
-    fee_calc_config: dict,
-):
-    """Owning officer nhập học phí thủ công (không discount): base_amount = số gõ
-    (9,000,000 ≠ canonical 5,000,000), final = base, notes có dòng audit, invoice
-    khớp final."""
-    pid = await _create_approved_profile(
-        client, admin_token_headers, officer_user_in_db, fee_calc_config,
-        lead_name="Manual NoDiscount",
-    )
-    oh = await _login(
-        client, officer_user_in_db["username"], officer_user_in_db["password"]
-    )
-    resp = await client.post(
-        "/api/fees/calculate",
-        json={
-            "admission_profile_id": pid,
-            "fee_type": "tuition",
-            "installment_plan_code": "FULL",
-            "semester_no": 1,
-            "manual_base_amount": "9000000",
-            "manual_reason": "Học phí theo quyết định riêng của nhà trường",
-        },
-        headers=oh,
-    )
-    assert resp.status_code == 201, resp.text
-    body = resp.json()
-    assert Decimal(str(body["base_amount"])) == Decimal("9000000"), body
-    assert Decimal(str(body["total_discount"])) == Decimal("0"), body
-    assert Decimal(str(body["final_amount"])) == Decimal("9000000"), body
-    # Audit note lưu vết nhập tay + giá chuẩn → tay.
-    assert "Học phí nhập tay" in (body.get("notes") or ""), body.get("notes")
-    # Invoice khớp final (FULL = 1 installment 100%).
-    invoices = body.get("invoices") or []
-    assert invoices, body
-    assert sum(Decimal(str(inv["amount"])) for inv in invoices) == Decimal("9000000"), invoices
-
-
-@pytest.mark.asyncio
-async def test_manual_tuition_applies_existing_discount(
-    client: AsyncClient,
-    admin_token_headers: dict,
-    officer_user_in_db: dict,
-    fee_calc_config: dict,
-):
-    """Số gõ = BASE, discount VẪN áp: manual 8,000,000 − fixed 500,000 =
-    7,500,000 (final). Invoice khớp final, KHÔNG bằng số gõ."""
-    await _link_fixed_discount(fee_calc_config, amount="500000")
-    pid = await _create_approved_profile(
-        client, admin_token_headers, officer_user_in_db, fee_calc_config,
-        lead_name="Manual WithDiscount",
-    )
-    oh = await _login(
-        client, officer_user_in_db["username"], officer_user_in_db["password"]
-    )
-    resp = await client.post(
-        "/api/fees/calculate",
-        json={
-            "admission_profile_id": pid,
-            "fee_type": "tuition",
-            "installment_plan_code": "FULL",
-            "semester_no": 1,
-            "manual_base_amount": "8000000",
-            "manual_reason": "Học bổng đặc biệt theo quyết định khen thưởng",
-        },
-        headers=oh,
-    )
-    assert resp.status_code == 201, resp.text
-    body = resp.json()
-    assert Decimal(str(body["base_amount"])) == Decimal("8000000"), body
-    assert Decimal(str(body["total_discount"])) == Decimal("500000"), body
-    assert Decimal(str(body["final_amount"])) == Decimal("7500000"), body
-    invoices = body.get("invoices") or []
-    assert sum(Decimal(str(inv["amount"])) for inv in invoices) == Decimal("7500000"), invoices
-
-
-@pytest.mark.asyncio
-async def test_manual_tuition_unconfigured_semester_ok(
-    client: AsyncClient,
-    admin_token_headers: dict,
-    officer_user_in_db: dict,
-    fee_calc_config: dict,
-):
-    """Mục đích của tính năng: nhập tay học bổng/chuyển trường cho hồ sơ CHƯA cấu
-    hình học phí chuẩn HK. fixture chỉ seed HK1 → nhập tay HK2 (không có cấu hình)
-    vẫn phải tạo được (canonical best-effort = None, base = số gõ, note ghi 'chưa
-    cấu hình'). Trước fix: 400 'Chưa cấu hình học phí cho HK2'."""
-    pid = await _create_approved_profile(
-        client, admin_token_headers, officer_user_in_db, fee_calc_config,
-        lead_name="Manual NoConfigHK",
-    )
-    oh = await _login(
-        client, officer_user_in_db["username"], officer_user_in_db["password"]
-    )
-    resp = await client.post(
-        "/api/fees/calculate",
-        json={
-            "admission_profile_id": pid,
-            "fee_type": "tuition",
-            "installment_plan_code": "FULL",
-            "semester_no": 2,  # KHÔNG có offering_semester_tuition cho HK2
-            "manual_base_amount": "7000000",
-            "manual_reason": "Học phí học kỳ 2 theo quyết định riêng",
-        },
-        headers=oh,
-    )
-    assert resp.status_code == 201, resp.text
-    body = resp.json()
-    assert Decimal(str(body["base_amount"])) == Decimal("7000000"), body
-    assert Decimal(str(body["final_amount"])) == Decimal("7000000"), body
-    assert "chưa cấu hình" in (body.get("notes") or ""), body.get("notes")
-
-
-@pytest.mark.asyncio
-async def test_manual_reason_special_chars_short_422(
-    client: AsyncClient,
-    admin_token_headers: dict,
-    officer_user_in_db: dict,
-    fee_calc_config: dict,
-):
-    """Bypass-guard: reason '<<<<' (4 ký tự raw) escape thành 16 ký tự — KHÔNG
-    được lọt cửa ≥10. Độ dài phải đo trên chuỗi GỐC → 422."""
-    pid = await _create_approved_profile(
-        client, admin_token_headers, officer_user_in_db, fee_calc_config,
-        lead_name="Manual SpecialShort",
-    )
-    oh = await _login(
-        client, officer_user_in_db["username"], officer_user_in_db["password"]
-    )
-    resp = await client.post(
-        "/api/fees/calculate",
-        json={
-            "admission_profile_id": pid,
-            "fee_type": "tuition",
-            "installment_plan_code": "FULL",
-            "semester_no": 1,
-            "manual_base_amount": "9000000",
-            "manual_reason": "<<<<",
-        },
-        headers=oh,
-    )
-    assert resp.status_code == 422, resp.text
-
-
-@pytest.mark.asyncio
-async def test_manual_tuition_reason_too_short_422(
-    client: AsyncClient,
-    admin_token_headers: dict,
-    officer_user_in_db: dict,
-    fee_calc_config: dict,
-):
-    """Lý do <10 ký tự → schema model_validator → 422 (RequestValidationError)."""
-    pid = await _create_approved_profile(
-        client, admin_token_headers, officer_user_in_db, fee_calc_config,
-        lead_name="Manual ShortReason",
-    )
-    oh = await _login(
-        client, officer_user_in_db["username"], officer_user_in_db["password"]
-    )
-    resp = await client.post(
-        "/api/fees/calculate",
-        json={
-            "admission_profile_id": pid,
-            "fee_type": "tuition",
-            "installment_plan_code": "FULL",
-            "semester_no": 1,
-            "manual_base_amount": "9000000",
-            "manual_reason": "ngắn",
-        },
-        headers=oh,
-    )
-    assert resp.status_code == 422, resp.text
-
-
-@pytest.mark.asyncio
-async def test_manual_amount_on_nontuition_422(
-    client: AsyncClient,
-    admin_token_headers: dict,
-    officer_user_in_db: dict,
-    fee_calc_config: dict,
-):
-    """manual_base_amount kèm non-tuition → schema model_validator → 422."""
-    pid = await _create_approved_profile(
-        client, admin_token_headers, officer_user_in_db, fee_calc_config,
-        lead_name="Manual NonTuition",
-    )
-    oh = await _login(
-        client, officer_user_in_db["username"], officer_user_in_db["password"]
-    )
-    resp = await client.post(
-        "/api/fees/calculate",
-        json={
-            "admission_profile_id": pid,
-            "fee_type": "application",
-            "installment_plan_code": "FULL",
-            "manual_base_amount": "9000000",
-            "manual_reason": "Lý do hợp lệ đủ mười ký tự trở lên",
-        },
-        headers=oh,
-    )
-    assert resp.status_code == 422, resp.text
-
-
-@pytest.mark.asyncio
-async def test_accountant_can_manual_tuition(
-    client: AsyncClient,
-    admin_token_headers: dict,
-    officer_user_in_db: dict,
-    accountant_same_unit: dict,
-    fee_calc_config: dict,
-):
-    """Accountant cũng nhập học phí thủ công được (vai trò tài chính trung tâm)."""
-    pid = await _create_approved_profile(
-        client, admin_token_headers, officer_user_in_db, fee_calc_config,
-        lead_name="Manual Accountant", approve=False,
-    )
-    ah = await _login(
-        client, accountant_same_unit["username"], accountant_same_unit["password"]
-    )
-    resp = await client.post(
-        "/api/fees/calculate",
-        json={
-            "admission_profile_id": pid,
-            "fee_type": "tuition",
-            "installment_plan_code": "FULL",
-            "semester_no": 1,
-            "manual_base_amount": "12000000",
-            "manual_reason": "Điều chỉnh học phí theo trường hợp đặc biệt",
-        },
-        headers=ah,
-    )
-    assert resp.status_code == 201, resp.text
-    assert Decimal(str(resp.json()["base_amount"])) == Decimal("12000000")
 
 
 @pytest.mark.asyncio
@@ -1564,63 +1324,110 @@ async def test_tuition_preview_reflects_discount(
 
 
 @pytest.mark.asyncio
-async def test_service_guard_rejects_invalid_manual_before_resolve():
-    """🔴 REVISIONS #7 — guard TẦNG SERVICE: gọi thẳng calculate_fee() với manual
-    params invalid raise domain error (BadRequest) TRƯỚC mọi resolve giá / DB.
+async def test_down_payment_splits_into_two_invoices(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Đóng trước 2,000,000 (canonical 5,000,000) → GIỮ tổng (base/final =
+    5,000,000), 2 hóa đơn issued (2,000,000 + 3,000,000), còn nợ 3,000,000."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="DownPay Split",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "semester_no": 1,
+            "collection_schedule_mode": "down_payment",
+            "down_payment": "2000000",
+            "down_payment_due": "2026-09-01",
+            "remainder_due": "2026-11-01",
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    # NGHĨA VỤ không đổi (đóng trước chỉ giãn lịch thu).
+    assert Decimal(str(body["base_amount"])) == Decimal("5000000"), body
+    assert Decimal(str(body["final_amount"])) == Decimal("5000000"), body
+    assert Decimal(str(body["remaining_amount"])) == Decimal("5000000"), body
+    invoices = sorted(
+        body.get("invoices") or [], key=lambda i: i["installment_no"]
+    )
+    assert len(invoices) == 2, invoices
+    assert Decimal(str(invoices[0]["amount"])) == Decimal("2000000"), invoices
+    assert Decimal(str(invoices[1]["amount"])) == Decimal("3000000"), invoices
+    assert sum(Decimal(str(i["amount"])) for i in invoices) == Decimal("5000000")
+    # Đợt 2 (phần còn lại = công nợ) có hạn tương lai cụ thể, cả 2 đã phát hành.
+    assert invoices[0]["due_date"] == "2026-09-01", invoices
+    assert invoices[1]["due_date"] == "2026-11-01", invoices
+    assert all(i["status"] == "issued" for i in invoices), invoices
 
-    Dùng profile_id không tồn tại: nếu guard KHÔNG fire trước, hàm sẽ chạy tới
-    lookup profile rồi raise ResourceNotFoundError (404) thay vì BadRequest (400)
-    — test này khóa thứ tự guard-trước-resolve cho direct/test caller (lớp ngoài
-    HTTP 422)."""
-    from app.services.fee_calculation_service import FeeCalculationService
-    from app.utils.exceptions import BadRequest
-    from app.models.finance import FeeTypeEnum
 
-    GHOST = 99999999
-    async with AsyncSessionLocal() as s:
-        svc = FeeCalculationService(s)
+@pytest.mark.asyncio
+async def test_down_payment_exceeds_total_rejected(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Đóng trước >= tổng phải thu (canonical 5,000,000) → 400 (remainder <= 0)."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="DownPay TooBig",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "semester_no": 1,
+            "collection_schedule_mode": "down_payment",
+            "down_payment": "6000000",
+            "down_payment_due": "2026-09-01",
+            "remainder_due": "2026-11-01",
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 400, resp.text
 
-        # (a) non-tuition + manual
-        with pytest.raises(BadRequest):
-            await svc.calculate_fee(
-                admission_profile_id=GHOST,
-                fee_type=FeeTypeEnum.application,
-                base_amount=None,
-                academic_year="2026",
-                manual_base_amount=Decimal("5000000"),
-                manual_reason="Lý do hợp lệ đủ mười ký tự",
-            )
 
-        # (b) reason <10
-        with pytest.raises(BadRequest):
-            await svc.calculate_fee(
-                admission_profile_id=GHOST,
-                fee_type=FeeTypeEnum.tuition,
-                base_amount=None,
-                academic_year="2026",
-                manual_base_amount=Decimal("5000000"),
-                manual_reason="ngắn",
-            )
-
-        # (c) reason nhưng thiếu mức học phí
-        with pytest.raises(BadRequest):
-            await svc.calculate_fee(
-                admission_profile_id=GHOST,
-                fee_type=FeeTypeEnum.tuition,
-                base_amount=None,
-                academic_year="2026",
-                manual_base_amount=None,
-                manual_reason="Lý do hợp lệ đủ mười ký tự",
-            )
-
-        # (d) manual_base_amount kèm base_amount tường minh → combo mâu thuẫn
-        # (nhánh ép giá chuẩn sẽ bỏ thầm manual). Phải raise TRƯỚC resolve.
-        with pytest.raises(BadRequest):
-            await svc.calculate_fee(
-                admission_profile_id=GHOST,
-                fee_type=FeeTypeEnum.tuition,
-                base_amount=Decimal("5000000"),
-                academic_year="2026",
-                manual_base_amount=Decimal("9000000"),
-                manual_reason="Lý do hợp lệ đủ mười ký tự",
-            )
+@pytest.mark.asyncio
+async def test_down_payment_remainder_due_before_first_422(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Hạn phần còn lại < hạn đợt đầu → schema model_validator → 422."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="DownPay BadDates",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "semester_no": 1,
+            "collection_schedule_mode": "down_payment",
+            "down_payment": "2000000",
+            "down_payment_due": "2026-11-01",
+            "remainder_due": "2026-09-01",
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 422, resp.text

--- a/frontend/src/components/admissions/CalculateFeeDialog.test.tsx
+++ b/frontend/src/components/admissions/CalculateFeeDialog.test.tsx
@@ -22,8 +22,8 @@ vi.mock("@/hooks/finance/useFees", async () => {
   return {
     ...actual,
     useCalculateFee: () => ({ mutateAsync, isPending: false }),
-    // Manual override add-on (#2) — stub giá chuẩn so the preview block renders
-    // deterministically without a network call when the toggle is on.
+    // Lịch thu "đóng trước" — stub tổng phải thu (final) để khối preview render
+    // tất định, không gọi mạng, khi bật toggle.
     useTuitionPreview: () => ({
       data: {
         base_amount: "5000000",
@@ -91,76 +91,68 @@ describe("CalculateFeeDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  // ---- Manual tuition override (2026-06-28) ----
+  // ---- Lịch thu "đóng trước" (2026-06-29) ----
 
-  it("manual toggle reveals amount + reason inputs", () => {
+  it("down-payment toggle reveals amount + due-date inputs", () => {
     render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
     // Hidden by default.
-    expect(screen.queryByLabelText(/mức học phí/i)).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("switch", { name: /nhập học phí thủ công/i }));
-    expect(screen.getByLabelText(/mức học phí/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/lý do nhập tay/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/số đóng đợt đầu/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("switch", { name: /đóng trước theo đợt/i }));
+    expect(screen.getByLabelText(/số đóng đợt đầu/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/hạn đợt đầu/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/hạn phần còn lại/i)).toBeInTheDocument();
   });
 
-  it("submit is blocked until a manual amount + reason ≥10 chars are present", () => {
+  it("submit is blocked until down-payment + both due dates are present", () => {
     render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
-    fireEvent.click(screen.getByRole("switch", { name: /nhập học phí thủ công/i }));
+    fireEvent.click(screen.getByRole("switch", { name: /đóng trước theo đợt/i }));
 
     const submit = screen.getByRole("button", { name: /^tính học phí$/i });
     expect(submit).toBeDisabled();
 
-    fireEvent.change(screen.getByLabelText(/mức học phí/i), {
-      target: { value: "9000000" },
+    fireEvent.change(screen.getByLabelText(/số đóng đợt đầu/i), {
+      target: { value: "2000000" },
     });
-    // Reason still empty → blocked.
+    // Dates still empty → blocked.
     expect(submit).toBeDisabled();
 
-    fireEvent.change(screen.getByLabelText(/lý do nhập tay/i), {
-      target: { value: "Hoc bong dac biet theo quyet dinh" },
+    fireEvent.change(screen.getByLabelText(/hạn đợt đầu/i), {
+      target: { value: "2026-09-01" },
+    });
+    fireEvent.change(screen.getByLabelText(/hạn phần còn lại/i), {
+      target: { value: "2026-11-01" },
     });
     expect(submit).toBeEnabled();
   });
 
-  it("reason chip sets a ≥10-char reason value", () => {
+  it("posts collection_schedule_mode + down-payment fields (no plan code)", async () => {
     render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
-    fireEvent.click(screen.getByRole("switch", { name: /nhập học phí thủ công/i }));
-    fireEvent.click(screen.getByRole("button", { name: /^học bổng$/i }));
-    const reason = screen.getByLabelText(/lý do nhập tay/i) as HTMLTextAreaElement;
-    expect(reason.value.length).toBeGreaterThanOrEqual(10);
-  });
-
-  it("manual submit opens the confirm dialog, then posts manual fields", async () => {
-    render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
-    fireEvent.click(screen.getByRole("switch", { name: /nhập học phí thủ công/i }));
-    fireEvent.change(screen.getByLabelText(/mức học phí/i), {
-      target: { value: "9000000" },
+    fireEvent.click(screen.getByRole("switch", { name: /đóng trước theo đợt/i }));
+    fireEvent.change(screen.getByLabelText(/số đóng đợt đầu/i), {
+      target: { value: "2000000" },
     });
-    fireEvent.change(screen.getByLabelText(/lý do nhập tay/i), {
-      target: { value: "Hoc bong dac biet theo quyet dinh" },
+    fireEvent.change(screen.getByLabelText(/hạn đợt đầu/i), {
+      target: { value: "2026-09-01" },
+    });
+    fireEvent.change(screen.getByLabelText(/hạn phần còn lại/i), {
+      target: { value: "2026-11-01" },
     });
 
-    // First click only opens the confirm dialog — no mutation yet (#3).
     fireEvent.click(screen.getByRole("button", { name: /^tính học phí$/i }));
-    expect(mutateAsync).not.toHaveBeenCalled();
-    expect(
-      screen.getByText(/xác nhận nhập học phí thủ công/i)
-    ).toBeInTheDocument();
-
-    // Confirm → mutation fires with the manual fields.
-    fireEvent.click(screen.getByRole("button", { name: /xác nhận tạo/i }));
     await waitFor(() => {
       expect(mutateAsync).toHaveBeenCalledWith({
         admission_profile_id: 42,
         fee_type: "tuition",
         semester_no: 1,
-        installment_plan_code: "FULL",
-        manual_base_amount: "9000000",
-        manual_reason: "Hoc bong dac biet theo quyet dinh",
+        collection_schedule_mode: "down_payment",
+        down_payment: "2000000",
+        down_payment_due: "2026-09-01",
+        remainder_due: "2026-11-01",
       });
     });
   });
 
-  it("does NOT include manual fields when the toggle stays off", async () => {
+  it("posts installment_plan_code (no schedule fields) when toggle stays off", async () => {
     render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
     fireEvent.click(screen.getByRole("button", { name: /^tính học phí$/i }));
     await waitFor(() => {

--- a/frontend/src/components/admissions/CalculateFeeDialog.test.tsx
+++ b/frontend/src/components/admissions/CalculateFeeDialog.test.tsx
@@ -22,6 +22,18 @@ vi.mock("@/hooks/finance/useFees", async () => {
   return {
     ...actual,
     useCalculateFee: () => ({ mutateAsync, isPending: false }),
+    // Manual override add-on (#2) — stub giá chuẩn so the preview block renders
+    // deterministically without a network call when the toggle is on.
+    useTuitionPreview: () => ({
+      data: {
+        base_amount: "5000000",
+        total_discount: "0",
+        final_amount: "5000000",
+        semester_no: 1,
+      },
+      isLoading: false,
+      isError: false,
+    }),
   };
 });
 
@@ -77,5 +89,87 @@ describe("CalculateFeeDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: /hủy/i }));
     expect(mutateAsync).not.toHaveBeenCalled();
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ---- Manual tuition override (2026-06-28) ----
+
+  it("manual toggle reveals amount + reason inputs", () => {
+    render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
+    // Hidden by default.
+    expect(screen.queryByLabelText(/mức học phí/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("switch", { name: /nhập học phí thủ công/i }));
+    expect(screen.getByLabelText(/mức học phí/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/lý do nhập tay/i)).toBeInTheDocument();
+  });
+
+  it("submit is blocked until a manual amount + reason ≥10 chars are present", () => {
+    render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
+    fireEvent.click(screen.getByRole("switch", { name: /nhập học phí thủ công/i }));
+
+    const submit = screen.getByRole("button", { name: /^tính học phí$/i });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/mức học phí/i), {
+      target: { value: "9000000" },
+    });
+    // Reason still empty → blocked.
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/lý do nhập tay/i), {
+      target: { value: "Hoc bong dac biet theo quyet dinh" },
+    });
+    expect(submit).toBeEnabled();
+  });
+
+  it("reason chip sets a ≥10-char reason value", () => {
+    render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
+    fireEvent.click(screen.getByRole("switch", { name: /nhập học phí thủ công/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^học bổng$/i }));
+    const reason = screen.getByLabelText(/lý do nhập tay/i) as HTMLTextAreaElement;
+    expect(reason.value.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("manual submit opens the confirm dialog, then posts manual fields", async () => {
+    render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
+    fireEvent.click(screen.getByRole("switch", { name: /nhập học phí thủ công/i }));
+    fireEvent.change(screen.getByLabelText(/mức học phí/i), {
+      target: { value: "9000000" },
+    });
+    fireEvent.change(screen.getByLabelText(/lý do nhập tay/i), {
+      target: { value: "Hoc bong dac biet theo quyet dinh" },
+    });
+
+    // First click only opens the confirm dialog — no mutation yet (#3).
+    fireEvent.click(screen.getByRole("button", { name: /^tính học phí$/i }));
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/xác nhận nhập học phí thủ công/i)
+    ).toBeInTheDocument();
+
+    // Confirm → mutation fires with the manual fields.
+    fireEvent.click(screen.getByRole("button", { name: /xác nhận tạo/i }));
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        admission_profile_id: 42,
+        fee_type: "tuition",
+        semester_no: 1,
+        installment_plan_code: "FULL",
+        manual_base_amount: "9000000",
+        manual_reason: "Hoc bong dac biet theo quyet dinh",
+      });
+    });
+  });
+
+  it("does NOT include manual fields when the toggle stays off", async () => {
+    render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
+    fireEvent.click(screen.getByRole("button", { name: /^tính học phí$/i }));
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        admission_profile_id: 42,
+        fee_type: "tuition",
+        semester_no: 1,
+        installment_plan_code: "FULL",
+      });
+    });
   });
 });

--- a/frontend/src/components/admissions/CalculateFeeDialog.tsx
+++ b/frontend/src/components/admissions/CalculateFeeDialog.tsx
@@ -18,6 +18,14 @@
  *    single-payment invoice.
  *  - Form schema no longer uses z.coerce + default() defaults so the
  *    RHF<Values> generic resolves cleanly under strict tsc.
+ *
+ * Manual tuition override (2026-06-28):
+ *  - Khi loại phí là HỌC PHÍ, accountant/officer có thể bật toggle "Nhập
+ *    học phí thủ công" để đặt mức học phí đặc biệt (học bổng / chuyển
+ *    trường / theo quyết định). Số gõ là BASE (TRƯỚC giảm giá): backend
+ *    VẪN áp discount hiện hành → invoice khớp final (≠ số gõ nếu có giảm).
+ *  - Add-on: (1) toggle, (2) hiện giá chuẩn + chênh lệch + dự kiến phải
+ *    thu (useTuitionPreview), (3) dialog xác nhận tóm tắt, (4) chip lý do.
  */
 import { useMemo, useState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
@@ -32,7 +40,21 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
+import { CurrencyInput } from "@/components/ui/currency-input"
 import {
   Select,
   SelectContent,
@@ -41,10 +63,11 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 
-import { useCalculateFee, feesKeys } from "@/hooks/finance/useFees"
+import { useCalculateFee, useTuitionPreview, feesKeys } from "@/hooks/finance/useFees"
 import { useInstallmentPlans } from "@/hooks/finance/useInstallmentPlans"
 import { admissionsKeys } from "@/hooks/admissions/useAdmissions"
 import { financeDashboardKeys } from "@/hooks/finance/useFinanceDashboard"
+import { formatVND } from "@/lib/zod/finance"
 
 type FeeType = "tuition" | "application" | "dormitory" | "other"
 
@@ -62,6 +85,18 @@ const SEMESTER_OPTIONS = [
   { value: 3, label: "Học kỳ 3+" },
 ]
 
+const MANUAL_REASON_MIN = 10
+const MANUAL_REASON_MAX = 500
+
+// (#4) Chip lý do mẫu — label ngắn để bấm nhanh, value đầy đủ (≥10 ký tự để
+// thỏa ràng buộc reason) set vào ô lý do.
+const REASON_CHIPS: { label: string; value: string }[] = [
+  { label: "Học bổng", value: "Học bổng theo quyết định của nhà trường" },
+  { label: "Chuyển trường", value: "Điều chỉnh học phí do chuyển trường" },
+  { label: "Theo quyết định", value: "Áp dụng học phí theo quyết định riêng" },
+  { label: "Điều chỉnh khác", value: "Điều chỉnh học phí trường hợp đặc biệt" },
+]
+
 export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }: Props) {
   const queryClient = useQueryClient()
   const calculateFee = useCalculateFee()
@@ -72,6 +107,12 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
   const [feeType, setFeeType] = useState<FeeType>("tuition")
   const [semesterNo, setSemesterNo] = useState<number>(1)
   const [planCode, setPlanCode] = useState<string>("")
+
+  // Manual tuition override state.
+  const [manualMode, setManualMode] = useState<boolean>(false)
+  const [manualAmount, setManualAmount] = useState<number | null>(null)
+  const [manualReason, setManualReason] = useState<string>("")
+  const [confirmOpen, setConfirmOpen] = useState<boolean>(false)
 
   const activePlans = useMemo(
     () => (plansQuery.data ?? []).filter((p) => p.is_active !== false),
@@ -91,17 +132,51 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
   }, [planCode, activePlans])
 
   const isTuition = feeType === "tuition"
+  const isManual = isTuition && manualMode
   const isPending = calculateFee.isPending
-  const canSubmit = effectivePlanCode !== "" && !isPending && activePlans.length > 0
+
+  // (#2) Giá chuẩn — chỉ fetch khi bật nhập tay (read-only preview). Refetch
+  // khi đổi học kỳ (semesterNo nằm trong queryKey của hook).
+  const preview = useTuitionPreview(profileId, semesterNo, {
+    enabled: open && isManual && !!profileId,
+  })
+
+  const reasonLen = manualReason.trim().length
+  const manualValid =
+    !!manualAmount && manualAmount > 0 && reasonLen >= MANUAL_REASON_MIN && reasonLen <= MANUAL_REASON_MAX
+
+  const canSubmit =
+    effectivePlanCode !== "" &&
+    !isPending &&
+    activePlans.length > 0 &&
+    (!isManual || manualValid)
+
+  // Dẫn xuất hiển thị cho (#2)/(#3). Tất cả là NULL khi chưa có giá chuẩn
+  // (preview đang tải / lỗi vì ngành chưa xác định) → KHÔNG hiện số 0 gây hiểu
+  // nhầm "không giảm giá". "Ước tính phải thu" = số gõ − giảm giá hiện hành; backend
+  // là nguồn sự thật CUỐI — với discount %, backend tính lại trên SỐ GÕ nên ước
+  // tính có thể lệch hóa đơn. Vì vậy nhãn ghi rõ "ước tính" + không khẳng định.
+  const canonicalBase = preview.data ? Number(preview.data.base_amount) : null
+  const currentDiscount = preview.data ? Number(preview.data.total_discount) : null
+  const diffFromCanonical =
+    manualAmount != null && canonicalBase != null ? manualAmount - canonicalBase : null
+  const estimatedPayable =
+    manualAmount != null && currentDiscount != null
+      ? Math.max(0, manualAmount - currentDiscount)
+      : null
 
   const reset = () => {
     setFeeType("tuition")
     setSemesterNo(1)
     setPlanCode("")
+    setManualMode(false)
+    setManualAmount(null)
+    setManualReason("")
+    setConfirmOpen(false)
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  /** Thực thi mutate + invalidate cache + đóng dialog (sau khi đã xác nhận). */
+  const doSubmit = async () => {
     if (!canSubmit) return
 
     await calculateFee.mutateAsync({
@@ -111,6 +186,10 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
       // for non-tuition fee types, so omit entirely when switching away.
       semester_no: isTuition ? semesterNo : undefined,
       installment_plan_code: effectivePlanCode,
+      // Manual override chỉ gửi khi toggle bật (và là tuition). Decimal-as-string.
+      ...(isManual && manualAmount != null
+        ? { manual_base_amount: String(manualAmount), manual_reason: manualReason.trim() }
+        : {}),
     })
 
     // useCalculateFee already invalidates finance caches + toasts on
@@ -132,109 +211,327 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
     onOpenChange(false)
   }
 
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    // (#3) Khi nhập tay → mở dialog xác nhận tóm tắt trước khi tạo. Luồng cũ
+    // (không nhập tay) submit thẳng.
+    if (isManual) {
+      setConfirmOpen(true)
+      return
+    }
+    await doSubmit()
+  }
+
   return (
-    <Dialog open={open} onOpenChange={(next) => (isPending ? null : onOpenChange(next))}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Calculator className="h-5 w-5 text-primary" />
-            Tính học phí
-          </DialogTitle>
-          <DialogDescription>
-            Tạo bản ghi học phí chính thức cho hồ sơ. Hệ thống sẽ tự tạo
-            hóa đơn theo kế hoạch thanh toán đã chọn.
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={(next) => (isPending ? null : onOpenChange(next))}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Calculator className="h-5 w-5 text-primary" />
+              Tính học phí
+            </DialogTitle>
+            <DialogDescription>
+              Tạo bản ghi học phí chính thức cho hồ sơ. Hệ thống sẽ tự tạo
+              hóa đơn theo kế hoạch thanh toán đã chọn.
+            </DialogDescription>
+          </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4 py-2">
-          <div className="space-y-2">
-            <Label htmlFor="fee_type">Loại phí</Label>
-            <Select
-              value={feeType}
-              onValueChange={(v) => setFeeType(v as FeeType)}
-              disabled={isPending}
-            >
-              <SelectTrigger id="fee_type">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="tuition">Học phí</SelectItem>
-                <SelectItem value="application">Lệ phí xét tuyển</SelectItem>
-                <SelectItem value="dormitory">Phí ký túc xá</SelectItem>
-                <SelectItem value="other">Khác</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          {isTuition && (
+          <form onSubmit={handleSubmit} className="space-y-4 py-2">
             <div className="space-y-2">
-              <Label htmlFor="semester_no">Học kỳ</Label>
+              <Label htmlFor="fee_type">Loại phí</Label>
               <Select
-                value={String(semesterNo)}
-                onValueChange={(v) => setSemesterNo(parseInt(v, 10))}
+                value={feeType}
+                onValueChange={(v) => setFeeType(v as FeeType)}
                 disabled={isPending}
               >
-                <SelectTrigger id="semester_no">
+                <SelectTrigger id="fee_type">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {SEMESTER_OPTIONS.map((opt) => (
-                    <SelectItem key={opt.value} value={String(opt.value)}>
-                      {opt.label}
+                  <SelectItem value="tuition">Học phí</SelectItem>
+                  <SelectItem value="application">Lệ phí xét tuyển</SelectItem>
+                  <SelectItem value="dormitory">Phí ký túc xá</SelectItem>
+                  <SelectItem value="other">Khác</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {isTuition && (
+              <div className="space-y-2">
+                <Label htmlFor="semester_no">Học kỳ</Label>
+                <Select
+                  value={String(semesterNo)}
+                  onValueChange={(v) => setSemesterNo(parseInt(v, 10))}
+                  disabled={isPending}
+                >
+                  <SelectTrigger id="semester_no">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SEMESTER_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={String(opt.value)}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {/* (#1) Toggle nhập học phí thủ công — chỉ cho học phí. */}
+            {isTuition && (
+              <div className="rounded-lg border p-3 space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="manual_mode" className="cursor-pointer">
+                      Nhập học phí thủ công
+                    </Label>
+                    <p className="text-muted-foreground text-xs">
+                      Đặt mức học phí đặc biệt (học bổng / chuyển trường / theo quyết định).
+                    </p>
+                  </div>
+                  <Switch
+                    id="manual_mode"
+                    checked={manualMode}
+                    onCheckedChange={setManualMode}
+                    disabled={isPending}
+                  />
+                </div>
+
+                {isManual && (
+                  <div className="space-y-3 pt-1">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="manual_amount">
+                        Mức học phí (trước giảm giá){" "}
+                        <span className="text-destructive">*</span>
+                      </Label>
+                      <CurrencyInput
+                        id="manual_amount"
+                        value={manualAmount}
+                        onChange={setManualAmount}
+                        placeholder="Nhập mức học phí…"
+                        disabled={isPending}
+                      />
+
+                      {/* (#2) Giá chuẩn + chênh lệch + dự kiến phải thu. */}
+                      <div className="text-xs space-y-1 pt-1">
+                        {preview.isLoading && (
+                          <p className="text-muted-foreground">Đang tải giá chuẩn…</p>
+                        )}
+                        {preview.isError && (
+                          <p className="text-destructive">
+                            Không tải được giá chuẩn (hồ sơ có thể chưa xác định ngành).
+                          </p>
+                        )}
+                        {preview.data && (
+                          <>
+                            <div className="flex items-center justify-between">
+                              <span className="text-muted-foreground">Giá chuẩn (base):</span>
+                              <span className="font-medium">
+                                {formatVND(preview.data.base_amount)}
+                              </span>
+                            </div>
+                            {diffFromCanonical != null && diffFromCanonical !== 0 && (
+                              <div className="flex items-center justify-between">
+                                <span className="text-muted-foreground">Chênh lệch:</span>
+                                <Badge
+                                  variant={diffFromCanonical > 0 ? "destructive" : "secondary"}
+                                  className="font-normal"
+                                >
+                                  {diffFromCanonical > 0 ? "+" : "−"}
+                                  {formatVND(Math.abs(diffFromCanonical))}
+                                </Badge>
+                              </div>
+                            )}
+                            <div className="flex items-center justify-between">
+                              <span className="text-muted-foreground">
+                                Giảm giá (theo giá chuẩn):
+                              </span>
+                              <span className="font-medium">
+                                {formatVND(preview.data.total_discount)}
+                              </span>
+                            </div>
+                            {estimatedPayable != null && (
+                              <div className="flex items-center justify-between border-t pt-1">
+                                <span className="text-muted-foreground">
+                                  Ước tính phải thu:
+                                </span>
+                                <span className="font-semibold text-primary">
+                                  {formatVND(estimatedPayable)}
+                                </span>
+                              </div>
+                            )}
+                            {Number(preview.data.total_discount) > 0 && (
+                              <p className="text-muted-foreground pt-0.5">
+                                Số phải thu chính xác do hệ thống tính lại theo
+                                chính sách giảm giá khi tạo.
+                              </p>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="space-y-1.5">
+                      <Label htmlFor="manual_reason">
+                        Lý do nhập tay <span className="text-destructive">*</span>
+                      </Label>
+                      {/* (#4) Chip lý do mẫu. */}
+                      <div className="flex flex-wrap gap-1.5">
+                        {REASON_CHIPS.map((chip) => (
+                          <Button
+                            key={chip.label}
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="h-7 text-xs"
+                            disabled={isPending}
+                            onClick={() => setManualReason(chip.value)}
+                          >
+                            {chip.label}
+                          </Button>
+                        ))}
+                      </div>
+                      <Textarea
+                        id="manual_reason"
+                        value={manualReason}
+                        onChange={(e) => setManualReason(e.target.value)}
+                        placeholder="Ví dụ: Học bổng theo quyết định số…"
+                        rows={2}
+                        maxLength={MANUAL_REASON_MAX}
+                        disabled={isPending}
+                        className="resize-none"
+                      />
+                      <p
+                        className={
+                          reasonLen > 0 && reasonLen < MANUAL_REASON_MIN
+                            ? "text-destructive text-xs"
+                            : "text-muted-foreground text-xs"
+                        }
+                      >
+                        Tối thiểu {MANUAL_REASON_MIN} ký tự, tối đa {MANUAL_REASON_MAX} ({reasonLen}).
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="installment_plan_code">Kế hoạch thanh toán</Label>
+              <Select
+                value={effectivePlanCode}
+                onValueChange={setPlanCode}
+                disabled={isPending || plansQuery.isLoading || activePlans.length === 0}
+              >
+                <SelectTrigger id="installment_plan_code">
+                  <SelectValue
+                    placeholder={
+                      plansQuery.isLoading
+                        ? "Đang tải kế hoạch…"
+                        : activePlans.length === 0
+                        ? "Chưa có kế hoạch nào"
+                        : "Chọn kế hoạch"
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {activePlans.map((plan) => (
+                    <SelectItem key={plan.code} value={plan.code}>
+                      {plan.name}
+                      <span className="text-muted-foreground ml-2 text-xs">
+                        ({plan.code})
+                      </span>
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
             </div>
-          )}
 
-          <div className="space-y-2">
-            <Label htmlFor="installment_plan_code">Kế hoạch thanh toán</Label>
-            <Select
-              value={effectivePlanCode}
-              onValueChange={setPlanCode}
-              disabled={isPending || plansQuery.isLoading || activePlans.length === 0}
-            >
-              <SelectTrigger id="installment_plan_code">
-                <SelectValue
-                  placeholder={
-                    plansQuery.isLoading
-                      ? "Đang tải kế hoạch…"
-                      : activePlans.length === 0
-                      ? "Chưa có kế hoạch nào"
-                      : "Chọn kế hoạch"
-                  }
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {activePlans.map((plan) => (
-                  <SelectItem key={plan.code} value={plan.code}>
-                    {plan.name}
-                    <span className="text-muted-foreground ml-2 text-xs">
-                      ({plan.code})
-                    </span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+              >
+                Hủy
+              </Button>
+              <Button type="submit" disabled={!canSubmit}>
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Tính học phí
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* (#3) Dialog xác nhận nhập tay — tóm tắt 3 dòng trước khi tạo. */}
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Xác nhận nhập học phí thủ công</AlertDialogTitle>
+            <AlertDialogDescription>
+              Kiểm tra lại trước khi tạo bản ghi học phí. Hệ thống sẽ tính
+              <strong> số phải thu chính xác</strong> theo chính sách giảm giá
+              hiện hành khi tạo — số dưới đây là <strong>ước tính</strong>.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="rounded-lg border p-3 text-sm space-y-1.5">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Số gõ (base):</span>
+              <span className="font-medium">
+                {manualAmount != null ? formatVND(manualAmount) : "—"}
+              </span>
+            </div>
+            {/* Ước tính giảm giá/phải thu CHỈ hiện khi đã có giá chuẩn — tránh
+                hiện "0 ₫" gây hiểu nhầm khi preview chưa tải / lỗi. */}
+            {currentDiscount != null ? (
+              <>
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Giảm giá (theo giá chuẩn):</span>
+                  <span className="font-medium">{formatVND(currentDiscount)}</span>
+                </div>
+                <div className="flex items-center justify-between border-t pt-1.5">
+                  <span className="text-muted-foreground">Ước tính phải thu:</span>
+                  <span className="font-semibold text-primary">
+                    {estimatedPayable != null ? formatVND(estimatedPayable) : "—"}
+                  </span>
+                </div>
+              </>
+            ) : (
+              <div className="border-t pt-1.5 text-muted-foreground text-xs">
+                Chưa tải được giá chuẩn — hệ thống sẽ tính số phải thu (theo giảm
+                giá hiện hành) khi tạo.
+              </div>
+            )}
+            <div className="border-t pt-1.5">
+              <span className="text-muted-foreground">Lý do: </span>
+              <span className="break-words">{manualReason.trim()}</span>
+            </div>
           </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Quay lại</AlertDialogCancel>
+            <AlertDialogAction
               disabled={isPending}
+              onClick={(e) => {
+                // Đóng AlertDialog (mặc định) rồi submit. doSubmit tự đóng dialog
+                // chính khi thành công; lỗi → toast + giữ nguyên giá trị đã nhập.
+                e.preventDefault()
+                setConfirmOpen(false)
+                void doSubmit()
+              }}
             >
-              Hủy
-            </Button>
-            <Button type="submit" disabled={!canSubmit}>
               {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Tính học phí
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+              Xác nhận tạo
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }

--- a/frontend/src/components/admissions/CalculateFeeDialog.tsx
+++ b/frontend/src/components/admissions/CalculateFeeDialog.tsx
@@ -12,20 +12,15 @@
  * PR #7 review (2026-04-24):
  *  - Installment plan codes now come from `useInstallmentPlans` rather
  *    than a hard-coded list. Backend seed currently ships FULL /
- *    TWO_TERM / QUARTERLY; the dialog no longer guesses codes that
- *    might not exist. Backend also now rejects unknown codes with 400
- *    so a drift gets surfaced instead of silently creating a
- *    single-payment invoice.
- *  - Form schema no longer uses z.coerce + default() defaults so the
- *    RHF<Values> generic resolves cleanly under strict tsc.
+ *    TWO_TERM / QUARTERLY; the dialog no longer guesses codes.
  *
- * Manual tuition override (2026-06-28):
- *  - Khi loại phí là HỌC PHÍ, accountant/officer có thể bật toggle "Nhập
- *    học phí thủ công" để đặt mức học phí đặc biệt (học bổng / chuyển
- *    trường / theo quyết định). Số gõ là BASE (TRƯỚC giảm giá): backend
- *    VẪN áp discount hiện hành → invoice khớp final (≠ số gõ nếu có giảm).
- *  - Add-on: (1) toggle, (2) hiện giá chuẩn + chênh lệch + dự kiến phải
- *    thu (useTuitionPreview), (3) dialog xác nhận tóm tắt, (4) chip lý do.
+ * Lịch thu "đóng trước" (Pha 1, 2026-06-29):
+ *  - Khi loại phí là HỌC PHÍ, có thể bật "Đóng trước theo đợt" để chia
+ *    số phải thu thành ĐỢT ĐẦU + PHẦN CÒN LẠI (2 hóa đơn). NGHĨA VỤ
+ *    (tổng học phí) KHÔNG đổi — chỉ giãn lịch thu; phần còn lại thành
+ *    công nợ có hạn. Khác hẳn "giảm học phí" (sẽ làm ở pha sau).
+ *  - useTuitionPreview hiển tổng phải thu (final) để chia + kiểm số
+ *    đóng trước < tổng trước khi gửi.
  */
 import { useMemo, useState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
@@ -40,20 +35,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
-import { Textarea } from "@/components/ui/textarea"
-import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
 import { CurrencyInput } from "@/components/ui/currency-input"
 import {
   Select,
@@ -85,46 +69,28 @@ const SEMESTER_OPTIONS = [
   { value: 3, label: "Học kỳ 3+" },
 ]
 
-const MANUAL_REASON_MIN = 10
-const MANUAL_REASON_MAX = 500
-
-// (#4) Chip lý do mẫu — label ngắn để bấm nhanh, value đầy đủ (≥10 ký tự để
-// thỏa ràng buộc reason) set vào ô lý do.
-const REASON_CHIPS: { label: string; value: string }[] = [
-  { label: "Học bổng", value: "Học bổng theo quyết định của nhà trường" },
-  { label: "Tạm thu", value: "Tạm thu học phí nhập học" },
-  { label: "Theo quyết định", value: "Áp dụng học phí theo quyết định riêng" },
-  { label: "Điều chỉnh khác", value: "Điều chỉnh học phí trường hợp đặc biệt" },
-]
-
 export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }: Props) {
   const queryClient = useQueryClient()
   const calculateFee = useCalculateFee()
   const plansQuery = useInstallmentPlans({ enabled: open })
 
-  // Local state — simpler than RHF for 3 controlled selects and avoids
-  // the strict-tsc friction with zod `z.coerce` + `.default()` generics.
+  // Local state — simpler than RHF for a few controlled inputs.
   const [feeType, setFeeType] = useState<FeeType>("tuition")
   const [semesterNo, setSemesterNo] = useState<number>(1)
   const [planCode, setPlanCode] = useState<string>("")
 
-  // Manual tuition override state.
-  const [manualMode, setManualMode] = useState<boolean>(false)
-  const [manualAmount, setManualAmount] = useState<number | null>(null)
-  const [manualReason, setManualReason] = useState<string>("")
-  const [confirmOpen, setConfirmOpen] = useState<boolean>(false)
+  // Lịch thu "đóng trước" — giãn lịch, KHÔNG đổi tổng học phí.
+  const [downPaymentMode, setDownPaymentMode] = useState<boolean>(false)
+  const [downPayment, setDownPayment] = useState<number | null>(null)
+  const [downPaymentDue, setDownPaymentDue] = useState<string>("")
+  const [remainderDue, setRemainderDue] = useState<string>("")
 
   const activePlans = useMemo(
     () => (plansQuery.data ?? []).filter((p) => p.is_active !== false),
     [plansQuery.data]
   )
 
-  // Derived default (no useEffect — avoids react-hooks/incompatible-library
-  // setState-in-effect lint error). When user hasn't explicitly picked,
-  // prefer FULL (matches backend FeeCalculateRequest.installment_plan_code
-  // default), otherwise the first active option. setPlanCode only fires on
-  // explicit user choice, so derived value flips back to default if the
-  // plan list reloads after a reset.
+  // Derived default plan (no useEffect). Prefer FULL, else first active.
   const effectivePlanCode = useMemo(() => {
     if (planCode) return planCode
     if (activePlans.length === 0) return ""
@@ -132,72 +98,72 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
   }, [planCode, activePlans])
 
   const isTuition = feeType === "tuition"
-  const isManual = isTuition && manualMode
+  const isDownPayment = isTuition && downPaymentMode
   const isPending = calculateFee.isPending
 
-  // (#2) Giá chuẩn — chỉ fetch khi bật nhập tay (read-only preview). Refetch
-  // khi đổi học kỳ (semesterNo nằm trong queryKey của hook).
+  // Giá chuẩn — chỉ fetch khi bật "đóng trước" để hiển tổng phải thu + chia đợt.
   const preview = useTuitionPreview(profileId, semesterNo, {
-    enabled: open && isManual && !!profileId,
+    enabled: open && isDownPayment && !!profileId,
   })
 
-  const reasonLen = manualReason.trim().length
-  const manualValid =
-    !!manualAmount && manualAmount > 0 && reasonLen >= MANUAL_REASON_MIN && reasonLen <= MANUAL_REASON_MAX
+  // Tổng PHẢI THU (final) — lịch thu chia con số này (Σ hóa đơn = final − waived;
+  // waived=0 lúc tạo). NULL khi preview chưa tải / lỗi (ngành chưa xác định).
+  const finalAmount = preview.data ? Number(preview.data.final_amount) : null
+  const remainder =
+    finalAmount != null && downPayment != null ? finalAmount - downPayment : null
+
+  // Hợp lệ khi: có số đóng trước > 0, có cả 2 hạn, hạn đợt 2 >= đợt 1, VÀ đã biết
+  // tổng phải thu (preview.data) với số đóng trước < tổng. Bắt buộc có giá chuẩn:
+  // chia "đóng trước" cần biết tổng để tính phần còn lại — nếu preview đang tải /
+  // lỗi (ngành chưa xác định), chặn submit thay vì để backend từ chối (400).
+  const downPaymentValid =
+    downPayment != null &&
+    downPayment > 0 &&
+    !!downPaymentDue &&
+    !!remainderDue &&
+    remainderDue >= downPaymentDue &&
+    finalAmount != null &&
+    downPayment < finalAmount
 
   const canSubmit =
-    effectivePlanCode !== "" &&
     !isPending &&
-    activePlans.length > 0 &&
-    (!isManual || manualValid)
-
-  // Dẫn xuất hiển thị cho (#2)/(#3). Tất cả là NULL khi chưa có giá chuẩn
-  // (preview đang tải / lỗi vì ngành chưa xác định) → KHÔNG hiện số 0 gây hiểu
-  // nhầm "không giảm giá". "Ước tính phải thu" = số gõ − giảm giá hiện hành; backend
-  // là nguồn sự thật CUỐI — với discount %, backend tính lại trên SỐ GÕ nên ước
-  // tính có thể lệch hóa đơn. Vì vậy nhãn ghi rõ "ước tính" + không khẳng định.
-  const canonicalBase = preview.data ? Number(preview.data.base_amount) : null
-  const currentDiscount = preview.data ? Number(preview.data.total_discount) : null
-  const diffFromCanonical =
-    manualAmount != null && canonicalBase != null ? manualAmount - canonicalBase : null
-  const estimatedPayable =
-    manualAmount != null && currentDiscount != null
-      ? Math.max(0, manualAmount - currentDiscount)
-      : null
+    (isDownPayment
+      ? downPaymentValid
+      : effectivePlanCode !== "" && activePlans.length > 0)
 
   const reset = () => {
     setFeeType("tuition")
     setSemesterNo(1)
     setPlanCode("")
-    setManualMode(false)
-    setManualAmount(null)
-    setManualReason("")
-    setConfirmOpen(false)
+    setDownPaymentMode(false)
+    setDownPayment(null)
+    setDownPaymentDue("")
+    setRemainderDue("")
   }
 
-  /** Thực thi mutate + invalidate cache + đóng dialog (sau khi đã xác nhận). */
-  const doSubmit = async () => {
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
     if (!canSubmit) return
 
     await calculateFee.mutateAsync({
       admission_profile_id: profileId,
       fee_type: feeType,
-      // Only tuition carries semester_no; backend validator rejects it
-      // for non-tuition fee types, so omit entirely when switching away.
+      // Only tuition carries semester_no; backend rejects it for non-tuition.
       semester_no: isTuition ? semesterNo : undefined,
-      installment_plan_code: effectivePlanCode,
-      // Manual override chỉ gửi khi toggle bật (và là tuition). Decimal-as-string.
-      ...(isManual && manualAmount != null
-        ? { manual_base_amount: String(manualAmount), manual_reason: manualReason.trim() }
-        : {}),
+      // Lịch thu "đóng trước" GIỮ tổng học phí — chỉ chia 2 đợt; KHÔNG gửi
+      // installment_plan_code (backend bỏ plan ở mode này). Ngược lại gửi plan.
+      ...(isDownPayment && downPayment != null
+        ? {
+            collection_schedule_mode: "down_payment" as const,
+            down_payment: String(downPayment),
+            down_payment_due: downPaymentDue,
+            remainder_due: remainderDue,
+          }
+        : { installment_plan_code: effectivePlanCode }),
     })
 
-    // useCalculateFee already invalidates finance caches + toasts on
-    // success. Extend to the admission caches + dashboard so the
-    // Tuition tab refreshes without a reload. Use admissionsKeys.all
-    // (root) so status-counts + stats refetch alongside list/detail —
-    // calculating a fee flips the row's payment-status tab, so the
-    // tab badges on /admissions need to update too.
+    // useCalculateFee already invalidates finance caches + toasts on success.
+    // Extend to admission caches + dashboard so the Tuition tab refreshes.
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: admissionsKeys.all }),
       queryClient.invalidateQueries({ queryKey: feesKeys.lists() }),
@@ -211,214 +177,182 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
     onOpenChange(false)
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!canSubmit) return
-    // (#3) Khi nhập tay → mở dialog xác nhận tóm tắt trước khi tạo. Luồng cũ
-    // (không nhập tay) submit thẳng.
-    if (isManual) {
-      setConfirmOpen(true)
-      return
-    }
-    await doSubmit()
-  }
-
   return (
-    <>
-      <Dialog open={open} onOpenChange={(next) => (isPending ? null : onOpenChange(next))}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Calculator className="h-5 w-5 text-primary" />
-              Tính học phí
-            </DialogTitle>
-            <DialogDescription>
-              Tạo bản ghi học phí chính thức cho hồ sơ. Hệ thống sẽ tự tạo
-              hóa đơn theo kế hoạch thanh toán đã chọn.
-            </DialogDescription>
-          </DialogHeader>
+    <Dialog open={open} onOpenChange={(next) => (isPending ? null : onOpenChange(next))}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Calculator className="h-5 w-5 text-primary" />
+            Tính học phí
+          </DialogTitle>
+          <DialogDescription>
+            Tạo bản ghi học phí chính thức cho hồ sơ. Hệ thống sẽ tự tạo
+            hóa đơn theo kế hoạch thanh toán đã chọn.
+          </DialogDescription>
+        </DialogHeader>
 
-          <form onSubmit={handleSubmit} className="space-y-4 py-2">
+        <form onSubmit={handleSubmit} className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="fee_type">Loại phí</Label>
+            <Select
+              value={feeType}
+              onValueChange={(v) => {
+                const next = v as FeeType
+                setFeeType(next)
+                // Lịch "đóng trước" chỉ cho tuition → đổi sang loại phí khác thì
+                // tắt + xóa luôn để toggle không kẹt "bật" khi quay lại tuition.
+                if (next !== "tuition") {
+                  setDownPaymentMode(false)
+                  setDownPayment(null)
+                  setDownPaymentDue("")
+                  setRemainderDue("")
+                }
+              }}
+              disabled={isPending}
+            >
+              <SelectTrigger id="fee_type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="tuition">Học phí</SelectItem>
+                <SelectItem value="application">Lệ phí xét tuyển</SelectItem>
+                <SelectItem value="dormitory">Phí ký túc xá</SelectItem>
+                <SelectItem value="other">Khác</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {isTuition && (
             <div className="space-y-2">
-              <Label htmlFor="fee_type">Loại phí</Label>
+              <Label htmlFor="semester_no">Học kỳ</Label>
               <Select
-                value={feeType}
-                onValueChange={(v) => setFeeType(v as FeeType)}
+                value={String(semesterNo)}
+                onValueChange={(v) => setSemesterNo(parseInt(v, 10))}
                 disabled={isPending}
               >
-                <SelectTrigger id="fee_type">
+                <SelectTrigger id="semester_no">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="tuition">Học phí</SelectItem>
-                  <SelectItem value="application">Lệ phí xét tuyển</SelectItem>
-                  <SelectItem value="dormitory">Phí ký túc xá</SelectItem>
-                  <SelectItem value="other">Khác</SelectItem>
+                  {SEMESTER_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={String(opt.value)}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
+          )}
 
-            {isTuition && (
-              <div className="space-y-2">
-                <Label htmlFor="semester_no">Học kỳ</Label>
-                <Select
-                  value={String(semesterNo)}
-                  onValueChange={(v) => setSemesterNo(parseInt(v, 10))}
-                  disabled={isPending}
-                >
-                  <SelectTrigger id="semester_no">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {SEMESTER_OPTIONS.map((opt) => (
-                      <SelectItem key={opt.value} value={String(opt.value)}>
-                        {opt.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-
-            {/* (#1) Toggle nhập học phí thủ công — chỉ cho học phí. */}
-            {isTuition && (
-              <div className="rounded-lg border p-3 space-y-3">
-                <div className="flex items-center justify-between">
-                  <div className="space-y-0.5">
-                    <Label htmlFor="manual_mode" className="cursor-pointer">
-                      Nhập học phí thủ công
-                    </Label>
-                    <p className="text-muted-foreground text-xs">
-                      Đặt mức học phí đặc biệt (học bổng / chuyển trường / theo quyết định).
-                    </p>
-                  </div>
-                  <Switch
-                    id="manual_mode"
-                    checked={manualMode}
-                    onCheckedChange={setManualMode}
-                    disabled={isPending}
-                  />
+          {/* Toggle "đóng trước theo đợt" — chỉ cho học phí. */}
+          {isTuition && (
+            <div className="rounded-lg border p-3 space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="down_payment_mode" className="cursor-pointer">
+                    Đóng trước theo đợt
+                  </Label>
+                  <p className="text-muted-foreground text-xs">
+                    Chia số phải thu thành đợt đầu + phần còn lại (giữ nguyên tổng
+                    học phí). Phần còn lại thành công nợ có hạn.
+                  </p>
                 </div>
+                <Switch
+                  id="down_payment_mode"
+                  checked={downPaymentMode}
+                  onCheckedChange={setDownPaymentMode}
+                  disabled={isPending}
+                />
+              </div>
 
-                {isManual && (
-                  <div className="space-y-3 pt-1">
-                    <div className="space-y-1.5">
-                      <Label htmlFor="manual_amount">
-                        Mức học phí (trước giảm giá){" "}
-                        <span className="text-destructive">*</span>
-                      </Label>
-                      <CurrencyInput
-                        id="manual_amount"
-                        value={manualAmount}
-                        onChange={setManualAmount}
-                        placeholder="Nhập mức học phí…"
-                        disabled={isPending}
-                      />
-
-                      {/* (#2) Giá chuẩn + chênh lệch + dự kiến phải thu. */}
-                      <div className="text-xs space-y-1 pt-1">
-                        {preview.isLoading && (
-                          <p className="text-muted-foreground">Đang tải giá chuẩn…</p>
-                        )}
-                        {preview.isError && (
-                          <p className="text-destructive">
-                            Không tải được giá chuẩn (hồ sơ có thể chưa xác định ngành).
-                          </p>
-                        )}
-                        {preview.data && (
-                          <>
-                            <div className="flex items-center justify-between">
-                              <span className="text-muted-foreground">Giá chuẩn (base):</span>
-                              <span className="font-medium">
-                                {formatVND(preview.data.base_amount)}
-                              </span>
-                            </div>
-                            {diffFromCanonical != null && diffFromCanonical !== 0 && (
-                              <div className="flex items-center justify-between">
-                                <span className="text-muted-foreground">Chênh lệch:</span>
-                                <Badge
-                                  variant={diffFromCanonical > 0 ? "destructive" : "secondary"}
-                                  className="font-normal"
-                                >
-                                  {diffFromCanonical > 0 ? "+" : "−"}
-                                  {formatVND(Math.abs(diffFromCanonical))}
-                                </Badge>
-                              </div>
-                            )}
-                            <div className="flex items-center justify-between">
-                              <span className="text-muted-foreground">
-                                Giảm giá (theo giá chuẩn):
-                              </span>
-                              <span className="font-medium">
-                                {formatVND(preview.data.total_discount)}
-                              </span>
-                            </div>
-                            {estimatedPayable != null && (
-                              <div className="flex items-center justify-between border-t pt-1">
-                                <span className="text-muted-foreground">
-                                  Ước tính phải thu:
-                                </span>
-                                <span className="font-semibold text-primary">
-                                  {formatVND(estimatedPayable)}
-                                </span>
-                              </div>
-                            )}
-                            {Number(preview.data.total_discount) > 0 && (
-                              <p className="text-muted-foreground pt-0.5">
-                                Số phải thu chính xác do hệ thống tính lại theo
-                                chính sách giảm giá khi tạo.
-                              </p>
-                            )}
-                          </>
-                        )}
+              {isDownPayment && (
+                <div className="space-y-3 pt-1">
+                  {/* Tổng phải thu (final) để người dùng chia đợt. */}
+                  <div className="text-xs">
+                    {preview.isLoading && (
+                      <p className="text-muted-foreground">Đang tải tổng phải thu…</p>
+                    )}
+                    {preview.isError && (
+                      <p className="text-destructive">
+                        Không tải được giá chuẩn (hồ sơ có thể chưa xác định ngành).
+                      </p>
+                    )}
+                    {preview.data && (
+                      <div className="flex items-center justify-between">
+                        <span className="text-muted-foreground">Tổng phải thu:</span>
+                        <span className="font-semibold text-primary">
+                          {formatVND(preview.data.final_amount)}
+                        </span>
                       </div>
-                    </div>
+                    )}
+                  </div>
 
-                    <div className="space-y-1.5">
-                      <Label htmlFor="manual_reason">
-                        Lý do nhập tay <span className="text-destructive">*</span>
-                      </Label>
-                      {/* (#4) Chip lý do mẫu. */}
-                      <div className="flex flex-wrap gap-1.5">
-                        {REASON_CHIPS.map((chip) => (
-                          <Button
-                            key={chip.label}
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            className="h-7 text-xs"
-                            disabled={isPending}
-                            onClick={() => setManualReason(chip.value)}
-                          >
-                            {chip.label}
-                          </Button>
-                        ))}
-                      </div>
-                      <Textarea
-                        id="manual_reason"
-                        value={manualReason}
-                        onChange={(e) => setManualReason(e.target.value)}
-                        placeholder="Ví dụ: Học bổng theo quyết định số…"
-                        rows={2}
-                        maxLength={MANUAL_REASON_MAX}
-                        disabled={isPending}
-                        className="resize-none"
-                      />
+                  <div className="space-y-1.5">
+                    <Label htmlFor="down_payment">
+                      Số đóng đợt đầu <span className="text-destructive">*</span>
+                    </Label>
+                    <CurrencyInput
+                      id="down_payment"
+                      value={downPayment}
+                      onChange={setDownPayment}
+                      placeholder="Nhập số tiền đóng trước…"
+                      disabled={isPending}
+                    />
+                    {remainder != null && (
                       <p
                         className={
-                          reasonLen > 0 && reasonLen < MANUAL_REASON_MIN
+                          remainder <= 0
                             ? "text-destructive text-xs"
                             : "text-muted-foreground text-xs"
                         }
                       >
-                        Tối thiểu {MANUAL_REASON_MIN} ký tự, tối đa {MANUAL_REASON_MAX} ({reasonLen}).
+                        {remainder > 0
+                          ? `Phần còn lại (công nợ): ${formatVND(remainder)}`
+                          : "Số đóng trước phải nhỏ hơn tổng phải thu."}
                       </p>
+                    )}
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="down_payment_due">
+                        Hạn đợt đầu <span className="text-destructive">*</span>
+                      </Label>
+                      <Input
+                        id="down_payment_due"
+                        type="date"
+                        value={downPaymentDue}
+                        onChange={(e) => setDownPaymentDue(e.target.value)}
+                        disabled={isPending}
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="remainder_due">
+                        Hạn phần còn lại <span className="text-destructive">*</span>
+                      </Label>
+                      <Input
+                        id="remainder_due"
+                        type="date"
+                        value={remainderDue}
+                        onChange={(e) => setRemainderDue(e.target.value)}
+                        disabled={isPending}
+                      />
                     </div>
                   </div>
-                )}
-              </div>
-            )}
+                  {!!downPaymentDue &&
+                    !!remainderDue &&
+                    remainderDue < downPaymentDue && (
+                      <p className="text-destructive text-xs">
+                        Hạn phần còn lại phải sau hoặc bằng hạn đợt đầu.
+                      </p>
+                    )}
+                </div>
+              )}
+            </div>
+          )}
 
+          {/* Kế hoạch thanh toán — ẩn khi chia "đóng trước" (dùng lịch tùy chỉnh). */}
+          {!isDownPayment && (
             <div className="space-y-2">
               <Label htmlFor="installment_plan_code">Kế hoạch thanh toán</Label>
               <Select
@@ -449,89 +383,24 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
                 </SelectContent>
               </Select>
             </div>
+          )}
 
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={isPending}
-              >
-                Hủy
-              </Button>
-              <Button type="submit" disabled={!canSubmit}>
-                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                Tính học phí
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
-
-      {/* (#3) Dialog xác nhận nhập tay — tóm tắt 3 dòng trước khi tạo. */}
-      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Xác nhận nhập học phí thủ công</AlertDialogTitle>
-            <AlertDialogDescription>
-              Kiểm tra lại trước khi tạo bản ghi học phí. Hệ thống sẽ tính
-              <strong> số phải thu chính xác</strong> theo chính sách giảm giá
-              hiện hành khi tạo — số dưới đây là <strong>ước tính</strong>.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-
-          <div className="rounded-lg border p-3 text-sm space-y-1.5">
-            <div className="flex items-center justify-between">
-              <span className="text-muted-foreground">Số gõ (base):</span>
-              <span className="font-medium">
-                {manualAmount != null ? formatVND(manualAmount) : "—"}
-              </span>
-            </div>
-            {/* Ước tính giảm giá/phải thu CHỈ hiện khi đã có giá chuẩn — tránh
-                hiện "0 ₫" gây hiểu nhầm khi preview chưa tải / lỗi. */}
-            {currentDiscount != null ? (
-              <>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">Giảm giá (theo giá chuẩn):</span>
-                  <span className="font-medium">{formatVND(currentDiscount)}</span>
-                </div>
-                <div className="flex items-center justify-between border-t pt-1.5">
-                  <span className="text-muted-foreground">Ước tính phải thu:</span>
-                  <span className="font-semibold text-primary">
-                    {estimatedPayable != null ? formatVND(estimatedPayable) : "—"}
-                  </span>
-                </div>
-              </>
-            ) : (
-              <div className="border-t pt-1.5 text-muted-foreground text-xs">
-                Chưa tải được giá chuẩn — hệ thống sẽ tính số phải thu (theo giảm
-                giá hiện hành) khi tạo.
-              </div>
-            )}
-            <div className="border-t pt-1.5">
-              <span className="text-muted-foreground">Lý do: </span>
-              <span className="break-words">{manualReason.trim()}</span>
-            </div>
-          </div>
-
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>Quay lại</AlertDialogCancel>
-            <AlertDialogAction
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
               disabled={isPending}
-              onClick={(e) => {
-                // Đóng AlertDialog (mặc định) rồi submit. doSubmit tự đóng dialog
-                // chính khi thành công; lỗi → toast + giữ nguyên giá trị đã nhập.
-                e.preventDefault()
-                setConfirmOpen(false)
-                void doSubmit()
-              }}
             >
+              Hủy
+            </Button>
+            <Button type="submit" disabled={!canSubmit}>
               {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              Xác nhận tạo
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
+              Tính học phí
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/frontend/src/components/admissions/CalculateFeeDialog.tsx
+++ b/frontend/src/components/admissions/CalculateFeeDialog.tsx
@@ -92,7 +92,7 @@ const MANUAL_REASON_MAX = 500
 // thỏa ràng buộc reason) set vào ô lý do.
 const REASON_CHIPS: { label: string; value: string }[] = [
   { label: "Học bổng", value: "Học bổng theo quyết định của nhà trường" },
-  { label: "Chuyển trường", value: "Điều chỉnh học phí do chuyển trường" },
+  { label: "Tạm thu", value: "Tạm thu học phí nhập học" },
   { label: "Theo quyết định", value: "Áp dụng học phí theo quyết định riêng" },
   { label: "Điều chỉnh khác", value: "Điều chỉnh học phí trường hợp đặc biệt" },
 ]

--- a/frontend/src/hooks/finance/useFees.ts
+++ b/frontend/src/hooks/finance/useFees.ts
@@ -18,6 +18,7 @@ import type {
   FeeWaiveRequest,
   ProfileFinanceSummary,
   ProfileCollection,
+  TuitionPreviewResponse,
 } from "@/types/finance.types"
 
 // =====================================================================
@@ -33,6 +34,8 @@ export const feesKeys = {
   byProfile: (profileId: number) => [...feesKeys.all, "by-profile", profileId] as const,
   profileSummary: (profileId: number) => [...feesKeys.all, "profile-summary", profileId] as const,
   collection: (profileId: number) => [...feesKeys.all, "collection", profileId] as const,
+  tuitionPreview: (profileId: number, semesterNo: number) =>
+    [...feesKeys.all, "tuition-preview", profileId, semesterNo] as const,
 }
 
 // =====================================================================
@@ -218,6 +221,24 @@ export function useProfileCollection(
     enabled: (options?.enabled ?? true) && !!profileId,
     staleTime: 1000 * 15,
     gcTime: 1000 * 60 * 5,
+  })
+}
+
+/**
+ * Giá chuẩn học phí (base / giảm giá / dự kiến phải thu) cho add-on "Nhập học
+ * phí thủ công" của dialog Tính phí. Chỉ fetch khi toggle nhập tay bật (caller
+ * truyền enabled). Refetch khi đổi semesterNo (nằm trong queryKey).
+ */
+export function useTuitionPreview(
+  profileId: number,
+  semesterNo: number,
+  options?: { enabled?: boolean }
+) {
+  return useQuery<TuitionPreviewResponse, AxiosError<ApiErrorResponse>>({
+    queryKey: feesKeys.tuitionPreview(profileId, semesterNo),
+    queryFn: () => feesApi.getTuitionPreview(profileId, semesterNo),
+    enabled: (options?.enabled ?? true) && !!profileId && !!semesterNo,
+    staleTime: 1000 * 60, // 1 minute — giá chuẩn ít đổi
   })
 }
 

--- a/frontend/src/hooks/finance/useFees.ts
+++ b/frontend/src/hooks/finance/useFees.ts
@@ -225,9 +225,9 @@ export function useProfileCollection(
 }
 
 /**
- * Giá chuẩn học phí (base / giảm giá / dự kiến phải thu) cho add-on "Nhập học
- * phí thủ công" của dialog Tính phí. Chỉ fetch khi toggle nhập tay bật (caller
- * truyền enabled). Refetch khi đổi semesterNo (nằm trong queryKey).
+ * Giá chuẩn học phí (base / giảm giá / dự kiến phải thu) cho dialog Tính phí —
+ * hiển tổng phải thu để đối chiếu khi chọn lịch thu (vd chia "đóng trước + còn
+ * lại"). Chỉ fetch khi caller bật (enabled). Refetch khi đổi semesterNo.
  */
 export function useTuitionPreview(
   profileId: number,

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -245,6 +245,7 @@ export const API_ENDPOINTS = {
       PROFILE_SUMMARY: (profileId: number) => `/api/fees/summary/${profileId}`,
       COLLECTION: (profileId: number) => `/api/fees/collection/${profileId}`,
       CALCULABLE_PROFILES: "/api/fees/calculable-profiles",
+      TUITION_PREVIEW: "/api/fees/tuition-preview",
       WAIVE: (feeId: number) => `/api/fees/${feeId}/waive`,
       CANCEL: (feeId: number) => `/api/fees/${feeId}/cancel`,
       RECALCULATE: (feeId: number) => `/api/fees/${feeId}/recalculate`,

--- a/frontend/src/lib/api/fees.ts
+++ b/frontend/src/lib/api/fees.ts
@@ -141,8 +141,8 @@ export async function listCalculableProfiles(
 }
 
 /**
- * Giá chuẩn học phí (read-only) cho add-on "Nhập học phí thủ công" của dialog
- * Tính phí. Trả base / giảm giá hiện hành / dự kiến phải thu cho HK đã chọn.
+ * Giá chuẩn học phí (read-only) cho dialog Tính phí — trả base / giảm giá hiện
+ * hành / dự kiến phải thu cho HK đã chọn (đối chiếu khi chọn lịch thu).
  *
  * @param profileId - admission profile ID
  * @param semesterNo - số học kỳ (HK1=1)

--- a/frontend/src/lib/api/fees.ts
+++ b/frontend/src/lib/api/fees.ts
@@ -16,6 +16,7 @@ import type {
   FeeWaiveRequest,
   ProfileFinanceSummary,
   ProfileCollection,
+  TuitionPreviewResponse,
 } from "@/types/finance.types"
 
 // ============================================================================
@@ -139,6 +140,25 @@ export async function listCalculableProfiles(
   return response.data
 }
 
+/**
+ * Giá chuẩn học phí (read-only) cho add-on "Nhập học phí thủ công" của dialog
+ * Tính phí. Trả base / giảm giá hiện hành / dự kiến phải thu cho HK đã chọn.
+ *
+ * @param profileId - admission profile ID
+ * @param semesterNo - số học kỳ (HK1=1)
+ * @throws {AxiosError} 404 nếu hồ sơ ngoài scope; 400 nếu ngành chưa xác định
+ */
+export async function getTuitionPreview(
+  profileId: number,
+  semesterNo: number
+): Promise<TuitionPreviewResponse> {
+  const response = await api.get<TuitionPreviewResponse>(
+    API_ENDPOINTS.FINANCE.FEES.TUITION_PREVIEW,
+    { params: { admission_profile_id: profileId, semester_no: semesterNo } }
+  )
+  return response.data
+}
+
 // ============================================================================
 // FEE ACTIONS
 // ============================================================================
@@ -232,6 +252,7 @@ export const feesApi = {
   getProfileFinanceSummary,
   getProfileCollection,
   listCalculableProfiles,
+  getTuitionPreview,
   // Actions
   calculateFee,
   waiveFee,

--- a/frontend/src/lib/zod/finance.ts
+++ b/frontend/src/lib/zod/finance.ts
@@ -573,43 +573,49 @@ export const feeCalculateRequestSchema = z
     // for non-tuition types). max(12) mirrors backend FeeCalculateRequest
     // (Field le=12) — chặn HK ngoài int32.
     semester_no: z.number().int().positive().max(12).nullable().optional(),
-    // Manual tuition override — số nhập tay là BASE (Decimal as string). Backend
-    // vẫn áp discount → invoice khớp final. Mirror backend model_validator dưới.
-    manual_base_amount: z
+    // Lịch thu "đóng trước" (Pha 1) — GIỮ tổng học phí, chỉ chia 2 đợt. Mirror
+    // backend validate_collection_schedule. down_payment là Decimal-as-string;
+    // các hạn là chuỗi ISO YYYY-MM-DD.
+    collection_schedule_mode: z.enum(["standard", "down_payment"]).optional(),
+    down_payment: z
       .string()
-      .regex(/^\d+(\.\d{1,2})?$/, "Mức học phí không hợp lệ")
+      .regex(/^\d+(\.\d{1,2})?$/, "Số đóng trước không hợp lệ")
       .nullable()
       .optional(),
-    manual_reason: z
-      .string()
-      .max(500, "Lý do không được quá 500 ký tự")
-      .nullable()
-      .optional(),
+    down_payment_due: z.string().nullable().optional(),
+    remainder_due: z.string().nullable().optional(),
   })
-  // Mirror backend FeeCalculateRequest.validate_manual_tuition: nhập tay ⟹
-  // fee_type=tuition + reason ≥10; có reason mà thiếu số ⟹ reject.
+  // Mirror backend validate_collection_schedule: mode="down_payment" ⟹
+  // fee_type=tuition + đủ số đóng trước & 2 hạn + hạn đợt 2 >= đợt 1.
   .refine(
     (d) =>
-      d.manual_base_amount == null ||
+      d.collection_schedule_mode !== "down_payment" ||
       (d.fee_type ?? "tuition") === "tuition",
     {
-      message: "Nhập học phí thủ công chỉ áp dụng cho học phí",
-      path: ["manual_base_amount"],
+      message: "Lịch 'đóng trước' chỉ áp dụng cho học phí",
+      path: ["collection_schedule_mode"],
     }
   )
   .refine(
     (d) =>
-      d.manual_base_amount == null ||
-      (!!d.manual_reason && d.manual_reason.trim().length >= 10),
+      d.collection_schedule_mode !== "down_payment" ||
+      (d.down_payment != null && !!d.down_payment_due && !!d.remainder_due),
     {
-      message: "Cần lý do nhập học phí thủ công (tối thiểu 10 ký tự)",
-      path: ["manual_reason"],
+      message: "Lịch 'đóng trước' cần số đóng trước và hạn cả hai đợt",
+      path: ["down_payment"],
     }
   )
-  .refine((d) => !d.manual_reason || d.manual_base_amount != null, {
-    message: "Có lý do nhập tay nhưng thiếu mức học phí",
-    path: ["manual_base_amount"],
-  })
+  .refine(
+    (d) =>
+      d.collection_schedule_mode !== "down_payment" ||
+      !d.down_payment_due ||
+      !d.remainder_due ||
+      d.remainder_due >= d.down_payment_due,
+    {
+      message: "Hạn phần còn lại phải >= hạn đợt đầu",
+      path: ["remainder_due"],
+    }
+  )
 
 export type FeeCalculateRequest = z.infer<typeof feeCalculateRequestSchema>
 

--- a/frontend/src/lib/zod/finance.ts
+++ b/frontend/src/lib/zod/finance.ts
@@ -563,15 +563,52 @@ export type PaymentPaginatedResponse = z.infer<typeof paymentPaginatedResponseSc
 // REQUEST SCHEMAS (for API calls - match backend request schemas)
 // ==============================================================================
 
-export const feeCalculateRequestSchema = z.object({
-  admission_profile_id: z.number().int().positive("Vui lòng chọn hồ sơ"),
-  fee_type: feeTypeSchema.optional(),
-  installment_plan_code: z.string().optional(), // defaults to "FULL"
-  // PR #7 — HK number for tuition. Optional + nullable mirrors the backend
-  // contract (defaults to 1 when omitted for tuition; must be null/unset
-  // for non-tuition types).
-  semester_no: z.number().int().positive().nullable().optional(),
-})
+export const feeCalculateRequestSchema = z
+  .object({
+    admission_profile_id: z.number().int().positive("Vui lòng chọn hồ sơ"),
+    fee_type: feeTypeSchema.optional(),
+    installment_plan_code: z.string().optional(), // defaults to "FULL"
+    // PR #7 — HK number for tuition. Optional + nullable mirrors the backend
+    // contract (defaults to 1 when omitted for tuition; must be null/unset
+    // for non-tuition types).
+    semester_no: z.number().int().positive().nullable().optional(),
+    // Manual tuition override — số nhập tay là BASE (Decimal as string). Backend
+    // vẫn áp discount → invoice khớp final. Mirror backend model_validator dưới.
+    manual_base_amount: z
+      .string()
+      .regex(/^\d+(\.\d{1,2})?$/, "Mức học phí không hợp lệ")
+      .nullable()
+      .optional(),
+    manual_reason: z
+      .string()
+      .max(500, "Lý do không được quá 500 ký tự")
+      .nullable()
+      .optional(),
+  })
+  // Mirror backend FeeCalculateRequest.validate_manual_tuition: nhập tay ⟹
+  // fee_type=tuition + reason ≥10; có reason mà thiếu số ⟹ reject.
+  .refine(
+    (d) =>
+      d.manual_base_amount == null ||
+      (d.fee_type ?? "tuition") === "tuition",
+    {
+      message: "Nhập học phí thủ công chỉ áp dụng cho học phí",
+      path: ["manual_base_amount"],
+    }
+  )
+  .refine(
+    (d) =>
+      d.manual_base_amount == null ||
+      (!!d.manual_reason && d.manual_reason.trim().length >= 10),
+    {
+      message: "Cần lý do nhập học phí thủ công (tối thiểu 10 ký tự)",
+      path: ["manual_reason"],
+    }
+  )
+  .refine((d) => !d.manual_reason || d.manual_base_amount != null, {
+    message: "Có lý do nhập tay nhưng thiếu mức học phí",
+    path: ["manual_base_amount"],
+  })
 
 export type FeeCalculateRequest = z.infer<typeof feeCalculateRequestSchema>
 

--- a/frontend/src/lib/zod/finance.ts
+++ b/frontend/src/lib/zod/finance.ts
@@ -570,8 +570,9 @@ export const feeCalculateRequestSchema = z
     installment_plan_code: z.string().optional(), // defaults to "FULL"
     // PR #7 — HK number for tuition. Optional + nullable mirrors the backend
     // contract (defaults to 1 when omitted for tuition; must be null/unset
-    // for non-tuition types).
-    semester_no: z.number().int().positive().nullable().optional(),
+    // for non-tuition types). max(12) mirrors backend FeeCalculateRequest
+    // (Field le=12) — chặn HK ngoài int32.
+    semester_no: z.number().int().positive().max(12).nullable().optional(),
     // Manual tuition override — số nhập tay là BASE (Decimal as string). Backend
     // vẫn áp discount → invoice khớp final. Mirror backend model_validator dưới.
     manual_base_amount: z

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -571,6 +571,20 @@ export interface FeeCalculateRequest {
   // PR #7 — semester number for tuition fees. Defaults to 1 (HK1) on the
   // backend when omitted; must stay null/undefined for non-tuition types.
   semester_no?: number | null
+  // Manual tuition override — số nhập tay là BASE (TRƯỚC giảm giá), Decimal as
+  // string. Backend vẫn áp discount hiện hành → invoice khớp final (≠ số gõ nếu
+  // có giảm). CHỈ hợp lệ khi fee_type === "tuition" + manual_reason ≥10 ký tự
+  // (mirror backend model_validator). Bỏ cả hai khi không nhập tay (luồng cũ).
+  manual_base_amount?: string | null
+  manual_reason?: string | null
+}
+
+/** Giá chuẩn học phí (GET /api/fees/tuition-preview) — Decimal as string. */
+export interface TuitionPreviewResponse {
+  base_amount: string
+  total_discount: string
+  final_amount: string
+  semester_no: number
 }
 
 export interface FeeWaiveRequest {

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -571,12 +571,14 @@ export interface FeeCalculateRequest {
   // PR #7 — semester number for tuition fees. Defaults to 1 (HK1) on the
   // backend when omitted; must stay null/undefined for non-tuition types.
   semester_no?: number | null
-  // Manual tuition override — số nhập tay là BASE (TRƯỚC giảm giá), Decimal as
-  // string. Backend vẫn áp discount hiện hành → invoice khớp final (≠ số gõ nếu
-  // có giảm). CHỈ hợp lệ khi fee_type === "tuition" + manual_reason ≥10 ký tự
-  // (mirror backend model_validator). Bỏ cả hai khi không nhập tay (luồng cũ).
-  manual_base_amount?: string | null
-  manual_reason?: string | null
+  // Lịch thu "đóng trước" (Pha 1) — GIỮ nguyên tổng học phí, chỉ chia số phải
+  // thu thành đợt đầu + phần còn lại (2 hóa đơn). "down_payment" CHỈ cho tuition;
+  // cần down_payment + cả 2 hạn (mirror backend validate_collection_schedule).
+  // Bỏ hết khi mode "standard" (theo kế hoạch trả góp như cũ).
+  collection_schedule_mode?: "standard" | "down_payment"
+  down_payment?: string | null // Decimal as string
+  down_payment_due?: string | null // YYYY-MM-DD
+  remainder_due?: string | null // YYYY-MM-DD
 }
 
 /** Giá chuẩn học phí (GET /api/fees/tuition-preview) — Decimal as string. */


### PR DESCRIPTION
## Mục tiêu
Cho phép **chia số phải thu thành "đóng trước + phần còn lại"** ngay tại dialog Tính phí (officer dùng được) khi người học chưa đủ khả năng đóng đủ — **GIỮ NGUYÊN tổng học phí** (nghĩa vụ không đổi), phần còn lại thành **công nợ có hạn cụ thể**.

> Rework đúng trục so với bản cũ: bản trước (`manual_base_amount`) ghi đè `base_amount` = số gõ → nhập "tạm thu 2tr" làm **mất công nợ 5.2tr**. Đã GỠ HOÀN TOÀN manual base override; thay bằng lịch thu (chia ở tầng hóa đơn, không đụng nghĩa vụ).

## Thiết kế
- `collection_schedule_mode = "standard" | "down_payment"` (Pha 1 chỉ 2 đợt; mở rộng N-đợt sau).
- **down_payment KHÔNG đụng `base_amount`/`final_amount`** — chỉ chia `amount_to_invoice = final − waived` thành **HĐ1 = đóng trước** (hạn đợt 1) + **HĐ2 = phần còn lại** (hạn tương lai), **cả hai phát hành (issued)** → công nợ đợt 2 có mốc (overdue/nhắc).
- Guard (service `generate_invoices_for_fee`): `0 < down_payment < amount_to_invoice` (→400), `Σ HĐ = final − waived`. Schema validator (→422): tuition-only + đủ field + `remainder_due >= down_payment_due`.
- Giữ `GET /api/fees/tuition-preview` (read-only) hiển tổng phải thu để chia + kiểm số đóng trước < tổng trước khi gửi.

## Test
- BE **82 pass** (auth full + invoice_service + fee_calc_service one-off): down-payment chia-2-HĐ · giữ final · đóng-trước ≥ tổng → 400 · hạn-ngược → 422 · preview.
- FE: type-check sạch + **7 dialog test**.
- ✅ /code-review max = **0 bug correctness**.

## ⚠️ Deploy (KHÔNG code-only)
1. **Alembic migration `mta20260628001`** (Casbin grant `GET /api/fees/tuition-preview` cho officer + accountant).
2. **Restart backend** (enforcer load grant).

## Ghi chú
- **Pha 2 (PR riêng, chưa làm):** miễn/giảm học phí THẬT (giảm tổng) = `FeeAppliedDiscount(policy_id=NULL)` + `calculation_snapshot.source="manual_discount"`, quyền accountant/manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)