### PR TITLE
feat(sms): PR-6 UI admin — báo cáo CTR + dashboard chiến dịch + opt-out

### DIFF
--- a/frontend/src/app/(dashboard)/admin/sms/opt-out/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/sms/opt-out/page.tsx
@@ -1,0 +1,24 @@
+// src/app/(dashboard)/admin/sms/opt-out/page.tsx
+/**
+ * SMS Marketing — Quản lý số từ chối nhận tin (admin, PR-6).
+ * Gate: proxy /admin/* + sidebar roles:["admin"]; BE require_admin là chốt
+ * cuối.
+ */
+import { BellOff } from "lucide-react"
+
+import { PageContainer } from "@/components/layouts/PageContainer"
+import { PageHeader } from "@/components/layouts/PageHeader"
+import { SmsOptOutClient } from "@/components/sms/admin/SmsOptOutClient"
+
+export default function SmsOptOutPage() {
+  return (
+    <PageContainer maxWidth="full">
+      <PageHeader
+        title="Từ chối nhận tin (SMS)"
+        description="Danh sách số chặn gửi toàn cục và thêm thủ công từ kênh ngoài."
+        icon={<BellOff className="h-6 w-6" />}
+      />
+      <SmsOptOutClient />
+    </PageContainer>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/sms/reports/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/sms/reports/page.tsx
@@ -1,0 +1,24 @@
+// src/app/(dashboard)/admin/sms/reports/page.tsx
+/**
+ * SMS Marketing — Báo cáo click + dashboard chiến dịch (admin, PR-6).
+ * Gate: proxy /admin/* + sidebar roles:["admin"]; BE require_admin là chốt
+ * cuối. Server component bọc client Tabs.
+ */
+import { BarChart3 } from "lucide-react"
+
+import { PageContainer } from "@/components/layouts/PageContainer"
+import { PageHeader } from "@/components/layouts/PageHeader"
+import { SmsReportsClient } from "@/components/sms/admin/SmsReportsClient"
+
+export default function SmsReportsPage() {
+  return (
+    <PageContainer maxWidth="full">
+      <PageHeader
+        title="Báo cáo SMS Marketing"
+        description="Hiệu quả click theo thời gian và theo từng chiến dịch."
+        icon={<BarChart3 className="h-6 w-6" />}
+      />
+      <SmsReportsClient />
+    </PageContainer>
+  )
+}

--- a/frontend/src/components/sms/admin/SmsCampaignDashboardPanel.tsx
+++ b/frontend/src/components/sms/admin/SmsCampaignDashboardPanel.tsx
@@ -36,17 +36,7 @@ import {
   formatInt,
   formatPercent,
 } from "./labels"
-
-function SummaryCard({ label, value }: { label: string; value: string }) {
-  return (
-    <Card>
-      <CardContent className="pt-6">
-        <p className="text-muted-foreground text-xs">{label}</p>
-        <p className="mt-1 text-2xl font-bold tabular-nums">{value}</p>
-      </CardContent>
-    </Card>
-  )
-}
+import { SmsSummaryCard } from "./SmsSummaryCard"
 
 /**
  * Dashboard 1 chiến dịch: chọn campaign → CTR + phân bố nhà mạng + danh sách
@@ -169,23 +159,23 @@ export function SmsCampaignDashboardPanel() {
           )}
 
           <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
-            <SummaryCard
+            <SmsSummaryCard
               label="Đã bàn giao gửi"
               value={formatInt(data.recipients_handed_off)}
             />
-            <SummaryCard
+            <SmsSummaryCard
               label="Tổng lượt click"
               value={formatInt(data.total_clicks)}
             />
-            <SummaryCard
+            <SmsSummaryCard
               label="Click thật (đã lọc bot)"
               value={formatInt(data.human_clicks)}
             />
-            <SummaryCard
+            <SmsSummaryCard
               label="Số người click"
               value={formatInt(data.distinct_contacts_clicked)}
             />
-            <SummaryCard label="CTR" value={formatPercent(data.ctr_percent)} />
+            <SmsSummaryCard label="CTR" value={formatPercent(data.ctr_percent)} />
           </div>
 
           {/* Phân bố nhà mạng */}

--- a/frontend/src/components/sms/admin/SmsCampaignDashboardPanel.tsx
+++ b/frontend/src/components/sms/admin/SmsCampaignDashboardPanel.tsx
@@ -1,0 +1,277 @@
+// src/components/sms/admin/SmsCampaignDashboardPanel.tsx
+"use client"
+
+import { useState } from "react"
+import { AlertCircle, LinkIcon, Link2Off } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  useSmsCampaignDashboard,
+  useSmsCampaignList,
+} from "@/hooks/useSmsAdmin"
+
+import {
+  campaignStatusLabel,
+  carrierLabel,
+  formatDateTimeVN,
+  formatInt,
+  formatPercent,
+} from "./labels"
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <p className="text-muted-foreground text-xs">{label}</p>
+        <p className="mt-1 text-2xl font-bold tabular-nums">{value}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+/**
+ * Dashboard 1 chiến dịch: chọn campaign → CTR + phân bố nhà mạng + danh sách
+ * số đã click (đã lọc bot, PII masked). has_link=false → chiến dịch không có
+ * short-link nên không đo được click.
+ */
+export function SmsCampaignDashboardPanel() {
+  const [selected, setSelected] = useState<string>("")
+  const { data: campaignData, isLoading: campaignsLoading } =
+    useSmsCampaignList({ limit: 200 })
+
+  const campaignId = selected ? Number(selected) : null
+  const { data, isLoading, isError, refetch } =
+    useSmsCampaignDashboard(campaignId)
+
+  const carrierEntries = data
+    ? Object.entries(data.carrier_distribution).sort((a, b) => b[1] - a[1])
+    : []
+
+  return (
+    <div className="space-y-6">
+      {/* Chọn chiến dịch */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Chọn chiến dịch</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="max-w-md space-y-1.5">
+            <Label htmlFor="sms-dashboard-campaign">Chiến dịch</Label>
+            <Select
+              value={selected}
+              onValueChange={setSelected}
+              disabled={campaignsLoading}
+            >
+              <SelectTrigger id="sms-dashboard-campaign">
+                <SelectValue
+                  placeholder={
+                    campaignsLoading
+                      ? "Đang tải danh sách…"
+                      : "— Chọn một chiến dịch —"
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {campaignData?.items.map((c) => (
+                  <SelectItem key={c.id} value={String(c.id)}>
+                    {c.name} ({campaignStatusLabel(c.status)})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {!campaignsLoading && campaignData?.items.length === 0 && (
+              <p className="text-muted-foreground text-xs">
+                Chưa có chiến dịch nào.
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Chưa chọn */}
+      {campaignId == null && (
+        <p className="text-muted-foreground py-8 text-center text-sm">
+          Chọn một chiến dịch để xem báo cáo hiệu quả.
+        </p>
+      )}
+
+      {/* Lỗi */}
+      {campaignId != null && isError && (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+            <AlertCircle className="text-destructive h-8 w-8" />
+            <p className="text-muted-foreground text-sm">
+              Không thể tải dashboard chiến dịch.
+            </p>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              Thử lại
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Đang tải */}
+      {campaignId != null && isLoading && (
+        <div className="space-y-6">
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full" />
+            ))}
+          </div>
+          <Skeleton className="h-64 w-full" />
+        </div>
+      )}
+
+      {/* Dữ liệu */}
+      {campaignId != null && data && !isLoading && (
+        <div className="space-y-6">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">
+              Bản dựng #{data.build_revision}
+            </Badge>
+            {data.has_link ? (
+              <Badge variant="outline" className="gap-1">
+                <LinkIcon className="h-3 w-3" /> Có short-link
+              </Badge>
+            ) : (
+              <Badge variant="outline" className="gap-1 text-amber-600">
+                <Link2Off className="h-3 w-3" /> Không có short-link
+              </Badge>
+            )}
+          </div>
+
+          {!data.has_link && (
+            <Card className="border-amber-300 bg-amber-50">
+              <CardContent className="text-sm text-amber-800">
+                Chiến dịch này không chèn short-link nên hệ thống không đo được
+                lượt click. Các chỉ số click bên dưới sẽ bằng 0.
+              </CardContent>
+            </Card>
+          )}
+
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
+            <SummaryCard
+              label="Đã bàn giao gửi"
+              value={formatInt(data.recipients_handed_off)}
+            />
+            <SummaryCard
+              label="Tổng lượt click"
+              value={formatInt(data.total_clicks)}
+            />
+            <SummaryCard
+              label="Click thật (đã lọc bot)"
+              value={formatInt(data.human_clicks)}
+            />
+            <SummaryCard
+              label="Số người click"
+              value={formatInt(data.distinct_contacts_clicked)}
+            />
+            <SummaryCard label="CTR" value={formatPercent(data.ctr_percent)} />
+          </div>
+
+          {/* Phân bố nhà mạng */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Phân bố theo nhà mạng (đã bàn giao)
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {carrierEntries.length === 0 ? (
+                <p className="text-muted-foreground py-4 text-center text-sm">
+                  Chưa có dữ liệu phân bố.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {carrierEntries.map(([bucket, count]) => (
+                    <div
+                      key={bucket}
+                      className="flex items-center justify-between border-b py-1.5 last:border-0"
+                    >
+                      <span className="text-sm">{carrierLabel(bucket)}</span>
+                      <span className="text-sm font-semibold tabular-nums">
+                        {formatInt(count)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Danh sách số đã click */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Số đã click ({formatInt(data.clickers.length)})
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {data.clickers.length === 0 ? (
+                <p className="text-muted-foreground py-8 text-center text-sm">
+                  Chưa có người nhận nào click (đã loại bot).
+                </p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Họ tên</TableHead>
+                        <TableHead>Số điện thoại</TableHead>
+                        <TableHead>Nhà mạng</TableHead>
+                        <TableHead className="text-right">Lượt click</TableHead>
+                        <TableHead>Click đầu</TableHead>
+                        <TableHead>Click gần nhất</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {data.clickers.map((c) => (
+                        <TableRow key={c.recipient_id}>
+                          <TableCell className="font-medium">
+                            {c.full_name}
+                          </TableCell>
+                          <TableCell className="tabular-nums">
+                            {c.phone_masked}
+                          </TableCell>
+                          <TableCell>{carrierLabel(c.carrier_bucket)}</TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {formatInt(c.human_click_count)}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground text-xs">
+                            {formatDateTimeVN(c.first_human_clicked_at)}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground text-xs">
+                            {formatDateTimeVN(c.last_human_clicked_at)}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/sms/admin/SmsClickReportPanel.tsx
+++ b/frontend/src/components/sms/admin/SmsClickReportPanel.tsx
@@ -1,0 +1,297 @@
+// src/components/sms/admin/SmsClickReportPanel.tsx
+"use client"
+
+import { useMemo, useState } from "react"
+import { AlertCircle, RotateCcw } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  useSmsCampaignList,
+  useSmsClickReport,
+} from "@/hooks/useSmsAdmin"
+import type { SmsClickReportParams } from "@/lib/api/sms"
+import type { SmsGranularity } from "@/lib/zod/sms"
+
+import {
+  CARRIER_FILTER_OPTIONS,
+  GRANULARITY_OPTIONS,
+  campaignStatusLabel,
+  formatInt,
+  formatPercent,
+} from "./labels"
+
+const ALL = "all"
+
+/** Chuyển date string (YYYY-MM-DD, giờ địa phương) → ISO tz-aware (Z). */
+function toIsoStart(d: string): string | undefined {
+  if (!d) return undefined
+  const parsed = new Date(`${d}T00:00:00`)
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString()
+}
+function toIsoEnd(d: string): string | undefined {
+  if (!d) return undefined
+  const parsed = new Date(`${d}T23:59:59.999`)
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString()
+}
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <p className="text-muted-foreground text-xs">{label}</p>
+        <p className="mt-1 text-2xl font-bold tabular-nums">{value}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+/**
+ * Báo cáo click tổng hợp theo ngày/tháng/năm (§9). Filter: granularity +
+ * chiến dịch + nhà mạng + khoảng ngày. CTR chính = distinct non-bot /
+ * recipients_handed_off (BE tính sẵn `ctr_percent`).
+ */
+export function SmsClickReportPanel() {
+  const [granularity, setGranularity] = useState<SmsGranularity>("day")
+  const [campaignId, setCampaignId] = useState<string>(ALL)
+  const [carrier, setCarrier] = useState<string>(ALL)
+  const [dateFrom, setDateFrom] = useState<string>("")
+  const [dateTo, setDateTo] = useState<string>("")
+
+  const { data: campaignData } = useSmsCampaignList({ limit: 200 })
+
+  const params = useMemo<SmsClickReportParams>(
+    () => ({
+      granularity,
+      campaign_id: campaignId === ALL ? undefined : Number(campaignId),
+      carrier: carrier === ALL ? undefined : carrier,
+      date_from: toIsoStart(dateFrom),
+      date_to: toIsoEnd(dateTo),
+    }),
+    [granularity, campaignId, carrier, dateFrom, dateTo],
+  )
+
+  const { data, isLoading, isError, refetch, isFetching } =
+    useSmsClickReport(params)
+
+  const resetFilters = () => {
+    setCampaignId(ALL)
+    setCarrier(ALL)
+    setDateFrom("")
+    setDateTo("")
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Bộ lọc */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Bộ lọc</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="sms-report-granularity">Khoảng thời gian</Label>
+              <Select
+                value={granularity}
+                onValueChange={(v) => setGranularity(v as SmsGranularity)}
+              >
+                <SelectTrigger id="sms-report-granularity">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {GRANULARITY_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="sms-report-campaign">Chiến dịch</Label>
+              <Select value={campaignId} onValueChange={setCampaignId}>
+                <SelectTrigger id="sms-report-campaign">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL}>Tất cả chiến dịch</SelectItem>
+                  {campaignData?.items.map((c) => (
+                    <SelectItem key={c.id} value={String(c.id)}>
+                      {c.name} ({campaignStatusLabel(c.status)})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="sms-report-carrier">Nhà mạng</Label>
+              <Select value={carrier} onValueChange={setCarrier}>
+                <SelectTrigger id="sms-report-carrier">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL}>Tất cả nhà mạng</SelectItem>
+                  {CARRIER_FILTER_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="sms-report-from">Từ ngày</Label>
+              <Input
+                id="sms-report-from"
+                type="date"
+                value={dateFrom}
+                max={dateTo || undefined}
+                onChange={(e) => setDateFrom(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="sms-report-to">Đến ngày</Label>
+              <Input
+                id="sms-report-to"
+                type="date"
+                value={dateTo}
+                min={dateFrom || undefined}
+                onChange={(e) => setDateTo(e.target.value)}
+              />
+            </div>
+
+            <div className="flex items-end">
+              <Button
+                variant="outline"
+                onClick={resetFilters}
+                className="w-full sm:w-auto"
+              >
+                <RotateCcw className="mr-2 h-4 w-4" /> Xóa lọc
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Trạng thái lỗi */}
+      {isError && (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+            <AlertCircle className="text-destructive h-8 w-8" />
+            <p className="text-muted-foreground text-sm">
+              Không thể tải báo cáo. Vui lòng thử lại.
+            </p>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              Thử lại
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Thẻ tổng hợp */}
+      {isLoading ? (
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full" />
+          ))}
+        </div>
+      ) : data ? (
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
+          <SummaryCard
+            label="Tổng lượt click"
+            value={formatInt(data.total_clicks)}
+          />
+          <SummaryCard
+            label="Click thật (đã lọc bot)"
+            value={formatInt(data.human_clicks)}
+          />
+          <SummaryCard
+            label="Số người click"
+            value={formatInt(data.distinct_contacts_clicked)}
+          />
+          <SummaryCard
+            label="Đã bàn giao gửi"
+            value={formatInt(data.recipients_handed_off)}
+          />
+          <SummaryCard label="CTR" value={formatPercent(data.ctr_percent)} />
+        </div>
+      ) : null}
+
+      {/* Bảng theo mốc thời gian */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            Diễn tiến theo mốc thời gian
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : !data || data.buckets.length === 0 ? (
+            <p className="text-muted-foreground py-8 text-center text-sm">
+              {isFetching
+                ? "Đang tải…"
+                : "Chưa có lượt click nào trong phạm vi đã chọn."}
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Mốc</TableHead>
+                    <TableHead className="text-right">Tổng click</TableHead>
+                    <TableHead className="text-right">Click thật</TableHead>
+                    <TableHead className="text-right">Số người click</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.buckets.map((b) => (
+                    <TableRow key={b.period}>
+                      <TableCell className="font-medium">{b.period}</TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatInt(b.total_clicks)}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatInt(b.human_clicks)}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatInt(b.distinct_contacts_clicked)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/components/sms/admin/SmsClickReportPanel.tsx
+++ b/frontend/src/components/sms/admin/SmsClickReportPanel.tsx
@@ -38,6 +38,7 @@ import {
   formatInt,
   formatPercent,
 } from "./labels"
+import { SmsSummaryCard } from "./SmsSummaryCard"
 
 const ALL = "all"
 
@@ -51,17 +52,6 @@ function toIsoEnd(d: string): string | undefined {
   if (!d) return undefined
   const parsed = new Date(`${d}T23:59:59.999`)
   return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString()
-}
-
-function SummaryCard({ label, value }: { label: string; value: string }) {
-  return (
-    <Card>
-      <CardContent className="pt-6">
-        <p className="text-muted-foreground text-xs">{label}</p>
-        <p className="mt-1 text-2xl font-bold tabular-nums">{value}</p>
-      </CardContent>
-    </Card>
-  )
 }
 
 /**
@@ -91,6 +81,9 @@ export function SmsClickReportPanel() {
 
   const { data, isLoading, isError, refetch, isFetching } =
     useSmsClickReport(params)
+
+  // So sánh chuỗi YYYY-MM-DD đủ để phát hiện khoảng đảo ngược (cùng định dạng).
+  const invalidRange = dateFrom !== "" && dateTo !== "" && dateFrom > dateTo
 
   const resetFilters = () => {
     setCampaignId(ALL)
@@ -193,6 +186,13 @@ export function SmsClickReportPanel() {
               </Button>
             </div>
           </div>
+
+          {invalidRange && (
+            <p className="text-destructive mt-3 text-xs">
+              Mốc bắt đầu đang muộn hơn mốc kết thúc — vui lòng chọn lại khoảng
+              ngày hợp lệ.
+            </p>
+          )}
         </CardContent>
       </Card>
 
@@ -220,78 +220,84 @@ export function SmsClickReportPanel() {
         </div>
       ) : data ? (
         <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
-          <SummaryCard
+          <SmsSummaryCard
             label="Tổng lượt click"
             value={formatInt(data.total_clicks)}
           />
-          <SummaryCard
+          <SmsSummaryCard
             label="Click thật (đã lọc bot)"
             value={formatInt(data.human_clicks)}
           />
-          <SummaryCard
+          <SmsSummaryCard
             label="Số người click"
             value={formatInt(data.distinct_contacts_clicked)}
           />
-          <SummaryCard
+          <SmsSummaryCard
             label="Đã bàn giao gửi"
             value={formatInt(data.recipients_handed_off)}
           />
-          <SummaryCard label="CTR" value={formatPercent(data.ctr_percent)} />
+          <SmsSummaryCard label="CTR" value={formatPercent(data.ctr_percent)} />
         </div>
       ) : null}
 
-      {/* Bảng theo mốc thời gian */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">
-            Diễn tiến theo mốc thời gian
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div className="space-y-3">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <Skeleton key={i} className="h-10 w-full" />
-              ))}
-            </div>
-          ) : !data || data.buckets.length === 0 ? (
-            <p className="text-muted-foreground py-8 text-center text-sm">
-              {isFetching
-                ? "Đang tải…"
-                : "Chưa có lượt click nào trong phạm vi đã chọn."}
-            </p>
-          ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Mốc</TableHead>
-                    <TableHead className="text-right">Tổng click</TableHead>
-                    <TableHead className="text-right">Click thật</TableHead>
-                    <TableHead className="text-right">Số người click</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {data.buckets.map((b) => (
-                    <TableRow key={b.period}>
-                      <TableCell className="font-medium">{b.period}</TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {formatInt(b.total_clicks)}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {formatInt(b.human_clicks)}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {formatInt(b.distinct_contacts_clicked)}
-                      </TableCell>
+      {/* Bảng theo mốc thời gian — ẩn khi lỗi (đã có thẻ lỗi riêng ở trên) */}
+      {!isError && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              Diễn tiến theo mốc thời gian
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-3">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-10 w-full" />
+                ))}
+              </div>
+            ) : !data || data.buckets.length === 0 ? (
+              <p className="text-muted-foreground py-8 text-center text-sm">
+                {isFetching
+                  ? "Đang tải…"
+                  : "Chưa có lượt click nào trong phạm vi đã chọn."}
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Mốc</TableHead>
+                      <TableHead className="text-right">Tổng click</TableHead>
+                      <TableHead className="text-right">Click thật</TableHead>
+                      <TableHead className="text-right">
+                        Số người click
+                      </TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                  </TableHeader>
+                  <TableBody>
+                    {data.buckets.map((b) => (
+                      <TableRow key={b.period}>
+                        <TableCell className="font-medium">
+                          {b.period}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatInt(b.total_clicks)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatInt(b.human_clicks)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatInt(b.distinct_contacts_clicked)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/sms/admin/SmsManualOptOutDialog.tsx
+++ b/frontend/src/components/sms/admin/SmsManualOptOutDialog.tsx
@@ -161,6 +161,7 @@ export function SmsManualOptOutDialog({ open, onOpenChange }: Props) {
                   <FormControl>
                     <Input
                       placeholder="VD: mã ticket, ID cuộc gọi…"
+                      maxLength={512}
                       disabled={mutation.isPending}
                       {...field}
                       value={field.value ?? ""}
@@ -180,6 +181,7 @@ export function SmsManualOptOutDialog({ open, onOpenChange }: Props) {
                   <FormControl>
                     <Textarea
                       rows={3}
+                      maxLength={2000}
                       placeholder="Ghi chú lý do từ chối (không bắt buộc)."
                       disabled={mutation.isPending}
                       {...field}

--- a/frontend/src/components/sms/admin/SmsManualOptOutDialog.tsx
+++ b/frontend/src/components/sms/admin/SmsManualOptOutDialog.tsx
@@ -1,0 +1,215 @@
+// src/components/sms/admin/SmsManualOptOutDialog.tsx
+"use client"
+
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Loader2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { useCreateManualOptOut } from "@/hooks/useSmsAdmin"
+import {
+  smsManualOptOutSchema,
+  type SmsManualOptOutInput,
+} from "@/lib/zod/sms"
+
+import { MANUAL_OPT_OUT_SOURCE_OPTIONS } from "./labels"
+
+const DEFAULTS: SmsManualOptOutInput = {
+  phone: "",
+  source: "manual",
+  source_reference: "",
+  reason: "",
+}
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Form admin ghi opt-out thủ công (số từ chối nhận tin qua đối tác / điện
+ * thoại / SMS reply). BE chuẩn hóa SĐT + idempotent.
+ */
+export function SmsManualOptOutDialog({ open, onOpenChange }: Props) {
+  const mutation = useCreateManualOptOut()
+
+  const form = useForm<SmsManualOptOutInput>({
+    resolver: zodResolver(smsManualOptOutSchema),
+    defaultValues: DEFAULTS,
+  })
+
+  // Reset mỗi khi mở lại để không giữ giá trị lần trước.
+  useEffect(() => {
+    if (open) form.reset(DEFAULTS)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  function onSubmit(values: SmsManualOptOutInput) {
+    mutation.mutate(
+      {
+        phone: values.phone,
+        source: values.source,
+        // "" → undefined: tránh lưu chuỗi rỗng cho field optional.
+        source_reference: values.source_reference?.trim() || undefined,
+        reason: values.reason?.trim() || undefined,
+      },
+      {
+        onSuccess: () => {
+          onOpenChange(false)
+          form.reset(DEFAULTS)
+        },
+      },
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Thêm số từ chối nhận tin</DialogTitle>
+          <DialogDescription>
+            Ghi nhận số điện thoại từ chối quảng cáo qua kênh ngoài trang đích
+            (điện thoại, trả lời SMS, đối tác). Hệ thống sẽ chặn gửi ở các chiến
+            dịch sau.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="phone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Số điện thoại *</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="tel"
+                      inputMode="tel"
+                      placeholder="0912345678"
+                      autoComplete="off"
+                      disabled={mutation.isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="source"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nguồn *</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    disabled={mutation.isPending}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {MANUAL_OPT_OUT_SOURCE_OPTIONS.map((o) => (
+                        <SelectItem key={o.value} value={o.value}>
+                          {o.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="source_reference"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Tham chiếu nguồn</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="VD: mã ticket, ID cuộc gọi…"
+                      disabled={mutation.isPending}
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="reason"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Lý do</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={3}
+                      placeholder="Ghi chú lý do từ chối (không bắt buộc)."
+                      disabled={mutation.isPending}
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={mutation.isPending}
+              >
+                Hủy
+              </Button>
+              <Button type="submit" disabled={mutation.isPending}>
+                {mutation.isPending && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Ghi nhận
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/sms/admin/SmsOptOutClient.tsx
+++ b/frontend/src/components/sms/admin/SmsOptOutClient.tsx
@@ -163,11 +163,25 @@ export function SmsOptOutClient() {
               ))}
             </div>
           ) : items.length === 0 ? (
-            <p className="text-muted-foreground py-10 text-center text-sm">
-              {search || source !== ALL
-                ? "Không có số nào khớp bộ lọc."
-                : "Chưa có số từ chối nhận tin nào."}
-            </p>
+            <div className="space-y-3 py-10 text-center">
+              <p className="text-muted-foreground text-sm">
+                {page > 0
+                  ? "Trang này không còn dữ liệu."
+                  : search || source !== ALL
+                    ? "Không có số nào khớp bộ lọc."
+                    : "Chưa có số từ chối nhận tin nào."}
+              </p>
+              {/* page>0 mà rỗng (tổng co lại) → lối thoát về trang đầu */}
+              {page > 0 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage(0)}
+                >
+                  Về trang đầu
+                </Button>
+              )}
+            </div>
           ) : (
             <>
               <div className="overflow-x-auto">

--- a/frontend/src/components/sms/admin/SmsOptOutClient.tsx
+++ b/frontend/src/components/sms/admin/SmsOptOutClient.tsx
@@ -1,0 +1,244 @@
+// src/components/sms/admin/SmsOptOutClient.tsx
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import {
+  AlertCircle,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  Search,
+} from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useSmsOptOuts } from "@/hooks/useSmsAdmin"
+
+import {
+  OPT_OUT_SOURCE_LABELS,
+  formatDateTimeVN,
+  formatInt,
+  optOutSourceLabel,
+} from "./labels"
+import { SmsManualOptOutDialog } from "./SmsManualOptOutDialog"
+
+const ALL = "all"
+const PAGE_SIZE = 50
+
+/** Debounce cục bộ — tránh gọi API mỗi lần gõ. */
+function useDebouncedValue<T>(value: T, delay = 400): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(t)
+  }, [value, delay])
+  return debounced
+}
+
+const SOURCE_FILTER_OPTIONS = Object.keys(OPT_OUT_SOURCE_LABELS)
+
+/**
+ * Quản lý danh sách số từ chối nhận tin (suppression toàn cục) + thêm thủ
+ * công. Admin-only (BE require_admin; sidebar roles:["admin"]).
+ */
+export function SmsOptOutClient() {
+  const [searchInput, setSearchInput] = useState("")
+  const [source, setSource] = useState<string>(ALL)
+  const [page, setPage] = useState(0) // 0-based
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const search = useDebouncedValue(searchInput.trim())
+
+  // Đổi filter/search → về trang đầu. Reset NGAY trong event handler (không
+  // dùng effect → tránh cascading render).
+  const handleSearchChange = (value: string) => {
+    setSearchInput(value)
+    setPage(0)
+  }
+  const handleSourceChange = (value: string) => {
+    setSource(value)
+    setPage(0)
+  }
+
+  const params = useMemo(
+    () => ({
+      skip: page * PAGE_SIZE,
+      limit: PAGE_SIZE,
+      search: search || undefined,
+      source: source === ALL ? undefined : source,
+    }),
+    [page, search, source],
+  )
+
+  const { data, isLoading, isError, refetch, isFetching } =
+    useSmsOptOuts(params)
+
+  const total = data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const items = data?.items ?? []
+
+  return (
+    <div className="space-y-4">
+      {/* Thanh công cụ */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="grid flex-1 grid-cols-1 gap-4 sm:grid-cols-2 lg:max-w-2xl">
+              <div className="space-y-1.5">
+                <Label htmlFor="optout-search">Tìm số điện thoại</Label>
+                <div className="relative">
+                  <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+                  <Input
+                    id="optout-search"
+                    className="pl-8"
+                    placeholder="Nhập số điện thoại…"
+                    value={searchInput}
+                    onChange={(e) => handleSearchChange(e.target.value)}
+                    maxLength={32}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="optout-source">Nguồn</Label>
+                <Select value={source} onValueChange={handleSourceChange}>
+                  <SelectTrigger id="optout-source">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ALL}>Tất cả nguồn</SelectItem>
+                    {SOURCE_FILTER_OPTIONS.map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {optOutSourceLabel(s)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <Button onClick={() => setDialogOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" /> Thêm thủ công
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Bảng */}
+      <Card>
+        <CardContent className="pt-6">
+          {isError ? (
+            <div className="flex flex-col items-center gap-3 py-10 text-center">
+              <AlertCircle className="text-destructive h-8 w-8" />
+              <p className="text-muted-foreground text-sm">
+                Không thể tải danh sách. Vui lòng thử lại.
+              </p>
+              <Button variant="outline" size="sm" onClick={() => refetch()}>
+                Thử lại
+              </Button>
+            </div>
+          ) : isLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : items.length === 0 ? (
+            <p className="text-muted-foreground py-10 text-center text-sm">
+              {search || source !== ALL
+                ? "Không có số nào khớp bộ lọc."
+                : "Chưa có số từ chối nhận tin nào."}
+            </p>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Số điện thoại</TableHead>
+                      <TableHead>Nguồn</TableHead>
+                      <TableHead>Tham chiếu</TableHead>
+                      <TableHead>Lý do</TableHead>
+                      <TableHead>Thời điểm</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {items.map((o) => (
+                      <TableRow key={o.id}>
+                        <TableCell className="font-medium tabular-nums">
+                          {o.phone_normalized}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="secondary">
+                            {optOutSourceLabel(o.source)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-muted-foreground max-w-[200px] truncate text-sm">
+                          {o.source_reference || "—"}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground max-w-[280px] truncate text-sm">
+                          {o.reason || "—"}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground text-xs whitespace-nowrap">
+                          {formatDateTimeVN(o.observed_at)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+
+              {/* Phân trang */}
+              <div className="mt-4 flex items-center justify-between">
+                <p className="text-muted-foreground text-sm">
+                  Tổng {formatInt(total)} số · Trang {page + 1}/{totalPages}
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    disabled={page === 0 || isFetching}
+                  >
+                    <ChevronLeft className="h-4 w-4" /> Trước
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      setPage((p) => Math.min(totalPages - 1, p + 1))
+                    }
+                    disabled={page >= totalPages - 1 || isFetching}
+                  >
+                    Sau <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <SmsManualOptOutDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+    </div>
+  )
+}

--- a/frontend/src/components/sms/admin/SmsReportsClient.tsx
+++ b/frontend/src/components/sms/admin/SmsReportsClient.tsx
@@ -1,0 +1,34 @@
+// src/components/sms/admin/SmsReportsClient.tsx
+"use client"
+
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs"
+
+import { SmsCampaignDashboardPanel } from "./SmsCampaignDashboardPanel"
+import { SmsClickReportPanel } from "./SmsClickReportPanel"
+
+/**
+ * Trang báo cáo SMS Marketing (admin). 2 tab:
+ * - "Tổng hợp click": báo cáo click theo ngày/tháng/năm + CTR (§9).
+ * - "Theo chiến dịch": dashboard 1 chiến dịch (CTR + nhà mạng + danh sách).
+ */
+export function SmsReportsClient() {
+  return (
+    <Tabs defaultValue="overview" className="space-y-4">
+      <TabsList>
+        <TabsTrigger value="overview">Tổng hợp click</TabsTrigger>
+        <TabsTrigger value="campaign">Theo chiến dịch</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview">
+        <SmsClickReportPanel />
+      </TabsContent>
+      <TabsContent value="campaign">
+        <SmsCampaignDashboardPanel />
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/frontend/src/components/sms/admin/SmsSummaryCard.tsx
+++ b/frontend/src/components/sms/admin/SmsSummaryCard.tsx
@@ -1,0 +1,22 @@
+// src/components/sms/admin/SmsSummaryCard.tsx
+"use client"
+
+import { Card, CardContent } from "@/components/ui/card"
+
+/** Thẻ số liệu tổng hợp dùng chung cho các panel báo cáo SMS. */
+export function SmsSummaryCard({
+  label,
+  value,
+}: {
+  label: string
+  value: string
+}) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <p className="text-muted-foreground text-xs">{label}</p>
+        <p className="mt-1 text-2xl font-bold tabular-nums">{value}</p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/sms/admin/labels.ts
+++ b/frontend/src/components/sms/admin/labels.ts
@@ -1,0 +1,107 @@
+// src/components/sms/admin/labels.ts
+/**
+ * Nhãn tiếng Việt cho enum SMS Marketing (carrier / opt-out source /
+ * campaign status / granularity). Dùng cho mọi trang admin PR-6.
+ *
+ * Thin-client: BE là nguồn sự thật của status; UI chỉ tra nhãn hiển thị và
+ * LUÔN có fallback cho giá trị enum lạ (hiển thị raw) — không suy luận.
+ */
+import { format, parseISO } from "date-fns"
+import { vi } from "date-fns/locale"
+
+import type {
+  SmsCarrierBucket,
+  SmsGranularity,
+  SmsManualOptOutSource,
+} from "@/lib/zod/sms"
+
+export const CARRIER_LABELS: Record<string, string> = {
+  viettel: "Viettel",
+  vinaphone: "VinaPhone",
+  mobifone: "MobiFone",
+  vietnamobile: "Vietnamobile",
+  gmobile: "Gmobile",
+  unknown: "Không xác định",
+}
+
+export function carrierLabel(value: string): string {
+  return CARRIER_LABELS[value] ?? value
+}
+
+/**
+ * Nguồn opt-out — gồm cả `landing_optout` (số tự hủy qua trang, KHÔNG nằm
+ * trong nhóm thêm-thủ-công nhưng có thể xuất hiện ở danh sách).
+ */
+export const OPT_OUT_SOURCE_LABELS: Record<string, string> = {
+  manual: "Thủ công",
+  sms_reply: "Trả lời SMS",
+  phone_call: "Điện thoại",
+  external_suppression: "Chặn ngoài hệ thống",
+  landing_optout: "Hủy qua trang đích",
+}
+
+export function optOutSourceLabel(value: string): string {
+  return OPT_OUT_SOURCE_LABELS[value] ?? value
+}
+
+/** Nguồn cho FORM thêm thủ công (khớp SmsManualOptOutSource ở BE). */
+export const MANUAL_OPT_OUT_SOURCE_OPTIONS: {
+  value: SmsManualOptOutSource
+  label: string
+}[] = [
+  { value: "manual", label: "Thủ công" },
+  { value: "sms_reply", label: "Trả lời SMS" },
+  { value: "phone_call", label: "Điện thoại" },
+  { value: "external_suppression", label: "Chặn ngoài hệ thống" },
+]
+
+export const CAMPAIGN_STATUS_LABELS: Record<string, string> = {
+  draft: "Nháp",
+  ready: "Sẵn sàng",
+  exported: "Đã xuất",
+  handed_off: "Đã bàn giao",
+  closed: "Đã đóng",
+}
+
+export function campaignStatusLabel(value: string): string {
+  return CAMPAIGN_STATUS_LABELS[value] ?? value
+}
+
+export const GRANULARITY_OPTIONS: { value: SmsGranularity; label: string }[] = [
+  { value: "day", label: "Theo ngày" },
+  { value: "month", label: "Theo tháng" },
+  { value: "year", label: "Theo năm" },
+]
+
+export const CARRIER_FILTER_OPTIONS: { value: SmsCarrierBucket; label: string }[] =
+  [
+    { value: "viettel", label: "Viettel" },
+    { value: "vinaphone", label: "VinaPhone" },
+    { value: "mobifone", label: "MobiFone" },
+    { value: "vietnamobile", label: "Vietnamobile" },
+    { value: "gmobile", label: "Gmobile" },
+    { value: "unknown", label: "Không xác định" },
+  ]
+
+/** Định dạng số nguyên kiểu Việt (1.234.567). */
+export function formatInt(n: number): string {
+  return n.toLocaleString("vi-VN")
+}
+
+/** Định dạng phần trăm CTR (BE trả sẵn dạng %; tối đa 1 chữ số thập phân). */
+export function formatPercent(n: number): string {
+  return `${n.toLocaleString("vi-VN", { maximumFractionDigits: 1 })}%`
+}
+
+/**
+ * Định dạng ISO datetime → "dd/MM/yyyy HH:mm" (giờ trình duyệt). An toàn:
+ * giá trị null/parse lỗi → "—" (không crash render).
+ */
+export function formatDateTimeVN(iso: string | null | undefined): string {
+  if (!iso) return "—"
+  try {
+    return format(parseISO(iso), "dd/MM/yyyy HH:mm", { locale: vi })
+  } catch {
+    return iso
+  }
+}

--- a/frontend/src/components/sms/admin/labels.ts
+++ b/frontend/src/components/sms/admin/labels.ts
@@ -96,8 +96,9 @@ export function formatPercent(n: number): string {
 }
 
 /**
- * Định dạng ISO datetime → "dd/MM/yyyy HH:mm" (giờ trình duyệt). An toàn:
- * giá trị null/parse lỗi → "—" (không crash render).
+ * Định dạng ISO datetime → "dd/MM/yyyy HH:mm" (giờ trình duyệt). An toàn,
+ * không crash render: giá trị rỗng (null/undefined/"") → "—"; chuỗi không
+ * parse được → trả lại chính chuỗi gốc (hiển thị raw).
  */
 export function formatDateTimeVN(iso: string | null | undefined): string {
   if (!iso) return "—"

--- a/frontend/src/components/sms/admin/labels.ts
+++ b/frontend/src/components/sms/admin/labels.ts
@@ -9,10 +9,12 @@
 import { format, parseISO } from "date-fns"
 import { vi } from "date-fns/locale"
 
-import type {
-  SmsCarrierBucket,
-  SmsGranularity,
-  SmsManualOptOutSource,
+import {
+  SMS_CARRIER_BUCKETS,
+  SMS_MANUAL_OPT_OUT_SOURCES,
+  type SmsCarrierBucket,
+  type SmsGranularity,
+  type SmsManualOptOutSource,
 } from "@/lib/zod/sms"
 
 export const CARRIER_LABELS: Record<string, string> = {
@@ -44,16 +46,17 @@ export function optOutSourceLabel(value: string): string {
   return OPT_OUT_SOURCE_LABELS[value] ?? value
 }
 
-/** Nguồn cho FORM thêm thủ công (khớp SmsManualOptOutSource ở BE). */
+/**
+ * Nguồn cho FORM thêm thủ công (khớp SmsManualOptOutSource ở BE). Derive từ
+ * enum + label map để nhãn không lệch giữa form và danh sách.
+ */
 export const MANUAL_OPT_OUT_SOURCE_OPTIONS: {
   value: SmsManualOptOutSource
   label: string
-}[] = [
-  { value: "manual", label: "Thủ công" },
-  { value: "sms_reply", label: "Trả lời SMS" },
-  { value: "phone_call", label: "Điện thoại" },
-  { value: "external_suppression", label: "Chặn ngoài hệ thống" },
-]
+}[] = SMS_MANUAL_OPT_OUT_SOURCES.map((value) => ({
+  value,
+  label: OPT_OUT_SOURCE_LABELS[value],
+}))
 
 export const CAMPAIGN_STATUS_LABELS: Record<string, string> = {
   draft: "Nháp",
@@ -73,15 +76,14 @@ export const GRANULARITY_OPTIONS: { value: SmsGranularity; label: string }[] = [
   { value: "year", label: "Theo năm" },
 ]
 
-export const CARRIER_FILTER_OPTIONS: { value: SmsCarrierBucket; label: string }[] =
-  [
-    { value: "viettel", label: "Viettel" },
-    { value: "vinaphone", label: "VinaPhone" },
-    { value: "mobifone", label: "MobiFone" },
-    { value: "vietnamobile", label: "Vietnamobile" },
-    { value: "gmobile", label: "Gmobile" },
-    { value: "unknown", label: "Không xác định" },
-  ]
+/** Tùy chọn filter nhà mạng — derive từ enum + CARRIER_LABELS (DRY). */
+export const CARRIER_FILTER_OPTIONS: {
+  value: SmsCarrierBucket
+  label: string
+}[] = SMS_CARRIER_BUCKETS.map((value) => ({
+  value,
+  label: CARRIER_LABELS[value],
+}))
 
 /** Định dạng số nguyên kiểu Việt (1.234.567). */
 export function formatInt(n: number): string {

--- a/frontend/src/hooks/useSmsAdmin.ts
+++ b/frontend/src/hooks/useSmsAdmin.ts
@@ -1,0 +1,119 @@
+// src/hooks/useSmsAdmin.ts
+/**
+ * React Query hooks cho SMS Marketing admin (PR-6).
+ *
+ * Tiêu thụ router admin của PR-5 (Backend_FastAPI/app/routers/sms_reports.py
+ * + sms_campaigns.py). Tất cả endpoint `require_admin` ở BE — đây là tầng
+ * server-state, mọi gating hiển thị do sidebar/proxy lo (admin-only).
+ */
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+import { AxiosError } from "axios"
+import { toast } from "sonner"
+
+import {
+  createManualOptOut,
+  getSmsCampaignDashboard,
+  getSmsClickReport,
+  listSmsCampaigns,
+  listSmsOptOuts,
+  type ManualOptOutPayload,
+  type SmsCampaignListParams,
+  type SmsClickReportParams,
+  type SmsOptOutListParams,
+} from "@/lib/api/sms"
+import type { ApiErrorResponse } from "@/types/api.types"
+
+// ---------------------------------------------------------------------
+// Query-key factory
+// ---------------------------------------------------------------------
+export const smsAdminKeys = {
+  all: ["sms-admin"] as const,
+  clickReport: (params: SmsClickReportParams) =>
+    [...smsAdminKeys.all, "click-report", params] as const,
+  dashboard: (campaignId: number) =>
+    [...smsAdminKeys.all, "dashboard", campaignId] as const,
+  campaigns: (params: SmsCampaignListParams) =>
+    [...smsAdminKeys.all, "campaigns", params] as const,
+  optOuts: (params: SmsOptOutListParams) =>
+    [...smsAdminKeys.all, "opt-outs", params] as const,
+}
+
+/** Trích thông điệp lỗi từ response BE (detail string | mảng | message). */
+function extractErrorMessage(
+  err: AxiosError<ApiErrorResponse>,
+  fallback: string,
+): string {
+  const detail = err.response?.data?.detail
+  if (typeof detail === "string") return detail
+  if (Array.isArray(detail) && detail.length > 0 && detail[0]?.msg) {
+    return detail[0].msg
+  }
+  if (err.response?.data?.message) return err.response.data.message
+  return fallback
+}
+
+// ---------------------------------------------------------------------
+// Reports + dashboard
+// ---------------------------------------------------------------------
+export function useSmsClickReport(params: SmsClickReportParams) {
+  return useQuery({
+    queryKey: smsAdminKeys.clickReport(params),
+    queryFn: () => getSmsClickReport(params),
+    staleTime: 60 * 1000,
+  })
+}
+
+export function useSmsCampaignDashboard(campaignId: number | null) {
+  return useQuery({
+    queryKey: smsAdminKeys.dashboard(campaignId ?? 0),
+    queryFn: () => getSmsCampaignDashboard(campaignId as number),
+    enabled: campaignId != null,
+    staleTime: 60 * 1000,
+  })
+}
+
+export function useSmsCampaignList(params: SmsCampaignListParams = {}) {
+  return useQuery({
+    queryKey: smsAdminKeys.campaigns(params),
+    queryFn: () => listSmsCampaigns(params),
+    staleTime: 60 * 1000,
+  })
+}
+
+// ---------------------------------------------------------------------
+// Opt-out
+// ---------------------------------------------------------------------
+export function useSmsOptOuts(params: SmsOptOutListParams = {}) {
+  return useQuery({
+    queryKey: smsAdminKeys.optOuts(params),
+    queryFn: () => listSmsOptOuts(params),
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useCreateManualOptOut() {
+  const queryClient = useQueryClient()
+  return useMutation<
+    Awaited<ReturnType<typeof createManualOptOut>>,
+    AxiosError<ApiErrorResponse>,
+    ManualOptOutPayload
+  >({
+    mutationFn: createManualOptOut,
+    onSuccess: () => {
+      toast.success("Đã ghi nhận số từ chối nhận tin.")
+      // Làm mới mọi danh sách opt-out (mọi filter/phân trang).
+      queryClient.invalidateQueries({
+        queryKey: [...smsAdminKeys.all, "opt-outs"],
+      })
+    },
+    onError: (err) => {
+      toast.error(
+        extractErrorMessage(err, "Không thể ghi nhận số từ chối nhận tin."),
+      )
+    },
+  })
+}

--- a/frontend/src/hooks/useSmsAdmin.ts
+++ b/frontend/src/hooks/useSmsAdmin.ts
@@ -25,6 +25,7 @@ import {
   type SmsClickReportParams,
   type SmsOptOutListParams,
 } from "@/lib/api/sms"
+import { parseApiError } from "@/lib/utils/api-errors"
 import type { ApiErrorResponse } from "@/types/api.types"
 
 // ---------------------------------------------------------------------
@@ -40,20 +41,6 @@ export const smsAdminKeys = {
     [...smsAdminKeys.all, "campaigns", params] as const,
   optOuts: (params: SmsOptOutListParams) =>
     [...smsAdminKeys.all, "opt-outs", params] as const,
-}
-
-/** Trích thông điệp lỗi từ response BE (detail string | mảng | message). */
-function extractErrorMessage(
-  err: AxiosError<ApiErrorResponse>,
-  fallback: string,
-): string {
-  const detail = err.response?.data?.detail
-  if (typeof detail === "string") return detail
-  if (Array.isArray(detail) && detail.length > 0 && detail[0]?.msg) {
-    return detail[0].msg
-  }
-  if (err.response?.data?.message) return err.response.data.message
-  return fallback
 }
 
 // ---------------------------------------------------------------------
@@ -112,7 +99,7 @@ export function useCreateManualOptOut() {
     },
     onError: (err) => {
       toast.error(
-        extractErrorMessage(err, "Không thể ghi nhận số từ chối nhận tin."),
+        parseApiError(err, "Không thể ghi nhận số từ chối nhận tin."),
       )
     },
   })

--- a/frontend/src/lib/api/sms.ts
+++ b/frontend/src/lib/api/sms.ts
@@ -1,15 +1,30 @@
 /**
- * SMS Marketing public landing API client (PR-5).
+ * SMS Marketing API client.
  *
- * Public endpoints — no auth header, CSRF-exempt `/api/public/` prefix
- * (Backend_FastAPI/app/middleware/csrf.py). Validates BE response with the
- * mirror Zod schema before returning (thin-client contract).
+ * - Public landing endpoints (PR-5): no auth header, CSRF-exempt
+ *   `/api/public/` prefix (Backend_FastAPI/app/middleware/csrf.py).
+ * - Admin endpoints (PR-6 tiêu thụ router PR-5): yêu cầu đăng nhập +
+ *   `require_admin` ở BE; `api` tự gắn cookie + CSRF cho mutation.
+ *
+ * Mọi response được validate bằng Zod mirror trước khi trả (thin-client).
  */
 import { api } from "@/lib/api/client"
 import {
+  smsCampaignDashboardSchema,
+  smsCampaignListSchema,
+  smsClickReportSchema,
   smsLandingResponseSchema,
+  smsOptOutListSchema,
+  smsOptOutSchema,
   smsPublicOptOutResponseSchema,
+  type SmsCampaignDashboard,
+  type SmsCampaignList,
+  type SmsClickReport,
+  type SmsGranularity,
   type SmsLandingResponse,
+  type SmsManualOptOutSource,
+  type SmsOptOut,
+  type SmsOptOutList,
   type SmsPublicOptOutResponse,
 } from "@/lib/zod/sms"
 
@@ -38,4 +53,83 @@ export async function postSmsOptOut(
     { code },
   )
   return smsPublicOptOutResponseSchema.parse(res.data)
+}
+
+// =====================================================================
+// Admin — Reports + Dashboard + Opt-out (require_admin ở BE)
+// =====================================================================
+
+export interface SmsClickReportParams {
+  granularity: SmsGranularity
+  campaign_id?: number
+  carrier?: string
+  group_id?: number
+  /** ISO datetime (kèm offset) — khoảng clicked_at. */
+  date_from?: string
+  date_to?: string
+}
+
+/** Báo cáo click tổng hợp theo ngày/tháng/năm + CTR (§9). */
+export async function getSmsClickReport(
+  params: SmsClickReportParams,
+): Promise<SmsClickReport> {
+  const res = await api.get<SmsClickReport>(`/api/sms/reports/clicks`, {
+    params,
+  })
+  return smsClickReportSchema.parse(res.data)
+}
+
+/** Dashboard 1 chiến dịch: CTR + phân bố nhà mạng + danh sách số đã click. */
+export async function getSmsCampaignDashboard(
+  campaignId: number,
+): Promise<SmsCampaignDashboard> {
+  const res = await api.get<SmsCampaignDashboard>(
+    `/api/sms/campaigns/${campaignId}/dashboard`,
+  )
+  return smsCampaignDashboardSchema.parse(res.data)
+}
+
+export interface SmsCampaignListParams {
+  skip?: number
+  limit?: number
+  status?: string
+  search?: string
+}
+
+/** Danh sách campaign (picker dashboard + filter report). */
+export async function listSmsCampaigns(
+  params: SmsCampaignListParams = {},
+): Promise<SmsCampaignList> {
+  const res = await api.get<SmsCampaignList>(`/api/sms/campaigns`, { params })
+  return smsCampaignListSchema.parse(res.data)
+}
+
+export interface SmsOptOutListParams {
+  skip?: number
+  limit?: number
+  search?: string
+  source?: string
+}
+
+/** Danh sách số từ chối nhận tin (suppression toàn cục). */
+export async function listSmsOptOuts(
+  params: SmsOptOutListParams = {},
+): Promise<SmsOptOutList> {
+  const res = await api.get<SmsOptOutList>(`/api/sms/opt-out`, { params })
+  return smsOptOutListSchema.parse(res.data)
+}
+
+export interface ManualOptOutPayload {
+  phone: string
+  source: SmsManualOptOutSource
+  source_reference?: string
+  reason?: string
+}
+
+/** Admin ghi opt-out thủ công (đối tác/điện thoại/SMS reply). */
+export async function createManualOptOut(
+  payload: ManualOptOutPayload,
+): Promise<SmsOptOut> {
+  const res = await api.post<SmsOptOut>(`/api/sms/opt-out/manual`, payload)
+  return smsOptOutSchema.parse(res.data)
 }

--- a/frontend/src/lib/api/sms.ts
+++ b/frontend/src/lib/api/sms.ts
@@ -63,7 +63,6 @@ export interface SmsClickReportParams {
   granularity: SmsGranularity
   campaign_id?: number
   carrier?: string
-  group_id?: number
   /** ISO datetime (kèm offset) — khoảng clicked_at. */
   date_from?: string
   date_to?: string

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -11,6 +11,7 @@ import {
   Activity,
   BarChart3,
   Bell,
+  BellOff,
   Building2,
   Calculator,
   ClipboardCheck,
@@ -24,6 +25,7 @@ import {
   History,
   LayoutDashboard,
   MapPin,
+  MessageSquareText,
   Percent,
   School,
   Receipt,
@@ -248,6 +250,27 @@ export const navigationConfig: NavigationConfig = {
           href: "/admin/notification-consents",
           icon: UserCheck,
           roles: ["admin"], // Admin-only consent management
+        },
+      ],
+    },
+
+    // =========================================================================
+    // 4b. SMS MARKETING - Admin-only (BE require_admin trên mọi endpoint)
+    // =========================================================================
+    {
+      title: "SMS Marketing",
+      items: [
+        {
+          label: "Báo cáo SMS",
+          href: "/admin/sms/reports",
+          icon: MessageSquareText,
+          roles: ["admin"], // BE require_admin → manager loại khỏi sidebar
+        },
+        {
+          label: "Từ chối nhận tin",
+          href: "/admin/sms/opt-out",
+          icon: BellOff,
+          roles: ["admin"], // BE require_admin
         },
       ],
     },

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -1,5 +1,7 @@
 // src/lib/zod/sms.ts
-// Mirror Backend Pydantic: SmsLandingResponse + SmsPublicOptOut* (PR-5 §19.4).
+// Mirror Backend Pydantic: SmsLandingResponse + SmsPublicOptOut* (PR-5 §19.4)
+// cho landing công khai, và các schema admin reports/dashboard/opt-out (PR-6
+// tiêu thụ router admin của PR-5: app/routers/sms_reports.py).
 // Public landing /lp/{code} — KHÔNG lộ PII recipient.
 import { z } from "zod"
 
@@ -21,3 +23,150 @@ export const smsPublicOptOutResponseSchema = z.object({
 export type SmsPublicOptOutResponse = z.infer<
   typeof smsPublicOptOutResponseSchema
 >
+
+// =====================================================================
+// Admin — enum literal (mirror CHECK constraint / Literal ở Backend)
+// =====================================================================
+/** granularity báo cáo click (sms_reports.py: pattern `^(day|month|year)$`). */
+export const SMS_GRANULARITIES = ["day", "month", "year"] as const
+export type SmsGranularity = (typeof SMS_GRANULARITIES)[number]
+
+/** Nguồn opt-out thủ công (Pydantic SmsManualOptOutSource). */
+export const SMS_MANUAL_OPT_OUT_SOURCES = [
+  "manual",
+  "sms_reply",
+  "phone_call",
+  "external_suppression",
+] as const
+export type SmsManualOptOutSource = (typeof SMS_MANUAL_OPT_OUT_SOURCES)[number]
+
+/**
+ * Nhóm nhà mạng (sms_prefix_carrier_rule.carrier_bucket). `unknown` = số
+ * không khớp prefix nào (BE seed comment). Dùng cho filter báo cáo + nhãn.
+ */
+export const SMS_CARRIER_BUCKETS = [
+  "viettel",
+  "vinaphone",
+  "mobifone",
+  "vietnamobile",
+  "gmobile",
+  "unknown",
+] as const
+export type SmsCarrierBucket = (typeof SMS_CARRIER_BUCKETS)[number]
+
+// =====================================================================
+// Admin — Reports click (§9 / SmsClickReport, SmsClickBucket)
+// =====================================================================
+export const smsClickBucketSchema = z.object({
+  period: z.string(),
+  total_clicks: z.number(),
+  human_clicks: z.number(),
+  distinct_contacts_clicked: z.number(),
+})
+export type SmsClickBucket = z.infer<typeof smsClickBucketSchema>
+
+export const smsClickReportSchema = z.object({
+  granularity: z.string(),
+  buckets: z.array(smsClickBucketSchema),
+  total_clicks: z.number(),
+  human_clicks: z.number(),
+  distinct_contacts_clicked: z.number(),
+  recipients_handed_off: z.number(),
+  ctr_percent: z.number(),
+})
+export type SmsClickReport = z.infer<typeof smsClickReportSchema>
+
+// =====================================================================
+// Admin — Dashboard chiến dịch (SmsCampaignDashboard, SmsClickerOut)
+// =====================================================================
+export const smsClickerSchema = z.object({
+  recipient_id: z.number(),
+  contact_id: z.number().nullable().optional(),
+  full_name: z.string(),
+  phone_masked: z.string(),
+  carrier_bucket: z.string(),
+  human_click_count: z.number(),
+  first_human_clicked_at: z.string().nullable().optional(),
+  last_human_clicked_at: z.string().nullable().optional(),
+})
+export type SmsClicker = z.infer<typeof smsClickerSchema>
+
+export const smsCampaignDashboardSchema = z.object({
+  campaign_id: z.number(),
+  build_revision: z.number(),
+  has_link: z.boolean(),
+  recipients_handed_off: z.number(),
+  total_clicks: z.number(),
+  human_clicks: z.number(),
+  distinct_contacts_clicked: z.number(),
+  ctr_percent: z.number(),
+  carrier_distribution: z.record(z.string(), z.number()),
+  clickers: z.array(smsClickerSchema),
+})
+export type SmsCampaignDashboard = z.infer<typeof smsCampaignDashboardSchema>
+
+// =====================================================================
+// Admin — danh sách campaign (cho picker dashboard + filter report).
+// Subset cố ý của SmsCampaignOut: chỉ field UI dùng (Zod strip key thừa).
+// =====================================================================
+export const smsCampaignListItemSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  code: z.string(),
+  status: z.string(),
+  build_revision: z.number(),
+  has_link: z.boolean().nullable().optional(),
+})
+export type SmsCampaignListItem = z.infer<typeof smsCampaignListItemSchema>
+
+export const smsCampaignListSchema = z.object({
+  total: z.number(),
+  items: z.array(smsCampaignListItemSchema),
+})
+export type SmsCampaignList = z.infer<typeof smsCampaignListSchema>
+
+// =====================================================================
+// Admin — Opt-out (suppression toàn cục)
+// =====================================================================
+export const smsOptOutSchema = z.object({
+  id: z.number(),
+  phone_normalized: z.string(),
+  source: z.string(),
+  source_reference: z.string().nullable().optional(),
+  reason: z.string().nullable().optional(),
+  observed_at: z.string(),
+  created_at: z.string(),
+})
+export type SmsOptOut = z.infer<typeof smsOptOutSchema>
+
+export const smsOptOutListSchema = z.object({
+  total: z.number(),
+  items: z.array(smsOptOutSchema),
+})
+export type SmsOptOutList = z.infer<typeof smsOptOutListSchema>
+
+/**
+ * Form thêm opt-out thủ công. Mirror Pydantic SmsOptOutManualCreate:
+ * phone 8–32 ký tự; reason ≤ 2000; source_reference ≤ 512.
+ */
+export const smsManualOptOutSchema = z.object({
+  phone: z
+    .string()
+    .trim()
+    .min(8, "Số điện thoại tối thiểu 8 ký tự")
+    .max(32, "Số điện thoại tối đa 32 ký tự"),
+  source: z.enum(SMS_MANUAL_OPT_OUT_SOURCES),
+  source_reference: z
+    .string()
+    .trim()
+    .max(512, "Tham chiếu nguồn tối đa 512 ký tự")
+    .optional()
+    .or(z.literal("")),
+  reason: z
+    .string()
+    .trim()
+    .max(2000, "Lý do tối đa 2000 ký tự")
+    .optional()
+    .or(z.literal("")),
+})
+export type SmsManualOptOutInput = z.infer<typeof smsManualOptOutSchema>

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -156,17 +156,17 @@ export const smsManualOptOutSchema = z.object({
     .min(8, "Số điện thoại tối thiểu 8 ký tự")
     .max(32, "Số điện thoại tối đa 32 ký tự"),
   source: z.enum(SMS_MANUAL_OPT_OUT_SOURCES),
+  // "" hợp lệ (length 0 ≤ max) nên `.optional()` đủ — không cần `.or("")`;
+  // giữ message max cụ thể khi vượt giới hạn.
   source_reference: z
     .string()
     .trim()
     .max(512, "Tham chiếu nguồn tối đa 512 ký tự")
-    .optional()
-    .or(z.literal("")),
+    .optional(),
   reason: z
     .string()
     .trim()
     .max(2000, "Lý do tối đa 2000 ký tự")
-    .optional()
-    .or(z.literal("")),
+    .optional(),
 })
 export type SmsManualOptOutInput = z.infer<typeof smsManualOptOutSchema>


### PR DESCRIPTION
## Mục tiêu
PR-6 (FE) xây UI admin tiêu thụ các endpoint admin của PR-5 (#449, đã merge):
`GET /api/sms/reports/clicks`, `GET /api/sms/campaigns/{id}/dashboard`,
`GET+POST /api/sms/opt-out[/manual]`, `GET /api/sms/campaigns`.

## Thay đổi
- **Zod mirror + API client** (`lib/zod/sms.ts`, `lib/api/sms.ts`): click report,
  campaign dashboard, opt-out list/manual-create, campaign list (subset cho picker).
- **React Query hooks** (`hooks/useSmsAdmin.ts`): query + mutation opt-out
  (toast + invalidate), reuse `parseApiError`.
- **`/admin/sms/reports`** — 2 tab: "Tổng hợp click" (CTR theo ngày/tháng/năm +
  filter chiến dịch/nhà mạng/khoảng ngày) · "Theo chiến dịch" (CTR, phân bố nhà
  mạng, danh sách số đã click PII-masked).
- **`/admin/sms/opt-out`** — danh sách (search SĐT + filter nguồn + phân trang) +
  dialog thêm thủ công.
- **Nav** group "SMS Marketing" admin-only (`roles:["admin"]`, khớp `require_admin` BE).
- Thin-client: mirror Zod, trust BE status, fallback đủ enum, không check role string
  ở component (gate qua proxy `/admin` + sidebar + BE).

## Kiểm thử
- **fe-check**: type-check ✅ · lint **0 error** ✅ · test **1752 PASS** ✅ · build ✅
- **/code-review max ×2**: 0 bug correctness/contract/convention (đã vá cleanup/UX-edge).
- **Chrome-smoke qlts_dev (admin)**: render 2 trang, endpoint **200**, thêm opt-out
  `POST 201` + list refresh, search filter, **0 console error**.

Không migration / không Casbin (FE thuần). Phụ thuộc PR-5 (#449) đã có trên main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)