### PR TITLE
feat(finance): miễn/giảm học phí thủ công (discount-line) — Pha 2

### DIFF
--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -51,6 +51,7 @@ from app.utils.exceptions import (
     BadRequest,
     BusinessRuleViolation,
     ConflictError,
+    PermissionDeniedError,
 )
 
 log = structlog.get_logger(__name__)
@@ -243,7 +244,20 @@ async def calculate_fee(
     **Security:**
     - IDOR protection: Only accessible for user's unit
     - Requires 'fees:create' permission
+    - Miễn/giảm học phí thủ công (``target_final_amount``): FIELD-LEVEL AUTHZ —
+      chỉ admin/manager/accountant (officer vẫn calculate thường + down-payment).
     """
+    # Field-level authz (Pha 2): officer được calculate + down-payment, nhưng
+    # KHÔNG được tự miễn/giảm học phí (đổi nghĩa vụ tiền). Gate Ở ROUTER (deps có
+    # role) TRƯỚC service; cùng role-set với require_finance_staff. PermissionDenied
+    # → 403 qua global handler (KHÔNG nằm trong except BadRequest dưới).
+    if data.target_final_amount is not None and current_user.role not in (
+        UserRole.ADMIN, UserRole.MANAGER, UserRole.ACCOUNTANT,
+    ):
+        raise PermissionDeniedError(
+            detail="Chỉ kế toán/quản lý/admin được miễn/giảm học phí thủ công."
+        )
+
     fee_service = FeeCalculationService(db)
     invoice_service = InvoiceService(db)
 
@@ -307,6 +321,8 @@ async def calculate_fee(
             user_id=current_user.id,
             unit_id=unit_id,
             semester_no=data.semester_no,
+            target_final_amount=data.target_final_amount,
+            manual_discount_reason=data.manual_discount_reason,
         )
 
         # Generate invoices based on installment plan.

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -279,6 +279,14 @@ class FeeCalculateRequest(BaseModel):
     remainder_due: Optional[date] = Field(
         None, description="Hạn đóng đợt 2 (phần còn lại)."
     )
+    # Miễn/giảm học phí THẬT (Pha 2) — GIẢM nghĩa vụ (final). "Học phí áp dụng"
+    # là final SAU MỌI giảm (gồm cả policy discount sẵn có). CHỈ tuition; quyền
+    # admin/manager/accountant (gate field-level ở router). None = không giảm tay.
+    target_final_amount: Optional[Decimal] = Field(
+        None, ge=0, le=MAX_AMOUNT,
+        description="Học phí áp dụng (final sau MỌI giảm) khi miễn/giảm thủ công.",
+    )
+    manual_discount_reason: Optional[str] = Field(None, max_length=500)
 
     @model_validator(mode="after")
     def default_semester_for_tuition(self):
@@ -318,6 +326,34 @@ class FeeCalculateRequest(BaseModel):
             # liệu lạc bị bỏ thầm).
             raise ValueError(
                 "Chỉ truyền down_payment khi collection_schedule_mode='down_payment'."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_manual_discount(self):
+        """Miễn/giảm học phí thủ công (HTTP layer → 422). Đo độ dài lý do trên
+        chuỗi RAW (đã strip) TRƯỚC ``html.escape`` (escape làm dài thêm → reason
+        rác vài ký tự đặc biệt sẽ lọt cửa ≥10). Ràng buộc ``target < net sau
+        policy`` đo ở service (chỉ biết sau khi resolve discount). AUTHZ vai trò
+        gate ở router (deps có role); schema chỉ lo bất biến dữ liệu.
+        """
+        if self.target_final_amount is not None:
+            if self.fee_type != FeeTypeEnum.tuition:
+                raise ValueError(
+                    "Miễn/giảm học phí thủ công chỉ áp dụng cho học phí (tuition)."
+                )
+            if (
+                not self.manual_discount_reason
+                or len(self.manual_discount_reason.strip()) < 10
+            ):
+                raise ValueError(
+                    "Cần lý do miễn/giảm học phí (tối thiểu 10 ký tự)."
+                )
+            # Độ dài đã đo trên RAW → giờ escape để lưu snapshot/audit an toàn.
+            self.manual_discount_reason = html.escape(self.manual_discount_reason.strip())
+        elif self.manual_discount_reason:
+            raise ValueError(
+                "Có lý do miễn/giảm nhưng thiếu mức học phí áp dụng."
             )
         return self
 

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -485,6 +485,8 @@ class FeeCalculationService:
         user_id: Optional[int] = None,
         unit_id: Optional[int] = None,
         semester_no: Optional[int] = None,
+        target_final_amount: Optional[Decimal] = None,
+        manual_discount_reason: Optional[str] = None,
     ) -> Tuple[Fee, Optional[Callable]]:
         """
         Calculate fee for an admission profile.
@@ -523,6 +525,25 @@ class FeeCalculationService:
             ResourceNotFoundError: If profile not found
             BadRequest: If fee already exists or semester tuition not configured
         """
+        # 🔴 GUARD SERVICE-SIDE (miễn/giảm học phí THẬT — Pha 2) — đặt TRƯỚC mọi
+        # resolve giá / DB. ``calculate_fee`` là business boundary có direct/test
+        # caller KHÔNG đi qua schema model_validator → tự bảo vệ invariant tiền
+        # nghĩa vụ: giảm tay chỉ cho tuition + lý do ≥10 + target >= 0. KIỂM tra
+        # AUTHZ field-level (chỉ admin/manager/accountant) nằm ở ROUTER (deps có
+        # role); service đảm bảo bất biến SỐ. Ràng buộc target < net-after-policy
+        # đo SAU khi resolve discount (manual_discount > 0 bên dưới).
+        if target_final_amount is not None:
+            if fee_type != FeeTypeEnum.tuition:
+                raise BadRequest(
+                    "Miễn/giảm học phí thủ công chỉ áp dụng cho học phí (tuition)."
+                )
+            if target_final_amount < 0:
+                raise BadRequest("Học phí áp dụng không được âm.")
+            if not manual_discount_reason or len(manual_discount_reason.strip()) < 10:
+                raise BadRequest("Cần lý do miễn/giảm học phí (tối thiểu 10 ký tự).")
+        elif manual_discount_reason:
+            raise BadRequest("Có lý do miễn/giảm nhưng thiếu mức học phí áp dụng.")
+
         # Normalize semester_no: tuition defaults to HK1, non-tuition
         # MUST be None (the DB CHECK chk_fee_nontuition_semester_no_null
         # rejects non-tuition rows with a non-NULL semester_no). Lives in
@@ -627,12 +648,50 @@ class FeeCalculationService:
                 f"academic year {academic_year}"
             )
 
-        # Calculate discounts
+        # Calculate discounts (policy-derived)
         total_discount, applied_discounts = await self._calculate_discounts(
             base_amount, discount_policy_ids or []
         )
 
-        # Calculate final amount
+        # Miễn/giảm học phí THẬT (Pha 2) — giảm NGHĨA VỤ (final) qua 1 dòng
+        # FeeAppliedDiscount ad-hoc (policy_id=NULL), GIỮ base_amount=canonical.
+        # "Học phí áp dụng" (target_final_amount) là final SAU MỌI giảm → manual
+        # discount = canonical − giảm-policy-sẵn-có − target (KHÔNG phải
+        # canonical − target, tránh giảm quá tay khi đã có policy discount). Sau
+        # đó final == target. Đánh dấu source="manual_discount" trong snapshot
+        # (KHÔNG dựa policy_id IS NULL — policy bị xoá cũng NULL).
+        if target_final_amount is not None:
+            existing_policy_discount = total_discount
+            manual_discount_amount = (
+                base_amount - existing_policy_discount - target_final_amount
+            )
+            if manual_discount_amount <= 0:
+                raise BadRequest(
+                    f"Học phí áp dụng ({target_final_amount}) phải NHỎ HƠN mức sau "
+                    f"giảm hiện hành ({base_amount - existing_policy_discount}). "
+                    "Nếu không cần giảm thêm thì bỏ miễn/giảm thủ công."
+                )
+            manual_snapshot = {
+                # source = dấu hiệu MÁY ĐỌC ĐƯỢC để soát giảm-tay (KHÔNG dựa
+                # policy_id IS NULL — policy bị xoá cũng NULL).
+                "source": "manual_discount",
+                "reason": manual_discount_reason,
+                "approved_by": user_id,
+                "canonical_amount": str(base_amount),
+                "existing_policy_discount": str(existing_policy_discount),
+                "target_final_amount": str(target_final_amount),
+                "discount_amount": str(manual_discount_amount),
+                "calculated_at": datetime.now(timezone.utc).isoformat(),
+                # policy_name/discount_type/discount_value để builder response
+                # (_build_fee_detail_response) hiển nhãn thay vì "Unknown".
+                "policy_name": "Miễn/giảm học phí (thủ công)",
+                "discount_type": "manual_amount",
+                "discount_value": str(manual_discount_amount),
+            }
+            applied_discounts.append((None, manual_discount_amount, manual_snapshot))
+            total_discount = existing_policy_discount + manual_discount_amount
+
+        # Calculate final amount (== target_final_amount khi có miễn/giảm tay)
         final_amount = max(Decimal("0"), base_amount - total_discount)
 
         # Get installment plan

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -879,7 +879,22 @@ class FeeCalculationService:
                 f"Paid amount: {fee.paid_amount} VND"
             )
 
-        # Block when any non-cancelled invoice is beyond draft. Recalc đổi
+        # Pha 2: chặn tính lại phí có MIỄN/GIẢM THỦ CÔNG (message cụ thể; cũng bắt
+        # cả khi HĐ đã bị HỦY HẾT — lúc đó issued-block dưới không fire). recalc
+        # chỉ tính lại discount theo policy (existing_policy_ids loại policy_id=NULL)
+        # → sẽ BỎ RƠI dòng giảm tay khỏi final (final nhảy lên) + để lại dòng
+        # orphan. Giảm tay là quyết định riêng (học bổng…), không tự suy lại theo
+        # base mới → bắt hủy & tạo lại thay vì âm thầm mất.
+        if any(
+            (ad.calculation_snapshot or {}).get("source") == "manual_discount"
+            for ad in fee.applied_discounts
+        ):
+            raise BusinessRuleViolation(
+                "Không thể tính lại phí có miễn/giảm học phí thủ công — hãy hủy "
+                "phí rồi tạo lại với mức áp dụng mới."
+            )
+
+        # Block when any non-cancelled invoice is beyond draft (#445). Recalc đổi
         # ``fee.final_amount`` nhưng payment thu theo ``invoice.amount`` (KHÔNG
         # đọc fee) → fee 10tr/HĐ issued 10tr, recalc 8tr ⇒ vẫn thu 10tr (dư 2tr);
         # ngược lại tăng giá ⇒ thu thiếu. Đối xứng

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -1607,3 +1607,50 @@ async def test_manual_discount_target_not_below_net_400(
         headers=ah,
     )
     assert resp.status_code == 400, resp.text
+
+
+@pytest.mark.asyncio
+async def test_recalculate_blocked_on_manual_discount_fee(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    accountant_same_unit: dict,
+    fee_calc_config: dict,
+):
+    """Fee có miễn/giảm thủ công → recalculate CHẶN (BusinessRuleViolation → 400):
+    recalc chỉ tính lại policy discount (existing_policy_ids loại policy_id=NULL),
+    nên sẽ BỎ RƠI giảm tay khỏi final + để lại dòng orphan. Bắt hủy & tạo lại."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="ManualDiscount Recalc", approve=False,
+    )
+    ah = await _login(
+        client, accountant_same_unit["username"], accountant_same_unit["password"]
+    )
+    created = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "semester_no": 1,
+            "target_final_amount": "1000000",
+            "manual_discount_reason": "Học bổng đặc biệt theo quyết định nhà trường",
+        },
+        headers=ah,
+    )
+    assert created.status_code == 201, created.text
+    fee_id = created.json()["id"]
+
+    # Gọi recalculate_fee TẦNG SERVICE (paid=0 nên KHÔNG dính M10) → guard
+    # miễn/giảm thủ công raise BusinessRuleViolation (route map → 400).
+    from app.services.fee_calculation_service import FeeCalculationService
+    from app.utils.exceptions import BusinessRuleViolation
+    async with AsyncSessionLocal() as s:
+        svc = FeeCalculationService(s)
+        with pytest.raises(BusinessRuleViolation):
+            await svc.recalculate_fee(
+                fee_id=fee_id,
+                new_base_amount=Decimal("6000000"),
+                reason="Điều chỉnh base test",
+                user_id=1,
+            )

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -1431,3 +1431,179 @@ async def test_down_payment_remainder_due_before_first_422(
         headers=oh,
     )
     assert resp.status_code == 422, resp.text
+
+
+# ==============================================================================
+# Miễn/giảm học phí THẬT (Pha 2, 2026-06-29) — discount-line, GIẢM nghĩa vụ
+# ==============================================================================
+#
+# "Học phí áp dụng" (target_final_amount) = final SAU MỌI giảm. Backend tính
+# manual_discount = canonical − giảm-policy-sẵn-có − target → final == target;
+# base_amount GIỮ canonical; ghi 1 FeeAppliedDiscount(policy_id=NULL) + snapshot
+# source="manual_discount". Quyền admin/manager/accountant (field-level ở router);
+# officer gửi → 403. Canonical HK1 trong fee_calc_config = 5,000,000.
+
+
+async def _manual_discount_rows(pid: int):
+    """Đọc các FeeAppliedDiscount của hồ sơ (để soát dòng giảm tay + snapshot)."""
+    from app.models.finance import FeeAppliedDiscount, Fee
+    from sqlalchemy import select as _select
+    async with AsyncSessionLocal() as s:
+        return (await s.execute(
+            _select(FeeAppliedDiscount)
+            .join(Fee, Fee.id == FeeAppliedDiscount.fee_id)
+            .where(Fee.admission_profile_id == pid)
+        )).scalars().all()
+
+
+@pytest.mark.asyncio
+async def test_manual_discount_reduces_final_keeps_base(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    accountant_same_unit: dict,
+    fee_calc_config: dict,
+):
+    """Accountant miễn/giảm (không policy): target 1,000,000 (canonical
+    5,000,000) → base GIỮ 5,000,000, total_discount 4,000,000, final = target;
+    invoice khớp final; 1 dòng giảm tay policy_id=NULL + snapshot
+    source='manual_discount'."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="ManualDiscount Base", approve=False,
+    )
+    ah = await _login(
+        client, accountant_same_unit["username"], accountant_same_unit["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "semester_no": 1,
+            "target_final_amount": "1000000",
+            "manual_discount_reason": "Học bổng đặc biệt theo quyết định khen thưởng",
+        },
+        headers=ah,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert Decimal(str(body["base_amount"])) == Decimal("5000000"), body
+    assert Decimal(str(body["total_discount"])) == Decimal("4000000"), body
+    assert Decimal(str(body["final_amount"])) == Decimal("1000000"), body
+    invoices = body.get("invoices") or []
+    assert sum(Decimal(str(i["amount"])) for i in invoices) == Decimal("1000000"), invoices
+
+    rows = await _manual_discount_rows(pid)
+    manual = [r for r in rows if (r.calculation_snapshot or {}).get("source") == "manual_discount"]
+    assert len(manual) == 1, [r.calculation_snapshot for r in rows]
+    assert manual[0].policy_id is None
+    assert Decimal(str(manual[0].discount_amount)) == Decimal("4000000")
+    snap = manual[0].calculation_snapshot
+    assert snap.get("approved_by") is not None, snap
+    assert Decimal(snap["canonical_amount"]) == Decimal("5000000"), snap
+    assert Decimal(snap["target_final_amount"]) == Decimal("1000000"), snap
+
+
+@pytest.mark.asyncio
+async def test_manual_discount_after_existing_policy(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    accountant_same_unit: dict,
+    fee_calc_config: dict,
+):
+    """Có policy discount 500,000 + target 1,000,000 → manual = 5tr − 500k − 1tr
+    = 3,500,000 (KHÔNG double-giảm); total_discount = 4,000,000; final = 1,000,000.
+    'Học phí áp dụng' là final SAU MỌI giảm."""
+    await _link_fixed_discount(fee_calc_config, amount="500000")
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="ManualDiscount Policy", approve=False,
+    )
+    ah = await _login(
+        client, accountant_same_unit["username"], accountant_same_unit["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "semester_no": 1,
+            "target_final_amount": "1000000",
+            "manual_discount_reason": "Giảm học phí theo quyết định nhà trường",
+        },
+        headers=ah,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert Decimal(str(body["base_amount"])) == Decimal("5000000"), body
+    assert Decimal(str(body["total_discount"])) == Decimal("4000000"), body
+    assert Decimal(str(body["final_amount"])) == Decimal("1000000"), body
+    rows = await _manual_discount_rows(pid)
+    manual = [r for r in rows if (r.calculation_snapshot or {}).get("source") == "manual_discount"]
+    assert len(manual) == 1, [r.calculation_snapshot for r in rows]
+    # manual = canonical − policy(500k) − target(1tr) = 3,500,000 (không phải 4tr).
+    assert Decimal(str(manual[0].discount_amount)) == Decimal("3500000"), manual[0].calculation_snapshot
+    assert Decimal(manual[0].calculation_snapshot["existing_policy_discount"]) == Decimal("500000")
+
+
+@pytest.mark.asyncio
+async def test_officer_cannot_manual_discount_403(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Officer gửi target_final_amount → 403 (field-level authz ở router). Officer
+    vẫn calculate thường được (test khác)."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Officer NoDiscount",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "semester_no": 1,
+            "target_final_amount": "1000000",
+            "manual_discount_reason": "Officer thử tự miễn giảm học phí",
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_manual_discount_target_not_below_net_400(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    accountant_same_unit: dict,
+    fee_calc_config: dict,
+):
+    """target >= mức sau giảm hiện hành (no policy → canonical 5tr) → manual <= 0
+    → 400 (không 'giảm' lên bằng/cao hơn)."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="ManualDiscount TooHigh", approve=False,
+    )
+    ah = await _login(
+        client, accountant_same_unit["username"], accountant_same_unit["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "semester_no": 1,
+            "target_final_amount": "5000000",
+            "manual_discount_reason": "Đặt bằng giá chuẩn - không hợp lệ",
+        },
+        headers=ah,
+    )
+    assert resp.status_code == 400, resp.text

--- a/frontend/src/components/admissions/CalculateFeeDialog.test.tsx
+++ b/frontend/src/components/admissions/CalculateFeeDialog.test.tsx
@@ -15,6 +15,13 @@ import { CalculateFeeDialog } from "./CalculateFeeDialog";
 
 const mutateAsync = vi.fn();
 
+// useAuth điều khiển role để test vùng "Miễn/giảm" (chỉ admin/manager/accountant).
+// Mặc định officer → vùng giảm ẩn (các test cũ không đổi). Đổi .role trong test.
+const { mockAuth } = vi.hoisted(() => ({ mockAuth: { role: "officer" } }));
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: mockAuth }),
+}));
+
 vi.mock("@/hooks/finance/useFees", async () => {
   const actual = await vi.importActual<typeof import("@/hooks/finance/useFees")>(
     "@/hooks/finance/useFees"
@@ -54,6 +61,7 @@ describe("CalculateFeeDialog", () => {
   beforeEach(() => {
     mutateAsync.mockReset();
     mutateAsync.mockResolvedValue({ id: 1, admission_profile_id: 42 });
+    mockAuth.role = "officer"; // mặc định: vùng miễn/giảm ẩn
   });
 
   it("renders semester dropdown only for tuition fee_type", () => {
@@ -163,5 +171,68 @@ describe("CalculateFeeDialog", () => {
         installment_plan_code: "FULL",
       });
     });
+  });
+
+  // ---- Miễn/giảm học phí (Pha 2, 2026-06-29) ----
+
+  it("discount section hidden for officer, visible for finance staff", () => {
+    const { unmount } = render(
+      <CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />
+    );
+    // Officer (mặc định) → không thấy toggle miễn/giảm.
+    expect(
+      screen.queryByRole("switch", { name: /miễn\/giảm học phí/i })
+    ).not.toBeInTheDocument();
+    unmount();
+
+    mockAuth.role = "accountant";
+    render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
+    expect(
+      screen.getByRole("switch", { name: /miễn\/giảm học phí/i })
+    ).toBeInTheDocument();
+  });
+
+  it("manual discount submit posts target_final_amount + reason", async () => {
+    mockAuth.role = "accountant";
+    render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
+    fireEvent.click(screen.getByRole("switch", { name: /miễn\/giảm học phí/i }));
+    fireEvent.change(screen.getByLabelText(/học phí áp dụng/i), {
+      target: { value: "1000000" },
+    });
+    fireEvent.change(screen.getByLabelText(/^lý do/i), {
+      target: { value: "Hoc bong dac biet theo quyet dinh" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^tính học phí$/i }));
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        admission_profile_id: 42,
+        fee_type: "tuition",
+        semester_no: 1,
+        installment_plan_code: "FULL",
+        target_final_amount: "1000000",
+        manual_discount_reason: "Hoc bong dac biet theo quyet dinh",
+      });
+    });
+  });
+
+  it("manual discount blocked until target < final + reason >=10", () => {
+    mockAuth.role = "manager";
+    render(<CalculateFeeDialog open onOpenChange={vi.fn()} profileId={42} />);
+    fireEvent.click(screen.getByRole("switch", { name: /miễn\/giảm học phí/i }));
+
+    const submit = screen.getByRole("button", { name: /^tính học phí$/i });
+    expect(submit).toBeDisabled();
+
+    // target hợp lệ (< 5,000,000 mock) nhưng chưa có lý do → vẫn chặn.
+    fireEvent.change(screen.getByLabelText(/học phí áp dụng/i), {
+      target: { value: "1000000" },
+    });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/^lý do/i), {
+      target: { value: "Hoc bong dac biet theo quyet dinh" },
+    });
+    expect(submit).toBeEnabled();
   });
 });

--- a/frontend/src/components/admissions/CalculateFeeDialog.tsx
+++ b/frontend/src/components/admissions/CalculateFeeDialog.tsx
@@ -38,6 +38,7 @@ import {
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
 import { CurrencyInput } from "@/components/ui/currency-input"
 import {
   Select,
@@ -47,11 +48,19 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 
+import { useAuth } from "@/hooks/useAuth"
 import { useCalculateFee, useTuitionPreview, feesKeys } from "@/hooks/finance/useFees"
 import { useInstallmentPlans } from "@/hooks/finance/useInstallmentPlans"
 import { admissionsKeys } from "@/hooks/admissions/useAdmissions"
 import { financeDashboardKeys } from "@/hooks/finance/useFinanceDashboard"
 import { formatVND } from "@/lib/zod/finance"
+
+const DISCOUNT_REASON_MIN = 10
+const DISCOUNT_REASON_MAX = 500
+// Vai trò được miễn/giảm học phí (giảm NGHĨA VỤ tiền). UX-gating; backend enforce
+// 403 ở route (field-level authz). Cùng tinh thần AdvancedTab (user.role + server
+// enforce) — dialog Tính phí chưa có resource để gắn cờ permission API.
+const FINANCE_ADJUST_ROLES = ["admin", "manager", "accountant"]
 
 type FeeType = "tuition" | "application" | "dormitory" | "other"
 
@@ -71,8 +80,12 @@ const SEMESTER_OPTIONS = [
 
 export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }: Props) {
   const queryClient = useQueryClient()
+  const { user } = useAuth()
   const calculateFee = useCalculateFee()
   const plansQuery = useInstallmentPlans({ enabled: open })
+
+  // Quyền miễn/giảm học phí (UX-gating — backend enforce 403). Chỉ tài chính.
+  const canManualDiscount = !!user && FINANCE_ADJUST_ROLES.includes(user.role)
 
   // Local state — simpler than RHF for a few controlled inputs.
   const [feeType, setFeeType] = useState<FeeType>("tuition")
@@ -84,6 +97,12 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
   const [downPayment, setDownPayment] = useState<number | null>(null)
   const [downPaymentDue, setDownPaymentDue] = useState<string>("")
   const [remainderDue, setRemainderDue] = useState<string>("")
+
+  // Miễn/giảm học phí THẬT — GIẢM nghĩa vụ (final). Loại trừ lẫn nhau với
+  // "đóng trước" (mỗi lần chỉ 1; có thể kết hợp ở thao tác sau).
+  const [discountMode, setDiscountMode] = useState<boolean>(false)
+  const [targetFinal, setTargetFinal] = useState<number | null>(null)
+  const [discountReason, setDiscountReason] = useState<string>("")
 
   const activePlans = useMemo(
     () => (plansQuery.data ?? []).filter((p) => p.is_active !== false),
@@ -99,23 +118,22 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
 
   const isTuition = feeType === "tuition"
   const isDownPayment = isTuition && downPaymentMode
+  const isDiscount = isTuition && canManualDiscount && discountMode
   const isPending = calculateFee.isPending
 
-  // Giá chuẩn — chỉ fetch khi bật "đóng trước" để hiển tổng phải thu + chia đợt.
+  // Giá chuẩn — fetch khi bật "đóng trước" HOẶC "miễn/giảm" để hiển mức phải thu.
   const preview = useTuitionPreview(profileId, semesterNo, {
-    enabled: open && isDownPayment && !!profileId,
+    enabled: open && (isDownPayment || isDiscount) && !!profileId,
   })
 
-  // Tổng PHẢI THU (final) — lịch thu chia con số này (Σ hóa đơn = final − waived;
-  // waived=0 lúc tạo). NULL khi preview chưa tải / lỗi (ngành chưa xác định).
+  // Mức PHẢI THU hiện hành (final = base − giảm policy) — "đóng trước" chia con số
+  // này; "miễn/giảm" yêu cầu target NHỎ HƠN nó. NULL khi preview chưa tải / lỗi.
   const finalAmount = preview.data ? Number(preview.data.final_amount) : null
   const remainder =
     finalAmount != null && downPayment != null ? finalAmount - downPayment : null
 
-  // Hợp lệ khi: có số đóng trước > 0, có cả 2 hạn, hạn đợt 2 >= đợt 1, VÀ đã biết
-  // tổng phải thu (preview.data) với số đóng trước < tổng. Bắt buộc có giá chuẩn:
-  // chia "đóng trước" cần biết tổng để tính phần còn lại — nếu preview đang tải /
-  // lỗi (ngành chưa xác định), chặn submit thay vì để backend từ chối (400).
+  // Đóng trước hợp lệ: có số > 0, đủ 2 hạn, hạn đợt 2 >= đợt 1, và đã biết mức phải
+  // thu (preview) với số đóng trước < mức đó. Chặn submit nếu preview chưa có.
   const downPaymentValid =
     downPayment != null &&
     downPayment > 0 &&
@@ -125,11 +143,26 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
     finalAmount != null &&
     downPayment < finalAmount
 
-  const canSubmit =
-    !isPending &&
-    (isDownPayment
-      ? downPaymentValid
-      : effectivePlanCode !== "" && activePlans.length > 0)
+  // Mức giảm tay (hiển thị) = mức-sau-giảm-policy − học-phí-áp-dụng.
+  const manualReduction =
+    finalAmount != null && targetFinal != null ? finalAmount - targetFinal : null
+
+  // Miễn/giảm hợp lệ: target >= 0, biết mức phải thu (preview), target < mức đó
+  // (phải thực sự giảm), lý do >= min. Bắt buộc có preview để biết mức nền.
+  const discountReasonLen = discountReason.trim().length
+  const discountValid =
+    targetFinal != null &&
+    targetFinal >= 0 &&
+    finalAmount != null &&
+    targetFinal < finalAmount &&
+    discountReasonLen >= DISCOUNT_REASON_MIN &&
+    discountReasonLen <= DISCOUNT_REASON_MAX
+
+  const scheduleValid = isDownPayment
+    ? downPaymentValid
+    : effectivePlanCode !== "" && activePlans.length > 0
+
+  const canSubmit = !isPending && scheduleValid && (!isDiscount || discountValid)
 
   const reset = () => {
     setFeeType("tuition")
@@ -139,6 +172,9 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
     setDownPayment(null)
     setDownPaymentDue("")
     setRemainderDue("")
+    setDiscountMode(false)
+    setTargetFinal(null)
+    setDiscountReason("")
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -160,6 +196,14 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
             remainder_due: remainderDue,
           }
         : { installment_plan_code: effectivePlanCode }),
+      // Miễn/giảm học phí THẬT (GIẢM nghĩa vụ) — "Học phí áp dụng" = final sau MỌI
+      // giảm. Chỉ gửi khi bật + có quyền (backend cũng enforce 403).
+      ...(isDiscount && targetFinal != null
+        ? {
+            target_final_amount: String(targetFinal),
+            manual_discount_reason: discountReason.trim(),
+          }
+        : {}),
     })
 
     // useCalculateFee already invalidates finance caches + toasts on success.
@@ -199,13 +243,16 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
               onValueChange={(v) => {
                 const next = v as FeeType
                 setFeeType(next)
-                // Lịch "đóng trước" chỉ cho tuition → đổi sang loại phí khác thì
-                // tắt + xóa luôn để toggle không kẹt "bật" khi quay lại tuition.
+                // Đóng trước / miễn-giảm chỉ cho tuition → đổi sang loại phí khác
+                // thì tắt + xóa để toggle không kẹt "bật" khi quay lại tuition.
                 if (next !== "tuition") {
                   setDownPaymentMode(false)
                   setDownPayment(null)
                   setDownPaymentDue("")
                   setRemainderDue("")
+                  setDiscountMode(false)
+                  setTargetFinal(null)
+                  setDiscountReason("")
                 }
               }}
               disabled={isPending}
@@ -244,8 +291,9 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
             </div>
           )}
 
-          {/* Toggle "đóng trước theo đợt" — chỉ cho học phí. */}
-          {isTuition && (
+          {/* Toggle "đóng trước theo đợt" — chỉ cho học phí; ẩn khi đang miễn/giảm
+              (loại trừ lẫn nhau để tránh nhập nhằng mức nền). */}
+          {isTuition && !discountMode && (
             <div className="rounded-lg border p-3 space-y-3">
               <div className="flex items-center justify-between">
                 <div className="space-y-0.5">
@@ -346,6 +394,106 @@ export function CalculateFeeDialog({ open, onOpenChange, profileId, onSuccess }:
                         Hạn phần còn lại phải sau hoặc bằng hạn đợt đầu.
                       </p>
                     )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Miễn/giảm học phí THẬT — GIẢM nghĩa vụ. Chỉ admin/manager/accountant
+              (UX-gating; backend enforce 403). Ẩn khi đang "đóng trước". */}
+          {isTuition && canManualDiscount && !downPaymentMode && (
+            <div className="rounded-lg border p-3 space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="discount_mode" className="cursor-pointer">
+                    Miễn/giảm học phí
+                  </Label>
+                  <p className="text-muted-foreground text-xs">
+                    Đặt mức học phí áp dụng thấp hơn (học bổng / chuyển trường / theo
+                    quyết định). GIẢM tổng nghĩa vụ — khác với đóng trước.
+                  </p>
+                </div>
+                <Switch
+                  id="discount_mode"
+                  checked={discountMode}
+                  onCheckedChange={setDiscountMode}
+                  disabled={isPending}
+                />
+              </div>
+
+              {isDiscount && (
+                <div className="space-y-3 pt-1">
+                  <div className="text-xs">
+                    {preview.isLoading && (
+                      <p className="text-muted-foreground">Đang tải mức phải thu…</p>
+                    )}
+                    {preview.isError && (
+                      <p className="text-destructive">
+                        Không tải được giá chuẩn (hồ sơ có thể chưa xác định ngành).
+                      </p>
+                    )}
+                    {preview.data && (
+                      <div className="flex items-center justify-between">
+                        <span className="text-muted-foreground">
+                          Mức phải thu hiện hành:
+                        </span>
+                        <span className="font-medium">
+                          {formatVND(preview.data.final_amount)}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <Label htmlFor="target_final_amount">
+                      Học phí áp dụng <span className="text-destructive">*</span>
+                    </Label>
+                    <CurrencyInput
+                      id="target_final_amount"
+                      value={targetFinal}
+                      onChange={setTargetFinal}
+                      placeholder="Mức học phí sau miễn/giảm…"
+                      disabled={isPending}
+                    />
+                    {manualReduction != null && (
+                      <p
+                        className={
+                          manualReduction <= 0
+                            ? "text-destructive text-xs"
+                            : "text-muted-foreground text-xs"
+                        }
+                      >
+                        {manualReduction > 0
+                          ? `Mức giảm: ${formatVND(manualReduction)}`
+                          : "Học phí áp dụng phải nhỏ hơn mức phải thu hiện hành."}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="space-y-1.5">
+                    <Label htmlFor="discount_reason">
+                      Lý do <span className="text-destructive">*</span>
+                    </Label>
+                    <Textarea
+                      id="discount_reason"
+                      value={discountReason}
+                      onChange={(e) => setDiscountReason(e.target.value)}
+                      placeholder="Ví dụ: Học bổng theo quyết định số…"
+                      rows={2}
+                      maxLength={DISCOUNT_REASON_MAX}
+                      disabled={isPending}
+                      className="resize-none"
+                    />
+                    <p
+                      className={
+                        discountReasonLen > 0 && discountReasonLen < DISCOUNT_REASON_MIN
+                          ? "text-destructive text-xs"
+                          : "text-muted-foreground text-xs"
+                      }
+                    >
+                      Tối thiểu {DISCOUNT_REASON_MIN} ký tự, tối đa {DISCOUNT_REASON_MAX} ({discountReasonLen}).
+                    </p>
+                  </div>
                 </div>
               )}
             </div>

--- a/frontend/src/lib/zod/finance.ts
+++ b/frontend/src/lib/zod/finance.ts
@@ -584,6 +584,18 @@ export const feeCalculateRequestSchema = z
       .optional(),
     down_payment_due: z.string().nullable().optional(),
     remainder_due: z.string().nullable().optional(),
+    // Miễn/giảm học phí THẬT (Pha 2) — "Học phí áp dụng" = final sau MỌI giảm
+    // (Decimal-as-string). Mirror backend validate_manual_tuition.
+    target_final_amount: z
+      .string()
+      .regex(/^\d+(\.\d{1,2})?$/, "Học phí áp dụng không hợp lệ")
+      .nullable()
+      .optional(),
+    manual_discount_reason: z
+      .string()
+      .max(500, "Lý do không được quá 500 ký tự")
+      .nullable()
+      .optional(),
   })
   // Mirror backend validate_collection_schedule: mode="down_payment" ⟹
   // fee_type=tuition + đủ số đóng trước & 2 hạn + hạn đợt 2 >= đợt 1.
@@ -616,6 +628,29 @@ export const feeCalculateRequestSchema = z
       path: ["remainder_due"],
     }
   )
+  // Mirror backend validate_manual_tuition: có target ⟹ tuition + reason ≥10;
+  // có reason ⟹ phải có target. (target < mức nền kiểm ở service — cần canonical.)
+  .refine(
+    (d) =>
+      d.target_final_amount == null || (d.fee_type ?? "tuition") === "tuition",
+    {
+      message: "Miễn/giảm học phí chỉ áp dụng cho học phí",
+      path: ["target_final_amount"],
+    }
+  )
+  .refine(
+    (d) =>
+      d.target_final_amount == null ||
+      (!!d.manual_discount_reason && d.manual_discount_reason.trim().length >= 10),
+    {
+      message: "Cần lý do miễn/giảm học phí (tối thiểu 10 ký tự)",
+      path: ["manual_discount_reason"],
+    }
+  )
+  .refine((d) => !d.manual_discount_reason || d.target_final_amount != null, {
+    message: "Có lý do miễn/giảm nhưng thiếu mức học phí áp dụng",
+    path: ["target_final_amount"],
+  })
 
 export type FeeCalculateRequest = z.infer<typeof feeCalculateRequestSchema>
 

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -579,6 +579,11 @@ export interface FeeCalculateRequest {
   down_payment?: string | null // Decimal as string
   down_payment_due?: string | null // YYYY-MM-DD
   remainder_due?: string | null // YYYY-MM-DD
+  // Miễn/giảm học phí THẬT (Pha 2) — GIẢM nghĩa vụ. "Học phí áp dụng" = final sau
+  // MỌI giảm (Decimal as string). CHỈ tuition + reason ≥10 + quyền
+  // admin/manager/accountant (backend enforce 403). Bỏ khi không miễn/giảm.
+  target_final_amount?: string | null
+  manual_discount_reason?: string | null
 }
 
 /** Giá chuẩn học phí (GET /api/fees/tuition-preview) — Decimal as string. */


### PR DESCRIPTION
## Mục tiêu
Cho **accountant/manager/admin** miễn/giảm học phí THẬT (học bổng / chuyển trường / theo quyết định) ngay tại dialog Tính phí — **GIẢM nghĩa vụ** (final), GIỮ `base_amount` = canonical. Khác Pha 1 (đóng trước chỉ giãn lịch thu).

> ⚠️ **Stacked PR**: base = `feat/manual-tuition-amount` (Pha 1, PR #446). Merge #446 trước, rồi rebase nhánh này lên `main` + đổi base PR → main. Diff hiện tại chỉ là phần Pha 2.

## Thiết kế (D1/D2/D3 = a/a/a)
- **D1** — áp ngay tại `POST /api/fees/calculate` (không re-sync hóa đơn).
- **D3 — công thức:** "Học phí áp dụng" (`target_final_amount`) = final SAU MỌI giảm → `manual_discount = canonical − existing_policy_discount − target` (**KHÔNG** canonical−target → tránh double-giảm khi đã có policy discount) → `final == target`. Ghi 1 `FeeAppliedDiscount(policy_id=NULL)` + `calculation_snapshot{source="manual_discount", reason, approved_by, canonical_amount, existing_policy_discount, target_final_amount, discount_amount}`. Guard `manual_discount > 0` (target < net) → 400; schema 422 (tuition-only, reason ≥10 đo RAW trước escape, target ≥ 0).
- **D2 — field-level authz Ở ROUTER:** officer gửi `target_final_amount` → **403** (`PermissionDeniedError`); officer vẫn calculate thường + down-payment. KHÔNG Casbin migration (cùng endpoint).
- **FE:** vùng "Miễn/giảm học phí" trong dialog, hiện cho admin/manager/accountant (useAuth role — UX-gating, backend enforce 403); **loại trừ lẫn nhau** với "đóng trước".

## /code-review max → 1 fix
- **#1 (money):** `recalculate_fee` trên phí có miễn/giảm thủ công → BỎ RƠI giảm tay khỏi final (recalc chỉ tính lại policy discount). **Đã vá:** chặn recalc (BusinessRuleViolation → 400) khi fee có dòng `source="manual_discount"` → bắt hủy & tạo lại. (#2/#3 là lệch convention đã chốt chủ ý: router field-level authz + FE user.role.)

## Test
- BE **+5** (giảm-giữ-base+snapshot · sau-policy KHÔNG-double-giảm 3.5tr · officer→403 · target≥net→400 · recalc-guard). One-off container.
- FE: type-check sạch + lint 0 error + **10 dialog test** (3 miễn/giảm).
- ✅ **Chrome smoke dev FULL-FLOW PASS** (accountant qua finance workspace): DB `base=7tr GIỮ · final=1tr=target · dòng manual policy_id=NULL 6tr source=manual_discount approved_by=accountant`.

## Deploy
Như Pha 1 — migration Casbin `mta20260628001` (tuition-preview) + restart backend. **Pha 2 KHÔNG thêm migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)