### PR TITLE
feat(sms): PR-5 Tracking + Landing + Reports + Opt-out

### DIFF
--- a/Backend_FastAPI/Dockerfile
+++ b/Backend_FastAPI/Dockerfile
@@ -40,15 +40,23 @@ COPY --from=builder /install /usr/local
 # Copy application code
 COPY . .
 
-# Create required directories and make entrypoint executable
+# Create required directories and make entrypoint executable.
+# /app/private_exports is the mount point cho named volume `sms_private_exports`
+# (PR-4 SMS export XLSX chứa PII, để ngoài webroot). PHẢI tạo + chown appuser
+# TRONG image: khi named volume rỗng mount lần đầu, Docker seed nội dung + quyền
+# từ image tại mount path → volume root thuộc appuser → app (chạy appuser) tạo
+# được subdir `sms`. Nếu không, mount point sinh ra root-owned → makedirs ném
+# PermissionError, batch export thành `failed`.
 RUN mkdir -p /app/uploads \
     /app/app/static/uploads/avatars \
     /app/geoip \
     /app/logs \
+    /app/private_exports/sms \
     && chown -R appuser:appuser /app/uploads \
     /app/app/static/uploads \
     /app/geoip \
     /app/logs \
+    /app/private_exports \
     && chmod +x /app/docker-entrypoint.sh
 
 USER appuser

--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -281,6 +281,18 @@ class Settings(BaseSettings):
         default=14, ge=1, le=365,
         validation_alias="SMS_EXPORT_RETENTION_DAYS",
     )  # re-download tới expires_at; cleanup job xoá file + set purged_at
+    # -- Landing page công khai /lp/{code} (PR-5) --
+    SMS_LANDING_SCHOOL_NAME: str = Field(
+        default="Nhà trường",
+        validation_alias="SMS_LANDING_SCHOOL_NAME",
+    )  # tên trường hiển thị header landing (nhận diện, chống nghi lừa đảo)
+    SMS_LANDING_CONSENT_NOTICE: str = Field(
+        default=(
+            "Bạn nhận tin này vì đã đăng ký/quan tâm tuyển sinh. "
+            "Không muốn nhận nữa? Bấm \"Hủy nhận tin\"."
+        ),
+        validation_alias="SMS_LANDING_CONSENT_NOTICE",
+    )  # câu thông báo cơ sở xử lý dữ liệu trên landing (§19.2)
 
     # -- Docker self-hosted deployment --
     # When True, skip TLS enforcement for DB/Redis connections.

--- a/Backend_FastAPI/app/core/client_ip.py
+++ b/Backend_FastAPI/app/core/client_ip.py
@@ -24,12 +24,21 @@ from starlette.requests import Request
 
 
 def get_client_ip(request: Request) -> str:
-    """Return the first hop in ``X-Forwarded-For`` (real client) or fall back
-    to ``request.client.host`` when the header is absent.
+    """Return the real client IP for per-IP rate limits / hashing.
 
-    Used as ``key_func`` for slowapi per-IP limits; correctness matters because
-    ``request.client.host`` is the nginx container IP in production.
+    Prefer ``X-Real-IP`` (nginx sets it to ``$remote_addr`` and OVERWRITES any
+    client-supplied value — see default.conf.template:82), so it is NOT
+    spoofable. Fall back to the first ``X-Forwarded-For`` hop (note: nginx uses
+    ``$proxy_add_x_forwarded_for`` which APPENDS, so the first hop is
+    client-controlled and spoofable — only used when X-Real-IP is absent, e.g.
+    no nginx in front), then ``request.client.host``.
+
+    Single trusted nginx hop only. A multi-proxy topology (CDN→nginx→backend)
+    would make X-Real-IP the CDN IP — revisit then.
     """
+    real = request.headers.get("x-real-ip", "").strip()
+    if real:
+        return real
     xff = request.headers.get("x-forwarded-for", "")
     if xff:
         first = xff.split(",", 1)[0].strip()

--- a/Backend_FastAPI/app/core/log_redaction.py
+++ b/Backend_FastAPI/app/core/log_redaction.py
@@ -1,0 +1,53 @@
+# app/core/log_redaction.py
+"""
+Redact raw SMS bearer code khỏi ACCESS LOG (uvicorn.access dev / gunicorn.access
+prod) — §11.3 "KHÔNG log raw code". nginx `access_log off` chỉ tắt tầng nginx;
+app-server vẫn ghi nguyên request line `GET /r/<code>` mỗi hit thành công →
+filter này thay code bằng `<redacted>` trong record TRƯỚC khi format.
+
+Redact ở record.msg + record.args (tuple cho uvicorn, dict-atoms cho gunicorn).
+"""
+import logging
+import re
+
+# Prefix bearer + phần code (tới whitespace/?/quote/&). PR-5: /r/, /lp/,
+# /api/public/sms/landing/.
+_BEARER_RE = re.compile(
+    r"(/r/|/lp/|/api/public/sms/landing/)[^\s?\"'&]+"
+)
+_REDACTED = r"\1<redacted>"
+
+
+def _redact(value):
+    if isinstance(value, str):
+        return _BEARER_RE.sub(_REDACTED, value)
+    return value
+
+
+class SmsBearerRedactionFilter(logging.Filter):
+    """logging.Filter che bearer code trong access-log record (best-effort —
+    không bao giờ làm hỏng log dù record dạng lạ)."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            args = record.args
+            if isinstance(args, dict):
+                record.args = {k: _redact(v) for k, v in args.items()}
+            elif isinstance(args, tuple):
+                record.args = tuple(_redact(a) for a in args)
+            if isinstance(record.msg, str):
+                record.msg = _BEARER_RE.sub(_REDACTED, record.msg)
+        except Exception:  # noqa: BLE001 — log filter không được phép ném
+            pass
+        return True
+
+
+def install_sms_log_redaction() -> None:
+    """Gắn filter vào các access logger (idempotent — không gắn trùng)."""
+    _filter = SmsBearerRedactionFilter()
+    for name in ("uvicorn.access", "gunicorn.access"):
+        logger = logging.getLogger(name)
+        if not any(
+            isinstance(f, SmsBearerRedactionFilter) for f in logger.filters
+        ):
+            logger.addFilter(_filter)

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -222,6 +222,12 @@ logging.getLogger("uvicorn.access").addHandler(log_handler)
 logging.getLogger("uvicorn.error").handlers.clear()
 logging.getLogger("uvicorn.error").addHandler(log_handler)
 
+# Redact raw SMS bearer code khỏi access log (§11.3) — uvicorn.access (dev) +
+# gunicorn.access (prod, qua post_worker_init).
+from app.core.log_redaction import install_sms_log_redaction  # noqa: E402
+
+install_sms_log_redaction()
+
 # Logger chính của app (giờ là đồng bộ)
 log = structlog.get_logger("app.main")
 

--- a/Backend_FastAPI/app/middleware/exception_handlers.py
+++ b/Backend_FastAPI/app/middleware/exception_handlers.py
@@ -56,6 +56,19 @@ from app.utils.exceptions import (
 
 logger = logging.getLogger(__name__)
 
+# SMS bearer-code routes (PR-5): path chứa raw short-code → KHÔNG được log
+# nguyên (design §11.3). Redact phần code khi ghi log lỗi.
+_SMS_BEARER_PREFIXES = ("/r/", "/lp/", "/api/public/sms/landing/")
+
+
+def _redact_path(path: str) -> str:
+    """Che raw bearer code trong path SMS trước khi log (tránh lộ code↔PII).
+    Giữ prefix để vẫn nhận diện route; thay phần code bằng '<redacted>'."""
+    for prefix in _SMS_BEARER_PREFIXES:
+        if path.startswith(prefix):
+            return prefix + "<redacted>"
+    return path
+
 
 # ============================================================================
 # CUSTOM EXCEPTION HANDLERS
@@ -87,7 +100,7 @@ async def base_app_exception_handler(
         extra={
             "error_code": exc.error_code,
             "context": exc.context,
-            "path": request.url.path,
+            "path": _redact_path(request.url.path),
             "method": request.method,
         },
     )
@@ -125,7 +138,7 @@ async def resource_not_found_handler(
         extra={
             "error_code": exc.error_code,
             "context": exc.context,
-            "path": request.url.path,
+            "path": _redact_path(request.url.path),
         },
     )
 
@@ -151,7 +164,7 @@ async def validation_error_handler(
         extra={
             "error_code": exc.error_code,
             "context": exc.context,
-            "path": request.url.path,
+            "path": _redact_path(request.url.path),
         },
     )
 
@@ -182,7 +195,7 @@ async def authentication_error_handler(
         f"Authentication error: {exc.detail}",
         extra={
             "error_code": exc.error_code,
-            "path": request.url.path,
+            "path": _redact_path(request.url.path),
         },
     )
 
@@ -209,7 +222,7 @@ async def service_error_handler(
         extra={
             "error_code": exc.error_code,
             "context": exc.context,
-            "path": request.url.path,
+            "path": _redact_path(request.url.path),
             "method": request.method,
         },
         exc_info=True,  # Include stack trace
@@ -258,7 +271,7 @@ async def pydantic_validation_error_handler(
     logger.info(
         f"Request validation error: {len(safe_errors)} errors",
         extra={
-            "path": request.url.path,
+            "path": _redact_path(request.url.path),
             "errors": safe_errors,
         },
     )
@@ -290,7 +303,7 @@ async def http_exception_handler(
         f"HTTP {exc.status_code}: {exc.detail}",
         extra={
             "status_code": exc.status_code,
-            "path": request.url.path,
+            "path": _redact_path(request.url.path),
         },
     )
 
@@ -319,7 +332,7 @@ async def generic_exception_handler(request: Request, exc: Exception) -> JSONRes
     logger.error(
         f"Unhandled exception: {type(exc).__name__}: {str(exc)}",
         extra={
-            "path": request.url.path,
+            "path": _redact_path(request.url.path),
             "method": request.method,
         },
         exc_info=True,

--- a/Backend_FastAPI/app/middleware/exception_handlers.py
+++ b/Backend_FastAPI/app/middleware/exception_handlers.py
@@ -19,7 +19,6 @@ Usage:
 """
 
 import logging
-from typing import Union
 
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
@@ -68,6 +67,12 @@ def _redact_path(path: str) -> str:
         if path.startswith(prefix):
             return prefix + "<redacted>"
     return path
+
+
+def _is_sms_bearer_route(path: str) -> bool:
+    """Route mang bearer code (path HOẶC body opt-out) → error 'input' lúc 422
+    có thể chứa raw code → KHÔNG log input (§11.3)."""
+    return path.startswith(_SMS_BEARER_PREFIXES) or path == "/api/public/sms/opt-out"
 
 
 # ============================================================================
@@ -268,11 +273,20 @@ async def pydantic_validation_error_handler(
 
     safe_errors = [serialize_error(e) for e in exc.errors()]
 
+    # Route bearer (/r/, /lp/, landing, body opt-out): error 'input' có thể là
+    # raw bearer code → loại 'input' khỏi LOG (vẫn giữ trong response cho chính
+    # người gửi). §11.3.
+    log_errors = safe_errors
+    if _is_sms_bearer_route(request.url.path):
+        log_errors = [
+            {k: v for k, v in e.items() if k != "input"} for e in safe_errors
+        ]
+
     logger.info(
         f"Request validation error: {len(safe_errors)} errors",
         extra={
             "path": _redact_path(request.url.path),
-            "errors": safe_errors,
+            "errors": log_errors,
         },
     )
 

--- a/Backend_FastAPI/app/repositories/sms_tracking_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_tracking_repository.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.models.sms import (
     SmsCampaign,
+    SmsCampaignExportBatch,
     SmsCampaignRecipient,
     SmsClickEvent,
     SmsOptOut,
@@ -122,6 +123,41 @@ class SmsTrackingRepository:
         self.db.add(row)
         await self.db.flush()
         return row
+
+    async def invalidate_unhanded_exports_for_phone(
+        self, phone_normalized: str
+    ) -> None:
+        """Khi 1 số opt-out: vô hiệu export batch (pending/generated, chưa bàn
+        giao, chưa invalidated) CÓ CHỨA số này ở revision của batch → file XLSX
+        cũ chứa số đã suppress KHÔNG còn tải/bàn giao được (download +
+        mark-handed-off chặn invalidated_at); admin export lại sẽ re-check
+        suppression và loại số. §8.4 (suppression đổi sau export, trước handoff)."""
+        has_suppressed_recipient = (
+            select(SmsCampaignRecipient.id)
+            .where(
+                SmsCampaignRecipient.campaign_id
+                == SmsCampaignExportBatch.campaign_id,
+                SmsCampaignRecipient.build_revision
+                == SmsCampaignExportBatch.build_revision,
+                SmsCampaignRecipient.carrier_bucket
+                == SmsCampaignExportBatch.carrier_bucket,
+                SmsCampaignRecipient.phone_normalized_snapshot
+                == phone_normalized,
+                SmsCampaignRecipient.excluded_reason.is_(None),
+                SmsCampaignRecipient.invalidated_at.is_(None),
+                SmsCampaignRecipient.handed_off_at.is_(None),
+            )
+            .exists()
+        )
+        await self.db.execute(
+            update(SmsCampaignExportBatch)
+            .where(
+                SmsCampaignExportBatch.status.in_(("pending", "generated")),
+                SmsCampaignExportBatch.invalidated_at.is_(None),
+                has_suppressed_recipient,
+            )
+            .values(status="invalidated", invalidated_at=func.now())
+        )
 
     async def list_opt_outs(
         self,

--- a/Backend_FastAPI/app/repositories/sms_tracking_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_tracking_repository.py
@@ -1,0 +1,305 @@
+# app/repositories/sms_tracking_repository.py
+"""
+Data-access SMS tracking/landing/reports/opt-out (PR-5): resolve token_hash →
+recipient+campaign, ghi click event + cập nhật denorm counter (atomic), tra
+opt-out, report click theo granularity (JOIN click↔recipient), dashboard CTR,
+và admin opt-out list/insert.
+
+Standalone repository. Service flush, router commit. Xem
+SMS_MARKETING_MODULE_DESIGN.md §6/§9/§19.
+"""
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy import case, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.sms import (
+    SmsCampaign,
+    SmsCampaignRecipient,
+    SmsClickEvent,
+    SmsOptOut,
+)
+
+
+class SmsTrackingRepository:
+    """Repository resolve + click + opt-out + report + dashboard."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    # ---------------------------------------------------------------
+    # Resolve token_hash → recipient + campaign (cho /r/ và landing)
+    # ---------------------------------------------------------------
+    async def lookup_by_token_hash(
+        self, token_hash: str
+    ) -> Optional[Tuple[SmsCampaignRecipient, SmsCampaign]]:
+        """(recipient, campaign) nếu token_hash khớp recipient CHƯA invalidated;
+        None nếu không thấy/đã invalidated. JOIN campaign để quyết định redirect/
+        landing."""
+        res = await self.db.execute(
+            select(SmsCampaignRecipient, SmsCampaign)
+            .join(SmsCampaign, SmsCampaign.id == SmsCampaignRecipient.campaign_id)
+            .where(
+                SmsCampaignRecipient.token_hash == token_hash,
+                SmsCampaignRecipient.invalidated_at.is_(None),
+            )
+            .limit(1)
+        )
+        row = res.first()
+        return (row[0], row[1]) if row else None
+
+    # ---------------------------------------------------------------
+    # Click event + denorm counter (atomic — chống lost update khi click //)
+    # ---------------------------------------------------------------
+    async def record_click(
+        self,
+        *,
+        recipient_id: int,
+        ip_hash: Optional[str],
+        user_agent: Optional[str],
+        is_bot: bool,
+        bot_reason: Optional[str],
+        now: datetime,
+    ) -> None:
+        self.db.add(
+            SmsClickEvent(
+                recipient_id=recipient_id,
+                ip_hash=ip_hash,
+                user_agent=(user_agent or None),
+                is_suspected_bot=is_bot,
+                bot_reason=bot_reason,
+            )
+        )
+        # UPDATE atomic (counter = counter + 1) → không read-modify-write nên
+        # nhiều click đồng thời không mất đếm. human + first/last chỉ khi non-bot.
+        inc_human = 0 if is_bot else 1
+        values = {
+            "raw_click_count": SmsCampaignRecipient.raw_click_count + 1,
+            "human_click_count": (
+                SmsCampaignRecipient.human_click_count + inc_human
+            ),
+        }
+        if not is_bot:
+            values["last_human_clicked_at"] = now
+            values["first_human_clicked_at"] = case(
+                (
+                    SmsCampaignRecipient.first_human_clicked_at.is_(None),
+                    now,
+                ),
+                else_=SmsCampaignRecipient.first_human_clicked_at,
+            )
+        await self.db.execute(
+            update(SmsCampaignRecipient)
+            .where(SmsCampaignRecipient.id == recipient_id)
+            .values(**values)
+        )
+
+    # ---------------------------------------------------------------
+    # Opt-out
+    # ---------------------------------------------------------------
+    async def is_phone_opted_out(self, phone_normalized: str) -> bool:
+        res = await self.db.scalar(
+            select(SmsOptOut.id)
+            .where(SmsOptOut.phone_normalized == phone_normalized)
+            .limit(1)
+        )
+        return res is not None
+
+    async def get_opt_out(self, phone_normalized: str) -> Optional[SmsOptOut]:
+        res = await self.db.execute(
+            select(SmsOptOut).where(
+                SmsOptOut.phone_normalized == phone_normalized
+            )
+        )
+        return res.scalars().first()
+
+    async def create_opt_out(self, fields: dict) -> SmsOptOut:
+        row = SmsOptOut(**fields)
+        self.db.add(row)
+        await self.db.flush()
+        return row
+
+    async def list_opt_outs(
+        self,
+        skip: int = 0,
+        limit: int = 50,
+        search: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> Tuple[int, List[SmsOptOut]]:
+        conds = []
+        if source:
+            conds.append(SmsOptOut.source == source)
+        if search:
+            conds.append(
+                SmsOptOut.phone_normalized.ilike(f"%{search.strip()}%")
+            )
+        base = select(SmsOptOut)
+        if conds:
+            base = base.where(*conds)
+        total = await self.db.scalar(
+            select(func.count()).select_from(base.subquery())
+        )
+        res = await self.db.execute(
+            base.order_by(SmsOptOut.observed_at.desc()).offset(skip).limit(limit)
+        )
+        return int(total or 0), list(res.scalars().all())
+
+    # ---------------------------------------------------------------
+    # Reports — click theo granularity (§9)
+    # ---------------------------------------------------------------
+    def _click_filters(
+        self,
+        *,
+        campaign_id: Optional[int] = None,
+        carrier: Optional[str] = None,
+        group_id: Optional[int] = None,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+    ):
+        conds = []
+        if campaign_id is not None:
+            conds.append(SmsCampaignRecipient.campaign_id == campaign_id)
+        if carrier:
+            conds.append(SmsCampaignRecipient.carrier_bucket == carrier)
+        if group_id is not None:
+            # GIN: group_ids_snapshot @> ARRAY[gid]
+            conds.append(
+                SmsCampaignRecipient.group_ids_snapshot.contains([group_id])
+            )
+        if date_from is not None:
+            conds.append(SmsClickEvent.clicked_at >= date_from)
+        if date_to is not None:
+            conds.append(SmsClickEvent.clicked_at <= date_to)
+        return conds
+
+    async def click_buckets(
+        self, *, granularity: str, **filters
+    ) -> List[Tuple[datetime, int, int, int]]:
+        """(period, total, human, distinct_human_recipients) theo bucket."""
+        conds = self._click_filters(**filters)
+        bucket = func.date_trunc(granularity, SmsClickEvent.clicked_at)
+        human = case((SmsClickEvent.is_suspected_bot.is_(False), 1), else_=0)
+        distinct_human = func.count(
+            func.distinct(
+                case(
+                    (
+                        SmsClickEvent.is_suspected_bot.is_(False),
+                        SmsClickEvent.recipient_id,
+                    ),
+                    else_=None,
+                )
+            )
+        )
+        res = await self.db.execute(
+            select(
+                bucket.label("period"),
+                func.count().label("total"),
+                func.coalesce(func.sum(human), 0).label("human"),
+                distinct_human.label("distinct_human"),
+            )
+            .select_from(SmsClickEvent)
+            .join(
+                SmsCampaignRecipient,
+                SmsCampaignRecipient.id == SmsClickEvent.recipient_id,
+            )
+            .where(*conds)
+            .group_by(bucket)
+            .order_by(bucket)
+        )
+        return [(r[0], int(r[1]), int(r[2]), int(r[3])) for r in res.all()]
+
+    async def click_totals(self, **filters) -> Tuple[int, int, int]:
+        """(total_clicks, human_clicks, distinct_human_recipients) toàn dải."""
+        conds = self._click_filters(**filters)
+        human = case((SmsClickEvent.is_suspected_bot.is_(False), 1), else_=0)
+        distinct_human = func.count(
+            func.distinct(
+                case(
+                    (
+                        SmsClickEvent.is_suspected_bot.is_(False),
+                        SmsClickEvent.recipient_id,
+                    ),
+                    else_=None,
+                )
+            )
+        )
+        res = await self.db.execute(
+            select(
+                func.count(),
+                func.coalesce(func.sum(human), 0),
+                distinct_human,
+            )
+            .select_from(SmsClickEvent)
+            .join(
+                SmsCampaignRecipient,
+                SmsCampaignRecipient.id == SmsClickEvent.recipient_id,
+            )
+            .where(*conds)
+        )
+        r = res.first()
+        return int(r[0]), int(r[1]), int(r[2])
+
+    async def count_handed_off(
+        self,
+        *,
+        campaign_id: Optional[int] = None,
+        carrier: Optional[str] = None,
+        group_id: Optional[int] = None,
+    ) -> int:
+        """Mẫu số CTR: số recipient ĐÃ bàn giao (handed_off_at NOT NULL),
+        exportable (excluded_reason NULL), khớp filter campaign/carrier/group."""
+        conds = [
+            SmsCampaignRecipient.handed_off_at.is_not(None),
+            SmsCampaignRecipient.excluded_reason.is_(None),
+        ]
+        if campaign_id is not None:
+            conds.append(SmsCampaignRecipient.campaign_id == campaign_id)
+        if carrier:
+            conds.append(SmsCampaignRecipient.carrier_bucket == carrier)
+        if group_id is not None:
+            conds.append(
+                SmsCampaignRecipient.group_ids_snapshot.contains([group_id])
+            )
+        res = await self.db.scalar(
+            select(func.count())
+            .select_from(SmsCampaignRecipient)
+            .where(*conds)
+        )
+        return int(res or 0)
+
+    # ---------------------------------------------------------------
+    # Dashboard campaign (§9)
+    # ---------------------------------------------------------------
+    async def carrier_distribution_handed_off(
+        self, campaign_id: int
+    ) -> Dict[str, int]:
+        res = await self.db.execute(
+            select(SmsCampaignRecipient.carrier_bucket, func.count())
+            .where(
+                SmsCampaignRecipient.campaign_id == campaign_id,
+                SmsCampaignRecipient.handed_off_at.is_not(None),
+                SmsCampaignRecipient.excluded_reason.is_(None),
+            )
+            .group_by(SmsCampaignRecipient.carrier_bucket)
+        )
+        return {r[0]: int(r[1]) for r in res.all()}
+
+    async def top_clickers(
+        self, campaign_id: int, limit: int = 100
+    ) -> List[SmsCampaignRecipient]:
+        """Recipient đã click (non-bot) của campaign — sắp theo lượt click giảm
+        dần (denorm human_click_count > 0)."""
+        res = await self.db.execute(
+            select(SmsCampaignRecipient)
+            .where(
+                SmsCampaignRecipient.campaign_id == campaign_id,
+                SmsCampaignRecipient.human_click_count > 0,
+            )
+            .order_by(
+                SmsCampaignRecipient.human_click_count.desc(),
+                SmsCampaignRecipient.last_human_clicked_at.desc(),
+            )
+            .limit(limit)
+        )
+        return list(res.scalars().all())

--- a/Backend_FastAPI/app/repositories/sms_tracking_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_tracking_repository.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional, Tuple
 from sqlalchemy import case, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.models.sms import (
     SmsCampaign,
     SmsCampaignRecipient,
@@ -66,7 +67,9 @@ class SmsTrackingRepository:
             SmsClickEvent(
                 recipient_id=recipient_id,
                 ip_hash=ip_hash,
-                user_agent=(user_agent or None),
+                # Cắt ≤512 khớp cột String(512) — UA dài (bot/client gửi >512)
+                # sẽ StringDataRightTruncation → /r/ 500 thay vì 302.
+                user_agent=(user_agent[:512] if user_agent else None),
                 is_suspected_bot=is_bot,
                 bot_reason=bot_reason,
             )
@@ -157,7 +160,9 @@ class SmsTrackingRepository:
         date_from: Optional[datetime] = None,
         date_to: Optional[datetime] = None,
     ):
-        conds = []
+        # Tử số click chỉ tính trên recipient handed-off (cùng quần thể mẫu số
+        # CTR) → ctr ≤ 100%, không đếm click trước-handoff/revision cũ (#6).
+        conds = list(self._handed_off_population())
         if campaign_id is not None:
             conds.append(SmsCampaignRecipient.campaign_id == campaign_id)
         if carrier:
@@ -173,19 +178,36 @@ class SmsTrackingRepository:
             conds.append(SmsClickEvent.clicked_at <= date_to)
         return conds
 
+    def _handed_off_population(self):
+        """Quần thể CTR (mẫu số): recipient ĐÃ bàn giao + exportable + chưa
+        invalidated → dùng CHUNG cho tử (click) lẫn mẫu (handed_off) để CTR ≤
+        100% và không đếm trùng qua revision."""
+        return (
+            SmsCampaignRecipient.handed_off_at.is_not(None),
+            SmsCampaignRecipient.excluded_reason.is_(None),
+            SmsCampaignRecipient.invalidated_at.is_(None),
+        )
+
     async def click_buckets(
         self, *, granularity: str, **filters
     ) -> List[Tuple[datetime, int, int, int]]:
         """(period, total, human, distinct_human_recipients) theo bucket."""
         conds = self._click_filters(**filters)
-        bucket = func.date_trunc(granularity, SmsClickEvent.clicked_at)
+        # Bucket theo GIỜ VN (AT TIME ZONE settings.TIMEZONE) — không UTC: click
+        # 00:00–07:00 giờ VN không bị rớt sang ngày hôm trước (#R3-4).
+        bucket = func.date_trunc(
+            granularity,
+            func.timezone(settings.TIMEZONE, SmsClickEvent.clicked_at),
+        )
         human = case((SmsClickEvent.is_suspected_bot.is_(False), 1), else_=0)
+        # distinct theo PHONE (không recipient_id): 1 người ở nhiều campaign/
+        # revision không bị đếm nhiều lần ở report cross-campaign (#10).
         distinct_human = func.count(
             func.distinct(
                 case(
                     (
                         SmsClickEvent.is_suspected_bot.is_(False),
-                        SmsClickEvent.recipient_id,
+                        SmsCampaignRecipient.phone_normalized_snapshot,
                     ),
                     else_=None,
                 )
@@ -213,12 +235,14 @@ class SmsTrackingRepository:
         """(total_clicks, human_clicks, distinct_human_recipients) toàn dải."""
         conds = self._click_filters(**filters)
         human = case((SmsClickEvent.is_suspected_bot.is_(False), 1), else_=0)
+        # distinct theo PHONE (không recipient_id): 1 người ở nhiều campaign/
+        # revision không bị đếm nhiều lần ở report cross-campaign (#10).
         distinct_human = func.count(
             func.distinct(
                 case(
                     (
                         SmsClickEvent.is_suspected_bot.is_(False),
-                        SmsClickEvent.recipient_id,
+                        SmsCampaignRecipient.phone_normalized_snapshot,
                     ),
                     else_=None,
                 )
@@ -247,12 +271,10 @@ class SmsTrackingRepository:
         carrier: Optional[str] = None,
         group_id: Optional[int] = None,
     ) -> int:
-        """Mẫu số CTR: số recipient ĐÃ bàn giao (handed_off_at NOT NULL),
-        exportable (excluded_reason NULL), khớp filter campaign/carrier/group."""
-        conds = [
-            SmsCampaignRecipient.handed_off_at.is_not(None),
-            SmsCampaignRecipient.excluded_reason.is_(None),
-        ]
+        """Mẫu số CTR: số NGƯỜI (distinct phone) đã bàn giao + exportable +
+        chưa invalidated. distinct phone (không recipient-row) để KHỚP đơn vị
+        tử số (distinct phone clicked) → CTR cross-campaign không lệch (#R3-1)."""
+        conds = list(self._handed_off_population())
         if campaign_id is not None:
             conds.append(SmsCampaignRecipient.campaign_id == campaign_id)
         if carrier:
@@ -262,7 +284,11 @@ class SmsTrackingRepository:
                 SmsCampaignRecipient.group_ids_snapshot.contains([group_id])
             )
         res = await self.db.scalar(
-            select(func.count())
+            select(
+                func.count(
+                    func.distinct(SmsCampaignRecipient.phone_normalized_snapshot)
+                )
+            )
             .select_from(SmsCampaignRecipient)
             .where(*conds)
         )
@@ -278,8 +304,7 @@ class SmsTrackingRepository:
             select(SmsCampaignRecipient.carrier_bucket, func.count())
             .where(
                 SmsCampaignRecipient.campaign_id == campaign_id,
-                SmsCampaignRecipient.handed_off_at.is_not(None),
-                SmsCampaignRecipient.excluded_reason.is_(None),
+                *self._handed_off_population(),
             )
             .group_by(SmsCampaignRecipient.carrier_bucket)
         )
@@ -289,12 +314,14 @@ class SmsTrackingRepository:
         self, campaign_id: int, limit: int = 100
     ) -> List[SmsCampaignRecipient]:
         """Recipient đã click (non-bot) của campaign — sắp theo lượt click giảm
-        dần (denorm human_click_count > 0)."""
+        dần. Lọc cùng population handed-off (#R3-2) → khớp totals/CTR ở dashboard
+        (không liệt kê clicker của recipient chưa-handoff/đã-invalidated)."""
         res = await self.db.execute(
             select(SmsCampaignRecipient)
             .where(
                 SmsCampaignRecipient.campaign_id == campaign_id,
                 SmsCampaignRecipient.human_click_count > 0,
+                *self._handed_off_population(),
             )
             .order_by(
                 SmsCampaignRecipient.human_click_count.desc(),

--- a/Backend_FastAPI/app/routers/sms_public.py
+++ b/Backend_FastAPI/app/routers/sms_public.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Path, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database
+from app.core.client_ip import get_client_ip
 from app.core.rate_limits import RateLimits, limiter
 from app.schemas import sms as sms_schemas
 from app.services.sms_landing_service import SmsLandingService
@@ -22,7 +23,7 @@ def _set_public_headers(response: Response) -> None:
 
 
 @router.get("/landing/{code}", response_model=sms_schemas.SmsLandingResponse)
-@limiter.limit(RateLimits.PUBLIC_READ)
+@limiter.limit(RateLimits.PUBLIC_READ, key_func=get_client_ip)
 async def get_landing(
     request: Request,  # required by slowapi rate limiter
     response: Response,
@@ -37,7 +38,7 @@ async def get_landing(
 
 
 @router.post("/opt-out", response_model=sms_schemas.SmsPublicOptOutResponse)
-@limiter.limit(RateLimits.PUBLIC_READ)
+@limiter.limit(RateLimits.PUBLIC_READ, key_func=get_client_ip)
 async def public_opt_out(
     request: Request,  # required by slowapi rate limiter
     response: Response,

--- a/Backend_FastAPI/app/routers/sms_public.py
+++ b/Backend_FastAPI/app/routers/sms_public.py
@@ -1,9 +1,51 @@
 # app/routers/sms_public.py
 """
-SMS Marketing — public surface (no auth, CSRF-exempt dưới /api/public/).
-Stub PR-1; routes thêm ở **PR-5 (Codex)**: GET landing/{code} (read-only,
-no-store) + POST opt-out. KHÔNG sửa main.py (đã wire ở PR-1).
+SMS Marketing — public surface (no auth, CSRF-exempt dưới /api/public/). PR-5:
+GET landing/{code} (read-only, no-store, noindex, no-referrer) + POST opt-out
+(idempotent). Router "dumb": commit (opt-out) rồi trả. KHÔNG sửa main.py.
 """
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Path, Request, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database
+from app.core.rate_limits import RateLimits, limiter
+from app.schemas import sms as sms_schemas
+from app.services.sms_landing_service import SmsLandingService
 
 router = APIRouter(prefix="/api/public/sms", tags=["SMS Public"])
+
+
+def _set_public_headers(response: Response) -> None:
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["X-Robots-Tag"] = "noindex"
+    response.headers["Referrer-Policy"] = "no-referrer"
+
+
+@router.get("/landing/{code}", response_model=sms_schemas.SmsLandingResponse)
+@limiter.limit(RateLimits.PUBLIC_READ)
+async def get_landing(
+    request: Request,  # required by slowapi rate limiter
+    response: Response,
+    code: str = Path(..., max_length=64),
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Nội dung landing — read-only, KHÔNG ghi click (đã ghi ở /r/), KHÔNG lộ
+    PII recipient. 404 generic nếu code sai/hết hạn."""
+    result = await SmsLandingService(db).get_landing(code)
+    _set_public_headers(response)
+    return result
+
+
+@router.post("/opt-out", response_model=sms_schemas.SmsPublicOptOutResponse)
+@limiter.limit(RateLimits.PUBLIC_READ)
+async def public_opt_out(
+    request: Request,  # required by slowapi rate limiter
+    response: Response,
+    payload: sms_schemas.SmsPublicOptOutRequest,
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Opt-out công khai từ landing — idempotent (UNIQUE phone)."""
+    result = await SmsLandingService(db).public_opt_out(payload.code)
+    await db.commit()
+    _set_public_headers(response)
+    return result

--- a/Backend_FastAPI/app/routers/sms_reports.py
+++ b/Backend_FastAPI/app/routers/sms_reports.py
@@ -1,8 +1,86 @@
 # app/routers/sms_reports.py
 """
-SMS Marketing — reports click ngày/tháng/năm + dashboard CTR (admin).
-Stub PR-1; routes thêm ở **PR-5 (Codex)**. KHÔNG sửa main.py (đã wire ở PR-1).
+SMS Marketing — reports click + dashboard CTR + opt-out admin (admin only).
+PR-5. Router "dumb": dịch HTTP ↔ service, commit (mutation), không business
+logic. Hard gate `require_admin`. KHÔNG sửa main.py (đã wire ở PR-1).
 """
-from fastapi import APIRouter
+from datetime import datetime
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, Path, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database, models
+from app.core.deps import require_admin
+from app.schemas import sms as sms_schemas
+from app.services.sms_report_service import SmsReportService
 
 router = APIRouter(prefix="/api/sms", tags=["SMS Reports"])
+
+_MAX_ID = 2147483647
+
+
+@router.get("/reports/clicks", response_model=sms_schemas.SmsClickReport)
+async def report_clicks(
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+    granularity: str = Query("day", pattern="^(day|month|year)$"),
+    campaign_id: Optional[int] = Query(None, ge=1, le=_MAX_ID),
+    carrier: Optional[str] = Query(None, max_length=20),
+    group_id: Optional[int] = Query(None, ge=1, le=_MAX_ID),
+    date_from: Optional[datetime] = Query(None),
+    date_to: Optional[datetime] = Query(None),
+):
+    """Report click theo ngày/tháng/năm + CTR (distinct non-bot / handed_off)."""
+    return await SmsReportService(db).click_report(
+        granularity=granularity,
+        campaign_id=campaign_id,
+        carrier=carrier,
+        group_id=group_id,
+        date_from=date_from,
+        date_to=date_to,
+    )
+
+
+@router.get(
+    "/campaigns/{campaign_id}/dashboard",
+    response_model=sms_schemas.SmsCampaignDashboard,
+)
+async def campaign_dashboard(
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    """CTR + phân bố nhà mạng + danh sách số đã click của 1 campaign."""
+    return await SmsReportService(db).dashboard(campaign_id)
+
+
+@router.get("/opt-out", response_model=sms_schemas.SmsOptOutList)
+async def list_opt_outs(
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+    skip: int = Query(0, ge=0, le=_MAX_ID),
+    limit: int = Query(50, ge=1, le=200),
+    search: Optional[str] = Query(None, max_length=32),
+    source: Optional[str] = Query(None, max_length=30),
+):
+    """Danh sách số từ chối nhận tin (suppression toàn cục)."""
+    return await SmsReportService(db).list_opt_outs(
+        skip=skip, limit=limit, search=search, source=source
+    )
+
+
+@router.post(
+    "/opt-out/manual",
+    response_model=sms_schemas.SmsOptOutOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def manual_opt_out(
+    payload: sms_schemas.SmsOptOutManualCreate,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    """Admin ghi opt-out thủ công (đối tác/điện thoại/SMS reply)."""
+    result = await SmsReportService(db).manual_opt_out(payload, current_user)
+    await db.commit()
+    return result

--- a/Backend_FastAPI/app/routers/sms_shortlink.py
+++ b/Backend_FastAPI/app/routers/sms_shortlink.py
@@ -7,14 +7,20 @@ KHÔNG sửa main.py (đã wire ở PR-1).
 """
 from fastapi import APIRouter, Depends, Path, Request
 from fastapi.responses import RedirectResponse
-from slowapi.util import get_remote_address
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database
-from app.core.rate_limits import RateLimits, limiter
+from app.core.client_ip import get_client_ip
+from app.core.rate_limits import limiter
 from app.services.sms_tracking_service import SmsTrackingService
 
 router = APIRouter(tags=["SMS Shortlink"])
+
+# /r/ là endpoint CLICK của người thật từ SMS → nhà mạng VN CGNAT chia IP
+# egress cho hàng nghìn thuê bao; trần phải rộng + KEY THEO get_client_ip
+# (XFF-aware) chứ KHÔNG get_remote_address (= IP nginx → khoá global). nginx
+# limit_req zone=general là lớp chặn DoS thật.
+_SHORTLINK_LIMIT = "2000/hour"
 
 # Bearer URL công khai → mọi response no-referrer/no-store/noindex (§6.1).
 _SEC_HEADERS = {
@@ -25,7 +31,7 @@ _SEC_HEADERS = {
 
 
 @router.get("/r/{code}")
-@limiter.limit(RateLimits.PUBLIC_READ)
+@limiter.limit(_SHORTLINK_LIMIT, key_func=get_client_ip)
 async def resolve_shortlink(
     request: Request,  # required by slowapi rate limiter + IP/UA
     code: str = Path(..., max_length=64),
@@ -35,7 +41,7 @@ async def resolve_shortlink(
     hạn → 404 generic (service raise ResourceNotFoundError)."""
     target = await SmsTrackingService(db).resolve(
         code,
-        ip=get_remote_address(request),
+        ip=get_client_ip(request),
         user_agent=request.headers.get("user-agent"),
         headers=request.headers,
     )

--- a/Backend_FastAPI/app/routers/sms_shortlink.py
+++ b/Backend_FastAPI/app/routers/sms_shortlink.py
@@ -1,9 +1,46 @@
 # app/routers/sms_shortlink.py
 """
 SMS Marketing — short-link resolver. Route GET /r/{code} (về backend, qua
-nginx location /r/). Stub PR-1; route thêm ở **PR-5 (Codex)**: resolve +
-rate-limit + click event + 302 redirect. KHÔNG sửa main.py (đã wire ở PR-1).
+nginx location /r/). PR-5: resolve token → ghi click + 302 redirect, public
+(không auth), rate-limit theo IP. Router "dumb": commit rồi trả 302.
+KHÔNG sửa main.py (đã wire ở PR-1).
 """
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Path, Request
+from fastapi.responses import RedirectResponse
+from slowapi.util import get_remote_address
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database
+from app.core.rate_limits import RateLimits, limiter
+from app.services.sms_tracking_service import SmsTrackingService
 
 router = APIRouter(tags=["SMS Shortlink"])
+
+# Bearer URL công khai → mọi response no-referrer/no-store/noindex (§6.1).
+_SEC_HEADERS = {
+    "Referrer-Policy": "no-referrer",
+    "Cache-Control": "no-store",
+    "X-Robots-Tag": "noindex",
+}
+
+
+@router.get("/r/{code}")
+@limiter.limit(RateLimits.PUBLIC_READ)
+async def resolve_shortlink(
+    request: Request,  # required by slowapi rate limiter + IP/UA
+    code: str = Path(..., max_length=64),
+    db: AsyncSession = Depends(database.get_db),
+) -> RedirectResponse:
+    """Resolve /r/{code} → ghi click (bot eval) → 302. Code sai/không thấy/hết
+    hạn → 404 generic (service raise ResourceNotFoundError)."""
+    target = await SmsTrackingService(db).resolve(
+        code,
+        ip=get_remote_address(request),
+        user_agent=request.headers.get("user-agent"),
+        headers=request.headers,
+    )
+    await db.commit()
+    resp = RedirectResponse(url=target, status_code=302)
+    for k, v in _SEC_HEADERS.items():
+        resp.headers[k] = v
+    return resp

--- a/Backend_FastAPI/app/schemas/sms.py
+++ b/Backend_FastAPI/app/schemas/sms.py
@@ -538,3 +538,115 @@ class SmsExportBatchList(BaseModel):
     campaign_id: int
     build_revision: int
     batches: List[SmsExportBatchOut] = Field(default_factory=list)
+
+
+# =====================================================================
+# Tracking / Landing / Reports / Opt-out (PR-5)
+# =====================================================================
+SmsGranularity = Literal["day", "month", "year"]
+# Nguồn opt-out admin ghi tay (mirror CHECK chk_sms_opt_out_source; landing
+# dùng riêng 'landing_optout').
+SmsManualOptOutSource = Literal[
+    "manual", "sms_reply", "phone_call", "external_suppression"
+]
+
+
+class SmsLandingResponse(BaseModel):
+    """Nội dung landing `/lp/{code}` — read-only, KHÔNG lộ PII recipient
+    (phòng code bị chia sẻ). §19.4."""
+
+    school_name: str
+    headline: Optional[str] = None
+    body: Optional[str] = None
+    cta_label: Optional[str] = None
+    cta_url: Optional[str] = None
+    consent_notice: str
+    already_opted_out: bool = False
+
+
+class SmsPublicOptOutRequest(BaseModel):
+    """Body opt-out công khai từ landing — chỉ mang bearer code (§19.3)."""
+
+    code: str = Field(..., min_length=1, max_length=64)
+
+
+class SmsPublicOptOutResponse(BaseModel):
+    """Idempotent: lần 2 vẫn success=True."""
+
+    success: bool = True
+    already_opted_out: bool = False
+
+
+class SmsOptOutManualCreate(BaseModel):
+    """Admin ghi opt-out thủ công (đối tác/điện thoại/SMS reply)."""
+
+    phone: str = Field(..., min_length=8, max_length=32)
+    source: SmsManualOptOutSource = "manual"
+    source_reference: Optional[str] = Field(None, max_length=512)
+    reason: Optional[str] = Field(None, max_length=2000)
+
+
+class SmsOptOutOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    phone_normalized: str
+    source: str
+    source_reference: Optional[str] = None
+    reason: Optional[str] = None
+    observed_at: datetime
+    created_at: datetime
+
+
+class SmsOptOutList(BaseModel):
+    total: int
+    items: List[SmsOptOutOut]
+
+
+class SmsClickBucket(BaseModel):
+    """1 mốc thời gian (day/month/year) — số liệu click."""
+
+    period: str
+    total_clicks: int
+    human_clicks: int
+    distinct_contacts_clicked: int
+
+
+class SmsClickReport(BaseModel):
+    """Report click theo granularity + tổng + CTR (mẫu số = handed_off). §9."""
+
+    granularity: str
+    buckets: List[SmsClickBucket] = Field(default_factory=list)
+    total_clicks: int = 0
+    human_clicks: int = 0
+    distinct_contacts_clicked: int = 0
+    recipients_handed_off: int = 0
+    ctr_percent: float = 0.0
+
+
+class SmsClickerOut(BaseModel):
+    """1 liên hệ đã click (non-bot) cho dashboard — admin xem (PII masked)."""
+
+    recipient_id: int
+    contact_id: Optional[int] = None
+    full_name: str
+    phone_masked: str
+    carrier_bucket: str
+    human_click_count: int
+    first_human_clicked_at: Optional[datetime] = None
+    last_human_clicked_at: Optional[datetime] = None
+
+
+class SmsCampaignDashboard(BaseModel):
+    """Dashboard CTR + phân bố nhà mạng + danh sách số đã click của campaign."""
+
+    campaign_id: int
+    build_revision: int
+    has_link: bool
+    recipients_handed_off: int = 0
+    total_clicks: int = 0
+    human_clicks: int = 0
+    distinct_contacts_clicked: int = 0
+    ctr_percent: float = 0.0
+    carrier_distribution: Dict[str, int] = Field(default_factory=dict)
+    clickers: List[SmsClickerOut] = Field(default_factory=list)

--- a/Backend_FastAPI/app/services/sms_campaign_service.py
+++ b/Backend_FastAPI/app/services/sms_campaign_service.py
@@ -13,7 +13,6 @@ import re
 import unicodedata
 from datetime import datetime, timezone
 from typing import List, Optional, Tuple
-from urllib.parse import urlparse
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -46,10 +45,10 @@ from app.utils.sms_token import (
     ensure_token_secrets_configured,
     generate_short_code,
 )
+from app.utils.sms_url import host_in_allowlist
 
 # Status cho phép build lại (chưa bàn giao/đóng).
 _REBUILDABLE = {"draft", "ready", "exported"}
-_IP_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
 _TOKEN_RETRY = 5  # số lần auto-retry khi token_hash collision (§6.1)
 
 
@@ -77,26 +76,10 @@ class SmsCampaignService:
     # Content validation (cross-field — cần config + candidate state)
     # ===============================================================
     def _host_allowed(self, url: str) -> bool:
-        """https + host ∈ SMS_ALLOWED_REDIRECT_DOMAINS (exact/subdomain);
-        chặn @, IP literal, scheme ≠ https (§6.2)."""
-        raw = (url or "").strip()
-        if "@" in raw:
-            return False
-        try:
-            parsed = urlparse(raw)
-        except ValueError:
-            return False
-        if parsed.scheme != "https":
-            return False
-        host = (parsed.hostname or "").lower()
-        if not host or _IP_RE.match(host):
-            return False
-        allowed = [
-            d.strip().lower()
-            for d in settings.SMS_ALLOWED_REDIRECT_DOMAINS.split(",")
-            if d.strip()
-        ]
-        return any(host == d or host.endswith("." + d) for d in allowed)
+        """Delegate sang util chung `host_in_allowlist` (PR-5) → 1 nguồn sự
+        thật cho allowlist redirect (gồm vá backslash/charset host §6.2),
+        tránh lệch giữa create-time và /r/-resolve."""
+        return host_in_allowlist(url)
 
     def _validate_content(
         self,

--- a/Backend_FastAPI/app/services/sms_landing_service.py
+++ b/Backend_FastAPI/app/services/sms_landing_service.py
@@ -101,6 +101,8 @@ class SmsLandingService:
             return sms_schemas.SmsPublicOptOutResponse(
                 success=True, already_opted_out=True
             )
+        # Opt-out MỚI → vô hiệu export batch chưa bàn giao chứa số này (§8.4).
+        await self.repo.invalidate_unhanded_exports_for_phone(phone)
         return sms_schemas.SmsPublicOptOutResponse(
             success=True, already_opted_out=False
         )

--- a/Backend_FastAPI/app/services/sms_landing_service.py
+++ b/Backend_FastAPI/app/services/sms_landing_service.py
@@ -1,0 +1,103 @@
+# app/services/sms_landing_service.py
+"""
+Business logic landing công khai `/lp/{code}` (PR-5): trả nội dung campaign
+(read-only, KHÔNG lộ PII recipient) + trạng thái đã-opt-out; và xử lý opt-out
+công khai từ landing (idempotent, source='landing_optout').
+
+KHÔNG import fastapi; raise domain exception; service flush (router commit).
+Landing GET KHÔNG ghi click (đã ghi ở /r/). Xem §19.
+"""
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.repositories.sms_tracking_repository import SmsTrackingRepository
+from app.schemas import sms as sms_schemas
+from app.utils.exceptions import ResourceNotFoundError
+from app.utils.sms_token import compute_token_hash, is_valid_code
+from app.utils.sms_url import host_in_allowlist
+
+log = logging.getLogger(__name__)
+
+_GENERIC_404 = "Liên kết không hợp lệ hoặc đã hết hạn"
+
+
+def _aware(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+class SmsLandingService:
+    """Landing read-only + opt-out công khai."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = SmsTrackingRepository(db)
+
+    async def _resolve(self, code: str):
+        if not is_valid_code(code):
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        found = await self.repo.lookup_by_token_hash(compute_token_hash(code))
+        if found is None:
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        recipient, campaign = found
+        if campaign.link_expires_at and _aware(
+            campaign.link_expires_at
+        ) <= datetime.now(timezone.utc):
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        return recipient, campaign
+
+    async def get_landing(self, code: str) -> sms_schemas.SmsLandingResponse:
+        recipient, campaign = await self._resolve(code)
+        already = await self.repo.is_phone_opted_out(
+            recipient.phone_normalized_snapshot
+        )
+        # CTA external → re-check allowlist lúc render; ngoài → ẩn CTA + log.
+        cta_label = campaign.landing_cta_label
+        cta_url = campaign.landing_cta_url
+        if cta_url and not host_in_allowlist(cta_url):
+            log.warning(
+                "SMS landing: CTA url ngoài allowlist campaign_id=%s", campaign.id
+            )
+            cta_label = cta_url = None
+        return sms_schemas.SmsLandingResponse(
+            school_name=settings.SMS_LANDING_SCHOOL_NAME,
+            headline=campaign.landing_headline,
+            body=campaign.landing_body,
+            cta_label=cta_label,
+            cta_url=cta_url,
+            consent_notice=settings.SMS_LANDING_CONSENT_NOTICE,
+            already_opted_out=already,
+        )
+
+    async def public_opt_out(
+        self, code: str
+    ) -> sms_schemas.SmsPublicOptOutResponse:
+        recipient, campaign = await self._resolve(code)
+        phone = recipient.phone_normalized_snapshot
+        if await self.repo.get_opt_out(phone) is not None:
+            return sms_schemas.SmsPublicOptOutResponse(
+                success=True, already_opted_out=True
+            )
+        try:
+            # SAVEPOINT: IntegrityError do race UNIQUE phone chỉ rollback nested,
+            # transaction ngoài còn nguyên (router vẫn commit được) — idempotent.
+            async with self.db.begin_nested():
+                await self.repo.create_opt_out(
+                    {
+                        "phone_normalized": phone,
+                        "source": "landing_optout",
+                        "campaign_id": campaign.id,
+                        "contact_id": recipient.contact_id,
+                        "observed_at": datetime.now(timezone.utc),
+                    }
+                )
+        except IntegrityError:
+            return sms_schemas.SmsPublicOptOutResponse(
+                success=True, already_opted_out=True
+            )
+        return sms_schemas.SmsPublicOptOutResponse(
+            success=True, already_opted_out=False
+        )

--- a/Backend_FastAPI/app/services/sms_landing_service.py
+++ b/Backend_FastAPI/app/services/sms_landing_service.py
@@ -36,14 +36,17 @@ class SmsLandingService:
         self.db = db
         self.repo = SmsTrackingRepository(db)
 
-    async def _resolve(self, code: str):
+    async def _resolve(self, code: str, *, enforce_expiry: bool = True):
         if not is_valid_code(code):
             raise ResourceNotFoundError(detail=_GENERIC_404)
         found = await self.repo.lookup_by_token_hash(compute_token_hash(code))
         if found is None:
             raise ResourceNotFoundError(detail=_GENERIC_404)
         recipient, campaign = found
-        if campaign.link_expires_at and _aware(
+        # Opt-out KHÔNG gate hết hạn (enforce_expiry=False): nghĩa vụ cho phép
+        # từ chối nhận tin phải LUÔN thực hiện được kể cả khi link đã hết hạn
+        # (NĐ91). Landing GET vẫn gate (hiện trang hết-hạn thân thiện).
+        if enforce_expiry and campaign.link_expires_at and _aware(
             campaign.link_expires_at
         ) <= datetime.now(timezone.utc):
             raise ResourceNotFoundError(detail=_GENERIC_404)
@@ -75,7 +78,7 @@ class SmsLandingService:
     async def public_opt_out(
         self, code: str
     ) -> sms_schemas.SmsPublicOptOutResponse:
-        recipient, campaign = await self._resolve(code)
+        recipient, campaign = await self._resolve(code, enforce_expiry=False)
         phone = recipient.phone_normalized_snapshot
         if await self.repo.get_opt_out(phone) is not None:
             return sms_schemas.SmsPublicOptOutResponse(

--- a/Backend_FastAPI/app/services/sms_report_service.py
+++ b/Backend_FastAPI/app/services/sms_report_service.py
@@ -10,6 +10,7 @@ Xem SMS_MARKETING_MODULE_DESIGN.md §9 / §19.3.
 from datetime import datetime, timezone
 from typing import Optional
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.sms_campaign_repository import SmsCampaignRepository
@@ -35,7 +36,10 @@ def _fmt_period(dt: datetime, granularity: str) -> str:
 
 
 def _ctr(distinct_human: int, handed_off: int) -> float:
-    return round(distinct_human / handed_off * 100, 2) if handed_off else 0.0
+    # clamp ≤100% (an toàn; distinct ⊆ handed sau khi cùng population).
+    if not handed_off:
+        return 0.0
+    return round(min(distinct_human, handed_off) / handed_off * 100, 2)
 
 
 class SmsReportService:
@@ -59,20 +63,18 @@ class SmsReportService:
         date_from: Optional[datetime] = None,
         date_to: Optional[datetime] = None,
     ) -> sms_schemas.SmsClickReport:
-        filters = dict(
-            campaign_id=campaign_id,
-            carrier=carrier,
-            group_id=group_id,
+        scope = dict(campaign_id=campaign_id, carrier=carrier, group_id=group_id)
+        # buckets = chuỗi thời gian (windowed theo date_from/date_to); totals +
+        # CTR + handed = cấp campaign TOÀN THỜI → 3 con số reconcile, date CHỈ
+        # ảnh hưởng buckets (#R3-3/#R3-5: bỏ query distinct lần 2).
+        buckets = await self.repo.click_buckets(
+            granularity=granularity,
             date_from=date_from,
             date_to=date_to,
+            **scope,
         )
-        buckets = await self.repo.click_buckets(
-            granularity=granularity, **filters
-        )
-        total, human, distinct = await self.repo.click_totals(**filters)
-        handed = await self.repo.count_handed_off(
-            campaign_id=campaign_id, carrier=carrier, group_id=group_id
-        )
+        total, human, distinct = await self.repo.click_totals(**scope)
+        handed = await self.repo.count_handed_off(**scope)
         return sms_schemas.SmsClickReport(
             granularity=granularity,
             buckets=[
@@ -148,16 +150,26 @@ class SmsReportService:
             raise DuplicateResourceError(
                 detail="Số này đã nằm trong danh sách từ chối."
             )
-        row = await self.repo.create_opt_out(
-            {
-                "phone_normalized": normalized,
-                "source": data.source,
-                "source_reference": data.source_reference,
-                "reason": data.reason,
-                "revoked_by_id": getattr(user, "id", None),
-                "observed_at": datetime.now(timezone.utc),
-            }
-        )
+        try:
+            # SAVEPOINT: race 2 request // cùng số (admin double-submit hoặc đua
+            # public landing opt-out) vượt check trên → UNIQUE phone vi phạm →
+            # 409 sạch thay vì 500 + abort transaction ngoài (đối xứng
+            # public_opt_out).
+            async with self.db.begin_nested():
+                row = await self.repo.create_opt_out(
+                    {
+                        "phone_normalized": normalized,
+                        "source": data.source,
+                        "source_reference": data.source_reference,
+                        "reason": data.reason,
+                        "revoked_by_id": getattr(user, "id", None),
+                        "observed_at": datetime.now(timezone.utc),
+                    }
+                )
+        except IntegrityError:
+            raise DuplicateResourceError(
+                detail="Số này đã nằm trong danh sách từ chối."
+            )
         return sms_schemas.SmsOptOutOut.model_validate(row)
 
     async def list_opt_outs(

--- a/Backend_FastAPI/app/services/sms_report_service.py
+++ b/Backend_FastAPI/app/services/sms_report_service.py
@@ -1,0 +1,174 @@
+# app/services/sms_report_service.py
+"""
+Business logic report SMS (PR-5): report click theo ngày/tháng/năm (CTR =
+distinct non-bot / recipients handed_off), dashboard 1 campaign, và opt-out
+admin (ghi tay + danh sách).
+
+KHÔNG import fastapi; raise domain exception; service flush (router commit).
+Xem SMS_MARKETING_MODULE_DESIGN.md §9 / §19.3.
+"""
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.sms_campaign_repository import SmsCampaignRepository
+from app.repositories.sms_tracking_repository import SmsTrackingRepository
+from app.schemas import sms as sms_schemas
+from app.utils.exceptions import (
+    DuplicateResourceError,
+    ResourceNotFoundError,
+    ValidationError,
+)
+from app.utils.masking import mask_phone
+from app.utils.phone_helpers import (
+    is_vietnam_mobile,
+    normalize_and_validate_vietnam_phone,
+)
+from app.utils.sms_render import has_link
+
+_FMT = {"day": "%Y-%m-%d", "month": "%Y-%m", "year": "%Y"}
+
+
+def _fmt_period(dt: datetime, granularity: str) -> str:
+    return dt.strftime(_FMT.get(granularity, "%Y-%m-%d"))
+
+
+def _ctr(distinct_human: int, handed_off: int) -> float:
+    return round(distinct_human / handed_off * 100, 2) if handed_off else 0.0
+
+
+class SmsReportService:
+    """Report click + dashboard + opt-out admin."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = SmsTrackingRepository(db)
+        self.campaign_repo = SmsCampaignRepository(db)
+
+    # ---------------------------------------------------------------
+    # Report click theo granularity
+    # ---------------------------------------------------------------
+    async def click_report(
+        self,
+        *,
+        granularity: str,
+        campaign_id: Optional[int] = None,
+        carrier: Optional[str] = None,
+        group_id: Optional[int] = None,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+    ) -> sms_schemas.SmsClickReport:
+        filters = dict(
+            campaign_id=campaign_id,
+            carrier=carrier,
+            group_id=group_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        buckets = await self.repo.click_buckets(
+            granularity=granularity, **filters
+        )
+        total, human, distinct = await self.repo.click_totals(**filters)
+        handed = await self.repo.count_handed_off(
+            campaign_id=campaign_id, carrier=carrier, group_id=group_id
+        )
+        return sms_schemas.SmsClickReport(
+            granularity=granularity,
+            buckets=[
+                sms_schemas.SmsClickBucket(
+                    period=_fmt_period(p, granularity),
+                    total_clicks=t,
+                    human_clicks=h,
+                    distinct_contacts_clicked=d,
+                )
+                for p, t, h, d in buckets
+            ],
+            total_clicks=total,
+            human_clicks=human,
+            distinct_contacts_clicked=distinct,
+            recipients_handed_off=handed,
+            ctr_percent=_ctr(distinct, handed),
+        )
+
+    # ---------------------------------------------------------------
+    # Dashboard 1 campaign
+    # ---------------------------------------------------------------
+    async def dashboard(
+        self, campaign_id: int
+    ) -> sms_schemas.SmsCampaignDashboard:
+        campaign = await self.campaign_repo.get_campaign(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        handed = await self.repo.count_handed_off(campaign_id=campaign_id)
+        total, human, distinct = await self.repo.click_totals(
+            campaign_id=campaign_id
+        )
+        carrier_dist = await self.repo.carrier_distribution_handed_off(
+            campaign_id
+        )
+        clickers = await self.repo.top_clickers(campaign_id)
+        return sms_schemas.SmsCampaignDashboard(
+            campaign_id=campaign_id,
+            build_revision=campaign.build_revision,
+            has_link=has_link(campaign.sms_template),
+            recipients_handed_off=handed,
+            total_clicks=total,
+            human_clicks=human,
+            distinct_contacts_clicked=distinct,
+            ctr_percent=_ctr(distinct, handed),
+            carrier_distribution=carrier_dist,
+            clickers=[
+                sms_schemas.SmsClickerOut(
+                    recipient_id=r.id,
+                    contact_id=r.contact_id,
+                    full_name=r.full_name_snapshot,
+                    phone_masked=mask_phone(r.phone_normalized_snapshot),
+                    carrier_bucket=r.carrier_bucket,
+                    human_click_count=r.human_click_count,
+                    first_human_clicked_at=r.first_human_clicked_at,
+                    last_human_clicked_at=r.last_human_clicked_at,
+                )
+                for r in clickers
+            ],
+        )
+
+    # ---------------------------------------------------------------
+    # Opt-out admin (ghi tay + danh sách)
+    # ---------------------------------------------------------------
+    async def manual_opt_out(
+        self, data: sms_schemas.SmsOptOutManualCreate, user
+    ) -> sms_schemas.SmsOptOutOut:
+        normalized, valid = normalize_and_validate_vietnam_phone(data.phone)
+        if not valid or not normalized or not is_vietnam_mobile(normalized):
+            raise ValidationError(
+                detail="Số điện thoại di động không hợp lệ."
+            )
+        if await self.repo.get_opt_out(normalized) is not None:
+            raise DuplicateResourceError(
+                detail="Số này đã nằm trong danh sách từ chối."
+            )
+        row = await self.repo.create_opt_out(
+            {
+                "phone_normalized": normalized,
+                "source": data.source,
+                "source_reference": data.source_reference,
+                "reason": data.reason,
+                "revoked_by_id": getattr(user, "id", None),
+                "observed_at": datetime.now(timezone.utc),
+            }
+        )
+        return sms_schemas.SmsOptOutOut.model_validate(row)
+
+    async def list_opt_outs(
+        self,
+        *,
+        skip: int,
+        limit: int,
+        search: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> sms_schemas.SmsOptOutList:
+        total, items = await self.repo.list_opt_outs(
+            skip=skip, limit=limit, search=search, source=source
+        )
+        return sms_schemas.SmsOptOutList(total=total, items=items)

--- a/Backend_FastAPI/app/services/sms_report_service.py
+++ b/Backend_FastAPI/app/services/sms_report_service.py
@@ -170,6 +170,8 @@ class SmsReportService:
             raise DuplicateResourceError(
                 detail="Số này đã nằm trong danh sách từ chối."
             )
+        # Opt-out MỚI → vô hiệu export batch chưa bàn giao chứa số này (§8.4).
+        await self.repo.invalidate_unhanded_exports_for_phone(normalized)
         return sms_schemas.SmsOptOutOut.model_validate(row)
 
     async def list_opt_outs(

--- a/Backend_FastAPI/app/services/sms_tracking_service.py
+++ b/Backend_FastAPI/app/services/sms_tracking_service.py
@@ -1,0 +1,88 @@
+# app/services/sms_tracking_service.py
+"""
+Business logic resolve short-link `/r/{code}` (PR-5): validate code → tra
+token_hash → kiểm hết hạn/invalidated → ghi click (bot eval + ip_hash) →
+quyết định đích 302. Response 404 GENERIC cho mọi trường hợp không hợp lệ
+(không lộ tồn tại code). KHÔNG log raw code.
+
+KHÔNG import fastapi; raise domain exception; service flush (router commit).
+Xem SMS_MARKETING_MODULE_DESIGN.md §6.
+"""
+import logging
+from datetime import datetime, timezone
+from typing import Mapping, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.sms_tracking_repository import SmsTrackingRepository
+from app.utils.exceptions import ResourceNotFoundError
+from app.utils.sms_bot import detect_bot
+from app.utils.sms_token import compute_ip_hash, compute_token_hash, is_valid_code
+from app.utils.sms_url import host_in_allowlist
+
+log = logging.getLogger(__name__)
+
+_GENERIC_404 = "Liên kết không hợp lệ hoặc đã hết hạn"
+
+
+def _aware(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+class SmsTrackingService:
+    """Resolve /r/{code} → click + 302 target."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = SmsTrackingRepository(db)
+
+    async def resolve(
+        self,
+        code: str,
+        *,
+        ip: Optional[str],
+        user_agent: Optional[str],
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> str:
+        """Trả URL đích cho 302. Raise ResourceNotFoundError (404 generic) nếu
+        code sai/không thấy/hết hạn/external ngoài allowlist."""
+        if not is_valid_code(code):
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        found = await self.repo.lookup_by_token_hash(compute_token_hash(code))
+        if found is None:
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        recipient, campaign = found
+        now = datetime.now(timezone.utc)
+        if campaign.link_expires_at and _aware(campaign.link_expires_at) <= now:
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+
+        # Đích redirect (re-check allowlist external — §6.2 lớp 2).
+        if campaign.landing_type == "external":
+            target = (campaign.landing_url or "").strip()
+            if not target or not host_in_allowlist(target):
+                log.warning(
+                    "SMS /r: external landing_url ngoài allowlist campaign_id=%s",
+                    campaign.id,
+                )
+                raise ResourceNotFoundError(detail=_GENERIC_404)
+        else:
+            # qlts_hosted → landing nội bộ (relative, cùng host public).
+            target = f"/lp/{code}"
+
+        # Ghi click (bot eval + ip_hash) — counter atomic ở repo.
+        is_bot, reason = detect_bot(
+            user_agent=user_agent,
+            headers=headers,
+            handed_off_at=recipient.handed_off_at,
+            now=now,
+        )
+        await self.repo.record_click(
+            recipient_id=recipient.id,
+            ip_hash=compute_ip_hash(ip),
+            user_agent=user_agent,
+            is_bot=is_bot,
+            bot_reason=reason,
+            now=now,
+        )
+        await self.db.flush()
+        return target

--- a/Backend_FastAPI/app/utils/sms_bot.py
+++ b/Backend_FastAPI/app/utils/sms_bot.py
@@ -1,0 +1,68 @@
+# app/utils/sms_bot.py
+"""
+SMS click bot heuristic (PR-5): phân loại 1 lượt /r/{code} có phải bot/link-
+preview KHÔNG, để KHÔNG tính vào CTR "người thật". Best-effort, fail-OPEN cho
+phía người (chỉ flag khi có dấu hiệu rõ) — CTR thà thiếu hơn thừa.
+
+3 dấu hiệu (khớp click_event.bot_reason §4.10):
+- known_scanner_ua: User-Agent của crawler/link-preview (Facebook, Zalo,
+  Telegram, WhatsApp, Slack, Google, bot/crawler/spider, curl/wget/python…).
+- prefetch_head: request mang header prefetch/preview (Purpose/X-Purpose) hoặc
+  Sec-Purpose=prefetch.
+- instant_after_send: click trong vài giây ngay sau bàn giao (preview server
+  fetch tức thì khi tin vừa gửi) — đo `now - recipient.handed_off_at`.
+"""
+from datetime import datetime, timedelta, timezone
+from typing import Mapping, Optional, Tuple
+
+# Token UA hay gặp ở crawler/link-preview/HTTP client (so khớp lower-case).
+_SCANNER_UA_TOKENS = (
+    "bot", "crawler", "spider", "scanner", "preview", "fetch",
+    "facebookexternalhit", "facebot", "zalo", "telegrambot", "whatsapp",
+    "slackbot", "discordbot", "skypeuripreview", "twitterbot", "linkedinbot",
+    "google", "bingbot", "yandex", "applebot", "pinterest", "embedly",
+    "curl", "wget", "python-requests", "python-httpx", "go-http-client",
+    "java/", "okhttp", "headlesschrome", "phantomjs",
+)
+_INSTANT_SECONDS = 8  # click ≤8s sau handoff → nghi preview server
+
+
+def _aware(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def detect_bot(
+    *,
+    user_agent: Optional[str],
+    headers: Optional[Mapping[str, str]] = None,
+    handed_off_at: Optional[datetime] = None,
+    now: Optional[datetime] = None,
+) -> Tuple[bool, Optional[str]]:
+    """Trả (is_bot, reason|None). Ưu tiên reason: UA > prefetch > instant."""
+    ua = (user_agent or "").lower()
+    if ua:
+        for tok in _SCANNER_UA_TOKENS:
+            if tok in ua:
+                return True, "known_scanner_ua"
+    if not ua:
+        # Không có UA hầu như chỉ gặp ở script/preview, không phải trình duyệt.
+        return True, "known_scanner_ua"
+
+    if headers:
+        purpose = (
+            headers.get("purpose")
+            or headers.get("x-purpose")
+            or headers.get("sec-purpose")
+            or ""
+        ).lower()
+        if "prefetch" in purpose or "preview" in purpose:
+            return True, "prefetch_head"
+        if (headers.get("x-moz") or "").lower() == "prefetch":
+            return True, "prefetch_head"
+
+    if handed_off_at is not None:
+        ref = now or datetime.now(timezone.utc)
+        if ref - _aware(handed_off_at) <= timedelta(seconds=_INSTANT_SECONDS):
+            return True, "instant_after_send"
+
+    return False, None

--- a/Backend_FastAPI/app/utils/sms_bot.py
+++ b/Backend_FastAPI/app/utils/sms_bot.py
@@ -45,8 +45,9 @@ def detect_bot(
             if tok in ua:
                 return True, "known_scanner_ua"
     if not ua:
-        # Không có UA hầu như chỉ gặp ở script/preview, không phải trình duyệt.
-        return True, "known_scanner_ua"
+        # Trình duyệt di động LUÔN gửi UA → thiếu UA hầu như chỉ script/preview.
+        # Flag bot nhưng nhãn TRUNG THỰC (≠ known_scanner_ua) cho audit/báo cáo.
+        return True, "no_user_agent"
 
     if headers:
         purpose = (

--- a/Backend_FastAPI/app/utils/sms_token.py
+++ b/Backend_FastAPI/app/utils/sms_token.py
@@ -44,6 +44,27 @@ def compute_token_hash(code: str) -> str:
     return hmac.new(secret, code.encode(), hashlib.sha256).hexdigest()
 
 
+def compute_ip_hash(ip: Optional[str]) -> Optional[str]:
+    """HMAC-SHA256(ip, SMS_IP_HASH_SECRET) → hex 64 (click event PR-5). Secret
+    TÁCH BIỆT token-hash (§2.2) → không suy ngược token↔IP. KHÔNG lưu IP thô.
+    None nếu ip rỗng."""
+    raw = (ip or "").strip()
+    if not raw:
+        return None
+    secret = settings.SMS_IP_HASH_SECRET.encode()
+    return hmac.new(secret, raw.encode(), hashlib.sha256).hexdigest()
+
+
+def is_valid_code(code: str) -> bool:
+    """Validate charset/length TRƯỚC khi chạm DB (§6.1) — base62 × 9 đúng
+    `CODE_LENGTH`. Chặn path lạ/inject trước lookup."""
+    return (
+        isinstance(code, str)
+        and len(code) == CODE_LENGTH
+        and all(c in _BASE62 for c in code)
+    )
+
+
 def _load_keyring() -> Tuple[Dict[str, str], str]:
     """Trả (keyring {version: fernet_key}, active_version).
 

--- a/Backend_FastAPI/app/utils/sms_url.py
+++ b/Backend_FastAPI/app/utils/sms_url.py
@@ -11,13 +11,17 @@ from urllib.parse import urlparse
 from app.config import settings
 
 _IP_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
+# Host hợp lệ chỉ gồm chữ/số/'.'/'-'. CHẶN backslash, '@', '/', '%', space…
+# (urlparse('https://evil.com\\.allowed.com') giữ '\\.' trong host → endswith
+# '.allowed.com' lọt allowlist; trình duyệt đổi '\\'→'/' → tới evil.com).
+_HOST_RE = re.compile(r"^[a-z0-9.-]+$")
 
 
 def host_in_allowlist(url: str) -> bool:
-    """https + host ∈ allowlist (exact/subdomain); chặn `@`, IP literal,
-    scheme ≠ https, userinfo. URL rỗng/sai → False (fail-closed)."""
+    """https + host ∈ allowlist (exact/subdomain); chặn `@`/`\\`, IP literal,
+    scheme ≠ https, userinfo, host ký tự lạ. URL rỗng/sai → False (fail-closed)."""
     raw = (url or "").strip()
-    if not raw or "@" in raw:
+    if not raw or "@" in raw or "\\" in raw:
         return False
     try:
         parsed = urlparse(raw)
@@ -26,7 +30,8 @@ def host_in_allowlist(url: str) -> bool:
     if parsed.scheme != "https" or parsed.username or parsed.password:
         return False
     host = (parsed.hostname or "").lower()
-    if not host or _IP_RE.match(host):
+    # Charset host nghiêm ngặt: chặn parser-differential (backslash, IDN raw…).
+    if not host or _IP_RE.match(host) or not _HOST_RE.match(host):
         return False
     allowed = [
         d.strip().lower()

--- a/Backend_FastAPI/app/utils/sms_url.py
+++ b/Backend_FastAPI/app/utils/sms_url.py
@@ -1,0 +1,36 @@
+# app/utils/sms_url.py
+"""
+SMS redirect allowlist (PR-5): kiểm host của landing_url/CTA external có thuộc
+`SMS_ALLOWED_REDIRECT_DOMAINS` không — chống open-redirect ở `/r/` và landing
+(§6.2). Cùng logic `_host_allowed` của campaign validate (PR-3) nhưng tách util
+để dùng ở public surface mà không import service.
+"""
+import re
+from urllib.parse import urlparse
+
+from app.config import settings
+
+_IP_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
+
+
+def host_in_allowlist(url: str) -> bool:
+    """https + host ∈ allowlist (exact/subdomain); chặn `@`, IP literal,
+    scheme ≠ https, userinfo. URL rỗng/sai → False (fail-closed)."""
+    raw = (url or "").strip()
+    if not raw or "@" in raw:
+        return False
+    try:
+        parsed = urlparse(raw)
+    except ValueError:
+        return False
+    if parsed.scheme != "https" or parsed.username or parsed.password:
+        return False
+    host = (parsed.hostname or "").lower()
+    if not host or _IP_RE.match(host):
+        return False
+    allowed = [
+        d.strip().lower()
+        for d in settings.SMS_ALLOWED_REDIRECT_DOMAINS.split(",")
+        if d.strip()
+    ]
+    return any(host == d or host.endswith("." + d) for d in allowed)

--- a/Backend_FastAPI/gunicorn.conf.py
+++ b/Backend_FastAPI/gunicorn.conf.py
@@ -38,5 +38,15 @@ accesslog = "-"
 errorlog = "-"
 loglevel = os.getenv("LOG_LEVEL", "info").lower()
 
+
+def post_worker_init(worker):
+    """Redact raw SMS bearer code khỏi gunicorn.access (§11.3) — gắn SAU khi
+    gunicorn dựng access logger per-worker (access_log='-' vẫn log request line
+    `GET /r/<code>` mỗi hit thành công)."""
+    from app.core.log_redaction import install_sms_log_redaction
+
+    install_sms_log_redaction()
+
+
 # --- Keep-Alive ---
 keepalive = 5

--- a/Backend_FastAPI/tests/integration/test_sms_tracking.py
+++ b/Backend_FastAPI/tests/integration/test_sms_tracking.py
@@ -394,6 +394,69 @@ async def test_external_redirect_and_open_redirect_blocked(
     assert res.headers["location"] == "https://tnpc.edu.vn/tuyensinh"
 
 
+async def test_optout_invalidates_pending_export(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    gid = await _mk_group(client, h, name="Inv nhom")
+    await _mk_contact(client, h, "PH inv", "0966000111")
+    await client.post(
+        f"{API}/contacts/1/groups", json={"group_id": gid}, headers=h
+    )
+    r = await client.post(
+        f"{API}/campaigns",
+        json={"name": "Inv camp", "sms_template": "Chao {full_name} {link}"},
+        headers=h,
+    )
+    cid = r.json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": gid}, headers=h
+    )
+    assert (
+        await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    ).status_code == 200
+    # Chèn 1 export batch 'generated' (mô phỏng đã export, CHƯA bàn giao).
+    async with AsyncSessionLocal() as s:
+        row = (
+            await s.execute(
+                text(
+                    "SELECT build_revision, carrier_bucket, "
+                    "phone_normalized_snapshot FROM sms_campaign_recipient "
+                    "WHERE campaign_id=:c LIMIT 1"
+                ),
+                {"c": cid},
+            )
+        ).first()
+        rev, carrier, phone = row[0], row[1], row[2]
+        await s.execute(
+            text(
+                "INSERT INTO sms_campaign_export_batch (campaign_id, "
+                "build_revision, carrier_bucket, recipient_count, status) "
+                "VALUES (:c, :r, :ca, 1, 'generated')"
+            ),
+            {"c": cid, "r": rev, "ca": carrier},
+        )
+        await s.commit()
+    # opt-out số đó → export batch chưa-bàn-giao phải invalidated (§8.4)
+    assert (
+        await client.post(
+            f"{API}/opt-out/manual", json={"phone": phone}, headers=h
+        )
+    ).status_code == 201
+    async with AsyncSessionLocal() as s:
+        st = (
+            await s.execute(
+                text(
+                    "SELECT status, invalidated_at FROM "
+                    "sms_campaign_export_batch WHERE campaign_id=:c"
+                ),
+                {"c": cid},
+            )
+        ).first()
+    assert st[0] == "invalidated"
+    assert st[1] is not None
+
+
 async def test_optout_does_not_block_click(
     client: AsyncClient, admin_token_headers: dict
 ):

--- a/Backend_FastAPI/tests/integration/test_sms_tracking.py
+++ b/Backend_FastAPI/tests/integration/test_sms_tracking.py
@@ -1,0 +1,291 @@
+# tests/integration/test_sms_tracking.py
+"""
+Integration test PR-5 (SMS Tracking / Landing / Reports / Opt-out).
+
+Phủ: /r/{code} resolve + ghi click (qlts_hosted→/lp; bot vs human; invalid/
+unknown→404), landing read-only (no PII + already_opted_out), opt-out công khai
+idempotent, report click + CTR, dashboard, opt-out admin (manual + list + dup).
+
+Lấy raw code bằng decrypt token_ciphertext (dev Fernet key). Handoff mô phỏng
+bằng SQL vì PR-4 không có ở nhánh này. Chạy one-off container (CLAUDE.md).
+"""
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.database import AsyncSessionLocal
+from app.utils.sms_token import decrypt_code
+
+API = "/api/sms"
+PUB = "/api/public/sms"
+_GRANT = {
+    "event_type": "granted",
+    "occurred_at": "2026-05-01T00:00:00+07:00",
+    "basis": "signed_form",
+    "disclosure_version": "v1",
+    "proof_reference": "ho-so/ref",
+}
+# UA người thật (không chứa token scanner) vs UA bot.
+_UA_HUMAN = (
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) "
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 "
+    "Safari/604.1"
+)
+_UA_BOT = "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
+
+
+async def _mk_group(client, h, name="Track Nhom"):
+    r = await client.post(
+        f"{API}/contact-groups", json={"name": name, "group_type": "custom"},
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _mk_contact(client, h, name, phone):
+    r = await client.post(
+        f"{API}/contacts", json={"full_name": name, "phone": phone}, headers=h
+    )
+    assert r.status_code == 201, r.text
+    cid = r.json()["id"]
+    rc = await client.post(
+        f"{API}/contacts/{cid}/consent-events", json=_GRANT, headers=h
+    )
+    assert rc.status_code == 201, rc.text
+    return cid
+
+
+async def _built_campaign(client, h, phone="0981234567"):
+    """group + 1 contact granted + campaign có {link} + build + mô phỏng handoff.
+    Trả (campaign_id, raw_code, phone_normalized)."""
+    gid = await _mk_group(client, h)
+    await _mk_contact(client, h, "Phu huynh A", phone)
+    await client.post(
+        f"{API}/contacts/1/groups", json={"group_id": gid}, headers=h
+    )
+    r = await client.post(
+        f"{API}/campaigns",
+        json={
+            "name": "Track QA",
+            "sms_template": "Chao {full_name}, xem {link}",
+            "landing_headline": "Tuyển sinh 2026",
+            "landing_body": "Thông tin tuyển sinh chi tiết.",
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    cid = r.json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": gid}, headers=h
+    )
+    rb = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert rb.status_code == 200, rb.text
+    # Lấy raw code + mô phỏng handoff (past để không bị 'instant_after_send').
+    async with AsyncSessionLocal() as s:
+        row = (
+            await s.execute(
+                text(
+                    "SELECT id, token_ciphertext, token_key_version, "
+                    "phone_normalized_snapshot FROM sms_campaign_recipient "
+                    "WHERE campaign_id=:c LIMIT 1"
+                ),
+                {"c": cid},
+            )
+        ).first()
+        await s.execute(
+            text(
+                "UPDATE sms_campaign_recipient SET handed_off_at = now() - "
+                "interval '1 hour' WHERE campaign_id=:c"
+            ),
+            {"c": cid},
+        )
+        await s.commit()
+    code = decrypt_code(row[1], row[2])
+    assert code, "decrypt token thất bại"
+    return cid, code, row[3]
+
+
+# ---------------------------------------------------------------------
+# /r/{code} resolve + click
+# ---------------------------------------------------------------------
+async def test_resolve_human_click_and_redirect(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid, code, _phone = await _built_campaign(client, h)
+    res = await client.get(
+        f"/r/{code}", headers={"User-Agent": _UA_HUMAN}, follow_redirects=False
+    )
+    assert res.status_code == 302, res.text
+    assert res.headers["location"] == f"/lp/{code}"
+    assert res.headers.get("cache-control") == "no-store"
+    async with AsyncSessionLocal() as s:
+        rec = (
+            await s.execute(
+                text(
+                    "SELECT raw_click_count, human_click_count, "
+                    "first_human_clicked_at FROM sms_campaign_recipient "
+                    "WHERE campaign_id=:c"
+                ),
+                {"c": cid},
+            )
+        ).first()
+        bot = (
+            await s.execute(
+                text(
+                    "SELECT is_suspected_bot FROM sms_click_event ORDER BY id "
+                    "DESC LIMIT 1"
+                )
+            )
+        ).scalar()
+    assert rec[0] == 1 and rec[1] == 1 and rec[2] is not None
+    assert bot is False
+
+
+async def test_resolve_bot_not_counted_human(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid, code, _ = await _built_campaign(client, h)
+    res = await client.get(
+        f"/r/{code}", headers={"User-Agent": _UA_BOT}, follow_redirects=False
+    )
+    assert res.status_code == 302
+    async with AsyncSessionLocal() as s:
+        rec = (
+            await s.execute(
+                text(
+                    "SELECT raw_click_count, human_click_count FROM "
+                    "sms_campaign_recipient WHERE campaign_id=:c"
+                ),
+                {"c": cid},
+            )
+        ).first()
+        reason = (
+            await s.execute(
+                text(
+                    "SELECT bot_reason FROM sms_click_event ORDER BY id DESC "
+                    "LIMIT 1"
+                )
+            )
+        ).scalar()
+    assert rec[0] == 1 and rec[1] == 0  # raw tăng, human KHÔNG
+    assert reason == "known_scanner_ua"
+
+
+async def test_resolve_invalid_and_unknown_404(
+    client: AsyncClient, admin_token_headers: dict
+):
+    # sai charset/length
+    assert (
+        await client.get("/r/xx", follow_redirects=False)
+    ).status_code == 404
+    # đúng format base62×9 nhưng không khớp recipient
+    assert (
+        await client.get("/r/ABCdef123", follow_redirects=False)
+    ).status_code == 404
+
+
+# ---------------------------------------------------------------------
+# Landing + opt-out công khai
+# ---------------------------------------------------------------------
+async def test_landing_and_public_optout_idempotent(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid, code, phone = await _built_campaign(client, h)
+    # landing read-only, KHÔNG lộ PII
+    lr = await client.get(f"{PUB}/landing/{code}")
+    assert lr.status_code == 200, lr.text
+    body = lr.json()
+    assert body["headline"] == "Tuyển sinh 2026"
+    assert body["already_opted_out"] is False
+    assert phone not in lr.text  # KHÔNG lộ số điện thoại recipient
+    assert lr.headers.get("cache-control") == "no-store"
+
+    # opt-out lần 1
+    o1 = await client.post(f"{PUB}/opt-out", json={"code": code})
+    assert o1.status_code == 200 and o1.json()["already_opted_out"] is False
+    # opt-out lần 2 → idempotent
+    o2 = await client.post(f"{PUB}/opt-out", json={"code": code})
+    assert o2.json()["already_opted_out"] is True
+    # landing lại → đã opt-out
+    lr2 = await client.get(f"{PUB}/landing/{code}")
+    assert lr2.json()["already_opted_out"] is True
+    # DB có opt-out source landing_optout
+    async with AsyncSessionLocal() as s:
+        src = (
+            await s.execute(
+                text(
+                    "SELECT source FROM sms_opt_out WHERE phone_normalized=:p"
+                ),
+                {"p": phone},
+            )
+        ).scalar()
+    assert src == "landing_optout"
+
+
+# ---------------------------------------------------------------------
+# Reports + dashboard
+# ---------------------------------------------------------------------
+async def test_report_clicks_and_dashboard(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid, code, _ = await _built_campaign(client, h)
+    await client.get(
+        f"/r/{code}", headers={"User-Agent": _UA_HUMAN}, follow_redirects=False
+    )
+    # report clicks
+    rep = await client.get(
+        f"{API}/reports/clicks?granularity=day&campaign_id={cid}", headers=h
+    )
+    assert rep.status_code == 200, rep.text
+    rb = rep.json()
+    assert rb["total_clicks"] == 1 and rb["human_clicks"] == 1
+    assert rb["distinct_contacts_clicked"] == 1
+    assert rb["recipients_handed_off"] == 1
+    assert rb["ctr_percent"] == 100.0
+    assert len(rb["buckets"]) == 1
+
+    # dashboard
+    dash = await client.get(f"{API}/campaigns/{cid}/dashboard", headers=h)
+    assert dash.status_code == 200, dash.text
+    db = dash.json()
+    assert db["ctr_percent"] == 100.0
+    assert db["recipients_handed_off"] == 1
+    assert db["has_link"] is True
+    assert len(db["clickers"]) == 1
+    assert db["clickers"][0]["human_click_count"] == 1
+
+
+# ---------------------------------------------------------------------
+# Opt-out admin
+# ---------------------------------------------------------------------
+async def test_admin_manual_optout_and_list(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    r = await client.post(
+        f"{API}/opt-out/manual",
+        json={"phone": "0987654321", "source": "phone_call", "reason": "goi dien"},
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["phone_normalized"] == "0987654321"
+    # trùng → 409
+    r2 = await client.post(
+        f"{API}/opt-out/manual", json={"phone": "0987654321"}, headers=h
+    )
+    assert r2.status_code == 409
+    # số ≥8 ký tự (qua schema) nhưng KHÔNG phải di động VN → service 400
+    r3 = await client.post(
+        f"{API}/opt-out/manual", json={"phone": "0123456789"}, headers=h
+    )
+    assert r3.status_code == 400
+    # list
+    lst = await client.get(f"{API}/opt-out", headers=h)
+    assert lst.status_code == 200
+    assert any(
+        it["phone_normalized"] == "0987654321" for it in lst.json()["items"]
+    )

--- a/Backend_FastAPI/tests/integration/test_sms_tracking.py
+++ b/Backend_FastAPI/tests/integration/test_sms_tracking.py
@@ -289,3 +289,132 @@ async def test_admin_manual_optout_and_list(
     assert any(
         it["phone_normalized"] == "0987654321" for it in lst.json()["items"]
     )
+
+
+# ---------------------------------------------------------------------
+# Bảo mật / compliance (vá /code-review max)
+# ---------------------------------------------------------------------
+async def test_optout_works_after_link_expired(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid, code, phone = await _built_campaign(client, h)
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text(
+                "UPDATE sms_campaign SET link_expires_at = now() - "
+                "interval '1 day' WHERE id=:c"
+            ),
+            {"c": cid},
+        )
+        await s.commit()
+    # landing GET → 404 (hết hạn) NHƯNG opt-out VẪN phải work (NĐ91)
+    assert (await client.get(f"{PUB}/landing/{code}")).status_code == 404
+    o = await client.post(f"{PUB}/opt-out", json={"code": code})
+    assert o.status_code == 200, o.text
+    assert o.json()["success"] is True
+    async with AsyncSessionLocal() as s:
+        src = (
+            await s.execute(
+                text(
+                    "SELECT source FROM sms_opt_out WHERE phone_normalized=:p"
+                ),
+                {"p": phone},
+            )
+        ).scalar()
+    assert src == "landing_optout"
+
+
+async def test_admin_endpoints_require_auth(client: AsyncClient):
+    assert (await client.get(f"{API}/reports/clicks")).status_code == 401
+    assert (
+        await client.get(f"{API}/campaigns/1/dashboard")
+    ).status_code == 401
+    assert (await client.get(f"{API}/opt-out")).status_code == 401
+    assert (
+        await client.post(f"{API}/opt-out/manual", json={"phone": "0987654321"})
+    ).status_code == 401
+
+
+async def test_external_redirect_and_open_redirect_blocked(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    # open-redirect: backslash trong landing_url → 400 lúc tạo (host charset)
+    bad = await client.post(
+        f"{API}/campaigns",
+        json={
+            "name": "Ext bad", "code": "extbad",
+            "sms_template": "Xem {link}",
+            "landing_type": "external",
+            "landing_url": "https://evil.com\\.tnpc.edu.vn/x",
+        },
+        headers=h,
+    )
+    assert bad.status_code == 400, bad.text
+    # external hợp lệ → /r/ 302 THẲNG landing_url (không /lp/)
+    gid = await _mk_group(client, h, name="Ext nhom")
+    await _mk_contact(client, h, "PH ext", "0978000111")
+    await client.post(
+        f"{API}/contacts/1/groups", json={"group_id": gid}, headers=h
+    )
+    r = await client.post(
+        f"{API}/campaigns",
+        json={
+            "name": "Ext ok", "code": "extok",
+            "sms_template": "Xem {link}",
+            "landing_type": "external",
+            "landing_url": "https://tnpc.edu.vn/tuyensinh",
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    cid = r.json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": gid}, headers=h
+    )
+    assert (
+        await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    ).status_code == 200
+    async with AsyncSessionLocal() as s:
+        row = (
+            await s.execute(
+                text(
+                    "SELECT token_ciphertext, token_key_version FROM "
+                    "sms_campaign_recipient WHERE campaign_id=:c LIMIT 1"
+                ),
+                {"c": cid},
+            )
+        ).first()
+    code = decrypt_code(row[0], row[1])
+    res = await client.get(
+        f"/r/{code}", headers={"User-Agent": _UA_HUMAN}, follow_redirects=False
+    )
+    assert res.status_code == 302
+    assert res.headers["location"] == "https://tnpc.edu.vn/tuyensinh"
+
+
+async def test_optout_does_not_block_click(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    cid, code, _phone = await _built_campaign(client, h)
+    assert (
+        await client.post(f"{PUB}/opt-out", json={"code": code})
+    ).status_code == 200
+    # opt-out = suppression-at-SEND, KHÔNG chặn /r/ click (vẫn 302 + ghi click)
+    res = await client.get(
+        f"/r/{code}", headers={"User-Agent": _UA_HUMAN}, follow_redirects=False
+    )
+    assert res.status_code == 302
+    async with AsyncSessionLocal() as s:
+        raw = (
+            await s.execute(
+                text(
+                    "SELECT raw_click_count FROM sms_campaign_recipient "
+                    "WHERE campaign_id=:c"
+                ),
+                {"c": cid},
+            )
+        ).scalar()
+    assert raw == 1

--- a/frontend/src/app/lp/[code]/page.tsx
+++ b/frontend/src/app/lp/[code]/page.tsx
@@ -1,0 +1,46 @@
+import { Suspense } from "react"
+import { notFound } from "next/navigation"
+import type { Metadata } from "next"
+
+import { SmsLandingClient } from "@/components/sms/SmsLandingClient"
+
+// Trang landing công khai mang bearer code (§19) — KHÔNG cho index.
+export const metadata: Metadata = {
+  title: "Thông tin tuyển sinh",
+  robots: { index: false, follow: false },
+}
+
+// Placeholder cho Next.js build validation; code thật xử lý runtime.
+export function generateStaticParams() {
+  return [{ code: "__placeholder__" }]
+}
+
+export default async function SmsLandingPage({
+  params,
+}: {
+  params: Promise<{ code: string }>
+}) {
+  const { code } = await params
+
+  if (code === "__placeholder__") {
+    notFound()
+  }
+
+  return (
+    <div className="bg-muted/40 flex min-h-screen items-start justify-center p-4">
+      <Suspense
+        fallback={
+          <div
+            role="status"
+            aria-live="polite"
+            className="text-muted-foreground mt-16"
+          >
+            Đang tải…
+          </div>
+        }
+      >
+        <SmsLandingClient code={code} />
+      </Suspense>
+    </div>
+  )
+}

--- a/frontend/src/components/sms/SmsLandingClient.tsx
+++ b/frontend/src/components/sms/SmsLandingClient.tsx
@@ -1,0 +1,146 @@
+// src/components/sms/SmsLandingClient.tsx
+"use client"
+
+import { useState } from "react"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { BellOff, CheckCircle2, Loader2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { getSmsLanding, postSmsOptOut } from "@/lib/api/sms"
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-card mt-8 w-full max-w-md space-y-4 rounded border p-6 shadow-md md:p-8">
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Trang landing công khai cho SMS marketing (§19). Thin-client: render ĐÚNG
+ * những gì BE trả (KHÔNG suy luận); body là plain text (whitespace-pre-line,
+ * KHÔNG render HTML → chống XSS). Opt-out idempotent qua AlertDialog xác nhận.
+ */
+export function SmsLandingClient({ code }: { code: string }) {
+  const [optedOut, setOptedOut] = useState(false)
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["sms-landing", code],
+    queryFn: () => getSmsLanding(code),
+    retry: false,
+  })
+
+  const optOut = useMutation({
+    mutationFn: () => postSmsOptOut(code),
+    onSuccess: () => setOptedOut(true),
+  })
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="text-muted-foreground mt-16 flex items-center gap-2"
+      >
+        <Loader2 className="h-4 w-4 animate-spin" /> Đang tải…
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <Shell>
+        <h1 className="text-lg font-semibold">
+          Liên kết không hợp lệ hoặc đã hết hạn
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          Vui lòng kiểm tra lại đường liên kết trong tin nhắn.
+        </p>
+      </Shell>
+    )
+  }
+
+  const isOptedOut = optedOut || data.already_opted_out
+
+  return (
+    <Shell>
+      <header className="text-center">
+        <p className="text-primary text-base font-semibold">
+          {data.school_name}
+        </p>
+      </header>
+
+      {data.headline && (
+        <h1 className="text-xl font-bold">{data.headline}</h1>
+      )}
+      {data.body && (
+        <p className="text-sm leading-relaxed whitespace-pre-line">
+          {data.body}
+        </p>
+      )}
+
+      {data.cta_label && data.cta_url && (
+        <a href={data.cta_url} rel="noreferrer" target="_blank">
+          <Button className="w-full">{data.cta_label}</Button>
+        </a>
+      )}
+
+      <hr className="border-border" />
+
+      <section className="space-y-3">
+        <p className="text-muted-foreground text-xs">{data.consent_notice}</p>
+
+        {isOptedOut ? (
+          <p className="flex items-center gap-2 text-sm font-medium text-green-700">
+            <CheckCircle2 className="h-4 w-4" /> Đã hủy nhận tin. Bạn sẽ không
+            nhận tin quảng cáo từ {data.school_name} nữa.
+          </p>
+        ) : (
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="outline"
+                className="w-full"
+                disabled={optOut.isPending}
+              >
+                <BellOff className="mr-2 h-4 w-4" /> Hủy nhận tin
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Hủy nhận tin?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Bạn chắc chắn muốn ngừng nhận tin quảng cáo tuyển sinh từ{" "}
+                  {data.school_name}?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Không</AlertDialogCancel>
+                <AlertDialogAction onClick={() => optOut.mutate()}>
+                  Hủy nhận tin
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
+
+        {optOut.isError && (
+          <p className="text-destructive text-xs">
+            Không thể hủy lúc này. Vui lòng thử lại.
+          </p>
+        )}
+      </section>
+    </Shell>
+  )
+}

--- a/frontend/src/lib/api/sms.ts
+++ b/frontend/src/lib/api/sms.ts
@@ -1,0 +1,41 @@
+/**
+ * SMS Marketing public landing API client (PR-5).
+ *
+ * Public endpoints — no auth header, CSRF-exempt `/api/public/` prefix
+ * (Backend_FastAPI/app/middleware/csrf.py). Validates BE response with the
+ * mirror Zod schema before returning (thin-client contract).
+ */
+import { api } from "@/lib/api/client"
+import {
+  smsLandingResponseSchema,
+  smsPublicOptOutResponseSchema,
+  type SmsLandingResponse,
+  type SmsPublicOptOutResponse,
+} from "@/lib/zod/sms"
+
+/**
+ * Lấy nội dung landing cho 1 bearer code.
+ * @throws AxiosError 404 — code sai/hết hạn (hiển thị trang lỗi thân thiện).
+ */
+export async function getSmsLanding(
+  code: string,
+): Promise<SmsLandingResponse> {
+  const res = await api.get<SmsLandingResponse>(
+    `/api/public/sms/landing/${encodeURIComponent(code)}`,
+  )
+  return smsLandingResponseSchema.parse(res.data)
+}
+
+/**
+ * Hủy nhận tin (opt-out) — idempotent; hoạt động kể cả khi link đã hết hạn.
+ * @throws AxiosError 404 — code sai.
+ */
+export async function postSmsOptOut(
+  code: string,
+): Promise<SmsPublicOptOutResponse> {
+  const res = await api.post<SmsPublicOptOutResponse>(
+    `/api/public/sms/opt-out`,
+    { code },
+  )
+  return smsPublicOptOutResponseSchema.parse(res.data)
+}

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -1,0 +1,23 @@
+// src/lib/zod/sms.ts
+// Mirror Backend Pydantic: SmsLandingResponse + SmsPublicOptOut* (PR-5 §19.4).
+// Public landing /lp/{code} — KHÔNG lộ PII recipient.
+import { z } from "zod"
+
+export const smsLandingResponseSchema = z.object({
+  school_name: z.string(),
+  headline: z.string().nullable().optional(),
+  body: z.string().nullable().optional(),
+  cta_label: z.string().nullable().optional(),
+  cta_url: z.string().nullable().optional(),
+  consent_notice: z.string(),
+  already_opted_out: z.boolean(),
+})
+export type SmsLandingResponse = z.infer<typeof smsLandingResponseSchema>
+
+export const smsPublicOptOutResponseSchema = z.object({
+  success: z.boolean(),
+  already_opted_out: z.boolean(),
+})
+export type SmsPublicOptOutResponse = z.infer<
+  typeof smsPublicOptOutResponseSchema
+>

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -43,6 +43,9 @@ const PUBLIC_ROUTE_PREFIXES = [
   // Backend exempts /api/v2/admissions/magic-link/* from CSRF; the
   // page itself is candidate-driven and must NOT bounce to /login.
   "/magic-link",
+  // SMS Marketing landing (PR-5): /lp/{code} — người nhận tới từ link SMS,
+  // KHÔNG đăng nhập. Backend /api/public/sms/* CSRF-exempt; trang phải render.
+  "/lp",
 ];
 
 /**

--- a/nginx/conf.d/default.conf.template
+++ b/nginx/conf.d/default.conf.template
@@ -185,6 +185,13 @@ server {
         limit_req zone=general burst=30 nodelay;
         proxy_pass http://backend;
         proxy_read_timeout 30s;
+        # add_header KHÔNG kế thừa khi location tự khai → lặp lại header
+        # server-level (HSTS/X-Frame-Options/nosniff/cross-domain) kẻo /lp/
+        # (frontend, không có middleware bù) mất chống clickjacking/MIME-sniff.
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Permitted-Cross-Domain-Policies "none" always;
         add_header Referrer-Policy "no-referrer" always;
         add_header Cache-Control "no-store" always;
         add_header X-Robots-Tag "noindex" always;
@@ -195,6 +202,13 @@ server {
         access_log off;
         limit_req zone=general burst=30 nodelay;
         proxy_pass http://backend;
+        # add_header KHÔNG kế thừa khi location tự khai → lặp lại header
+        # server-level (HSTS/X-Frame-Options/nosniff/cross-domain) kẻo /lp/
+        # (frontend, không có middleware bù) mất chống clickjacking/MIME-sniff.
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Permitted-Cross-Domain-Policies "none" always;
         add_header Referrer-Policy "no-referrer" always;
         add_header Cache-Control "no-store" always;
         add_header X-Robots-Tag "noindex" always;
@@ -205,6 +219,13 @@ server {
         access_log off;
         limit_req zone=general burst=30 nodelay;
         proxy_pass http://frontend;
+        # add_header KHÔNG kế thừa khi location tự khai → lặp lại header
+        # server-level (HSTS/X-Frame-Options/nosniff/cross-domain) kẻo /lp/
+        # (frontend, không có middleware bù) mất chống clickjacking/MIME-sniff.
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Permitted-Cross-Domain-Policies "none" always;
         add_header Referrer-Policy "no-referrer" always;
         add_header Cache-Control "no-store" always;
         add_header X-Robots-Tag "noindex" always;

--- a/nginx/conf.d/default.conf.template
+++ b/nginx/conf.d/default.conf.template
@@ -177,6 +177,39 @@ server {
         root /var/www/certbot;
     }
 
+    # --- SMS short-link resolver (PR-5: về backend, KHÔNG về frontend) ---
+    # access_log off vì $request chứa raw bearer code; +security headers. Prefix
+    # dài hơn nên thắng /api/ và catch-all (nginx longest-prefix match).
+    location /r/ {
+        access_log off;
+        limit_req zone=general burst=30 nodelay;
+        proxy_pass http://backend;
+        proxy_read_timeout 30s;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Cache-Control "no-store" always;
+        add_header X-Robots-Tag "noindex" always;
+    }
+
+    # --- SMS landing API (code trong path) → backend ---
+    location /api/public/sms/landing/ {
+        access_log off;
+        limit_req zone=general burst=30 nodelay;
+        proxy_pass http://backend;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Cache-Control "no-store" always;
+        add_header X-Robots-Tag "noindex" always;
+    }
+
+    # --- SMS landing page (code trong path) → frontend ---
+    location /lp/ {
+        access_log off;
+        limit_req zone=general burst=30 nodelay;
+        proxy_pass http://frontend;
+        add_header Referrer-Policy "no-referrer" always;
+        add_header Cache-Control "no-store" always;
+        add_header X-Robots-Tag "noindex" always;
+    }
+
     # --- Catch-all: Next.js pages ---
     location / {
         limit_req zone=general burst=30 nodelay;


### PR DESCRIPTION
## Tổng quan
PR-5 của module **SMS Marketing** (Phase 1): tracking click qua short-link bearer, trang landing công khai `/lp/{code}`, opt-out (NĐ91), và báo cáo CTR/dashboard cho admin. Cross-stack (BE + FE + nginx).

Base: `b5b28ce2` (sau PR-4 Export #448).

## Endpoint (7)
| Method | Path | Mô tả |
|---|---|---|
| GET | `/r/{code}` | Resolve short-link → ghi click + bot-detect → 302 tới đích |
| GET | `/api/public/sms/landing/{code}` | Nội dung landing (read-only, KHÔNG PII) + cờ `already_opted_out` |
| POST | `/api/public/sms/opt-out` | Hủy nhận tin (idempotent; chạy cả khi link hết hạn) |
| GET | `/api/sms/reports/clicks` | CTR theo day/month/year |
| GET | `/api/sms/campaigns/{id}/dashboard` | Dashboard chiến dịch |
| GET/POST | `/api/sms/opt-out[/manual]` | Quản lý opt-out (admin) |

## Trang landing `/lp/{code}` (FE, thin-client)
- `app/lp/[code]/page.tsx` (server, `robots: noindex`) + `SmsLandingClient.tsx` (render tên trường/headline/body/CTA + consent notice; opt-out qua AlertDialog; 404 → trang lỗi thân thiện).
- `lib/api/sms.ts` + `lib/zod/sms.ts` (mirror Pydantic).
- `proxy.ts`: `/lp` là public-route (người nhận chưa đăng nhập, đồng nhất `/magic-link`/`/confirm`).

## Bảo mật & correctness (qua 2 vòng /code-review max — 19 phát hiện)
- **Open-redirect**: `utils/sms_url.host_in_allowlist` validate host charset + chặn `\` (vá luôn PR-3 `_host_allowed`).
- **Không lộ bearer code trong log**: `core/log_redaction` filter cho uvicorn/gunicorn access-log (`<redacted>`); exception handler bỏ `input` khỏi log 422 route bearer.
- **IP keying**: `get_client_ip` ưu tiên `X-Real-IP` (chống XFF spoof; nginx set `$remote_addr`).
- **nginx**: lặp security header ở 3 location (`/r/`, landing API, `/lp/`) vì `add_header` không kế thừa.
- **Opt-out không gate hết hạn** (NĐ91) + **opt-out vô hiệu hóa export-batch chưa bàn giao** (`invalidate_unhanded_exports_for_phone`).
- **CTR** = distinct non-bot / recipients đã handed-off (loại invalidated, all-time, VN-tz); click counter ATOMIC; opt-out idempotent (savepoint).

## Vá blocker P1 (expanded SMS gate) — export volume
`Dockerfile`: tạo + `chown appuser` `/app/private_exports/sms` trước `USER appuser`. Trước đó named volume `sms_private_exports` mount lên path không có trong image → mount point root-owned → app (appuser) `PermissionError` khi ghi export XLSX → batch `failed`. Fix giúp fresh volume seed quyền từ image.

## Kiểm thử
- Integration **23/23 PASS** (12 export + 11 tracking) trên fresh volume; flake8 sạch.
- FE type-check + `next build` PASS (route table có `/lp/[code]`).
- **Chrome-smoke `/lp/` trên qlts_dev PASS**: render đúng (không PII) · opt-out POST 200 · DB `sms_opt_out` source=`landing_optout` · reload→`already_opted_out` · suppression enforced ở build · access-log `<redacted>`.
- Redaction probe (validation-log + access-log) OK; `git diff --check` PASS.

## Lưu ý deploy (KHÔNG code-only)
- Sửa `nginx/conf.d/default.conf.template` → **restart nginx**.
- Deploy **image đã vá Dockerfile** → fresh volume `sms_private_exports` seed đúng (prod volume chưa tồn tại; nếu lỡ root-owned từ image cũ thì `chown` một lần).
- Prod cần env: `SMS_IP_HASH_SECRET` thật + (đã có từ PR-4) `SMS_TOKEN_*`/`SMS_PUBLIC_BASE_URL`.
- KHÔNG migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)