### PR TITLE
feat(sms): PR-4 Export Excel per nhà mạng + download + mark-handed-off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ virtualenv/
 # Uploaded files
 **/static/uploads/**
 **/uploads/**
+# SMS export files (PII — private, ngoài webroot; PR-4)
+**/private_exports/**
 
 # Celery
 celerybeat-schedule

--- a/Backend_FastAPI/app/celery_app.py
+++ b/Backend_FastAPI/app/celery_app.py
@@ -155,6 +155,12 @@ celery_app.conf.beat_schedule = {
         "schedule": crontab(hour=2, minute=30),  # Shifted to 02:30 (was 02:00, now taken by plan sync)
         "options": {"queue": "default"},
     },
+    # --- SMS Marketing export retention (PR-4) ---
+    "cleanup-sms-export-files-daily": {
+        "task": "cleanup_sms_export_files_task",
+        "schedule": crontab(hour=3, minute=45),  # 03:45 — dọn export hết hạn
+        "options": {"queue": "default"},
+    },
 
     # --- KPI Plan Daily Actuals Sync (P4) ---
     "sync-kpi-plan-actuals-daily": {

--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -271,6 +271,16 @@ class Settings(BaseSettings):
         default=SMS_OPTOUT_INSTRUCTION_DEFAULT,
         validation_alias="SMS_OPTOUT_INSTRUCTION",
     )  # hướng dẫn từ chối SMS/điện thoại — org BẮT BUỘC đặt nội dung thật
+    # -- Export file Excel per nhà mạng (PR-4) --
+    SMS_EXPORT_STORAGE_DIR: str = Field(
+        default="/app/private_exports/sms",
+        validation_alias="SMS_EXPORT_STORAGE_DIR",
+    )  # NGOÀI webroot (§11.7) — file chứa phone + raw short code; chỉ tải qua
+    # endpoint admin có auth, KHÔNG khai báo nginx location public
+    SMS_EXPORT_RETENTION_DAYS: int = Field(
+        default=14, ge=1, le=365,
+        validation_alias="SMS_EXPORT_RETENTION_DAYS",
+    )  # re-download tới expires_at; cleanup job xoá file + set purged_at
 
     # -- Docker self-hosted deployment --
     # When True, skip TLS enforcement for DB/Redis connections.

--- a/Backend_FastAPI/app/repositories/sms_export_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_export_repository.py
@@ -1,0 +1,258 @@
+# app/repositories/sms_export_repository.py
+"""
+Data-access SMS export (PR-4): export-batch lifecycle (find-or-create idempotent
+theo (campaign, revision, carrier), update generated/failed/handed_off/purged),
+recipient EXPORTABLE per nhà mạng (để sinh Excel), re-check consent/suppression
+drift fail-closed, và đánh dấu handed_off (recipient + contact freq-cap).
+
+Standalone repository (giống sms_campaign_repository). Service flush, router
+commit. Xem SMS_MARKETING_MODULE_DESIGN.md §8 / §11.7.
+"""
+from datetime import datetime
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.sms import (
+    SmsCampaignExportBatch,
+    SmsCampaignRecipient,
+    SmsContact,
+    SmsContactGroup,
+    SmsOptOut,
+)
+
+
+class SmsExportRepository:
+    """Repository export-batch + recipient export + drift re-check + handoff."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_group_names(
+        self, group_ids: Sequence[int]
+    ) -> Dict[int, str]:
+        """{group_id: tên nhóm} để dựng nhãn filename B2 (1 nhóm→tên; nhiều
+        nhóm→'A+B+N'). Lấy tên kể cả nhóm đã ngừng hoạt động (nhãn = snapshot
+        lựa chọn)."""
+        if not group_ids:
+            return {}
+        res = await self.db.execute(
+            select(SmsContactGroup.id, SmsContactGroup.name).where(
+                SmsContactGroup.id.in_(set(group_ids))
+            )
+        )
+        return {r[0]: r[1] for r in res.all()}
+
+    # ---------------------------------------------------------------
+    # Recipient EXPORTABLE (revision hiện tại, chưa invalidated, không bị loại)
+    # ---------------------------------------------------------------
+    def _exportable_filter(self, campaign_id: int, revision: int):
+        return (
+            SmsCampaignRecipient.campaign_id == campaign_id,
+            SmsCampaignRecipient.build_revision == revision,
+            SmsCampaignRecipient.invalidated_at.is_(None),
+            SmsCampaignRecipient.excluded_reason.is_(None),
+        )
+
+    async def get_exportable_recipients(
+        self, campaign_id: int, revision: int, carrier_bucket: str
+    ) -> List[SmsCampaignRecipient]:
+        """Recipient sẽ ghi vào file của 1 nhà mạng — order id ổn định."""
+        res = await self.db.execute(
+            select(SmsCampaignRecipient)
+            .where(
+                *self._exportable_filter(campaign_id, revision),
+                SmsCampaignRecipient.carrier_bucket == carrier_bucket,
+            )
+            .order_by(SmsCampaignRecipient.id)
+        )
+        return list(res.scalars().all())
+
+    async def counts_by_carrier_exportable(
+        self, campaign_id: int, revision: int
+    ) -> List[Tuple[str, int]]:
+        """(carrier_bucket, count) cho recipient exportable — mỗi carrier 1 file."""
+        res = await self.db.execute(
+            select(SmsCampaignRecipient.carrier_bucket, func.count())
+            .where(*self._exportable_filter(campaign_id, revision))
+            .group_by(SmsCampaignRecipient.carrier_bucket)
+            .order_by(SmsCampaignRecipient.carrier_bucket)
+        )
+        return [(r[0], int(r[1])) for r in res.all()]
+
+    async def count_over_limit(self, campaign_id: int, revision: int) -> int:
+        """Số recipient bị loại VÌ over_limit (gate export chặn nếu >0, §8.4)."""
+        res = await self.db.scalar(
+            select(func.count())
+            .select_from(SmsCampaignRecipient)
+            .where(
+                SmsCampaignRecipient.campaign_id == campaign_id,
+                SmsCampaignRecipient.build_revision == revision,
+                SmsCampaignRecipient.invalidated_at.is_(None),
+                SmsCampaignRecipient.excluded_reason == "over_limit",
+            )
+        )
+        return int(res or 0)
+
+    # ---------------------------------------------------------------
+    # Re-check consent/suppression FRESH ngay trước export (fail-closed §8.4)
+    # ---------------------------------------------------------------
+    async def count_lost_consent(self, campaign_id: int, revision: int) -> int:
+        """Recipient exportable mà contact ĐÃ mất consent (revoked/unknown) hoặc
+        contact bị xoá (contact_id NULL → consent không xác định được)."""
+        res = await self.db.scalar(
+            select(func.count())
+            .select_from(SmsCampaignRecipient)
+            .outerjoin(
+                SmsContact, SmsContact.id == SmsCampaignRecipient.contact_id
+            )
+            .where(
+                *self._exportable_filter(campaign_id, revision),
+                (SmsContact.id.is_(None))
+                | (SmsContact.marketing_consent_status != "granted"),
+            )
+        )
+        return int(res or 0)
+
+    async def count_new_suppression(
+        self, campaign_id: int, revision: int
+    ) -> int:
+        """Recipient exportable mà số ĐÃ vào sms_opt_out (opt-out/DNC) sau build."""
+        suppressed = select(SmsOptOut.phone_normalized)
+        res = await self.db.scalar(
+            select(func.count())
+            .select_from(SmsCampaignRecipient)
+            .where(
+                *self._exportable_filter(campaign_id, revision),
+                SmsCampaignRecipient.phone_normalized_snapshot.in_(suppressed),
+            )
+        )
+        return int(res or 0)
+
+    # ---------------------------------------------------------------
+    # Export batch lifecycle
+    # ---------------------------------------------------------------
+    async def get_batch_for_carrier_locked(
+        self, campaign_id: int, revision: int, carrier_bucket: str
+    ) -> Optional[SmsCampaignExportBatch]:
+        """Lock batch (campaign, revision, carrier) — find-or-create idempotent.
+        Concurrent caller gom về cùng row qua UNIQUE + FOR UPDATE."""
+        res = await self.db.execute(
+            select(SmsCampaignExportBatch)
+            .where(
+                SmsCampaignExportBatch.campaign_id == campaign_id,
+                SmsCampaignExportBatch.build_revision == revision,
+                SmsCampaignExportBatch.carrier_bucket == carrier_bucket,
+            )
+            .with_for_update()
+        )
+        return res.scalar_one_or_none()
+
+    async def create_batch(self, fields: dict) -> SmsCampaignExportBatch:
+        batch = SmsCampaignExportBatch(**fields)
+        self.db.add(batch)
+        await self.db.flush()
+        return batch
+
+    async def get_batch(
+        self, batch_id: int
+    ) -> Optional[SmsCampaignExportBatch]:
+        res = await self.db.execute(
+            select(SmsCampaignExportBatch).where(
+                SmsCampaignExportBatch.id == batch_id
+            )
+        )
+        return res.scalars().first()
+
+    async def get_batch_for_update(
+        self, batch_id: int
+    ) -> Optional[SmsCampaignExportBatch]:
+        res = await self.db.execute(
+            select(SmsCampaignExportBatch)
+            .where(SmsCampaignExportBatch.id == batch_id)
+            .with_for_update()
+        )
+        return res.scalar_one_or_none()
+
+    async def list_batches(
+        self, campaign_id: int, revision: int
+    ) -> List[SmsCampaignExportBatch]:
+        res = await self.db.execute(
+            select(SmsCampaignExportBatch)
+            .where(
+                SmsCampaignExportBatch.campaign_id == campaign_id,
+                SmsCampaignExportBatch.build_revision == revision,
+            )
+            .order_by(SmsCampaignExportBatch.carrier_bucket)
+        )
+        return list(res.scalars().all())
+
+    async def list_purgeable_batches(
+        self, now: datetime, limit: int = 500
+    ) -> List[SmsCampaignExportBatch]:
+        """Batch còn file (generated/handed_off/failed) đã quá expires_at →
+        cleanup job xoá file + set purged. failed cũng dọn temp nếu sót."""
+        res = await self.db.execute(
+            select(SmsCampaignExportBatch)
+            .where(
+                SmsCampaignExportBatch.status.in_(
+                    ("generated", "handed_off", "failed")
+                ),
+                SmsCampaignExportBatch.purged_at.is_(None),
+                SmsCampaignExportBatch.expires_at.is_not(None),
+                SmsCampaignExportBatch.expires_at < now,
+            )
+            .order_by(SmsCampaignExportBatch.id)
+            .limit(limit)
+        )
+        return list(res.scalars().all())
+
+    # ---------------------------------------------------------------
+    # Handed-off: recipient + contact freq-cap proxy
+    # ---------------------------------------------------------------
+    async def mark_recipients_handed_off(
+        self, campaign_id: int, revision: int, carrier_bucket: str, now: datetime
+    ) -> Sequence[int]:
+        """Set handed_off_at cho recipient exportable của batch → chặn rebuild
+        (has_handed_off_recipients) + neo freq-cap. Trả contact_id liên quan."""
+        res = await self.db.execute(
+            update(SmsCampaignRecipient)
+            .where(
+                *self._exportable_filter(campaign_id, revision),
+                SmsCampaignRecipient.carrier_bucket == carrier_bucket,
+                SmsCampaignRecipient.handed_off_at.is_(None),
+            )
+            .values(handed_off_at=now)
+            .returning(SmsCampaignRecipient.contact_id)
+        )
+        return [r[0] for r in res.all() if r[0] is not None]
+
+    async def touch_contacts_handed_off(
+        self, contact_ids: Sequence[int], now: datetime
+    ) -> None:
+        """Cập nhật last_handed_off_at (frequency-cap proxy §4.2) cho contact
+        vừa bàn giao."""
+        if not contact_ids:
+            return
+        await self.db.execute(
+            update(SmsContact)
+            .where(SmsContact.id.in_(set(contact_ids)))
+            .values(last_handed_off_at=now)
+        )
+
+    async def count_unhanded_batches(
+        self, campaign_id: int, revision: int
+    ) -> int:
+        """Số batch của revision CHƯA bàn giao (status != handed_off) — để
+        chuyển campaign sang 'closed' khi tất cả nhà mạng đã bàn giao."""
+        res = await self.db.scalar(
+            select(func.count())
+            .select_from(SmsCampaignExportBatch)
+            .where(
+                SmsCampaignExportBatch.campaign_id == campaign_id,
+                SmsCampaignExportBatch.build_revision == revision,
+                SmsCampaignExportBatch.status != "handed_off",
+            )
+        )
+        return int(res or 0)

--- a/Backend_FastAPI/app/repositories/sms_export_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_export_repository.py
@@ -48,11 +48,15 @@ class SmsExportRepository:
     # Recipient EXPORTABLE (revision hiện tại, chưa invalidated, không bị loại)
     # ---------------------------------------------------------------
     def _exportable_filter(self, campaign_id: int, revision: int):
+        # handed_off_at IS NULL: chỉ recipient CHƯA bàn giao → drift gate +
+        # sinh file chỉ xét/ghi người chưa gửi. Tránh wedge: drift trên nhà
+        # mạng ĐÃ bàn giao không chặn re-export nhà mạng khác đang failed.
         return (
             SmsCampaignRecipient.campaign_id == campaign_id,
             SmsCampaignRecipient.build_revision == revision,
             SmsCampaignRecipient.invalidated_at.is_(None),
             SmsCampaignRecipient.excluded_reason.is_(None),
+            SmsCampaignRecipient.handed_off_at.is_(None),
         )
 
     async def get_exportable_recipients(
@@ -237,6 +241,10 @@ class SmsExportRepository:
             )
             .order_by(SmsCampaignExportBatch.id)
             .limit(limit)
+            # FOR UPDATE SKIP LOCKED: giữ khoá khi cleanup ghi purged → không
+            # lost-update với prepare_export đang re-export reset CÙNG batch;
+            # batch đang bị re-export (đã khoá) thì cleanup BỎ QUA (skip).
+            .with_for_update(skip_locked=True)
         )
         return list(res.scalars().all())
 

--- a/Backend_FastAPI/app/repositories/sms_export_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_export_repository.py
@@ -9,9 +9,9 @@ Standalone repository (giống sms_campaign_repository). Service flush, router
 commit. Xem SMS_MARKETING_MODULE_DESIGN.md §8 / §11.7.
 """
 from datetime import datetime
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence
 
-from sqlalchemy import func, select, update
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.sms import (
@@ -58,28 +58,29 @@ class SmsExportRepository:
     async def get_exportable_recipients(
         self, campaign_id: int, revision: int, carrier_bucket: str
     ) -> List[SmsCampaignRecipient]:
-        """Recipient sẽ ghi vào file của 1 nhà mạng — order id ổn định."""
+        """Recipient sẽ ghi vào file của 1 nhà mạng — order id ổn định.
+
+        Fail-closed TẠI THỜI ĐIỂM SINH FILE (đóng khe TOCTOU giữa gate
+        pre-commit và sinh file post-commit sau khi nhả lock): chỉ lấy
+        recipient mà contact VẪN consent 'granted' VÀ số CHƯA vào sms_opt_out.
+        Recipient mất contact (contact_id NULL → INNER JOIN loại) cũng bị loại."""
+        suppressed = select(SmsOptOut.phone_normalized)
         res = await self.db.execute(
             select(SmsCampaignRecipient)
+            .join(
+                SmsContact, SmsContact.id == SmsCampaignRecipient.contact_id
+            )
             .where(
                 *self._exportable_filter(campaign_id, revision),
                 SmsCampaignRecipient.carrier_bucket == carrier_bucket,
+                SmsContact.marketing_consent_status == "granted",
+                SmsCampaignRecipient.phone_normalized_snapshot.notin_(
+                    suppressed
+                ),
             )
             .order_by(SmsCampaignRecipient.id)
         )
         return list(res.scalars().all())
-
-    async def counts_by_carrier_exportable(
-        self, campaign_id: int, revision: int
-    ) -> List[Tuple[str, int]]:
-        """(carrier_bucket, count) cho recipient exportable — mỗi carrier 1 file."""
-        res = await self.db.execute(
-            select(SmsCampaignRecipient.carrier_bucket, func.count())
-            .where(*self._exportable_filter(campaign_id, revision))
-            .group_by(SmsCampaignRecipient.carrier_bucket)
-            .order_by(SmsCampaignRecipient.carrier_bucket)
-        )
-        return [(r[0], int(r[1])) for r in res.all()]
 
     async def count_over_limit(self, campaign_id: int, revision: int) -> int:
         """Số recipient bị loại VÌ over_limit (gate export chặn nếu >0, §8.4)."""
@@ -188,20 +189,51 @@ class SmsExportRepository:
         )
         return list(res.scalars().all())
 
+    async def invalidate_export_batches_before(
+        self, campaign_id: int, before_revision: int
+    ) -> None:
+        """Rebuild (revision mới) → vô hiệu MỌI export batch revision CŨ
+        (pending/generated/failed) → status='invalidated' + invalidated_at.
+        download check invalidated_at nên KHÔNG còn phục vụ file revision cũ
+        (PII lỗi thời/consent đã đổi). KHÔNG đụng batch đã 'handed_off' (giữ
+        audit; rebuild vốn đã bị chặn nếu có recipient handed_off)."""
+        await self.db.execute(
+            update(SmsCampaignExportBatch)
+            .where(
+                SmsCampaignExportBatch.campaign_id == campaign_id,
+                SmsCampaignExportBatch.build_revision < before_revision,
+                SmsCampaignExportBatch.status.in_(
+                    ("pending", "generated", "failed")
+                ),
+                SmsCampaignExportBatch.invalidated_at.is_(None),
+            )
+            .values(status="invalidated", invalidated_at=func.now())
+        )
+
     async def list_purgeable_batches(
         self, now: datetime, limit: int = 500
     ) -> List[SmsCampaignExportBatch]:
-        """Batch còn file (generated/handed_off/failed) đã quá expires_at →
-        cleanup job xoá file + set purged. failed cũng dọn temp nếu sót."""
+        """Batch cần dọn file (purged_at NULL):
+        (a) generated/handed_off đã quá `expires_at` (hết retention); HOẶC
+        (b) failed/invalidated → dọn NGAY không phụ thuộc expires_at (file rác/
+        ghi-dở hoặc revision cũ; batch failed luôn có expires_at=NULL nên KHÔNG
+        thể gộp vào nhánh (a) — nếu không sẽ rò rỉ PII vĩnh viễn)."""
         res = await self.db.execute(
             select(SmsCampaignExportBatch)
             .where(
-                SmsCampaignExportBatch.status.in_(
-                    ("generated", "handed_off", "failed")
-                ),
                 SmsCampaignExportBatch.purged_at.is_(None),
-                SmsCampaignExportBatch.expires_at.is_not(None),
-                SmsCampaignExportBatch.expires_at < now,
+                or_(
+                    SmsCampaignExportBatch.status.in_(
+                        ("failed", "invalidated")
+                    ),
+                    and_(
+                        SmsCampaignExportBatch.status.in_(
+                            ("generated", "handed_off")
+                        ),
+                        SmsCampaignExportBatch.expires_at.is_not(None),
+                        SmsCampaignExportBatch.expires_at < now,
+                    ),
+                ),
             )
             .order_by(SmsCampaignExportBatch.id)
             .limit(limit)

--- a/Backend_FastAPI/app/routers/sms_export.py
+++ b/Backend_FastAPI/app/routers/sms_export.py
@@ -1,8 +1,108 @@
 # app/routers/sms_export.py
 """
 SMS Marketing — export Excel per nhà mạng + download + mark-handed-off (admin).
-Stub PR-1; routes thêm ở **PR-4 (Codex)**. KHÔNG sửa main.py (đã wire ở PR-1).
+PR-4. Router "dumb": dịch HTTP ↔ service, commit, không business logic. Hard
+gate `require_admin`. KHÔNG sửa main.py (đã wire ở PR-1).
+
+File export sinh ở POST-COMMIT (service trả callback) — router commit business
+transaction TRƯỚC rồi await callback (§8.3). Download trả bytes (đã verify
+sha256) qua Response no-store.
 """
-from fastapi import APIRouter
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, Request, status
+from fastapi.responses import Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database, models
+from app.core.deps import require_admin
+from app.core.rate_limits import RateLimits, limiter
+from app.schemas import sms as sms_schemas
+from app.services.sms_export_service import SmsExportService
 
 router = APIRouter(prefix="/api/sms", tags=["SMS Export"])
+
+# Giới hạn ID khớp cột Integer (int4) — chặn int32 overflow → 500.
+_MAX_ID = 2147483647
+
+
+@limiter.limit(RateLimits.DATA_EXPORT)  # build workbook nặng + chứa PII
+@router.post(
+    "/campaigns/{campaign_id}/export",
+    response_model=sms_schemas.SmsExportResult,
+    status_code=status.HTTP_201_CREATED,
+)
+async def export_campaign(
+    request: Request,  # required by slowapi rate limiter
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    """Sinh file Excel per nhà mạng cho bản build hiện tại (idempotent theo
+    campaign/revision/nhà mạng). Gate fail-closed: cần đủ 3 attestation đúng
+    revision, không còn over_limit, không drift consent/suppression."""
+    service = SmsExportService(db)
+    callback, _meta = await service.prepare_export(campaign_id, current_user)
+    await db.commit()
+    if callback is not None:
+        await callback()
+    return await service.get_export_result(campaign_id)
+
+
+@router.get(
+    "/campaigns/{campaign_id}/exports",
+    response_model=sms_schemas.SmsExportBatchList,
+)
+async def list_exports(
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    """Danh sách batch export của bản build hiện tại (FE hiển thị lại sau
+    reload)."""
+    return await SmsExportService(db).list_export_batches(campaign_id)
+
+
+@limiter.limit(RateLimits.DATA_EXPORT)
+@router.get("/campaigns/{campaign_id}/exports/{batch_id}/download")
+async def download_export(
+    request: Request,  # required by slowapi rate limiter
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    batch_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+) -> Response:
+    """Tải file export (auth + verify sha256 + chưa hết hạn/vô hiệu). Filename
+    đã sanitize ASCII nên Content-Disposition đơn giản là an toàn."""
+    content, filename, media = await SmsExportService(db).get_export_file(
+        campaign_id, batch_id
+    )
+    return Response(
+        content=content,
+        media_type=media,
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Cache-Control": "no-store",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+@router.post(
+    "/campaigns/{campaign_id}/exports/{batch_id}/mark-handed-off",
+    response_model=sms_schemas.SmsExportBatchOut,
+)
+async def mark_handed_off(
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    batch_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    """Xác nhận đã bàn giao/upload file cho nhà mạng (ngoài QLTS). Neo
+    handed_off lên recipient (chặn rebuild) + frequency-cap; đóng campaign khi
+    mọi nhà mạng đã bàn giao."""
+    result = await SmsExportService(db).mark_handed_off(
+        campaign_id, batch_id, current_user
+    )
+    await db.commit()
+    return result

--- a/Backend_FastAPI/app/routers/sms_export.py
+++ b/Backend_FastAPI/app/routers/sms_export.py
@@ -11,7 +11,7 @@ sha256) qua Response no-store.
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path, Request, status
-from fastapi.responses import Response
+from fastapi.responses import FileResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database, models
@@ -26,12 +26,12 @@ router = APIRouter(prefix="/api/sms", tags=["SMS Export"])
 _MAX_ID = 2147483647
 
 
-@limiter.limit(RateLimits.DATA_EXPORT)  # build workbook nặng + chứa PII
 @router.post(
     "/campaigns/{campaign_id}/export",
     response_model=sms_schemas.SmsExportResult,
     status_code=status.HTTP_201_CREATED,
 )
+@limiter.limit(RateLimits.DATA_EXPORT)  # build workbook nặng + chứa PII
 async def export_campaign(
     request: Request,  # required by slowapi rate limiter
     campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
@@ -63,25 +63,26 @@ async def list_exports(
     return await SmsExportService(db).list_export_batches(campaign_id)
 
 
-@limiter.limit(RateLimits.DATA_EXPORT)
 @router.get("/campaigns/{campaign_id}/exports/{batch_id}/download")
+@limiter.limit(RateLimits.DATA_EXPORT)
 async def download_export(
     request: Request,  # required by slowapi rate limiter
     campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
     batch_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(require_admin),
-) -> Response:
-    """Tải file export (auth + verify sha256 + chưa hết hạn/vô hiệu). Filename
-    đã sanitize ASCII nên Content-Disposition đơn giản là an toàn."""
-    content, filename, media = await SmsExportService(db).get_export_file(
+) -> FileResponse:
+    """Tải file export (auth + verify sha256 + chưa hết hạn/vô hiệu). Stream từ
+    đĩa bằng FileResponse (KHÔNG nạp cả file PII vào RAM); Starlette tự encode
+    Content-Disposition an toàn cho filename."""
+    storage_path, filename, media = await SmsExportService(db).get_export_file(
         campaign_id, batch_id
     )
-    return Response(
-        content=content,
+    return FileResponse(
+        storage_path,
         media_type=media,
+        filename=filename,
         headers={
-            "Content-Disposition": f'attachment; filename="{filename}"',
             "Cache-Control": "no-store",
             "X-Content-Type-Options": "nosniff",
         },

--- a/Backend_FastAPI/app/schemas/sms.py
+++ b/Backend_FastAPI/app/schemas/sms.py
@@ -480,3 +480,61 @@ class SmsAttestationCreate(BaseModel):
     @classmethod
     def _v_reference(cls, v):
         return _strip_required_text(v)
+
+
+# =====================================================================
+# Export batch (PR-4) — 1 file Excel / nhà mạng / build_revision
+# =====================================================================
+# Mirror CHECK chk_sms_export_batch_status.
+SmsExportStatus = Literal[
+    "pending", "generated", "handed_off", "failed", "purged", "invalidated"
+]
+
+
+class SmsExportBatchOut(BaseModel):
+    """Metadata + vòng đời 1 file export per nhà mạng. KHÔNG lộ
+    `storage_path`/`file_sha256` (nội bộ); FE thin-client đọc cờ `can_*`
+    thay vì tự suy trạng thái."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    campaign_id: int
+    build_revision: int
+    group_id: Optional[int] = None
+    group_name_snapshot: Optional[str] = None
+    carrier_bucket: str
+    recipient_count: int
+    file_name: Optional[str] = None
+    file_size_bytes: Optional[int] = None
+    status: str
+    failure_reason: Optional[str] = None
+    expires_at: Optional[datetime] = None
+    generated_at: Optional[datetime] = None
+    generated_by_id: Optional[int] = None
+    marked_handed_off_at: Optional[datetime] = None
+    invalidated_at: Optional[datetime] = None
+    # Computed (service điền) — thin-client đọc cờ, không suy luận role/status.
+    can_download: bool = False
+    can_mark_handed_off: bool = False
+    is_expired: bool = False
+
+
+class SmsExportResult(BaseModel):
+    """Kết quả POST export: danh sách batch per nhà mạng + tổng quan. File
+    sinh ở post-commit (status có thể 'pending'→'generated' khi callback xong)."""
+
+    campaign_id: int
+    build_revision: int
+    total_exportable: int
+    batches: List[SmsExportBatchOut] = Field(default_factory=list)
+    message: Optional[str] = None
+
+
+class SmsExportBatchList(BaseModel):
+    """GET danh sách batch của campaign (revision hiện tại) — FE hiển thị lại
+    sau reload."""
+
+    campaign_id: int
+    build_revision: int
+    batches: List[SmsExportBatchOut] = Field(default_factory=list)

--- a/Backend_FastAPI/app/services/sms_campaign_service.py
+++ b/Backend_FastAPI/app/services/sms_campaign_service.py
@@ -391,6 +391,14 @@ class SmsCampaignService:
 
         new_revision = campaign.build_revision + 1
         await self.repo.invalidate_recipients_before(campaign_id, new_revision)
+        # Rebuild → vô hiệu export batch revision CŨ (PR-4): file revision cũ
+        # KHÔNG còn tải được (PII/consent lỗi thời) + status='invalidated' để
+        # cleanup dọn. Import cục bộ tránh phụ thuộc vòng tại module-load.
+        from app.repositories.sms_export_repository import SmsExportRepository
+
+        await SmsExportRepository(self.db).invalidate_export_batches_before(
+            campaign_id, new_revision
+        )
 
         # Gom member → dedupe theo phone, gom group_ids đóng góp.
         members = await self.repo.get_members_of_groups(group_ids)

--- a/Backend_FastAPI/app/services/sms_export_service.py
+++ b/Backend_FastAPI/app/services/sms_export_service.py
@@ -199,7 +199,9 @@ class SmsExportService:
         now = datetime.now(timezone.utc)
         to_generate: List[int] = []
 
-        for carrier_bucket, count in carriers.items():
+        # sorted(): khoá batch theo carrier ĐỊNH TÍNH → tránh deadlock thứ tự
+        # khoá ngẫu nhiên (dict order) với job khác khoá theo id.
+        for carrier_bucket, count in sorted(carriers.items()):
             file_name = sanitize_export_filename(
                 group_label, campaign.name, _carrier_label(carrier_bucket)
             )
@@ -225,6 +227,11 @@ class SmsExportService:
                 )
                 to_generate.append(batch.id)
                 continue
+            # Stat file ngoài event loop (to_thread) — không chặn loop khi đang
+            # giữ lock campaign; chỉ chạy cho batch đã có storage_path.
+            file_present = bool(
+                batch.storage_path
+            ) and await asyncio.to_thread(os.path.isfile, batch.storage_path)
             # Regenerate khi chưa-có-file (pending/failed/purged/invalidated)
             # HOẶC 'generated' nhưng đã hết hạn / file biến mất trên đĩa (#9 —
             # tránh admin re-export mà vẫn không có file dùng được).
@@ -235,10 +242,7 @@ class SmsExportService:
                         batch.expires_at is not None
                         and _aware(batch.expires_at) <= now
                     )
-                    or not (
-                        batch.storage_path
-                        and os.path.isfile(batch.storage_path)
-                    )
+                    or not file_present
                 )
             )
             if needs_regen:

--- a/Backend_FastAPI/app/services/sms_export_service.py
+++ b/Backend_FastAPI/app/services/sms_export_service.py
@@ -10,10 +10,9 @@ chỉ `flush` (router commit). File sinh trong callback dùng `AsyncSessionLocal
 MỚI vì db gốc đã commit/đóng transaction — §8.3.
 Xem SMS_MARKETING_MODULE_DESIGN.md §8 / §11.7.
 """
-import hashlib
+import asyncio
 import logging
 import os
-import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Callable, List, Optional, Tuple
 
@@ -28,9 +27,10 @@ from app.schemas import sms as sms_schemas
 from app.utils.exceptions import BusinessRuleViolation, ResourceNotFoundError
 from app.utils.sms_export import (
     XLSX_MEDIA,
-    build_carrier_workbook,
     render_export_message,
     sanitize_export_filename,
+    sha256_file,
+    write_export_atomic,
 )
 from app.utils.sms_render import has_link
 
@@ -38,7 +38,11 @@ log = logging.getLogger(__name__)
 
 # Campaign đã build, được phép export (lần đầu 'ready'; re-export idempotent
 # khi 'exported'). 'draft' = chưa build/stale; 'handed_off'/'closed' = khoá.
-_EXPORTABLE_CAMPAIGN_STATUS = {"ready", "exported"}
+# Campaign được phép export: 'ready' (lần đầu), 'exported' (re-export), và
+# 'handed_off' (re-export để RETRY batch failed của nhà mạng khác mà không
+# kẹt — xem mark_handed_off). 'draft' = chưa build/stale; 'closed' = đã bàn
+# giao hết → khoá.
+_EXPORTABLE_CAMPAIGN_STATUS = {"ready", "exported", "handed_off"}
 # Batch ở các trạng thái này = CHƯA có file dùng được → (re)generate.
 _REGENERATE_BATCH_STATUS = {"pending", "failed", "purged", "invalidated"}
 
@@ -48,7 +52,9 @@ def _aware(dt: datetime) -> datetime:
 
 
 def _carrier_label(carrier_bucket: str) -> str:
-    return (carrier_bucket or "unknown").replace("_", " ").strip().title()
+    # carrier_bucket NOT NULL + classify_carrier luôn trả chuỗi ('unknown' nếu
+    # đầu số không khớp) → không cần guard rỗng.
+    return carrier_bucket.replace("_", " ").strip().title()
 
 
 def _build_group_label(
@@ -60,11 +66,15 @@ def _build_group_label(
         return None, None
     ordered = sorted(group_ids)
     labels = [names.get(g) or f"Nhom{g}" for g in ordered]
+    # group_name_snapshot là VARCHAR(200) → cắt [:200] tránh tràn cột → 500
+    # khi export campaign đa-nhóm (nhãn ghép có thể >200 ký tự).
     if len(ordered) == 1:
-        return ordered[0], labels[0]
+        return ordered[0], labels[0][:200]
     if len(ordered) == 2:
-        return None, f"{labels[0]}+{labels[1]}"
-    return None, f"{labels[0]}+{labels[1]}+{len(ordered) - 2}"
+        label = f"{labels[0]}+{labels[1]}"
+    else:
+        label = f"{labels[0]}+{labels[1]}+{len(ordered) - 2}"
+    return None, label[:200]
 
 
 class SmsExportService:
@@ -172,7 +182,10 @@ class SmsExportService:
                 f"consent, {supp} người mới opt-out/DNC — Build lại để cập nhật "
                 "snapshot trước khi export (fail-closed)."
             )
-        carriers = await self.repo.counts_by_carrier_exportable(
+        # Dùng đếm carrier của PR-3 (cùng predicate _rev_filter + excluded NULL)
+        # → 1 nguồn sự thật cho "carrier exportable"; số dòng THẬT (sau live
+        # re-check consent/opt-out) tự khớp lại ở _generate_one.
+        carriers = await self.campaign_repo.counts_by_carrier_exportable(
             campaign_id, rev
         )
         if not carriers:
@@ -183,9 +196,10 @@ class SmsExportService:
 
         group_id, group_label = await self._resolve_group_label(campaign_id)
         base_dir = settings.SMS_EXPORT_STORAGE_DIR
+        now = datetime.now(timezone.utc)
         to_generate: List[int] = []
 
-        for carrier_bucket, count in carriers:
+        for carrier_bucket, count in carriers.items():
             file_name = sanitize_export_filename(
                 group_label, campaign.name, _carrier_label(carrier_bucket)
             )
@@ -210,8 +224,24 @@ class SmsExportService:
                     }
                 )
                 to_generate.append(batch.id)
-            elif batch.status in _REGENERATE_BATCH_STATUS:
-                # Re-export cùng revision sau lỗi/purge/invalidate → reset.
+                continue
+            # Regenerate khi chưa-có-file (pending/failed/purged/invalidated)
+            # HOẶC 'generated' nhưng đã hết hạn / file biến mất trên đĩa (#9 —
+            # tránh admin re-export mà vẫn không có file dùng được).
+            needs_regen = batch.status in _REGENERATE_BATCH_STATUS or (
+                batch.status == "generated"
+                and (
+                    (
+                        batch.expires_at is not None
+                        and _aware(batch.expires_at) <= now
+                    )
+                    or not (
+                        batch.storage_path
+                        and os.path.isfile(batch.storage_path)
+                    )
+                )
+            )
+            if needs_regen:
                 batch.group_id = group_id
                 batch.group_name_snapshot = group_label
                 batch.recipient_count = count
@@ -237,7 +267,7 @@ class SmsExportService:
         meta = {
             "campaign_id": campaign_id,
             "build_revision": rev,
-            "total_exportable": sum(c for _, c in carriers),
+            "total_exportable": sum(carriers.values()),
         }
         if not to_generate:
             return None, meta
@@ -311,35 +341,17 @@ class SmsExportService:
             )
             return
 
-        content = build_carrier_workbook(rows)
-        sha = hashlib.sha256(content).hexdigest()
-        final_path = batch.storage_path
-        os.makedirs(os.path.dirname(final_path), exist_ok=True)
-        # Atomic: ghi staging cùng thư mục → fsync → os.replace (atomic kể cả
-        # khi đích đã tồn tại; cùng filesystem nên rename nguyên tử).
-        staging = os.path.join(
-            os.path.dirname(final_path), f".staging.{uuid.uuid4().hex[:12]}.xlsx"
+        # Dựng workbook + ghi atomic (staging->fsync->os.replace) + sha256
+        # trong THREAD riêng → KHÔNG chặn event loop (openpyxl.save/fsync là
+        # blocking; campaign lớn sẽ treo worker nếu chạy thẳng trên loop).
+        sha, size = await asyncio.to_thread(
+            write_export_atomic, rows, batch.storage_path
         )
-        try:
-            with open(staging, "wb") as f:
-                f.write(content)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(staging, final_path)
-        except Exception:
-            # Dọn staging dở rồi để caller đánh dấu failed.
-            if os.path.exists(staging):
-                try:
-                    os.remove(staging)
-                except OSError:
-                    pass
-            raise
-
         now = datetime.now(timezone.utc)
         batch.status = "generated"
         batch.recipient_count = len(rows)
         batch.file_sha256 = sha
-        batch.file_size_bytes = len(content)
+        batch.file_size_bytes = size
         batch.generated_by_id = generated_by
         batch.generated_at = now
         batch.expires_at = now + timedelta(days=retention)
@@ -404,10 +416,22 @@ class SmsExportService:
     # ===============================================================
     async def get_export_file(
         self, campaign_id: int, batch_id: int
-    ) -> Tuple[bytes, str, str]:
+    ) -> Tuple[str, str, str]:
+        """Trả (storage_path, file_name, media_type) sau verify trạng thái +
+        sha256 (chunked). Router stream bằng FileResponse (KHÔNG nạp cả file
+        PII vào RAM)."""
         batch = await self.repo.get_batch(batch_id)
         if batch is None or batch.campaign_id != campaign_id:
             raise ResourceNotFoundError(detail="Không tìm thấy file export")
+        campaign = await self.campaign_repo.get_campaign(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        # Chặn tải file bản build CŨ (sau rebuild) dù chưa kịp invalidate (#3).
+        if batch.build_revision != campaign.build_revision:
+            raise BusinessRuleViolation(
+                detail="File thuộc bản build cũ đã bị thay thế — export lại "
+                "bản hiện tại."
+            )
         now = datetime.now(timezone.utc)
         if batch.status not in ("generated", "handed_off"):
             raise BusinessRuleViolation(
@@ -431,16 +455,20 @@ class SmsExportService:
             raise BusinessRuleViolation(
                 detail="File export không còn trên hệ thống — export lại."
             )
-        with open(batch.storage_path, "rb") as f:
-            content = f.read()
-        if (
-            batch.file_sha256
-            and hashlib.sha256(content).hexdigest() != batch.file_sha256
-        ):
-            raise BusinessRuleViolation(
-                detail="File export sai checksum (có thể hỏng) — export lại."
-            )
-        return content, batch.file_name or "sms_export.xlsx", XLSX_MEDIA
+        # Verify sha256 đọc theo chunk trong thread → KHÔNG nạp cả file PII vào
+        # RAM / không chặn loop; router stream bằng FileResponse.
+        if batch.file_sha256:
+            actual = await asyncio.to_thread(sha256_file, batch.storage_path)
+            if actual != batch.file_sha256:
+                raise BusinessRuleViolation(
+                    detail="File export sai checksum (có thể hỏng) — export "
+                    "lại."
+                )
+        return (
+            batch.storage_path,
+            batch.file_name or "sms_export.xlsx",
+            XLSX_MEDIA,
+        )
 
     # ===============================================================
     # Mark handed-off — recipient + contact freq-cap + campaign status
@@ -448,6 +476,11 @@ class SmsExportService:
     async def mark_handed_off(
         self, campaign_id: int, batch_id: int, user
     ) -> sms_schemas.SmsExportBatchOut:
+        # Khoá campaign TRƯỚC rồi batch (cùng thứ tự campaign→batch với
+        # prepare_export) → tránh deadlock ABBA giữa export và mark-handed-off.
+        campaign = await self.campaign_repo.get_campaign_for_update(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
         batch = await self.repo.get_batch_for_update(batch_id)
         if batch is None or batch.campaign_id != campaign_id:
             raise ResourceNotFoundError(detail="Không tìm thấy file export")
@@ -464,10 +497,6 @@ class SmsExportService:
             raise BusinessRuleViolation(
                 detail="File đã bị vô hiệu — không thể bàn giao; export lại."
             )
-        # Lock campaign → serialize đổi status vs build/export.
-        campaign = await self.campaign_repo.get_campaign_for_update(campaign_id)
-        if campaign is None:
-            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
         if batch.build_revision != campaign.build_revision:
             raise BusinessRuleViolation(
                 detail="File thuộc bản build cũ — export lại bản hiện tại "

--- a/Backend_FastAPI/app/services/sms_export_service.py
+++ b/Backend_FastAPI/app/services/sms_export_service.py
@@ -1,0 +1,497 @@
+# app/services/sms_export_service.py
+"""
+Business logic SMS export (PR-4): gate fail-closed (§8.4) → find-or-create
+export batch idempotent per nhà mạng → sinh file Excel ở POST-COMMIT callback
+(session MỚI, atomic staging→os.replace + fsync + sha256) → download (verify
+sha256) → mark-handed-off (recipient + contact freq-cap + campaign status).
+
+Tuân thủ kiến trúc QLTS: KHÔNG import fastapi; raise domain exception; service
+chỉ `flush` (router commit). File sinh trong callback dùng `AsyncSessionLocal`
+MỚI vì db gốc đã commit/đóng transaction — §8.3.
+Xem SMS_MARKETING_MODULE_DESIGN.md §8 / §11.7.
+"""
+import hashlib
+import logging
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Callable, List, Optional, Tuple
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import AsyncSessionLocal
+from app.models.sms import SmsCampaign, SmsCampaignExportBatch
+from app.repositories.sms_campaign_repository import SmsCampaignRepository
+from app.repositories.sms_export_repository import SmsExportRepository
+from app.schemas import sms as sms_schemas
+from app.utils.exceptions import BusinessRuleViolation, ResourceNotFoundError
+from app.utils.sms_export import (
+    XLSX_MEDIA,
+    build_carrier_workbook,
+    render_export_message,
+    sanitize_export_filename,
+)
+from app.utils.sms_render import has_link
+
+log = logging.getLogger(__name__)
+
+# Campaign đã build, được phép export (lần đầu 'ready'; re-export idempotent
+# khi 'exported'). 'draft' = chưa build/stale; 'handed_off'/'closed' = khoá.
+_EXPORTABLE_CAMPAIGN_STATUS = {"ready", "exported"}
+# Batch ở các trạng thái này = CHƯA có file dùng được → (re)generate.
+_REGENERATE_BATCH_STATUS = {"pending", "failed", "purged", "invalidated"}
+
+
+def _aware(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def _carrier_label(carrier_bucket: str) -> str:
+    return (carrier_bucket or "unknown").replace("_", " ").strip().title()
+
+
+def _build_group_label(
+    group_ids: List[int], names: dict
+) -> Tuple[Optional[int], Optional[str]]:
+    """B2 nhãn nhóm cho file: 1 nhóm → (group_id, tên); ≥2 nhóm → (None,
+    'A+B' hoặc 'A+B+N' với N = số nhóm còn lại)."""
+    if not group_ids:
+        return None, None
+    ordered = sorted(group_ids)
+    labels = [names.get(g) or f"Nhom{g}" for g in ordered]
+    if len(ordered) == 1:
+        return ordered[0], labels[0]
+    if len(ordered) == 2:
+        return None, f"{labels[0]}+{labels[1]}"
+    return None, f"{labels[0]}+{labels[1]}+{len(ordered) - 2}"
+
+
+class SmsExportService:
+    """Service export-batch lifecycle + sinh file + download + handoff."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = SmsExportRepository(db)
+        self.campaign_repo = SmsCampaignRepository(db)
+
+    # ===============================================================
+    # Serialize helpers (cờ thin-client + group label)
+    # ===============================================================
+    def _batch_out(
+        self, b: SmsCampaignExportBatch, now: datetime
+    ) -> sms_schemas.SmsExportBatchOut:
+        is_expired = bool(
+            b.expires_at is not None and _aware(b.expires_at) <= now
+        )
+        out = sms_schemas.SmsExportBatchOut.model_validate(b)
+        out.is_expired = is_expired
+        out.can_download = bool(
+            b.status in ("generated", "handed_off")
+            and b.invalidated_at is None
+            and b.purged_at is None
+            and not is_expired
+        )
+        out.can_mark_handed_off = bool(
+            b.status == "generated"
+            and b.invalidated_at is None
+            and not is_expired
+        )
+        return out
+
+    async def _resolve_group_label(
+        self, campaign_id: int
+    ) -> Tuple[Optional[int], Optional[str]]:
+        gids = await self.campaign_repo.get_campaign_group_ids(campaign_id)
+        names = await self.repo.get_group_names(gids)
+        return _build_group_label(gids, names)
+
+    # ===============================================================
+    # Gate fail-closed (§8.4)
+    # ===============================================================
+    def _assert_exportable(self, campaign: SmsCampaign) -> None:
+        if campaign.status == "draft":
+            raise BusinessRuleViolation(
+                detail="Campaign chưa Build (hoặc đã đổi nhóm/nội dung sau "
+                "Build) — Build lại trước khi export."
+            )
+        if campaign.status not in _EXPORTABLE_CAMPAIGN_STATUS:
+            raise BusinessRuleViolation(
+                detail="Campaign đã bàn giao/đóng — không export lại; tạo "
+                "campaign mới."
+            )
+        rev = campaign.build_revision
+        if rev < 1:
+            raise BusinessRuleViolation(detail="Campaign chưa Build.")
+        # 3 attestation phải khớp build_revision hiện tại + có reference thật.
+        missing: List[str] = []
+        if campaign.consent_checked_build_revision != rev or not (
+            campaign.consent_reference or ""
+        ).strip():
+            missing.append("xác nhận đã kiểm consent")
+        if campaign.dnc_checked_build_revision != rev or not (
+            campaign.dnc_reference or ""
+        ).strip():
+            missing.append("xác nhận đối soát DNC")
+        if campaign.optout_channel_checked_build_revision != rev or not (
+            campaign.optout_channel_reference or ""
+        ).strip():
+            missing.append("xác nhận kênh từ chối (SMS/điện thoại) hoạt động")
+        if missing:
+            raise BusinessRuleViolation(
+                detail="Thiếu xác nhận cho bản build hiện tại: "
+                + "; ".join(missing)
+                + ". Ghi đủ 3 attestation (đúng revision) rồi export."
+            )
+
+    # ===============================================================
+    # Prepare export — gate + find-or-create batch + post-commit callback
+    # ===============================================================
+    async def prepare_export(
+        self, campaign_id: int, user
+    ) -> Tuple[Optional[Callable], dict]:
+        # Lock campaign (cùng lock build/attestation) → serialize export vs
+        # rebuild/đổi nhóm; gate re-check chạy trên trạng thái nhất quán.
+        campaign = await self.campaign_repo.get_campaign_for_update(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        self._assert_exportable(campaign)
+        rev = campaign.build_revision
+
+        # Re-check fail-closed NGAY trước khi tạo batch (§8.4).
+        if await self.repo.count_over_limit(campaign_id, rev) > 0:
+            raise BusinessRuleViolation(
+                detail="Còn người nhận vượt 1 segment (over_limit) — rút gọn "
+                "template/dữ liệu rồi Build lại trước khi export."
+            )
+        lost = await self.repo.count_lost_consent(campaign_id, rev)
+        supp = await self.repo.count_new_suppression(campaign_id, rev)
+        if lost or supp:
+            raise BusinessRuleViolation(
+                detail=f"Phát hiện thay đổi kể từ lần Build: {lost} người mất "
+                f"consent, {supp} người mới opt-out/DNC — Build lại để cập nhật "
+                "snapshot trước khi export (fail-closed)."
+            )
+        carriers = await self.repo.counts_by_carrier_exportable(
+            campaign_id, rev
+        )
+        if not carriers:
+            raise BusinessRuleViolation(
+                detail="Không có người nhận nào đủ điều kiện export (sau lọc "
+                "consent/suppression/over-limit)."
+            )
+
+        group_id, group_label = await self._resolve_group_label(campaign_id)
+        base_dir = settings.SMS_EXPORT_STORAGE_DIR
+        to_generate: List[int] = []
+
+        for carrier_bucket, count in carriers:
+            file_name = sanitize_export_filename(
+                group_label, campaign.name, _carrier_label(carrier_bucket)
+            )
+            storage_path = os.path.join(
+                base_dir, str(campaign_id), str(rev), file_name
+            )
+            batch = await self.repo.get_batch_for_carrier_locked(
+                campaign_id, rev, carrier_bucket
+            )
+            if batch is None:
+                batch = await self.repo.create_batch(
+                    {
+                        "campaign_id": campaign_id,
+                        "build_revision": rev,
+                        "group_id": group_id,
+                        "group_name_snapshot": group_label,
+                        "carrier_bucket": carrier_bucket,
+                        "recipient_count": count,
+                        "file_name": file_name,
+                        "storage_path": storage_path,
+                        "status": "pending",
+                    }
+                )
+                to_generate.append(batch.id)
+            elif batch.status in _REGENERATE_BATCH_STATUS:
+                # Re-export cùng revision sau lỗi/purge/invalidate → reset.
+                batch.group_id = group_id
+                batch.group_name_snapshot = group_label
+                batch.recipient_count = count
+                batch.file_name = file_name
+                batch.storage_path = storage_path
+                batch.status = "pending"
+                batch.failure_reason = None
+                batch.file_sha256 = None
+                batch.file_size_bytes = None
+                batch.generated_at = None
+                batch.generated_by_id = None
+                batch.purged_at = None
+                batch.invalidated_at = None
+                batch.expires_at = None
+                to_generate.append(batch.id)
+            # else status in ('generated','handed_off') → idempotent: giữ file
+            # hiện có, không sinh lại/không đổi token.
+
+        if campaign.status == "ready":
+            campaign.status = "exported"
+        await self.db.flush()
+
+        meta = {
+            "campaign_id": campaign_id,
+            "build_revision": rev,
+            "total_exportable": sum(c for _, c in carriers),
+        }
+        if not to_generate:
+            return None, meta
+
+        generated_by = getattr(user, "id", None)
+        retention = settings.SMS_EXPORT_RETENTION_DAYS
+
+        async def _post_commit() -> None:
+            await self._generate_files(to_generate, generated_by, retention)
+
+        return _post_commit, meta
+
+    # ===============================================================
+    # File generation (POST-COMMIT — session MỚI, §8.3)
+    # ===============================================================
+    async def _generate_files(
+        self, batch_ids: List[int], generated_by: Optional[int], retention: int
+    ) -> None:
+        for batch_id in batch_ids:
+            try:
+                async with AsyncSessionLocal() as db:
+                    await self._generate_one(
+                        db, batch_id, generated_by, retention
+                    )
+                    await db.commit()
+            except Exception:  # noqa: BLE001
+                log.exception("SMS export sinh file batch %s lỗi", batch_id)
+                await self._mark_failed_safe(batch_id)
+
+    async def _generate_one(
+        self,
+        db: AsyncSession,
+        batch_id: int,
+        generated_by: Optional[int],
+        retention: int,
+    ) -> None:
+        repo = SmsExportRepository(db)
+        campaign_repo = SmsCampaignRepository(db)
+        batch = await repo.get_batch_for_update(batch_id)
+        if batch is None or batch.status != "pending":
+            return  # đã xử lý / không còn pending (idempotent giữa caller)
+        campaign = await campaign_repo.get_campaign(batch.campaign_id)
+        if campaign is None:
+            batch.status = "failed"
+            batch.failure_reason = "Campaign không còn tồn tại."
+            return
+        link = has_link(campaign.sms_template)
+        recipients = await repo.get_exportable_recipients(
+            batch.campaign_id, batch.build_revision, batch.carrier_bucket
+        )
+        rows: List[Tuple[str, str]] = []
+        for r in recipients:
+            msg = render_export_message(
+                r.rendered_message_skeleton,
+                has_link=link,
+                token_ciphertext=r.token_ciphertext,
+                token_key_version=r.token_key_version,
+            )
+            if msg is None:
+                batch.status = "failed"
+                batch.failure_reason = (
+                    "Không giải mã được link của ≥1 người nhận (kiểm tra "
+                    "key-ring SMS) — không xuất file thiếu link."
+                )
+                return
+            rows.append((r.phone_international_snapshot, msg))
+        if not rows:
+            batch.status = "failed"
+            batch.failure_reason = (
+                "Không còn người nhận đủ điều kiện cho nhà mạng này."
+            )
+            return
+
+        content = build_carrier_workbook(rows)
+        sha = hashlib.sha256(content).hexdigest()
+        final_path = batch.storage_path
+        os.makedirs(os.path.dirname(final_path), exist_ok=True)
+        # Atomic: ghi staging cùng thư mục → fsync → os.replace (atomic kể cả
+        # khi đích đã tồn tại; cùng filesystem nên rename nguyên tử).
+        staging = os.path.join(
+            os.path.dirname(final_path), f".staging.{uuid.uuid4().hex[:12]}.xlsx"
+        )
+        try:
+            with open(staging, "wb") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(staging, final_path)
+        except Exception:
+            # Dọn staging dở rồi để caller đánh dấu failed.
+            if os.path.exists(staging):
+                try:
+                    os.remove(staging)
+                except OSError:
+                    pass
+            raise
+
+        now = datetime.now(timezone.utc)
+        batch.status = "generated"
+        batch.recipient_count = len(rows)
+        batch.file_sha256 = sha
+        batch.file_size_bytes = len(content)
+        batch.generated_by_id = generated_by
+        batch.generated_at = now
+        batch.expires_at = now + timedelta(days=retention)
+        batch.failure_reason = None
+
+    async def _mark_failed_safe(self, batch_id: int) -> None:
+        """Đánh dấu batch 'failed' ở session riêng (best-effort) khi sinh file
+        ném exception ngoài _generate_one (vd ghi đĩa lỗi)."""
+        try:
+            async with AsyncSessionLocal() as db:
+                b = await SmsExportRepository(db).get_batch_for_update(batch_id)
+                if b is not None and b.status == "pending":
+                    b.status = "failed"
+                    b.failure_reason = "Lỗi sinh/ghi file (xem log hệ thống)."
+                    await db.commit()
+        except Exception:  # noqa: BLE001
+            log.exception(
+                "SMS export đánh dấu failed batch %s lỗi", batch_id
+            )
+
+    # ===============================================================
+    # Read: kết quả export + danh sách batch (GET)
+    # ===============================================================
+    async def get_export_result(
+        self, campaign_id: int
+    ) -> sms_schemas.SmsExportResult:
+        # File sinh ở session callback KHÁC → expire instance cũ trong session
+        # này để list_batches đọc trạng thái mới nhất (pending→generated).
+        self.db.expire_all()
+        campaign = await self.campaign_repo.get_campaign(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        now = datetime.now(timezone.utc)
+        batches = await self.repo.list_batches(
+            campaign_id, campaign.build_revision
+        )
+        return sms_schemas.SmsExportResult(
+            campaign_id=campaign_id,
+            build_revision=campaign.build_revision,
+            total_exportable=sum(b.recipient_count for b in batches),
+            batches=[self._batch_out(b, now) for b in batches],
+        )
+
+    async def list_export_batches(
+        self, campaign_id: int
+    ) -> sms_schemas.SmsExportBatchList:
+        campaign = await self.campaign_repo.get_campaign(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        now = datetime.now(timezone.utc)
+        batches = await self.repo.list_batches(
+            campaign_id, campaign.build_revision
+        )
+        return sms_schemas.SmsExportBatchList(
+            campaign_id=campaign_id,
+            build_revision=campaign.build_revision,
+            batches=[self._batch_out(b, now) for b in batches],
+        )
+
+    # ===============================================================
+    # Download (verify sha256) — trả bytes cho router dựng Response
+    # ===============================================================
+    async def get_export_file(
+        self, campaign_id: int, batch_id: int
+    ) -> Tuple[bytes, str, str]:
+        batch = await self.repo.get_batch(batch_id)
+        if batch is None or batch.campaign_id != campaign_id:
+            raise ResourceNotFoundError(detail="Không tìm thấy file export")
+        now = datetime.now(timezone.utc)
+        if batch.status not in ("generated", "handed_off"):
+            raise BusinessRuleViolation(
+                detail="File export chưa sẵn sàng (đang sinh hoặc đã lỗi) — "
+                "thử export lại."
+            )
+        if batch.invalidated_at is not None:
+            raise BusinessRuleViolation(
+                detail="File export đã bị vô hiệu (dữ liệu thay đổi) — export "
+                "lại bản hiện tại."
+            )
+        expired = batch.expires_at is not None and _aware(
+            batch.expires_at
+        ) <= now
+        if batch.purged_at is not None or expired:
+            raise BusinessRuleViolation(
+                detail="File export đã hết hạn/đã dọn — export lại để tạo file "
+                "mới."
+            )
+        if not batch.storage_path or not os.path.isfile(batch.storage_path):
+            raise BusinessRuleViolation(
+                detail="File export không còn trên hệ thống — export lại."
+            )
+        with open(batch.storage_path, "rb") as f:
+            content = f.read()
+        if (
+            batch.file_sha256
+            and hashlib.sha256(content).hexdigest() != batch.file_sha256
+        ):
+            raise BusinessRuleViolation(
+                detail="File export sai checksum (có thể hỏng) — export lại."
+            )
+        return content, batch.file_name or "sms_export.xlsx", XLSX_MEDIA
+
+    # ===============================================================
+    # Mark handed-off — recipient + contact freq-cap + campaign status
+    # ===============================================================
+    async def mark_handed_off(
+        self, campaign_id: int, batch_id: int, user
+    ) -> sms_schemas.SmsExportBatchOut:
+        batch = await self.repo.get_batch_for_update(batch_id)
+        if batch is None or batch.campaign_id != campaign_id:
+            raise ResourceNotFoundError(detail="Không tìm thấy file export")
+        if batch.status == "handed_off":
+            raise BusinessRuleViolation(
+                detail="Batch này đã được đánh dấu bàn giao."
+            )
+        if batch.status != "generated":
+            raise BusinessRuleViolation(
+                detail="Chỉ đánh dấu bàn giao khi file đã sinh xong "
+                "(generated)."
+            )
+        if batch.invalidated_at is not None:
+            raise BusinessRuleViolation(
+                detail="File đã bị vô hiệu — không thể bàn giao; export lại."
+            )
+        # Lock campaign → serialize đổi status vs build/export.
+        campaign = await self.campaign_repo.get_campaign_for_update(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        if batch.build_revision != campaign.build_revision:
+            raise BusinessRuleViolation(
+                detail="File thuộc bản build cũ — export lại bản hiện tại "
+                "trước khi bàn giao."
+            )
+
+        now = datetime.now(timezone.utc)
+        batch.status = "handed_off"
+        batch.marked_handed_off_at = now
+        # Neo handed_off lên recipient (chặn rebuild) + last_handed_off_at lên
+        # contact (frequency-cap proxy cho campaign sau).
+        contact_ids = await self.repo.mark_recipients_handed_off(
+            campaign_id, batch.build_revision, batch.carrier_bucket, now
+        )
+        await self.repo.touch_contacts_handed_off(contact_ids, now)
+        if campaign.handed_off_marked_at is None:
+            campaign.handed_off_marked_at = now
+        if campaign.status in ("ready", "exported"):
+            campaign.status = "handed_off"
+        await self.db.flush()
+        # Tất cả batch của revision đã bàn giao → đóng campaign.
+        if await self.repo.count_unhanded_batches(
+            campaign_id, campaign.build_revision
+        ) == 0:
+            campaign.status = "closed"
+            await self.db.flush()
+        return self._batch_out(batch, now)

--- a/Backend_FastAPI/app/tasks/__init__.py
+++ b/Backend_FastAPI/app/tasks/__init__.py
@@ -47,6 +47,7 @@ from .notification_outbox_tasks import (
     dispatch_pending_outbox,  # T0-4a skeleton; T0-4b will replace body
 )
 from .sla_tasks import auto_close_stale_rejected_leads_task
+from .sms_tasks import cleanup_sms_export_files_task
 
 __all__ = [
     # Email tasks
@@ -79,4 +80,6 @@ __all__ = [
     "dispatch_pending_outbox",
     # Lead lifecycle SLA tasks
     "auto_close_stale_rejected_leads_task",
+    # SMS Marketing export cleanup (PR-4)
+    "cleanup_sms_export_files_task",
 ]

--- a/Backend_FastAPI/app/tasks/sms_tasks.py
+++ b/Backend_FastAPI/app/tasks/sms_tasks.py
@@ -11,11 +11,11 @@ from datetime import datetime, timezone
 
 from ..celery_app import celery_app
 from ..config import settings
+from ..utils.sms_export import STAGING_PREFIX
 from .utils import run_async_task, task_db_session
 
 log = logging.getLogger(__name__)
 
-_STAGING_PREFIX = ".staging."
 _STAGING_MAX_AGE_SECONDS = 3600  # staging > 1h = orphan (sinh file thất bại)
 
 
@@ -28,7 +28,7 @@ def _sweep_staging_orphans(base_dir: str) -> int:
     cutoff = time.time() - _STAGING_MAX_AGE_SECONDS
     for root, _dirs, files in os.walk(base_dir):
         for fn in files:
-            if not fn.startswith(_STAGING_PREFIX):
+            if not fn.startswith(STAGING_PREFIX):
                 continue
             path = os.path.join(root, fn)
             try:

--- a/Backend_FastAPI/app/tasks/sms_tasks.py
+++ b/Backend_FastAPI/app/tasks/sms_tasks.py
@@ -1,0 +1,88 @@
+# app/tasks/sms_tasks.py
+"""
+SMS Marketing Celery tasks (PR-4): dọn file export hết hạn (retention → set
+purged_at + xoá file) + dọn file staging orphan (sinh dở rồi crash). Chạy
+hằng ngày qua Celery Beat. Xem SMS_MARKETING_MODULE_DESIGN.md §8.3 / §11.7.
+"""
+import logging
+import os
+import time
+from datetime import datetime, timezone
+
+from ..celery_app import celery_app
+from ..config import settings
+from .utils import run_async_task, task_db_session
+
+log = logging.getLogger(__name__)
+
+_STAGING_PREFIX = ".staging."
+_STAGING_MAX_AGE_SECONDS = 3600  # staging > 1h = orphan (sinh file thất bại)
+
+
+def _sweep_staging_orphans(base_dir: str) -> int:
+    """Xoá file `.staging.*` cũ (ghi dở rồi crash giữa chừng). Best-effort —
+    KHÔNG fail task nếu lỗi I/O lẻ tẻ."""
+    removed = 0
+    if not base_dir or not os.path.isdir(base_dir):
+        return 0
+    cutoff = time.time() - _STAGING_MAX_AGE_SECONDS
+    for root, _dirs, files in os.walk(base_dir):
+        for fn in files:
+            if not fn.startswith(_STAGING_PREFIX):
+                continue
+            path = os.path.join(root, fn)
+            try:
+                if os.path.getmtime(path) < cutoff:
+                    os.remove(path)
+                    removed += 1
+            except OSError:
+                continue
+    return removed
+
+
+@celery_app.task(
+    name="cleanup_sms_export_files_task",
+    bind=True,
+    autoretry_for=(Exception,),
+    max_retries=2,
+    default_retry_delay=120,
+)
+def cleanup_sms_export_files_task(self):
+    """Dọn file export quá `expires_at` (xoá file + set purged_at; giữ nhãn
+    'handed_off' cho audit, generated/failed → 'purged') + staging orphan.
+    Runs daily via Celery Beat."""
+
+    async def _cleanup():
+        from app.repositories.sms_export_repository import SmsExportRepository
+
+        now = datetime.now(timezone.utc)
+        purged = 0
+        async with task_db_session() as db:
+            repo = SmsExportRepository(db)
+            batches = await repo.list_purgeable_batches(now)
+            for b in batches:
+                if b.storage_path and os.path.isfile(b.storage_path):
+                    try:
+                        os.remove(b.storage_path)
+                    except OSError as exc:
+                        log.warning(
+                            "cleanup_sms_export: xoá file batch %s lỗi: %s",
+                            b.id,
+                            exc,
+                        )
+                        continue
+                b.purged_at = now
+                if b.status in ("generated", "failed"):
+                    b.status = "purged"
+                purged += 1
+            await db.commit()
+
+        orphans = _sweep_staging_orphans(settings.SMS_EXPORT_STORAGE_DIR)
+        log.info(
+            "cleanup_sms_export: purged=%s staging_orphans=%s",
+            purged,
+            orphans,
+        )
+        return {"purged": purged, "staging_orphans": orphans}
+
+    return run_async_task(_cleanup, "cleanup_sms_export_files_task", log)

--- a/Backend_FastAPI/app/utils/sms_export.py
+++ b/Backend_FastAPI/app/utils/sms_export.py
@@ -43,7 +43,10 @@ def _slug_label(text: str) -> str:
     s = s.encode("ascii", "ignore").decode("ascii")
     s = _BAD_FILENAME_CHARS.sub("-", s)
     s = re.sub(r"\s+", "-", s.strip())
-    s = re.sub(r"-{2,}", "-", s).strip("-")
+    # strip cả '.' đầu/cuối: filename KHÔNG bao giờ mở đầu bằng '.' → tránh
+    # đụng tiền tố STAGING_PREFIX ('.staging.') khiến orphan-sweep xoá nhầm
+    # file final; cũng tránh tạo file ẩn.
+    s = re.sub(r"-{2,}", "-", s).strip(".-")
     return s
 
 
@@ -145,6 +148,16 @@ def write_export_atomic(
             except OSError:
                 pass
         raise
+    # Best-effort fsync thư mục cha → bền vững entry rename qua crash/mất điện
+    # (Linux/prod; Windows không fsync directory được → bỏ qua sạch).
+    try:
+        dir_fd = os.open(os.path.dirname(final_path), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except (OSError, AttributeError):
+        pass
     return sha, len(content)
 
 

--- a/Backend_FastAPI/app/utils/sms_export.py
+++ b/Backend_FastAPI/app/utils/sms_export.py
@@ -1,0 +1,103 @@
+# app/utils/sms_export.py
+"""
+SMS export (PR-4) helpers: sanitize tên file theo mẫu nhà mạng, render TIN
+CUỐI thật (thay sentinel link bằng URL chứa raw code giải mã từ Fernet
+ciphertext), và dựng workbook Excel đúng format mẫu (Sheet1, KHÔNG header,
+data từ row 2, cột A = 84xxxxxxxxx text, cột B = nội dung text).
+
+Xem SMS_MARKETING_MODULE_DESIGN.md §8.1 / §8.2.
+"""
+import io
+import re
+import unicodedata
+from typing import Optional, Sequence, Tuple
+
+from openpyxl import Workbook
+
+from app.utils.sms_token import LINK_SENTINEL, build_link, decrypt_code
+
+XLSX_MEDIA = (
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+)
+# Ký tự không hợp lệ trong tên file (Windows + *nix) → thay '-'.
+_BAD_FILENAME_CHARS = re.compile(r'[\\/:*?"<>|\r\n\t]+')
+_FILENAME_MAX = 120
+
+
+def _slug_label(text: str) -> str:
+    """Bỏ dấu tiếng Việt + gọn khoảng trắng → nhãn an toàn cho hệ thống nhà
+    mạng kén unicode. GIỮ chữ hoa/thường (không lowercase toàn bộ như slug-url)
+    để tên file vẫn đọc được."""
+    s = unicodedata.normalize("NFD", text or "")
+    s = "".join(c for c in s if unicodedata.category(c) != "Mn")
+    s = s.replace("đ", "d").replace("Đ", "D")
+    s = _BAD_FILENAME_CHARS.sub("-", s)
+    s = re.sub(r"\s+", "-", s.strip())
+    s = re.sub(r"-{2,}", "-", s).strip("-")
+    return s
+
+
+def sanitize_export_filename(
+    group_label: Optional[str], campaign_name: str, carrier_label: str
+) -> str:
+    """`{Nhóm}-{Campaign}-{NhàMạng}.xlsx` đã sanitize + ≤120 ký tự. Cắt phần
+    tên campaign (giữa) nếu quá dài — giữ nhóm (đầu) + nhà mạng (cuối) để vẫn
+    phân biệt được file."""
+    grp = _slug_label(group_label or "Nhom") or "Nhom"
+    camp = _slug_label(campaign_name) or "Campaign"
+    carrier = _slug_label(carrier_label) or "NhaMang"
+    stem = f"{grp}-{camp}-{carrier}"
+    if len(stem) + 5 > _FILENAME_MAX:  # +5 = ".xlsx"
+        keep = _FILENAME_MAX - 5 - len(grp) - len(carrier) - 2  # 2 dấu '-'
+        camp = camp[: max(keep, 1)].rstrip("-") or "Campaign"
+        stem = f"{grp}-{camp}-{carrier}"
+    return f"{stem}.xlsx"[:_FILENAME_MAX]
+
+
+def render_export_message(
+    skeleton: Optional[str],
+    *,
+    has_link: bool,
+    token_ciphertext: Optional[str],
+    token_key_version: Optional[str],
+) -> Optional[str]:
+    """TIN CUỐI THẬT cho file nhà mạng. Campaign có {link}: giải mã code từ
+    ciphertext (Fernet) → URL thật → thay sentinel. Trả **None** nếu KHÔNG
+    giải mã được (key-ring sai) hoặc tin cuối còn sót sentinel — caller fail
+    cả batch thay vì ghi tin hỏng/thiếu link cho nhà mạng."""
+    msg = skeleton or ""
+    if has_link:
+        if not (token_ciphertext and token_key_version):
+            return None
+        code = decrypt_code(token_ciphertext, token_key_version)
+        if not code:
+            return None
+        msg = msg.replace(LINK_SENTINEL, build_link(code))
+    # Bất biến: tin cuối KHÔNG còn sentinel nội bộ.
+    if LINK_SENTINEL in msg:
+        return None
+    return msg
+
+
+def build_carrier_workbook(rows: Sequence[Tuple[str, str]]) -> bytes:
+    """Excel đúng mẫu nhà mạng: Sheet1, KHÔNG header, data từ row 2; cột A =
+    84xxxxxxxxx (text), cột B = nội dung SMS (text). rows = [(phone_intl, msg)].
+
+    Nội dung cột B GIỮ NGUYÊN tin cuối (KHÔNG escape CSV-injection): đây là văn
+    bản nhà mạng GỬI thật — thêm prefix sẽ sai tin. An toàn vì mọi tin luôn bắt
+    đầu bằng `[QC]` (assemble_skeleton, NĐ91) nên không thể mở đầu bằng
+    `=`/`+`/`-`/`@` → Excel không diễn dịch thành formula; cột số chỉ chứa
+    digit; danh bạ do admin tự nhập (không phải public untrusted)."""
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    r = 2  # row 1 để trống theo mẫu nhà mạng
+    for phone_intl, msg in rows:
+        a = ws.cell(row=r, column=1, value=phone_intl)
+        a.number_format = "@"
+        b = ws.cell(row=r, column=2, value=msg)
+        b.number_format = "@"
+        r += 1
+    bio = io.BytesIO()
+    wb.save(bio)
+    return bio.getvalue()

--- a/Backend_FastAPI/app/utils/sms_export.py
+++ b/Backend_FastAPI/app/utils/sms_export.py
@@ -2,14 +2,17 @@
 """
 SMS export (PR-4) helpers: sanitize tên file theo mẫu nhà mạng, render TIN
 CUỐI thật (thay sentinel link bằng URL chứa raw code giải mã từ Fernet
-ciphertext), và dựng workbook Excel đúng format mẫu (Sheet1, KHÔNG header,
-data từ row 2, cột A = 84xxxxxxxxx text, cột B = nội dung text).
+ciphertext), dựng + ghi workbook Excel atomic (staging→fsync→os.replace) +
+sha256, và verify sha256 theo chunk.
 
-Xem SMS_MARKETING_MODULE_DESIGN.md §8.1 / §8.2.
+Xem SMS_MARKETING_MODULE_DESIGN.md §8.1 / §8.2 / §8.3.
 """
+import hashlib
 import io
+import os
 import re
 import unicodedata
+import uuid
 from typing import Optional, Sequence, Tuple
 
 from openpyxl import Workbook
@@ -19,18 +22,25 @@ from app.utils.sms_token import LINK_SENTINEL, build_link, decrypt_code
 XLSX_MEDIA = (
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 )
+# Tiền tố file staging (ghi dở) — DÙNG CHUNG service (ghi) + cleanup task (quét
+# orphan) để không lệch quy ước. §8.3.
+STAGING_PREFIX = ".staging."
 # Ký tự không hợp lệ trong tên file (Windows + *nix) → thay '-'.
 _BAD_FILENAME_CHARS = re.compile(r'[\\/:*?"<>|\r\n\t]+')
 _FILENAME_MAX = 120
+_HASH_CHUNK = 65536
 
 
 def _slug_label(text: str) -> str:
-    """Bỏ dấu tiếng Việt + gọn khoảng trắng → nhãn an toàn cho hệ thống nhà
-    mạng kén unicode. GIỮ chữ hoa/thường (không lowercase toàn bộ như slug-url)
-    để tên file vẫn đọc được."""
+    """Bỏ dấu tiếng Việt + ÉP ASCII (loại emoji/CJK/Cyrillic còn lại) + gọn
+    khoảng trắng → nhãn an toàn cho hệ thống nhà mạng VÀ cho header
+    Content-Disposition (Starlette encode latin-1; ký tự >U+00FF sẽ 500)."""
     s = unicodedata.normalize("NFD", text or "")
     s = "".join(c for c in s if unicodedata.category(c) != "Mn")
     s = s.replace("đ", "d").replace("Đ", "D")
+    # Ép ASCII: bỏ MỌI ký tự non-ASCII còn lại (emoji/CJK/…) → filename
+    # luôn latin-1-safe, không crash header lúc download.
+    s = s.encode("ascii", "ignore").decode("ascii")
     s = _BAD_FILENAME_CHARS.sub("-", s)
     s = re.sub(r"\s+", "-", s.strip())
     s = re.sub(r"-{2,}", "-", s).strip("-")
@@ -40,18 +50,24 @@ def _slug_label(text: str) -> str:
 def sanitize_export_filename(
     group_label: Optional[str], campaign_name: str, carrier_label: str
 ) -> str:
-    """`{Nhóm}-{Campaign}-{NhàMạng}.xlsx` đã sanitize + ≤120 ký tự. Cắt phần
-    tên campaign (giữa) nếu quá dài — giữ nhóm (đầu) + nhà mạng (cuối) để vẫn
-    phân biệt được file."""
+    """`{Nhóm}-{Campaign}-{NhàMạng}.xlsx` ≤120 ký tự, ASCII. ĐẢM BẢO:
+    (1) luôn kết thúc `.xlsx`; (2) phần nhà mạng LUÔN hiện diện đầy đủ → 2 nhà
+    mạng KHÔNG bao giờ trùng tên (cùng storage_path → ghi đè). Chỉ cắt phần
+    nhóm/campaign (đầu) khi quá dài."""
     grp = _slug_label(group_label or "Nhom") or "Nhom"
     camp = _slug_label(campaign_name) or "Campaign"
     carrier = _slug_label(carrier_label) or "NhaMang"
-    stem = f"{grp}-{camp}-{carrier}"
-    if len(stem) + 5 > _FILENAME_MAX:  # +5 = ".xlsx"
-        keep = _FILENAME_MAX - 5 - len(grp) - len(carrier) - 2  # 2 dấu '-'
-        camp = camp[: max(keep, 1)].rstrip("-") or "Campaign"
-        stem = f"{grp}-{camp}-{carrier}"
-    return f"{stem}.xlsx"[:_FILENAME_MAX]
+    ext = ".xlsx"
+    # Carrier dài bất thường (gần như không xảy ra) — cắt nhẹ nhưng vẫn giữ +
+    # chừa tối thiểu 1 ký tự cho head.
+    max_carrier = _FILENAME_MAX - len(ext) - 2
+    if len(carrier) > max_carrier:
+        carrier = carrier[:max_carrier] or "NhaMang"
+    head_budget = _FILENAME_MAX - len(ext) - len(carrier) - 1  # 1 dấu '-'
+    head = f"{grp}-{camp}"[:head_budget].rstrip("-")
+    if not head:
+        head = (grp or "Nhom")[:head_budget] or "Nhom"
+    return f"{head}-{carrier}{ext}"
 
 
 def render_export_message(
@@ -101,3 +117,42 @@ def build_carrier_workbook(rows: Sequence[Tuple[str, str]]) -> bytes:
     bio = io.BytesIO()
     wb.save(bio)
     return bio.getvalue()
+
+
+def write_export_atomic(
+    rows: Sequence[Tuple[str, str]], final_path: str
+) -> Tuple[str, int]:
+    """Dựng workbook + ghi ATOMIC ra `final_path`: staging cùng thư mục →
+    fsync → os.replace. Trả (sha256_hex, size_bytes). SYNC + blocking →
+    caller chạy qua `asyncio.to_thread` để KHÔNG chặn event loop (§8.3)."""
+    content = build_carrier_workbook(rows)
+    sha = hashlib.sha256(content).hexdigest()
+    os.makedirs(os.path.dirname(final_path), exist_ok=True)
+    staging = os.path.join(
+        os.path.dirname(final_path),
+        f"{STAGING_PREFIX}{uuid.uuid4().hex[:12]}.xlsx",
+    )
+    try:
+        with open(staging, "wb") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(staging, final_path)  # atomic kể cả khi đích đã tồn tại
+    except Exception:
+        if os.path.exists(staging):
+            try:
+                os.remove(staging)
+            except OSError:
+                pass
+        raise
+    return sha, len(content)
+
+
+def sha256_file(path: str) -> str:
+    """sha256 đọc theo chunk (bộ nhớ chặn) — verify integrity lúc download mà
+    KHÔNG nạp cả file PII vào RAM. SYNC → caller dùng `asyncio.to_thread`."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(_HASH_CHUNK), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/Backend_FastAPI/tests/integration/test_sms_export.py
+++ b/Backend_FastAPI/tests/integration/test_sms_export.py
@@ -323,3 +323,116 @@ async def test_download_unknown_batch_404(
         f"{API}/campaigns/{cid}/exports/999999/download", headers=h
     )
     assert res.status_code == 404
+
+
+# ---------------------------------------------------------------------
+# Gate drift suppression + lifecycle guards (vá lỗ test /code-review)
+# ---------------------------------------------------------------------
+async def test_export_blocks_suppression_drift(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid = await _build_ready(client, h)
+    await _attest_all(client, h, cid)
+    # Số vào sms_opt_out SAU build (chưa rebuild) → gate count_new_suppression.
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text(
+                "INSERT INTO sms_opt_out (phone_normalized, source, "
+                "observed_at) VALUES (:p, 'manual', now())"
+            ),
+            {"p": _PHONE_VIETTEL},
+        )
+        await s.commit()
+    res = await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    assert res.status_code == 400, res.text
+    assert "opt-out" in res.json()["detail"].lower()
+
+
+async def test_stale_revision_download_blocked_after_rebuild(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid = await _build_ready(client, h, phones=[_PHONE_VIETTEL])
+    await _attest_all(client, h, cid)
+    exp = (await client.post(f"{API}/campaigns/{cid}/export", headers=h)).json()
+    old_batch = exp["batches"][0]["id"]
+    # cùng revision → tải được
+    assert (
+        await client.get(
+            f"{API}/campaigns/{cid}/exports/{old_batch}/download", headers=h
+        )
+    ).status_code == 200
+    # rebuild → revision mới; batch cũ bị vô hiệu + chặn download
+    assert (
+        await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    ).status_code == 200
+    dl = await client.get(
+        f"{API}/campaigns/{cid}/exports/{old_batch}/download", headers=h
+    )
+    assert dl.status_code == 400, dl.text
+    async with AsyncSessionLocal() as s:
+        row = (
+            await s.execute(
+                text(
+                    "SELECT status, invalidated_at FROM "
+                    "sms_campaign_export_batch WHERE id=:b"
+                ),
+                {"b": old_batch},
+            )
+        ).first()
+    assert row[0] == "invalidated"
+    assert row[1] is not None
+
+
+async def test_download_expired_returns_400(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid = await _build_ready(client, h, phones=[_PHONE_VIETTEL])
+    await _attest_all(client, h, cid)
+    bid = (
+        await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    ).json()["batches"][0]["id"]
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text(
+                "UPDATE sms_campaign_export_batch SET expires_at = now() - "
+                "interval '1 day' WHERE id=:b"
+            ),
+            {"b": bid},
+        )
+        await s.commit()
+    dl = await client.get(
+        f"{API}/campaigns/{cid}/exports/{bid}/download", headers=h
+    )
+    assert dl.status_code == 400, dl.text
+    lst = (
+        await client.get(f"{API}/campaigns/{cid}/exports", headers=h)
+    ).json()
+    b = next(x for x in lst["batches"] if x["id"] == bid)
+    assert b["is_expired"] is True
+    assert b["can_download"] is False
+
+
+async def test_mark_handed_off_guards(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid = await _build_ready(client, h, phones=[_PHONE_VIETTEL])
+    await _attest_all(client, h, cid)
+    bid = (
+        await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    ).json()["batches"][0]["id"]
+    base = f"{API}/campaigns/{cid}/exports"
+    assert (
+        await client.post(f"{base}/{bid}/mark-handed-off", headers=h)
+    ).status_code == 200
+    # lần 2 → 400 (đã bàn giao)
+    assert (
+        await client.post(f"{base}/{bid}/mark-handed-off", headers=h)
+    ).status_code == 400
+    # batch không tồn tại → 404
+    assert (
+        await client.post(f"{base}/999999/mark-handed-off", headers=h)
+    ).status_code == 404

--- a/Backend_FastAPI/tests/integration/test_sms_export.py
+++ b/Backend_FastAPI/tests/integration/test_sms_export.py
@@ -1,0 +1,325 @@
+# tests/integration/test_sms_export.py
+"""
+Integration test PR-4 (SMS Export BE).
+
+Phủ: gate fail-closed (thiếu attestation / over_limit / drift consent), export
+sinh file per nhà mạng (idempotent, campaign→exported), nội dung Excel đúng mẫu
+(Sheet1, row1 trống, cột A 84xxx text, cột B [QC]+tin+link thật đã giải mã),
+download verify sha256, mark-handed-off (recipient.handed_off_at +
+contact.last_handed_off_at + campaign closed + chặn rebuild). Chạy one-off
+container (CLAUDE.md).
+"""
+import io
+
+from httpx import AsyncClient
+from openpyxl import load_workbook
+from sqlalchemy import text
+
+from app.database import AsyncSessionLocal
+
+API = "/api/sms"
+_GRANT = {
+    "event_type": "granted",
+    "occurred_at": "2026-05-01T00:00:00+07:00",
+    "basis": "signed_form",
+    "disclosure_version": "v1",
+    "proof_reference": "ho-so/ref",
+}
+# 098 → viettel, 090 → mobifone → export tách 2 file.
+_PHONE_VIETTEL = "0981234567"
+_PHONE_MOBI = "0901234588"
+
+
+# ---------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------
+async def _mk_group(client, h, name="Nhom Export QA"):
+    res = await client.post(
+        f"{API}/contact-groups",
+        json={"name": name, "group_type": "custom"},
+        headers=h,
+    )
+    assert res.status_code == 201, res.text
+    return res.json()["id"]
+
+
+async def _mk_contact(client, h, name, phone, granted=True):
+    res = await client.post(
+        f"{API}/contacts", json={"full_name": name, "phone": phone}, headers=h
+    )
+    assert res.status_code == 201, res.text
+    cid = res.json()["id"]
+    if granted:
+        r = await client.post(
+            f"{API}/contacts/{cid}/consent-events", json=_GRANT, headers=h
+        )
+        assert r.status_code == 201, r.text
+    return cid
+
+
+async def _add(client, h, cid, gid):
+    r = await client.post(
+        f"{API}/contacts/{cid}/groups", json={"group_id": gid}, headers=h
+    )
+    assert r.status_code == 201, r.text
+
+
+async def _seed_carriers():
+    """qlts_test dùng create_all() (KHÔNG chạy migration seed) → bảng prefix
+    carrier rỗng, mọi số = 'unknown'. Seed 098→viettel, 090→mobifone để test
+    tách file per nhà mạng (idempotent qua ON CONFLICT)."""
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text(
+                "INSERT INTO sms_prefix_carrier_rule "
+                "(prefix, carrier_code, carrier_name, is_active) VALUES "
+                "('098','viettel','Viettel', true), "
+                "('090','mobifone','MobiFone', true) "
+                "ON CONFLICT (prefix) DO NOTHING"
+            )
+        )
+        await s.commit()
+
+
+async def _attest_all(client, h, cid):
+    for kind in ("consent", "dnc", "optout_channel"):
+        r = await client.post(
+            f"{API}/campaigns/{cid}/attestations",
+            json={"kind": kind, "reference": f"ref-{kind}"},
+            headers=h,
+        )
+        assert r.status_code == 201, r.text
+
+
+async def _build_ready(
+    client, h, template="Chao {full_name}, xem {link}", phones=None
+):
+    """group + contacts (granted) + campaign + attach + build → 'ready'. Trả cid."""
+    gid = await _mk_group(client, h)
+    phones = phones if phones is not None else [_PHONE_VIETTEL, _PHONE_MOBI]
+    for i, p in enumerate(phones):
+        cc = await _mk_contact(client, h, f"Phu huynh {i}", p)
+        await _add(client, h, cc, gid)
+    res = await client.post(
+        f"{API}/campaigns",
+        json={"name": "Export QA", "sms_template": template},
+        headers=h,
+    )
+    assert res.status_code == 201, res.text
+    cid = res.json()["id"]
+    r = await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": gid}, headers=h
+    )
+    assert r.status_code == 201, r.text
+    r = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "ready"
+    return cid
+
+
+# ---------------------------------------------------------------------
+# Gate fail-closed
+# ---------------------------------------------------------------------
+async def test_export_requires_attestation(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid = await _build_ready(client, h)
+    res = await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    assert res.status_code == 400, res.text
+    assert "xác nhận" in res.json()["detail"].lower()
+
+
+async def test_export_blocks_over_limit(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    long_tpl = "Chao " + ("a" * 200) + " {full_name}"  # tin cuối > 160 GSM7
+    cid = await _build_ready(client, h, template=long_tpl, phones=[_PHONE_VIETTEL])
+    await _attest_all(client, h, cid)
+    res = await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    assert res.status_code == 400, res.text
+    assert "over_limit" in res.json()["detail"] or "segment" in res.json()["detail"]
+
+
+async def test_export_blocks_consent_drift(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid = await _build_ready(client, h)
+    await _attest_all(client, h, cid)
+    # revoke consent 1 người SAU build (chưa rebuild) → drift fail-closed.
+    async with AsyncSessionLocal() as s:
+        row = (
+            await s.execute(
+                text("SELECT id FROM sms_contact WHERE phone_normalized=:p"),
+                {"p": _PHONE_VIETTEL},
+            )
+        ).first()
+    contact_id = row[0]
+    rv = await client.post(
+        f"{API}/contacts/{contact_id}/consent-events",
+        json={
+            "event_type": "revoked",
+            "occurred_at": "2026-06-10T00:00:00+07:00",
+            "revoke_source": "manual",
+        },
+        headers=h,
+    )
+    assert rv.status_code == 201, rv.text
+    res = await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    assert res.status_code == 400, res.text
+    assert "consent" in res.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------
+# Happy path + nội dung file + idempotent
+# ---------------------------------------------------------------------
+async def test_export_happy_path_per_carrier(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    await _seed_carriers()  # 098→viettel, 090→mobifone (trước build)
+    cid = await _build_ready(client, h)
+    await _attest_all(client, h, cid)
+    res = await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["total_exportable"] == 2
+    batches = body["batches"]
+    assert len(batches) == 2
+    assert {b["carrier_bucket"] for b in batches} == {"viettel", "mobifone"}
+    for b in batches:
+        assert b["status"] == "generated"
+        assert b["recipient_count"] == 1
+        assert b["can_download"] is True
+        assert b["can_mark_handed_off"] is True
+        assert b["file_name"].endswith(".xlsx")
+    # campaign → exported
+    assert (
+        await client.get(f"{API}/campaigns/{cid}", headers=h)
+    ).json()["status"] == "exported"
+
+    # download viettel → xlsx đúng mẫu (row1 trống, A=84xxx text, B=[QC]+link)
+    vb = next(b for b in batches if b["carrier_bucket"] == "viettel")
+    dl = await client.get(
+        f"{API}/campaigns/{cid}/exports/{vb['id']}/download", headers=h
+    )
+    assert dl.status_code == 200, dl.text
+    assert dl.headers["content-type"].startswith(
+        "application/vnd.openxmlformats"
+    )
+    ws = load_workbook(io.BytesIO(dl.content))["Sheet1"]
+    assert ws.cell(1, 1).value is None  # row 1 trống
+    assert ws.cell(2, 1).value == "84981234567"
+    msg = ws.cell(2, 2).value
+    assert msg.startswith("[QC]")
+    assert "/r/" in msg  # sentinel link đã thay bằng URL thật
+    assert "__SMS_LINK__" not in msg
+
+
+async def test_export_idempotent(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid = await _build_ready(client, h)
+    await _attest_all(client, h, cid)
+    r1 = await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    assert r1.status_code == 201
+    ids1 = sorted(b["id"] for b in r1.json()["batches"])
+    r2 = await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    assert r2.status_code == 201
+    ids2 = sorted(b["id"] for b in r2.json()["batches"])
+    assert ids1 == ids2  # cùng batch, không tạo file/token mới
+    assert all(b["status"] == "generated" for b in r2.json()["batches"])
+    # GET list khớp
+    lst = await client.get(f"{API}/campaigns/{cid}/exports", headers=h)
+    assert lst.status_code == 200
+    assert sorted(b["id"] for b in lst.json()["batches"]) == ids1
+
+
+async def test_export_no_link_campaign(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid = await _build_ready(
+        client, h, template="Chao {full_name} uu dai thang 6",
+        phones=[_PHONE_VIETTEL],
+    )
+    await _attest_all(client, h, cid)
+    res = await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    assert res.status_code == 201, res.text
+    b = res.json()["batches"][0]
+    dl = await client.get(
+        f"{API}/campaigns/{cid}/exports/{b['id']}/download", headers=h
+    )
+    msg = load_workbook(io.BytesIO(dl.content))["Sheet1"].cell(2, 2).value
+    assert msg.startswith("[QC]")
+    assert "/r/" not in msg  # campaign không có {link}
+
+
+# ---------------------------------------------------------------------
+# mark-handed-off + chặn rebuild
+# ---------------------------------------------------------------------
+async def test_mark_handed_off_and_block_rebuild(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid = await _build_ready(client, h)
+    await _attest_all(client, h, cid)
+    batches = (
+        await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    ).json()["batches"]
+    for b in batches:
+        r = await client.post(
+            f"{API}/campaigns/{cid}/exports/{b['id']}/mark-handed-off",
+            headers=h,
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "handed_off"
+        assert r.json()["can_mark_handed_off"] is False
+    # tất cả bàn giao → campaign closed
+    assert (
+        await client.get(f"{API}/campaigns/{cid}", headers=h)
+    ).json()["status"] == "closed"
+    # recipient.handed_off_at + contact.last_handed_off_at
+    async with AsyncSessionLocal() as s:
+        rc = (
+            await s.execute(
+                text(
+                    "SELECT count(*) FROM sms_campaign_recipient "
+                    "WHERE campaign_id=:c AND handed_off_at IS NOT NULL"
+                ),
+                {"c": cid},
+            )
+        ).scalar()
+        assert rc == 2
+        cc = (
+            await s.execute(
+                text(
+                    "SELECT count(*) FROM sms_contact WHERE "
+                    "last_handed_off_at IS NOT NULL AND "
+                    "phone_normalized IN (:a, :b)"
+                ),
+                {"a": _PHONE_VIETTEL, "b": _PHONE_MOBI},
+            )
+        ).scalar()
+        assert cc == 2
+    # rebuild sau handoff → 400; export lại (closed) → 400
+    assert (
+        await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    ).status_code == 400
+    assert (
+        await client.post(f"{API}/campaigns/{cid}/export", headers=h)
+    ).status_code == 400
+
+
+async def test_download_unknown_batch_404(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid = await _build_ready(client, h)
+    res = await client.get(
+        f"{API}/campaigns/{cid}/exports/999999/download", headers=h
+    )
+    assert res.status_code == 404

--- a/Documents/SMS_BUILD_COORDINATION.md
+++ b/Documents/SMS_BUILD_COORDINATION.md
@@ -3,7 +3,7 @@
 > **Nguồn sự thật chung cho 2 AI agent (Claude Code + Codex CLI) cùng build trên 1 repo local D:\QLTS.**
 > Cả 2 agent **đọc file này TRƯỚC mỗi phiên** và **cập nhật §9 status sau mỗi PR**.
 > Plan thiết kế gốc: **`Documents/SMS_MARKETING_MODULE_DESIGN.md`** (§1–§19). File này KHÔNG lặp lại thiết kế — nó trả lời: *agent nào làm gì, ở đâu, theo thứ tự nào, tránh giẫm chân ra sao, và luật repo bắt buộc.*
-> Cập nhật: 2026-06-11. Trạng thái: **GO (user authorize) — PR-1 schema CODE XONG + qua nhiều vòng Codex review (R1–R5), commit branch `sms/pr1-schema` (clean sau rebase) CHƯA push.** Workflow: **Claude code TOÀN BỘ, Codex review TOÀN BỘ** (đổi từ chia owner cũ).
+> Cập nhật: 2026-06-29 (audit code-verified). Trạng thái: **PR-1/2/3 ĐÃ MERGE main (#401/#403/#406) — BE core xong (schema + contact + campaign build). PR-4/5/6/7 CHƯA bắt đầu.** Module **chưa chạy end-to-end** (thiếu export-handoff + toàn bộ FE). Workflow: **Claude code TOÀN BỘ, Codex review TOÀN BỘ** (đổi từ chia owner cũ).
 > Contract v4 trong `SMS_MARKETING_MODULE_DESIGN.md` supersede mọi chi tiết v3 còn sót: 12 model core, token HMAC+Fernet base62×9, consent ledger, revisioned attestations, `handed_off` thay `sent`, landing opt-out chỉ là kênh bổ sung.
 
 ---
@@ -191,15 +191,15 @@ SMS marketing là export quảng cáo, không dùng `dispatch()`/`SystemEvents`/
 
 **Trạng thái PR** (🔲 chưa bắt đầu · 🔨 đang code · 👀 chờ review · ✅ chờ user push · 🟢 merged):
 
-| PR | Owner | Status | Branch | Ghi chú |
+| PR | Owner | Status | Branch | Ghi chú (audit code-verified 2026-06-29) |
 |---|---|---|---|---|
-| PR-1 Schema | Claude | ✅ review R1–R5 xong, chờ user push | `sms/pr1-schema` | branch clean sau rebase (hash xem `git log`); 8/8 pytest + alembic check + flake8 sạch |
-| PR-2 Contact | Codex | 🔲 | `sms/pr2-contact` | chờ PR-1 merge |
-| PR-3 Build | Claude | 🔲 | `sms/pr3-build` | chờ PR-2 merge |
-| PR-4 Export | Codex | 🔲 | `sms/pr4-export` | chờ PR-3 merge |
-| PR-5 Tracking/Landing | Codex | 🔲 | `sms/pr5-tracking` | public-surface // PR-2/3 sau PR-1 |
-| PR-6 FE | Claude | 🔲 | `sms/pr6-fe` | scaffolding theo §5 sớm |
-| PR-7 Segment+Conv | Claude | 🔲 | `sms/pr7-segment` | sau PR-5 |
+| PR-1 Schema | Claude | 🟢 merged | `#401` | 12 model + `__all__`; 2 migration create+seed; **DB dev: 12 bảng `sms_*` + 34 carrier rule seed**; schema đủ class |
+| PR-2 Contact | Claude | 🟢 merged | `#403` | `sms_contacts.py` 13 endpoint (6 group + 7 contact: CRUD + upload + consent-events ledger + membership); 23 test |
+| PR-3 Build | Claude | 🟢 merged | `#406` (+#405 int32) | `sms_campaigns.py` 9 endpoint (CRUD + groups + build + preflight + attestations); render+token HMAC/Fernet; 47+8 test; 0 stub ẩn |
+| PR-4 Export | Claude | ✅ code+test xong (local, chờ review/push) | `sms/pr4-export` | 4 endpoint (export/exports/download/mark-handed-off) + `sms_export_service`/`sms_export_repository`/`utils/sms_export` + cleanup Celery task + beat + config 2 setting + docker volume `sms_private_exports`. Gate fail-closed (3 attestation đúng rev + over_limit + drift consent/suppression); file Excel mẫu nhà mạng (decrypt Fernet→URL thật); atomic write+sha256; idempotent per carrier. **8 test PR-4 + 90 regression PASS, flake8 sạch. KHÔNG migration** (bảng PR-1) |
+| PR-5 Tracking/Landing | Claude | 🔲 chưa bắt đầu | `sms/pr5-tracking` | **STUB rỗng** shortlink/public/reports. Thiếu 7 endpoint (/r, landing, public opt-out, dashboard, reports/clicks, opt-out manual/list) + 4 service + nginx `location /r/` |
+| PR-6 FE | Claude | 🔲 chưa bắt đầu | `sms/pr6-fe` | **0 file** `frontend/src/**/sms`. Toàn bộ UI chưa khởi động |
+| PR-7 Segment+Conv | Claude | 🔲 chưa bắt đầu | `sms/pr7-segment` | Phase 1.5/2 — sau PR-5 |
 
 **Mục "cần phối hợp"** (ghi vào đây khi cần đụng shared file / đổi contract / phát hiện schema thiếu):
 - L1 consent source/proof/disclosure owner.
@@ -214,6 +214,8 @@ SMS marketing là export quảng cáo, không dùng `dispatch()`/`SystemEvents`/
 - 2026-06-11 — PR-1 schema code xong (12 model + migration + regression test) + Codex review **R1** (consent CASCADE→SET NULL, seed bỏ MVNO 055/087), **R2** (5 CHECK/FK invariant: granted-proof, token-triplet, import group SET NULL, count invariant, comment parity), **R3** (empty-string `coalesce`/`btrim`, ledger `revoke_source`, click_event bỏ denorm campaign/contact, regression test 7/7, fix 3 lỗ three-valued-logic). Branch `sms/pr1-schema`, CHƯA push.
 - 2026-06-11 — ✅ Commit lạ `81c3d5b0 fix(officer)` ĐÃ được rebase bỏ khỏi branch (clean SMS-only); hash R3+ đổi mới.
 - 2026-06-11 — Codex review R4 (token hash-len→hex regex, `_raises` rigor 23xxx, revoke no-grant-data) + R5 (range CHECK revision/counter/export non-âm + human≤raw, hex regex `^[0-9a-f]{64}$`, mask phone trong `__repr__`). 8/8 pytest.
+- 2026-06-29 — **Audit code-verified tiến độ** (đối chiếu git log + file thật + DB dev). PR-1 merged #401, PR-2 merged #403, PR-3 merged #406 (+int32 #405) → BE core (schema/contact/build) XONG. PR-4/5/6/7 chưa bắt đầu (router stub rỗng + 0 file FE). 22/32 endpoint §10 đã code; 78 test SMS (8+47+23). DB dev: 12 bảng `sms_*` + 34 carrier rule. §9 trước đó stale (ghi PR-2..7=🔲) → cập nhật. Lưu ý: design doc §14 cũng còn stale ("PR-1 chưa push" — trạng thái 06-11).
+- 2026-06-30 — **PR-4 Export code+test xong (local, chưa push)** nhánh `sms/pr4-export` off main `b9cf233c`. Endpoint: `POST/GET .../export`, `GET .../exports/{id}/download`, `POST .../mark-handed-off`. Gate fail-closed §8.4 (3 attestation khớp build_revision + reference; chặn over_limit; re-check drift consent/suppression). File Excel mẫu nhà mạng (Sheet1, row1 trống, A=84xxx text, B=[QC]+tin+link THẬT giải mã từ Fernet ciphertext). Sinh file ở post-commit (AsyncSessionLocal mới, atomic staging→os.replace+fsync, sha256). Idempotent per (campaign,revision,carrier). mark-handed-off neo recipient.handed_off_at + contact.last_handed_off_at (freq-cap) + campaign→handed_off/closed + chặn rebuild. Cleanup Celery `cleanup_sms_export_files_task` (beat 03:45) + config `SMS_EXPORT_STORAGE_DIR`/`SMS_EXPORT_RETENTION_DAYS` + docker volume `sms_private_exports` + `.gitignore`. **KHÔNG migration** (bảng `sms_campaign_export_batch` tạo ở PR-1). Verify: 8 test PR-4 + 90 regression (schema/contacts/build) PASS, flake8 sạch, Celery task+beat đăng ký OK, import app.main OK.
 
 ---
 

--- a/Documents/SMS_MARKETING_MODULE_DESIGN.md
+++ b/Documents/SMS_MARKETING_MODULE_DESIGN.md
@@ -660,7 +660,9 @@ Mỗi PR: type-check + test local trước push (`test-before-push`); FE PR Chro
 
 ## 14. Trạng thái quyết định thiết kế
 
-> **Verdict: GO (user/chủ dự án authorize 2026-06-11)** — override BLOCK hard-review trước; user xác nhận đủ evidence L1–L4 + lịch sử vận hành không vấn đề PL. PR-1 schema đã code + qua 3 vòng Codex review (R1–R3) trên `sms/pr1-schema` (CHƯA push). Reference L1–L4 trỏ vào `proof_reference`/`source_reference`/attestation khi build campaign thật.
+> **Verdict: GO (user/chủ dự án authorize 2026-06-11)** — override BLOCK hard-review trước; user xác nhận đủ evidence L1–L4 + lịch sử vận hành không vấn đề PL. Reference L1–L4 trỏ vào `proof_reference`/`source_reference`/attestation khi build campaign thật.
+>
+> **Trạng thái build (audit code-verified 2026-06-29):** BE core XONG, đã merge `main` — **PR-1 Schema #401** (12 model + 2 migration, DB dev có 12 bảng `sms_*` + 34 carrier rule seed), **PR-2 Contact #403** (CRUD groups/contacts + import + consent ledger), **PR-3 Build #406** (+int32 #405; snapshot revision + token HMAC/Fernet + preflight + attestations). 78 test SMS. **CHƯA bắt đầu: PR-4 Export · PR-5 Tracking/Landing/Reports · PR-6 Frontend (0 file) · PR-7 Segment+Conversion** — router stub rỗng cho PR-4/5. Module **chưa chạy end-to-end** (thiếu export-handoff + toàn bộ FE). Lộ trình PR §13; trạng thái phối hợp chi tiết: `Documents/SMS_BUILD_COORDINATION.md` §9.
 
 ### Launch gate bắt buộc
 - **L1 — Consent source contract**: mẫu disclosure, loại proof chấp nhận, retention và chủ sở hữu nghiệp vụ; không chấp nhận `implied_lead`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
     volumes:
       - backend_uploads:/app/uploads
       - backend_static_uploads:/app/app/static/uploads
+      - sms_private_exports:/app/private_exports
       - geoip_data:/app/geoip
       - backend_logs:/app/logs
     depends_on:
@@ -140,6 +141,7 @@ services:
     volumes:
       - backend_static_uploads:/app/app/static/uploads
       - backend_uploads:/app/uploads
+      - sms_private_exports:/app/private_exports
       - backend_logs:/app/logs
     depends_on:
       backend:
@@ -179,6 +181,7 @@ services:
     volumes:
       - backend_static_uploads:/app/app/static/uploads
       - backend_uploads:/app/uploads
+      - sms_private_exports:/app/private_exports
       - backend_logs:/app/logs
     depends_on:
       backend:
@@ -277,6 +280,7 @@ volumes:
   redis_data:
   backend_uploads:
   backend_static_uploads:
+  sms_private_exports:  # PR-4: file Excel export SMS (PII) — private, ngoài webroot
   geoip_data:
   backend_logs:
   certbot_certs:


### PR DESCRIPTION
## PR-4 — SMS Marketing Export (off `main`, KHÔNG migration)

Hoàn thiện PR-4 module SMS Marketing: sinh file Excel danh sách gửi per nhà mạng để bàn giao ngoài QLTS. Bảng `sms_campaign_export_batch` đã tạo ở PR-1 → **không migration**.

### Endpoint (admin, `/api/sms`, khớp design §10)
- `POST /campaigns/{id}/export` — sinh file per nhà mạng, idempotent
- `GET  /campaigns/{id}/exports` — list batch revision hiện tại
- `GET  /campaigns/{id}/exports/{batch_id}/download` — stream FileResponse + verify sha256
- `POST /campaigns/{id}/exports/{batch_id}/mark-handed-off`

### Cơ chế chính
- **Gate fail-closed (§8.4):** 3 attestation khớp `build_revision` + reference; chặn `over_limit`; re-check drift consent/suppression (pre-commit) + live re-check lúc sinh file (đóng khe TOCTOU).
- **File mẫu nhà mạng (§8.1):** Sheet1, row1 trống, cột A=`84xxx` (text), cột B=`[QC]`+tin+link THẬT (giải mã Fernet ciphertext → URL, thay sentinel).
- **Sinh file post-commit** (`AsyncSessionLocal` mới, `asyncio.to_thread` không chặn loop, atomic staging→fsync→`os.replace`, sha256). Idempotent theo `(campaign, revision, carrier)`.
- **mark-handed-off:** neo `recipient.handed_off_at` (chặn rebuild) + `contact.last_handed_off_at` (freq-cap) + campaign → `handed_off`/`closed`.
- **Cleanup Celery** `cleanup_sms_export_files_task` (beat 03:45) + retention config + docker volume `sms_private_exports` (private, ngoài webroot).

### Chất lượng
- 3 commit: feat + **/code-review max (16 fix)** + **re-review 4-agent (6 residual)** — gồm wedge campaign, stale-revision PII, filename collision/non-ASCII, ABBA deadlock, cleanup lost-update.
- **12 integration test + 90 regression PASS · flake8 sạch.**
- **Smoke thật trên dev qlts_dev PASS:** 3 nhà mạng thật, file Excel nội dung đúng (84xxx + [QC] + link thật), handoff→closed, guard re-export.

### ⚠️ Deploy (KHÔNG code-only)
Tạo volume `sms_private_exports` + RESTART backend/celery-worker/celery-beat. Prod campaign có `{link}` cần env `SMS_TOKEN_*` + `SMS_PUBLIC_BASE_URL` + `SMS_OPTOUT_INSTRUCTION` thật.

🤖 Generated with [Claude Code](https://claude.com/claude-code)