### PR TITLE
feat(sms): PR-6b FE — quản lý liên hệ / nhóm / consent

### DIFF
--- a/frontend/src/app/(dashboard)/admin/sms/contacts/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/sms/contacts/page.tsx
@@ -1,0 +1,23 @@
+// src/app/(dashboard)/admin/sms/contacts/page.tsx
+/**
+ * SMS Marketing — Quản lý liên hệ & nhóm & consent (admin, PR-6b).
+ * Gate: proxy /admin/* + sidebar roles:["admin"]; BE require_admin là chốt cuối.
+ */
+import { Users } from "lucide-react"
+
+import { PageContainer } from "@/components/layouts/PageContainer"
+import { PageHeader } from "@/components/layouts/PageHeader"
+import { SmsContactsClient } from "@/components/sms/admin/contacts/SmsContactsClient"
+
+export default function SmsContactsPage() {
+  return (
+    <PageContainer maxWidth="full">
+      <PageHeader
+        title="Liên hệ SMS"
+        description="Quản lý nhóm, liên hệ và bằng chứng đồng ý (consent) cho chiến dịch SMS."
+        icon={<Users className="h-6 w-6" />}
+      />
+      <SmsContactsClient />
+    </PageContainer>
+  )
+}

--- a/frontend/src/components/sms/admin/contacts/SmsConsentEventDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsConsentEventDialog.tsx
@@ -74,7 +74,12 @@ export function SmsConsentEventDialog({
   function onSubmit(values: SmsConsentEventCreateInput) {
     // occurred_at từ datetime-local (naive) → ISO tz-aware (Z). Chỉ gửi field
     // hợp lệ theo event_type để khớp ràng buộc BE (no grant-data khi revoke).
-    const occurredIso = new Date(values.occurred_at).toISOString()
+    const parsed = new Date(values.occurred_at)
+    if (Number.isNaN(parsed.getTime())) {
+      form.setError("occurred_at", { message: "Thời điểm không hợp lệ" })
+      return
+    }
+    const occurredIso = parsed.toISOString()
     const data: SmsConsentEventCreateInput =
       values.event_type === "granted"
         ? {

--- a/frontend/src/components/sms/admin/contacts/SmsConsentEventDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsConsentEventDialog.tsx
@@ -1,0 +1,276 @@
+// src/components/sms/admin/contacts/SmsConsentEventDialog.tsx
+"use client"
+
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Loader2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useAppendConsentEvent } from "@/hooks/useSmsContacts"
+import {
+  smsConsentEventCreateSchema,
+  type SmsConsentEventCreateInput,
+} from "@/lib/zod/sms"
+
+import { CONSENT_BASIS_OPTIONS, REVOKE_SOURCE_OPTIONS } from "../labels"
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  contactId: number
+}
+
+const DEFAULTS: SmsConsentEventCreateInput = {
+  event_type: "granted",
+  occurred_at: "",
+  basis: undefined,
+  disclosure_version: "",
+  proof_reference: "",
+  revoke_source: undefined,
+}
+
+export function SmsConsentEventDialog({
+  open,
+  onOpenChange,
+  contactId,
+}: Props) {
+  const mutation = useAppendConsentEvent()
+  const form = useForm<SmsConsentEventCreateInput>({
+    resolver: zodResolver(smsConsentEventCreateSchema),
+    defaultValues: DEFAULTS,
+  })
+  const eventType = form.watch("event_type")
+
+  useEffect(() => {
+    if (open) form.reset(DEFAULTS)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  function onSubmit(values: SmsConsentEventCreateInput) {
+    // occurred_at từ datetime-local (naive) → ISO tz-aware (Z). Chỉ gửi field
+    // hợp lệ theo event_type để khớp ràng buộc BE (no grant-data khi revoke).
+    const occurredIso = new Date(values.occurred_at).toISOString()
+    const data: SmsConsentEventCreateInput =
+      values.event_type === "granted"
+        ? {
+            event_type: "granted",
+            occurred_at: occurredIso,
+            basis: values.basis,
+            disclosure_version: values.disclosure_version?.trim(),
+            proof_reference: values.proof_reference?.trim(),
+          }
+        : {
+            event_type: "revoked",
+            occurred_at: occurredIso,
+            revoke_source: values.revoke_source,
+          }
+    mutation.mutate(
+      { contactId, data },
+      { onSuccess: () => onOpenChange(false) },
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Ghi sự kiện consent</DialogTitle>
+          <DialogDescription>
+            Ledger consent là append-only. GRANT cần đủ căn cứ + công bố + bằng
+            chứng; REVOKE cần nguồn từ chối.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="event_type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Loại sự kiện *</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    disabled={mutation.isPending}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="granted">Đồng ý (grant)</SelectItem>
+                      <SelectItem value="revoked">Từ chối (revoke)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="occurred_at"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Thời điểm xảy ra *</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="datetime-local"
+                      disabled={mutation.isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {eventType === "granted" ? (
+              <>
+                <FormField
+                  control={form.control}
+                  name="basis"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Căn cứ *</FormLabel>
+                      <Select
+                        value={field.value ?? ""}
+                        onValueChange={field.onChange}
+                        disabled={mutation.isPending}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="— Chọn căn cứ —" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {CONSENT_BASIS_OPTIONS.map((o) => (
+                            <SelectItem key={o.value} value={o.value}>
+                              {o.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="disclosure_version"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Phiên bản công bố *</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="VD: v2026.1"
+                          maxLength={50}
+                          disabled={mutation.isPending}
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="proof_reference"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Tham chiếu bằng chứng *</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="VD: link scan, mã hồ sơ"
+                          maxLength={512}
+                          disabled={mutation.isPending}
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </>
+            ) : (
+              <FormField
+                control={form.control}
+                name="revoke_source"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nguồn từ chối *</FormLabel>
+                    <Select
+                      value={field.value ?? ""}
+                      onValueChange={field.onChange}
+                      disabled={mutation.isPending}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="— Chọn nguồn —" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {REVOKE_SOURCE_OPTIONS.map((o) => (
+                          <SelectItem key={o.value} value={o.value}>
+                            {o.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={mutation.isPending}
+              >
+                Hủy
+              </Button>
+              <Button type="submit" disabled={mutation.isPending}>
+                {mutation.isPending && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Ghi nhận
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/sms/admin/contacts/SmsConsentEventDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsConsentEventDialog.tsx
@@ -37,7 +37,11 @@ import {
   type SmsConsentEventCreateInput,
 } from "@/lib/zod/sms"
 
-import { CONSENT_BASIS_OPTIONS, REVOKE_SOURCE_OPTIONS } from "../labels"
+import {
+  CONSENT_BASIS_OPTIONS,
+  REVOKE_SOURCE_OPTIONS,
+  nowDatetimeLocal,
+} from "../labels"
 
 interface Props {
   open: boolean
@@ -148,6 +152,7 @@ export function SmsConsentEventDialog({
                   <FormControl>
                     <Input
                       type="datetime-local"
+                      max={nowDatetimeLocal()}
                       disabled={mutation.isPending}
                       {...field}
                     />

--- a/frontend/src/components/sms/admin/contacts/SmsContactDetailDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsContactDetailDialog.tsx
@@ -1,0 +1,228 @@
+// src/components/sms/admin/contacts/SmsContactDetailDialog.tsx
+"use client"
+
+import { useState } from "react"
+import { Pencil, Plus, ShieldCheck } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  useAddContactToGroup,
+  useConsentEvents,
+  useSmsContactGroups,
+} from "@/hooks/useSmsContacts"
+import type { SmsContact } from "@/lib/zod/sms"
+
+import {
+  consentBasisLabel,
+  consentEventTypeLabel,
+  consentStatusLabel,
+  consentStatusVariant,
+  formatDateTimeVN,
+  optOutSourceLabel,
+} from "../labels"
+import { SmsConsentEventDialog } from "./SmsConsentEventDialog"
+import { SmsContactFormDialog } from "./SmsContactFormDialog"
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  contact: SmsContact | null
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <p className="text-muted-foreground text-xs">{label}</p>
+      <p className="text-sm">{children}</p>
+    </div>
+  )
+}
+
+export function SmsContactDetailDialog({ open, onOpenChange, contact }: Props) {
+  const [editOpen, setEditOpen] = useState(false)
+  const [consentOpen, setConsentOpen] = useState(false)
+  const [groupToAdd, setGroupToAdd] = useState<string>("")
+
+  const contactId = open && contact ? contact.id : null
+  const { data: events, isLoading: eventsLoading } = useConsentEvents(contactId)
+  const { data: groupsData } = useSmsContactGroups({ limit: 200 })
+  const addToGroup = useAddContactToGroup()
+
+  // Reset picker khi ĐÓNG (event handler → tránh setState-trong-effect).
+  const handleOpenChange = (o: boolean) => {
+    if (!o) setGroupToAdd("")
+    onOpenChange(o)
+  }
+
+  if (!contact) return null
+
+  const handleAddToGroup = () => {
+    if (!groupToAdd) return
+    addToGroup.mutate(
+      { contactId: contact.id, group_id: Number(groupToAdd) },
+      { onSuccess: () => setGroupToAdd("") },
+    )
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              {contact.full_name}
+              <Badge variant={consentStatusVariant(contact.marketing_consent_status)}>
+                {consentStatusLabel(contact.marketing_consent_status)}
+              </Badge>
+            </DialogTitle>
+            <DialogDescription>
+              {contact.phone_normalized} · {contact.phone_international}
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* Hành động */}
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
+              <Pencil className="mr-2 h-4 w-4" /> Sửa
+            </Button>
+            <Button size="sm" onClick={() => setConsentOpen(true)}>
+              <ShieldCheck className="mr-2 h-4 w-4" /> Ghi consent
+            </Button>
+          </div>
+
+          {/* Thông tin */}
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Nhãn nguồn">{contact.source_label || "—"}</Field>
+            <Field label="Ghi chú">{contact.note || "—"}</Field>
+            <Field label="Căn cứ consent">
+              {contact.marketing_consent_basis
+                ? consentBasisLabel(contact.marketing_consent_basis)
+                : "—"}
+            </Field>
+            <Field label="Đồng ý lúc">
+              {formatDateTimeVN(contact.marketing_consented_at)}
+            </Field>
+            <Field label="Phiên bản công bố">
+              {contact.consent_disclosure_version || "—"}
+            </Field>
+            <Field label="Tham chiếu bằng chứng">
+              {contact.marketing_consent_proof_ref || "—"}
+            </Field>
+          </div>
+
+          {/* Thêm vào nhóm */}
+          <div className="space-y-1.5 border-t pt-3">
+            <Label htmlFor="add-group">Thêm vào nhóm</Label>
+            <div className="flex gap-2">
+              <Select
+                value={groupToAdd}
+                onValueChange={setGroupToAdd}
+                disabled={addToGroup.isPending}
+              >
+                <SelectTrigger id="add-group" className="flex-1">
+                  <SelectValue placeholder="— Chọn nhóm —" />
+                </SelectTrigger>
+                <SelectContent>
+                  {groupsData?.items.map((g) => (
+                    <SelectItem key={g.id} value={String(g.id)}>
+                      {g.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                onClick={handleAddToGroup}
+                disabled={!groupToAdd || addToGroup.isPending}
+              >
+                <Plus className="mr-2 h-4 w-4" /> Thêm
+              </Button>
+            </div>
+          </div>
+
+          {/* Ledger consent */}
+          <div className="space-y-2 border-t pt-3">
+            <p className="text-sm font-medium">Lịch sử consent</p>
+            {eventsLoading ? (
+              <div className="space-y-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-8 w-full" />
+                ))}
+              </div>
+            ) : !events || events.items.length === 0 ? (
+              <p className="text-muted-foreground py-2 text-sm">
+                Chưa có sự kiện consent nào.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {events.items.map((e) => (
+                  <div
+                    key={e.id}
+                    className="flex items-start justify-between gap-3 border-b pb-2 text-sm last:border-0"
+                  >
+                    <div>
+                      <Badge
+                        variant={
+                          e.event_type === "granted" ? "default" : "destructive"
+                        }
+                      >
+                        {consentEventTypeLabel(e.event_type)}
+                      </Badge>
+                      <p className="text-muted-foreground mt-1 text-xs">
+                        {e.event_type === "granted"
+                          ? `${e.basis ? consentBasisLabel(e.basis) : ""}${
+                              e.disclosure_version
+                                ? ` · ${e.disclosure_version}`
+                                : ""
+                            }`
+                          : e.revoke_source
+                            ? optOutSourceLabel(e.revoke_source)
+                            : ""}
+                      </p>
+                    </div>
+                    <span className="text-muted-foreground shrink-0 text-xs whitespace-nowrap">
+                      {formatDateTimeVN(e.occurred_at)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <SmsContactFormDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        contact={contact}
+      />
+      <SmsConsentEventDialog
+        open={consentOpen}
+        onOpenChange={setConsentOpen}
+        contactId={contact.id}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/sms/admin/contacts/SmsContactDetailDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsContactDetailDialog.tsx
@@ -68,12 +68,19 @@ export function SmsContactDetailDialog({ open, onOpenChange, contact }: Props) {
 
   const contactId = open && contact ? contact.id : null
   const { data: events, isLoading: eventsLoading } = useConsentEvents(contactId)
-  const { data: groupsData } = useSmsContactGroups({ limit: 200 })
+  // Chỉ tải danh sách nhóm cho picker khi dialog mở (tránh fetch thừa lúc tab
+  // liên hệ render mà chưa mở chi tiết).
+  const { data: groupsData } = useSmsContactGroups({ limit: 200 }, { enabled: open })
   const addToGroup = useAddContactToGroup()
 
-  // Reset picker khi ĐÓNG (event handler → tránh setState-trong-effect).
+  // Reset state khi ĐÓNG (event handler → tránh setState-trong-effect) để
+  // mở lại liên hệ khác không kẹt picker/sub-dialog cũ.
   const handleOpenChange = (o: boolean) => {
-    if (!o) setGroupToAdd("")
+    if (!o) {
+      setGroupToAdd("")
+      setEditOpen(false)
+      setConsentOpen(false)
+    }
     onOpenChange(o)
   }
 

--- a/frontend/src/components/sms/admin/contacts/SmsContactFormDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsContactFormDialog.tsx
@@ -73,10 +73,12 @@ export function SmsContactFormDialog({ open, onOpenChange, contact }: Props) {
   function onSubmit(values: FormData) {
     const onDone = () => onOpenChange(false)
     if (isEdit && contact) {
+      // Update: gửi "" (không phải undefined) để CHO PHÉP xoá field — BE dùng
+      // exclude_unset nên undefined bị bỏ qua = không xoá được.
       const data: SmsContactUpdateInput = {
         full_name: values.full_name,
-        note: values.note?.trim() || undefined,
-        source_label: values.source_label?.trim() || undefined,
+        note: (values.note ?? "").trim(),
+        source_label: (values.source_label ?? "").trim(),
       }
       updateMut.mutate({ id: contact.id, data }, { onSuccess: onDone })
     } else {

--- a/frontend/src/components/sms/admin/contacts/SmsContactFormDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsContactFormDialog.tsx
@@ -1,0 +1,204 @@
+// src/components/sms/admin/contacts/SmsContactFormDialog.tsx
+"use client"
+
+import { useEffect } from "react"
+import { useForm, type Resolver } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Loader2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { useCreateContact, useUpdateContact } from "@/hooks/useSmsContacts"
+import {
+  smsContactCreateSchema,
+  smsContactUpdateSchema,
+  type SmsContact,
+  type SmsContactCreateInput,
+  type SmsContactUpdateInput,
+} from "@/lib/zod/sms"
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  contact?: SmsContact | null
+}
+
+type FormData = SmsContactCreateInput
+
+export function SmsContactFormDialog({ open, onOpenChange, contact }: Props) {
+  const isEdit = !!contact
+  const createMut = useCreateContact()
+  const updateMut = useUpdateContact()
+  const isPending = createMut.isPending || updateMut.isPending
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(
+      isEdit ? smsContactUpdateSchema : smsContactCreateSchema,
+    ) as unknown as Resolver<FormData>,
+    defaultValues: { full_name: "", phone: "", note: "", source_label: "" },
+  })
+
+  useEffect(() => {
+    if (!open) return
+    if (contact) {
+      form.reset({
+        full_name: contact.full_name,
+        phone: contact.phone_normalized,
+        note: contact.note ?? "",
+        source_label: contact.source_label ?? "",
+      })
+    } else {
+      form.reset({ full_name: "", phone: "", note: "", source_label: "" })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, contact?.id])
+
+  function onSubmit(values: FormData) {
+    const onDone = () => onOpenChange(false)
+    if (isEdit && contact) {
+      const data: SmsContactUpdateInput = {
+        full_name: values.full_name,
+        note: values.note?.trim() || undefined,
+        source_label: values.source_label?.trim() || undefined,
+      }
+      updateMut.mutate({ id: contact.id, data }, { onSuccess: onDone })
+    } else {
+      const data: SmsContactCreateInput = {
+        full_name: values.full_name,
+        phone: values.phone,
+        note: values.note?.trim() || undefined,
+        source_label: values.source_label?.trim() || undefined,
+      }
+      createMut.mutate(data, { onSuccess: onDone })
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Sửa liên hệ" : "Tạo liên hệ"}</DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Không đổi được số điện thoại (định danh). Consent ghi qua sự kiện riêng."
+              : "Liên hệ mới mặc định trạng thái consent “chưa rõ”."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="full_name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Họ tên *</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Nguyễn Văn A"
+                      disabled={isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="phone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Số điện thoại *</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="tel"
+                      inputMode="tel"
+                      placeholder="0912345678"
+                      disabled={isPending || isEdit}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="source_label"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nhãn nguồn</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="VD: Hội thảo 06/2026"
+                      maxLength={255}
+                      disabled={isPending}
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="note"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Ghi chú</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={2}
+                      maxLength={2000}
+                      disabled={isPending}
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+              >
+                Hủy
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isEdit ? "Lưu" : "Tạo"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/sms/admin/contacts/SmsContactsClient.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsContactsClient.tsx
@@ -1,0 +1,34 @@
+// src/components/sms/admin/contacts/SmsContactsClient.tsx
+"use client"
+
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs"
+
+import { SmsContactsPanel } from "./SmsContactsPanel"
+import { SmsGroupsPanel } from "./SmsGroupsPanel"
+
+/**
+ * Quản lý liên hệ SMS (admin). 2 tab:
+ * - "Nhóm": CRUD nhóm + import CSV/XLSX kèm bằng chứng consent.
+ * - "Liên hệ": danh sách toàn cục + tạo/sửa + ledger consent + gán nhóm.
+ */
+export function SmsContactsClient() {
+  return (
+    <Tabs defaultValue="groups" className="space-y-4">
+      <TabsList>
+        <TabsTrigger value="groups">Nhóm liên hệ</TabsTrigger>
+        <TabsTrigger value="contacts">Liên hệ</TabsTrigger>
+      </TabsList>
+      <TabsContent value="groups">
+        <SmsGroupsPanel />
+      </TabsContent>
+      <TabsContent value="contacts">
+        <SmsContactsPanel />
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/frontend/src/components/sms/admin/contacts/SmsContactsPanel.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsContactsPanel.tsx
@@ -1,0 +1,244 @@
+// src/components/sms/admin/contacts/SmsContactsPanel.tsx
+"use client"
+
+import { useState } from "react"
+import {
+  AlertCircle,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  Search,
+} from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useSmsContacts } from "@/hooks/useSmsContacts"
+import { useDebouncedValue } from "@/lib/hooks/use-debounced-value"
+import { SMS_CONSENT_STATUSES, type SmsContact } from "@/lib/zod/sms"
+
+import {
+  consentStatusLabel,
+  consentStatusVariant,
+  formatDateTimeVN,
+  formatInt,
+} from "../labels"
+import { SmsContactDetailDialog } from "./SmsContactDetailDialog"
+import { SmsContactFormDialog } from "./SmsContactFormDialog"
+
+const ALL = "all"
+const PAGE_SIZE = 50
+
+export function SmsContactsPanel() {
+  const [searchInput, setSearchInput] = useState("")
+  const [consent, setConsent] = useState<string>(ALL)
+  const [page, setPage] = useState(0)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [detail, setDetail] = useState<SmsContact | null>(null)
+
+  const search = useDebouncedValue(searchInput.trim())
+
+  const onSearch = (v: string) => {
+    setSearchInput(v)
+    setPage(0)
+  }
+  const onConsent = (v: string) => {
+    setConsent(v)
+    setPage(0)
+  }
+
+  const { data, isLoading, isError, refetch, isFetching } = useSmsContacts({
+    skip: page * PAGE_SIZE,
+    limit: PAGE_SIZE,
+    search: search || undefined,
+    consent_status: consent === ALL ? undefined : consent,
+  })
+
+  const total = data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const items = data?.items ?? []
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="grid flex-1 grid-cols-1 gap-4 sm:grid-cols-2 lg:max-w-xl">
+              <div className="space-y-1.5">
+                <Label htmlFor="ct-search">Tìm liên hệ</Label>
+                <div className="relative">
+                  <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+                  <Input
+                    id="ct-search"
+                    className="pl-8"
+                    placeholder="Tên / số điện thoại…"
+                    value={searchInput}
+                    onChange={(e) => onSearch(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="ct-consent">Consent</Label>
+                <Select value={consent} onValueChange={onConsent}>
+                  <SelectTrigger id="ct-consent">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ALL}>Tất cả</SelectItem>
+                    {SMS_CONSENT_STATUSES.map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {consentStatusLabel(s)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" /> Tạo liên hệ
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6">
+          {isError ? (
+            <div className="flex flex-col items-center gap-3 py-10 text-center">
+              <AlertCircle className="text-destructive h-8 w-8" />
+              <p className="text-muted-foreground text-sm">
+                Không thể tải danh sách liên hệ.
+              </p>
+              <Button variant="outline" size="sm" onClick={() => refetch()}>
+                Thử lại
+              </Button>
+            </div>
+          ) : isLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : items.length === 0 ? (
+            <div className="space-y-3 py-10 text-center">
+              <p className="text-muted-foreground text-sm">
+                {page > 0
+                  ? "Trang này không còn dữ liệu."
+                  : search || consent !== ALL
+                    ? "Không có liên hệ khớp bộ lọc."
+                    : "Chưa có liên hệ nào."}
+              </p>
+              {page > 0 && (
+                <Button variant="outline" size="sm" onClick={() => setPage(0)}>
+                  Về trang đầu
+                </Button>
+              )}
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Họ tên</TableHead>
+                      <TableHead>Số điện thoại</TableHead>
+                      <TableHead>Consent</TableHead>
+                      <TableHead>Nguồn</TableHead>
+                      <TableHead>Tạo lúc</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {items.map((c) => (
+                      <TableRow
+                        key={c.id}
+                        className="hover:bg-muted/50 cursor-pointer"
+                        onClick={() => setDetail(c)}
+                      >
+                        <TableCell className="font-medium">
+                          {c.full_name}
+                        </TableCell>
+                        <TableCell className="tabular-nums">
+                          {c.phone_normalized}
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={consentStatusVariant(
+                              c.marketing_consent_status,
+                            )}
+                          >
+                            {consentStatusLabel(c.marketing_consent_status)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-muted-foreground max-w-[160px] truncate text-sm">
+                          {c.source_label || "—"}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground text-xs whitespace-nowrap">
+                          {formatDateTimeVN(c.created_at)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+
+              <div className="mt-4 flex items-center justify-between">
+                <p className="text-muted-foreground text-sm">
+                  Tổng {formatInt(total)} liên hệ · Trang {page + 1}/{totalPages}
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    disabled={page === 0 || isFetching}
+                  >
+                    <ChevronLeft className="h-4 w-4" /> Trước
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      setPage((p) => Math.min(totalPages - 1, p + 1))
+                    }
+                    disabled={page >= totalPages - 1 || isFetching}
+                  >
+                    Sau <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <SmsContactFormDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        contact={null}
+      />
+      <SmsContactDetailDialog
+        open={detail != null}
+        onOpenChange={(o) => !o && setDetail(null)}
+        contact={detail}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/sms/admin/contacts/SmsContactsPanel.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsContactsPanel.tsx
@@ -237,7 +237,9 @@ export function SmsContactsPanel() {
       <SmsContactDetailDialog
         open={detail != null}
         onOpenChange={(o) => !o && setDetail(null)}
-        contact={detail}
+        // Ưu tiên bản tươi từ list (cập nhật sau mutation invalidate); fallback
+        // snapshot nếu rớt khỏi trang/bộ lọc hiện tại.
+        contact={items.find((c) => c.id === detail?.id) ?? detail}
       />
     </div>
   )

--- a/frontend/src/components/sms/admin/contacts/SmsGroupContactsDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsGroupContactsDialog.tsx
@@ -45,9 +45,12 @@ export function SmsGroupContactsDialog({ open, onOpenChange, group }: Props) {
   const [importOpen, setImportOpen] = useState(false)
   const search = useDebouncedValue(searchInput.trim())
 
-  // Reset ô tìm khi ĐÓNG (event handler → tránh setState-trong-effect).
+  // Reset khi ĐÓNG (event handler → tránh setState-trong-effect).
   const handleOpenChange = (o: boolean) => {
-    if (!o) setSearchInput("")
+    if (!o) {
+      setSearchInput("")
+      setImportOpen(false)
+    }
     onOpenChange(o)
   }
 

--- a/frontend/src/components/sms/admin/contacts/SmsGroupContactsDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsGroupContactsDialog.tsx
@@ -23,7 +23,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { useGroupContacts } from "@/hooks/useSmsContacts"
+import {
+  useGroupContacts,
+  useSmsContactGroup,
+} from "@/hooks/useSmsContacts"
 import { useDebouncedValue } from "@/lib/hooks/use-debounced-value"
 import type { SmsContactGroup } from "@/lib/zod/sms"
 
@@ -59,17 +62,21 @@ export function SmsGroupContactsDialog({ open, onOpenChange, group }: Props) {
     search: search || undefined,
     limit: 100,
   })
+  // Refetch single group (BE có GET /contact-groups/{id}) → member_count/name
+  // luôn tươi sau import, kể cả khi group rớt khỏi bộ lọc list ngoài.
+  const { data: freshGroup } = useSmsContactGroup(groupId)
+  const g = freshGroup ?? group
 
   return (
     <>
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[640px]">
           <DialogHeader>
-            <DialogTitle>{group?.name ?? "Nhóm"}</DialogTitle>
+            <DialogTitle>{g?.name ?? "Nhóm"}</DialogTitle>
             <DialogDescription>
               Liên hệ trong nhóm{" "}
-              {group?.member_count != null
-                ? `(${formatInt(group.member_count)} thành viên)`
+              {g?.member_count != null
+                ? `(${formatInt(g.member_count)} thành viên)`
                 : ""}
               .
             </DialogDescription>

--- a/frontend/src/components/sms/admin/contacts/SmsGroupContactsDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsGroupContactsDialog.tsx
@@ -1,0 +1,154 @@
+// src/components/sms/admin/contacts/SmsGroupContactsDialog.tsx
+"use client"
+
+import { useState } from "react"
+import { Search, Upload } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useGroupContacts } from "@/hooks/useSmsContacts"
+import { useDebouncedValue } from "@/lib/hooks/use-debounced-value"
+import type { SmsContactGroup } from "@/lib/zod/sms"
+
+import {
+  consentStatusLabel,
+  consentStatusVariant,
+  formatInt,
+} from "../labels"
+import { SmsImportDialog } from "./SmsImportDialog"
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  group: SmsContactGroup | null
+}
+
+export function SmsGroupContactsDialog({ open, onOpenChange, group }: Props) {
+  const [searchInput, setSearchInput] = useState("")
+  const [importOpen, setImportOpen] = useState(false)
+  const search = useDebouncedValue(searchInput.trim())
+
+  // Reset ô tìm khi ĐÓNG (event handler → tránh setState-trong-effect).
+  const handleOpenChange = (o: boolean) => {
+    if (!o) setSearchInput("")
+    onOpenChange(o)
+  }
+
+  const groupId = open && group ? group.id : null
+  const { data, isLoading } = useGroupContacts(groupId, {
+    search: search || undefined,
+    limit: 100,
+  })
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[640px]">
+          <DialogHeader>
+            <DialogTitle>{group?.name ?? "Nhóm"}</DialogTitle>
+            <DialogDescription>
+              Liên hệ trong nhóm{" "}
+              {group?.member_count != null
+                ? `(${formatInt(group.member_count)} thành viên)`
+                : ""}
+              .
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex items-center justify-between gap-3">
+            <div className="relative max-w-xs flex-1">
+              <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+              <Input
+                className="pl-8"
+                placeholder="Tìm tên/số…"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                maxLength={64}
+              />
+            </div>
+            <Button size="sm" onClick={() => setImportOpen(true)}>
+              <Upload className="mr-2 h-4 w-4" /> Import
+            </Button>
+          </div>
+
+          {isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-9 w-full" />
+              ))}
+            </div>
+          ) : !data || data.items.length === 0 ? (
+            <p className="text-muted-foreground py-8 text-center text-sm">
+              {search ? "Không có liên hệ khớp." : "Nhóm chưa có liên hệ nào."}
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Họ tên</TableHead>
+                    <TableHead>Số điện thoại</TableHead>
+                    <TableHead>Consent</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.items.map((c) => (
+                    <TableRow key={c.id}>
+                      <TableCell className="font-medium">
+                        {c.full_name}
+                      </TableCell>
+                      <TableCell className="tabular-nums">
+                        {c.phone_normalized}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={consentStatusVariant(
+                            c.marketing_consent_status,
+                          )}
+                        >
+                          {consentStatusLabel(c.marketing_consent_status)}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {data.total > data.items.length && (
+                <p className="text-muted-foreground mt-2 text-center text-xs">
+                  Hiển thị {formatInt(data.items.length)}/{formatInt(data.total)}{" "}
+                  — lọc thêm bằng ô tìm kiếm.
+                </p>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {group && (
+        <SmsImportDialog
+          open={importOpen}
+          onOpenChange={setImportOpen}
+          groupId={group.id}
+          groupName={group.name}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/sms/admin/contacts/SmsGroupFormDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsGroupFormDialog.tsx
@@ -99,10 +99,12 @@ export function SmsGroupFormDialog({ open, onOpenChange, group }: Props) {
   function onSubmit(values: FormData) {
     const onDone = () => onOpenChange(false)
     if (isEdit && group) {
+      // Update: gửi "" (không phải undefined) để CHO PHÉP xoá mô tả (BE
+      // exclude_unset bỏ qua undefined = không xoá được).
       const data: SmsContactGroupUpdateInput = {
         name: values.name,
         group_type: values.group_type,
-        description: values.description?.trim() || undefined,
+        description: (values.description ?? "").trim(),
         is_active: values.is_active ?? true,
       }
       updateMut.mutate({ id: group.id, data }, { onSuccess: onDone })

--- a/frontend/src/components/sms/admin/contacts/SmsGroupFormDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsGroupFormDialog.tsx
@@ -1,0 +1,263 @@
+// src/components/sms/admin/contacts/SmsGroupFormDialog.tsx
+"use client"
+
+import { useEffect } from "react"
+import { useForm, type Resolver } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Loader2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  useCreateContactGroup,
+  useUpdateContactGroup,
+} from "@/hooks/useSmsContacts"
+import {
+  smsContactGroupCreateSchema,
+  smsContactGroupUpdateSchema,
+  type SmsContactGroup,
+  type SmsContactGroupCreateInput,
+  type SmsContactGroupUpdateInput,
+} from "@/lib/zod/sms"
+
+import { GROUP_TYPE_OPTIONS } from "../labels"
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Có giá trị → chế độ sửa; null → tạo mới. */
+  group?: SmsContactGroup | null
+}
+
+type FormData = SmsContactGroupCreateInput & { is_active?: boolean }
+
+export function SmsGroupFormDialog({ open, onOpenChange, group }: Props) {
+  const isEdit = !!group
+  const createMut = useCreateContactGroup()
+  const updateMut = useUpdateContactGroup()
+  const isPending = createMut.isPending || updateMut.isPending
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(
+      isEdit ? smsContactGroupUpdateSchema : smsContactGroupCreateSchema,
+    ) as Resolver<FormData>,
+    defaultValues: {
+      name: "",
+      code: "",
+      group_type: "custom",
+      description: "",
+      is_active: true,
+    },
+  })
+
+  useEffect(() => {
+    if (!open) return
+    if (group) {
+      form.reset({
+        name: group.name,
+        group_type: group.group_type as FormData["group_type"],
+        description: group.description ?? "",
+        is_active: group.is_active,
+      })
+    } else {
+      form.reset({
+        name: "",
+        code: "",
+        group_type: "custom",
+        description: "",
+        is_active: true,
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, group?.id])
+
+  function onSubmit(values: FormData) {
+    const onDone = () => onOpenChange(false)
+    if (isEdit && group) {
+      const data: SmsContactGroupUpdateInput = {
+        name: values.name,
+        group_type: values.group_type,
+        description: values.description?.trim() || undefined,
+        is_active: values.is_active ?? true,
+      }
+      updateMut.mutate({ id: group.id, data }, { onSuccess: onDone })
+    } else {
+      const data: SmsContactGroupCreateInput = {
+        name: values.name,
+        code: values.code?.trim() || undefined,
+        group_type: values.group_type,
+        description: values.description?.trim() || undefined,
+      }
+      createMut.mutate(data, { onSuccess: onDone })
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit ? "Sửa nhóm liên hệ" : "Tạo nhóm liên hệ"}
+          </DialogTitle>
+          <DialogDescription>
+            Nhóm dùng để gom liên hệ và gắn vào chiến dịch SMS.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Tên nhóm *</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="VD: Phụ huynh khối 10 — 2026"
+                      disabled={isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {!isEdit && (
+              <FormField
+                control={form.control}
+                name="code"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Mã (slug) — tùy chọn</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="bỏ trống để tự sinh từ tên"
+                        disabled={isPending}
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="group_type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Loại nhóm *</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    disabled={isPending}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {GROUP_TYPE_OPTIONS.map((o) => (
+                        <SelectItem key={o.value} value={o.value}>
+                          {o.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Mô tả</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={2}
+                      maxLength={2000}
+                      placeholder="Ghi chú nội bộ (không bắt buộc)."
+                      disabled={isPending}
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {isEdit && (
+              <FormField
+                control={form.control}
+                name="is_active"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center gap-2 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        disabled={isPending}
+                      />
+                    </FormControl>
+                    <FormLabel className="font-normal">
+                      Nhóm đang hoạt động
+                    </FormLabel>
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+              >
+                Hủy
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isEdit ? "Lưu" : "Tạo"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/sms/admin/contacts/SmsGroupsPanel.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsGroupsPanel.tsx
@@ -1,0 +1,298 @@
+// src/components/sms/admin/contacts/SmsGroupsPanel.tsx
+"use client"
+
+import { useState } from "react"
+import {
+  AlertCircle,
+  ChevronLeft,
+  ChevronRight,
+  Pencil,
+  Plus,
+  Search,
+  Users,
+} from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useSmsContactGroups } from "@/hooks/useSmsContacts"
+import { useDebouncedValue } from "@/lib/hooks/use-debounced-value"
+import type { SmsContactGroup } from "@/lib/zod/sms"
+
+import {
+  GROUP_TYPE_OPTIONS,
+  formatDateTimeVN,
+  formatInt,
+  groupTypeLabel,
+} from "../labels"
+import { SmsGroupContactsDialog } from "./SmsGroupContactsDialog"
+import { SmsGroupFormDialog } from "./SmsGroupFormDialog"
+
+const ALL = "all"
+const PAGE_SIZE = 50
+
+export function SmsGroupsPanel() {
+  const [searchInput, setSearchInput] = useState("")
+  const [type, setType] = useState<string>(ALL)
+  const [active, setActive] = useState<string>(ALL)
+  const [page, setPage] = useState(0)
+  const [formOpen, setFormOpen] = useState(false)
+  const [editing, setEditing] = useState<SmsContactGroup | null>(null)
+  const [detailGroup, setDetailGroup] = useState<SmsContactGroup | null>(null)
+
+  const search = useDebouncedValue(searchInput.trim())
+
+  const resetPage = () => setPage(0)
+  const onSearch = (v: string) => {
+    setSearchInput(v)
+    resetPage()
+  }
+  const onType = (v: string) => {
+    setType(v)
+    resetPage()
+  }
+  const onActive = (v: string) => {
+    setActive(v)
+    resetPage()
+  }
+
+  const { data, isLoading, isError, refetch, isFetching } = useSmsContactGroups(
+    {
+      skip: page * PAGE_SIZE,
+      limit: PAGE_SIZE,
+      search: search || undefined,
+      group_type: type === ALL ? undefined : type,
+      is_active: active === ALL ? undefined : active === "active",
+    },
+  )
+
+  const total = data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const items = data?.items ?? []
+
+  const openCreate = () => {
+    setEditing(null)
+    setFormOpen(true)
+  }
+  const openEdit = (g: SmsContactGroup) => {
+    setEditing(g)
+    setFormOpen(true)
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="grid flex-1 grid-cols-1 gap-4 sm:grid-cols-3 lg:max-w-2xl">
+              <div className="space-y-1.5">
+                <Label htmlFor="grp-search">Tìm nhóm</Label>
+                <div className="relative">
+                  <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+                  <Input
+                    id="grp-search"
+                    className="pl-8"
+                    placeholder="Tên / mã nhóm…"
+                    value={searchInput}
+                    onChange={(e) => onSearch(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="grp-type">Loại</Label>
+                <Select value={type} onValueChange={onType}>
+                  <SelectTrigger id="grp-type">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ALL}>Tất cả loại</SelectItem>
+                    {GROUP_TYPE_OPTIONS.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>
+                        {o.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="grp-active">Trạng thái</Label>
+                <Select value={active} onValueChange={onActive}>
+                  <SelectTrigger id="grp-active">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ALL}>Tất cả</SelectItem>
+                    <SelectItem value="active">Đang hoạt động</SelectItem>
+                    <SelectItem value="inactive">Ngừng</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <Button onClick={openCreate}>
+              <Plus className="mr-2 h-4 w-4" /> Tạo nhóm
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6">
+          {isError ? (
+            <div className="flex flex-col items-center gap-3 py-10 text-center">
+              <AlertCircle className="text-destructive h-8 w-8" />
+              <p className="text-muted-foreground text-sm">
+                Không thể tải danh sách nhóm.
+              </p>
+              <Button variant="outline" size="sm" onClick={() => refetch()}>
+                Thử lại
+              </Button>
+            </div>
+          ) : isLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : items.length === 0 ? (
+            <div className="space-y-3 py-10 text-center">
+              <p className="text-muted-foreground text-sm">
+                {page > 0
+                  ? "Trang này không còn dữ liệu."
+                  : search || type !== ALL || active !== ALL
+                    ? "Không có nhóm khớp bộ lọc."
+                    : "Chưa có nhóm liên hệ nào."}
+              </p>
+              {page > 0 && (
+                <Button variant="outline" size="sm" onClick={() => setPage(0)}>
+                  Về trang đầu
+                </Button>
+              )}
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Tên nhóm</TableHead>
+                      <TableHead>Loại</TableHead>
+                      <TableHead className="text-right">Thành viên</TableHead>
+                      <TableHead>Trạng thái</TableHead>
+                      <TableHead>Tạo lúc</TableHead>
+                      <TableHead className="text-right">Thao tác</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {items.map((g) => (
+                      <TableRow key={g.id}>
+                        <TableCell>
+                          <button
+                            type="button"
+                            onClick={() => setDetailGroup(g)}
+                            className="text-left font-medium hover:underline"
+                          >
+                            {g.name}
+                          </button>
+                          <div className="text-muted-foreground text-xs">
+                            {g.code}
+                          </div>
+                        </TableCell>
+                        <TableCell>{groupTypeLabel(g.group_type)}</TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {g.member_count != null
+                            ? formatInt(g.member_count)
+                            : "—"}
+                        </TableCell>
+                        <TableCell>
+                          {g.is_active ? (
+                            <Badge variant="default">Hoạt động</Badge>
+                          ) : (
+                            <Badge variant="secondary">Ngừng</Badge>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground text-xs whitespace-nowrap">
+                          {formatDateTimeVN(g.created_at)}
+                        </TableCell>
+                        <TableCell className="text-right whitespace-nowrap">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setDetailGroup(g)}
+                          >
+                            <Users className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => openEdit(g)}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+
+              <div className="mt-4 flex items-center justify-between">
+                <p className="text-muted-foreground text-sm">
+                  Tổng {formatInt(total)} nhóm · Trang {page + 1}/{totalPages}
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    disabled={page === 0 || isFetching}
+                  >
+                    <ChevronLeft className="h-4 w-4" /> Trước
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      setPage((p) => Math.min(totalPages - 1, p + 1))
+                    }
+                    disabled={page >= totalPages - 1 || isFetching}
+                  >
+                    Sau <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <SmsGroupFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        group={editing}
+      />
+      <SmsGroupContactsDialog
+        open={detailGroup != null}
+        onOpenChange={(o) => !o && setDetailGroup(null)}
+        group={detailGroup}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/sms/admin/contacts/SmsGroupsPanel.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsGroupsPanel.tsx
@@ -291,7 +291,8 @@ export function SmsGroupsPanel() {
       <SmsGroupContactsDialog
         open={detailGroup != null}
         onOpenChange={(o) => !o && setDetailGroup(null)}
-        group={detailGroup}
+        // Bản tươi từ list để member_count cập nhật sau import; fallback snapshot.
+        group={items.find((g) => g.id === detailGroup?.id) ?? detailGroup}
       />
     </div>
   )

--- a/frontend/src/components/sms/admin/contacts/SmsGroupsPanel.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsGroupsPanel.tsx
@@ -291,8 +291,8 @@ export function SmsGroupsPanel() {
       <SmsGroupContactsDialog
         open={detailGroup != null}
         onOpenChange={(o) => !o && setDetailGroup(null)}
-        // Bản tươi từ list để member_count cập nhật sau import; fallback snapshot.
-        group={items.find((g) => g.id === detailGroup?.id) ?? detailGroup}
+        // Dialog tự refetch single group (useSmsContactGroup) → member_count tươi.
+        group={detailGroup}
       />
     </div>
   )

--- a/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
@@ -26,7 +26,11 @@ import {
 import { useUploadContacts } from "@/hooks/useSmsContacts"
 import type { SmsImportResult } from "@/lib/zod/sms"
 
-import { CONSENT_BASIS_OPTIONS, formatInt } from "../labels"
+import {
+  CONSENT_BASIS_OPTIONS,
+  formatInt,
+  nowDatetimeLocal,
+} from "../labels"
 
 const NONE = "none"
 
@@ -197,6 +201,7 @@ export function SmsImportDialog({
                   <Input
                     id="import-obtained"
                     type="datetime-local"
+                    max={nowDatetimeLocal()}
                     value={obtainedAt}
                     disabled={mutation.isPending}
                     onChange={(e) => setObtainedAt(e.target.value)}

--- a/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
@@ -136,7 +136,7 @@ export function SmsImportDialog({
               <Input
                 id="import-file"
                 type="file"
-                accept=".csv,.xlsx,.xls"
+                accept=".csv,.xlsx"
                 disabled={mutation.isPending}
                 onChange={(e) => setFile(e.target.files?.[0] ?? null)}
               />

--- a/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from "react"
 import { AlertTriangle, CheckCircle2, Loader2, Upload } from "lucide-react"
+import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -84,6 +85,15 @@ export function SmsImportDialog({
 
   function onSubmit() {
     if (!file) return
+    let consentObtainedAt: string | undefined
+    if (consentComplete) {
+      const parsed = new Date(obtainedAt)
+      if (Number.isNaN(parsed.getTime())) {
+        toast.error("Thời điểm đồng ý không hợp lệ.")
+        return
+      }
+      consentObtainedAt = parsed.toISOString()
+    }
     mutation.mutate(
       {
         groupId,
@@ -95,9 +105,7 @@ export function SmsImportDialog({
             ? disclosure.trim()
             : undefined,
           consent_proof_ref: consentComplete ? proofRef.trim() : undefined,
-          consent_obtained_at: consentComplete
-            ? new Date(obtainedAt).toISOString()
-            : undefined,
+          consent_obtained_at: consentObtainedAt,
         },
       },
       { onSuccess: (res) => setResult(res) },

--- a/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
@@ -1,0 +1,319 @@
+// src/components/sms/admin/contacts/SmsImportDialog.tsx
+"use client"
+
+import { useState } from "react"
+import { AlertTriangle, CheckCircle2, Loader2, Upload } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useUploadContacts } from "@/hooks/useSmsContacts"
+import type { SmsImportResult } from "@/lib/zod/sms"
+
+import { CONSENT_BASIS_OPTIONS, formatInt } from "../labels"
+
+const NONE = "none"
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  groupId: number
+  groupName: string
+}
+
+/**
+ * Import liên hệ (CSV/XLSX) vào nhóm + (tùy chọn) bằng chứng consent cho cả
+ * lô. Đủ basis + phiên bản công bố + tham chiếu + thời điểm → BE áp granted.
+ */
+export function SmsImportDialog({
+  open,
+  onOpenChange,
+  groupId,
+  groupName,
+}: Props) {
+  const [file, setFile] = useState<File | null>(null)
+  const [sourceLabel, setSourceLabel] = useState("")
+  const [basis, setBasis] = useState<string>(NONE)
+  const [disclosure, setDisclosure] = useState("")
+  const [proofRef, setProofRef] = useState("")
+  const [obtainedAt, setObtainedAt] = useState("")
+  const [result, setResult] = useState<SmsImportResult | null>(null)
+
+  const mutation = useUploadContacts()
+
+  // Reset khi ĐÓNG (event handler, không dùng effect → tránh cascading render).
+  const handleOpenChange = (o: boolean) => {
+    if (!o) {
+      setFile(null)
+      setSourceLabel("")
+      setBasis(NONE)
+      setDisclosure("")
+      setProofRef("")
+      setObtainedAt("")
+      setResult(null)
+    }
+    onOpenChange(o)
+  }
+
+  const consentComplete =
+    basis !== NONE &&
+    disclosure.trim() !== "" &&
+    proofRef.trim() !== "" &&
+    obtainedAt !== ""
+  const consentPartial =
+    (basis !== NONE ||
+      disclosure.trim() !== "" ||
+      proofRef.trim() !== "" ||
+      obtainedAt !== "") &&
+    !consentComplete
+
+  function onSubmit() {
+    if (!file) return
+    mutation.mutate(
+      {
+        groupId,
+        payload: {
+          file,
+          source_label: sourceLabel.trim() || undefined,
+          consent_basis: consentComplete ? basis : undefined,
+          consent_disclosure_version: consentComplete
+            ? disclosure.trim()
+            : undefined,
+          consent_proof_ref: consentComplete ? proofRef.trim() : undefined,
+          consent_obtained_at: consentComplete
+            ? new Date(obtainedAt).toISOString()
+            : undefined,
+        },
+      },
+      { onSuccess: (res) => setResult(res) },
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>Import liên hệ vào «{groupName}»</DialogTitle>
+          <DialogDescription>
+            File .csv hoặc .xlsx (cột số điện thoại + họ tên). Số cố định / không
+            hợp lệ sẽ bị bỏ qua và liệt kê ở kết quả.
+          </DialogDescription>
+        </DialogHeader>
+
+        {result ? (
+          <ImportResultView result={result} />
+        ) : (
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="import-file">Tệp danh sách *</Label>
+              <Input
+                id="import-file"
+                type="file"
+                accept=".csv,.xlsx,.xls"
+                disabled={mutation.isPending}
+                onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="import-source">Nhãn nguồn</Label>
+              <Input
+                id="import-source"
+                placeholder="VD: Hội thảo tuyển sinh 06/2026"
+                maxLength={255}
+                value={sourceLabel}
+                disabled={mutation.isPending}
+                onChange={(e) => setSourceLabel(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-3 rounded border p-3">
+              <p className="text-sm font-medium">
+                Bằng chứng đồng ý (tùy chọn)
+              </p>
+              <p className="text-muted-foreground text-xs">
+                Điền ĐỦ 4 trường để áp trạng thái “đã đồng ý” cho cả lô. Thiếu
+                bất kỳ → import nhưng giữ trạng thái “chưa rõ”.
+              </p>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="import-basis">Căn cứ</Label>
+                <Select
+                  value={basis}
+                  onValueChange={setBasis}
+                  disabled={mutation.isPending}
+                >
+                  <SelectTrigger id="import-basis">
+                    <SelectValue placeholder="— Chọn căn cứ —" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NONE}>— Không khai báo —</SelectItem>
+                    {CONSENT_BASIS_OPTIONS.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>
+                        {o.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="import-disclosure">Phiên bản công bố</Label>
+                  <Input
+                    id="import-disclosure"
+                    maxLength={50}
+                    placeholder="VD: v2026.1"
+                    value={disclosure}
+                    disabled={mutation.isPending}
+                    onChange={(e) => setDisclosure(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="import-obtained">Thời điểm đồng ý</Label>
+                  <Input
+                    id="import-obtained"
+                    type="datetime-local"
+                    value={obtainedAt}
+                    disabled={mutation.isPending}
+                    onChange={(e) => setObtainedAt(e.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="import-proof">Tham chiếu bằng chứng</Label>
+                <Input
+                  id="import-proof"
+                  maxLength={512}
+                  placeholder="VD: link file scan, mã hồ sơ"
+                  value={proofRef}
+                  disabled={mutation.isPending}
+                  onChange={(e) => setProofRef(e.target.value)}
+                />
+              </div>
+
+              {consentPartial && (
+                <p className="flex items-center gap-1.5 text-xs text-amber-600">
+                  <AlertTriangle className="h-3.5 w-3.5" /> Chưa đủ 4 trường —
+                  lô sẽ giữ trạng thái “chưa rõ”.
+                </p>
+              )}
+              {consentComplete && (
+                <p className="flex items-center gap-1.5 text-xs text-green-700">
+                  <CheckCircle2 className="h-3.5 w-3.5" /> Đủ bằng chứng — cả lô
+                  sẽ được đánh dấu “đã đồng ý”.
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          {result ? (
+            <Button onClick={() => handleOpenChange(false)}>Đóng</Button>
+          ) : (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={mutation.isPending}
+              >
+                Hủy
+              </Button>
+              <Button
+                type="button"
+                onClick={onSubmit}
+                disabled={!file || mutation.isPending}
+              >
+                {mutation.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Upload className="mr-2 h-4 w-4" />
+                )}
+                Import
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ResultRow({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="flex items-center justify-between border-b py-1 last:border-0">
+      <span className="text-muted-foreground text-sm">{label}</span>
+      <span className="text-sm font-semibold tabular-nums">
+        {formatInt(value)}
+      </span>
+    </div>
+  )
+}
+
+function ImportResultView({ result }: { result: SmsImportResult }) {
+  return (
+    <div className="space-y-4">
+      <div
+        className={
+          result.consent_applied
+            ? "flex items-center gap-2 rounded border border-green-300 bg-green-50 p-2 text-sm text-green-800"
+            : "flex items-center gap-2 rounded border border-amber-300 bg-amber-50 p-2 text-sm text-amber-800"
+        }
+      >
+        {result.consent_applied ? (
+          <CheckCircle2 className="h-4 w-4 shrink-0" />
+        ) : (
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+        )}
+        {result.consent_applied
+          ? "Đã áp trạng thái “đã đồng ý” cho cả lô."
+          : "Lô giữ trạng thái “chưa rõ” (chưa đủ bằng chứng consent)."}
+      </div>
+
+      <div className="grid grid-cols-1 gap-x-6 sm:grid-cols-2">
+        <ResultRow label="Tổng dòng" value={result.row_count} />
+        <ResultRow label="Hợp lệ" value={result.valid_count} />
+        <ResultRow label="Không hợp lệ" value={result.invalid_count} />
+        <ResultRow label="Liên hệ mới" value={result.inserted_contact_count} />
+        <ResultRow label="Thêm vào nhóm" value={result.added_member_count} />
+        <ResultRow label="Đã có sẵn" value={result.existing_member_count} />
+        <ResultRow label="Trùng" value={result.duplicate_contact_count} />
+        <ResultRow label="Bỏ qua" value={result.skipped_count} />
+      </div>
+
+      {result.errors.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-sm font-medium">
+            Dòng lỗi ({formatInt(result.errors.length)})
+          </p>
+          <div className="max-h-40 space-y-1 overflow-y-auto rounded border p-2 text-xs">
+            {result.errors.map((e, i) => (
+              <div key={i} className="text-muted-foreground">
+                Dòng {e.row_number}
+                {e.phone_raw ? ` (${e.phone_raw})` : ""}: {e.reason}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/sms/admin/labels.ts
+++ b/frontend/src/components/sms/admin/labels.ts
@@ -115,6 +115,18 @@ export function formatDateTimeVN(iso: string | null | undefined): string {
   }
 }
 
+/**
+ * "Bây giờ" ở dạng value của <input type="datetime-local"> (YYYY-MM-DDTHH:mm,
+ * giờ địa phương). Dùng cho `max` để chặn chọn thời điểm consent ở tương lai
+ * (BE `validate_consent_datetime` từ chối tương lai → tránh 422 bất ngờ).
+ */
+export function nowDatetimeLocal(): string {
+  const now = new Date()
+  return new Date(now.getTime() - now.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, 16)
+}
+
 // =====================================================================
 // Contact / Group / Consent (PR-6b)
 // =====================================================================

--- a/frontend/src/components/sms/admin/labels.ts
+++ b/frontend/src/components/sms/admin/labels.ts
@@ -11,10 +11,16 @@ import { vi } from "date-fns/locale"
 
 import {
   SMS_CARRIER_BUCKETS,
+  SMS_CONSENT_BASES,
+  SMS_GROUP_TYPES,
   SMS_MANUAL_OPT_OUT_SOURCES,
+  SMS_REVOKE_SOURCES,
   type SmsCarrierBucket,
+  type SmsConsentBasis,
   type SmsGranularity,
+  type SmsGroupType,
   type SmsManualOptOutSource,
+  type SmsRevokeSource,
 } from "@/lib/zod/sms"
 
 export const CARRIER_LABELS: Record<string, string> = {
@@ -107,4 +113,67 @@ export function formatDateTimeVN(iso: string | null | undefined): string {
   } catch {
     return iso
   }
+}
+
+// =====================================================================
+// Contact / Group / Consent (PR-6b)
+// =====================================================================
+export const GROUP_TYPE_LABELS: Record<string, string> = {
+  parent: "Phụ huynh",
+  student: "Học sinh",
+  teacher: "Giáo viên",
+  lead: "Lead",
+  custom: "Tùy chỉnh",
+}
+export function groupTypeLabel(v: string): string {
+  return GROUP_TYPE_LABELS[v] ?? v
+}
+export const GROUP_TYPE_OPTIONS: { value: SmsGroupType; label: string }[] =
+  SMS_GROUP_TYPES.map((value) => ({ value, label: GROUP_TYPE_LABELS[value] }))
+
+export const CONSENT_STATUS_LABELS: Record<string, string> = {
+  unknown: "Chưa rõ",
+  granted: "Đã đồng ý",
+  revoked: "Đã từ chối",
+}
+export function consentStatusLabel(v: string): string {
+  return CONSENT_STATUS_LABELS[v] ?? v
+}
+/** Badge variant cho trạng thái consent (shadcn Badge). */
+export function consentStatusVariant(
+  v: string,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (v === "granted") return "default"
+  if (v === "revoked") return "destructive"
+  return "secondary"
+}
+
+export const CONSENT_BASIS_LABELS: Record<string, string> = {
+  explicit_form: "Form điền rõ ràng",
+  signed_form: "Phiếu có chữ ký",
+  recorded_call: "Cuộc gọi ghi âm",
+  imported_proof: "Bằng chứng nhập sẵn",
+}
+export function consentBasisLabel(v: string): string {
+  return CONSENT_BASIS_LABELS[v] ?? v
+}
+export const CONSENT_BASIS_OPTIONS: { value: SmsConsentBasis; label: string }[] =
+  SMS_CONSENT_BASES.map((value) => ({
+    value,
+    label: CONSENT_BASIS_LABELS[value],
+  }))
+
+/** Nguồn REVOKE — tái dùng nhãn opt-out source (cùng tập + landing_optout). */
+export const REVOKE_SOURCE_OPTIONS: { value: SmsRevokeSource; label: string }[] =
+  SMS_REVOKE_SOURCES.map((value) => ({
+    value,
+    label: optOutSourceLabel(value),
+  }))
+
+export const CONSENT_EVENT_TYPE_LABELS: Record<string, string> = {
+  granted: "Đồng ý",
+  revoked: "Từ chối",
+}
+export function consentEventTypeLabel(v: string): string {
+  return CONSENT_EVENT_TYPE_LABELS[v] ?? v
 }

--- a/frontend/src/hooks/useSmsContacts.ts
+++ b/frontend/src/hooks/useSmsContacts.ts
@@ -65,10 +65,14 @@ function invalidateContacts(qc: ReturnType<typeof useQueryClient>) {
 // ---------------------------------------------------------------------
 // Queries
 // ---------------------------------------------------------------------
-export function useSmsContactGroups(params: SmsContactGroupListParams = {}) {
+export function useSmsContactGroups(
+  params: SmsContactGroupListParams = {},
+  options: { enabled?: boolean } = {},
+) {
   return useQuery({
     queryKey: smsContactKeys.groups(params),
     queryFn: () => listSmsContactGroups(params),
+    enabled: options.enabled ?? true,
     staleTime: 30 * 1000,
   })
 }

--- a/frontend/src/hooks/useSmsContacts.ts
+++ b/frontend/src/hooks/useSmsContacts.ts
@@ -1,0 +1,239 @@
+// src/hooks/useSmsContacts.ts
+/**
+ * React Query hooks cho SMS Marketing — Contact / Group / Consent (PR-6b).
+ * Tiêu thụ router PR-2 (sms_contacts.py). Tất cả `require_admin` ở BE.
+ */
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+import { AxiosError } from "axios"
+import { toast } from "sonner"
+
+import {
+  addContactToGroup,
+  appendConsentEvent,
+  createSmsContact,
+  createSmsContactGroup,
+  getSmsContactGroup,
+  listConsentEvents,
+  listGroupContacts,
+  listSmsContactGroups,
+  listSmsContacts,
+  removeContactFromGroup,
+  updateSmsContact,
+  updateSmsContactGroup,
+  uploadContactsToGroup,
+  type SmsContactGroupListParams,
+  type SmsContactListParams,
+  type UploadContactsPayload,
+} from "@/lib/api/sms"
+import { parseApiError } from "@/lib/utils/api-errors"
+import type {
+  SmsConsentEventCreateInput,
+  SmsContactCreateInput,
+  SmsContactGroupCreateInput,
+  SmsContactGroupUpdateInput,
+  SmsContactUpdateInput,
+} from "@/lib/zod/sms"
+import type { ApiErrorResponse } from "@/types/api.types"
+
+type ApiError = AxiosError<ApiErrorResponse>
+
+// ---------------------------------------------------------------------
+// Query keys
+// ---------------------------------------------------------------------
+export const smsContactKeys = {
+  all: ["sms-contacts"] as const,
+  groups: (p: SmsContactGroupListParams) =>
+    [...smsContactKeys.all, "groups", p] as const,
+  group: (id: number) => [...smsContactKeys.all, "group", id] as const,
+  groupContacts: (id: number, p: SmsContactListParams) =>
+    [...smsContactKeys.all, "group-contacts", id, p] as const,
+  contacts: (p: SmsContactListParams) =>
+    [...smsContactKeys.all, "contacts", p] as const,
+  consentEvents: (contactId: number) =>
+    [...smsContactKeys.all, "consent-events", contactId] as const,
+}
+
+function invalidateContacts(qc: ReturnType<typeof useQueryClient>) {
+  // Mọi danh sách contact + group (member_count, consent) có thể đổi.
+  qc.invalidateQueries({ queryKey: smsContactKeys.all })
+}
+
+// ---------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------
+export function useSmsContactGroups(params: SmsContactGroupListParams = {}) {
+  return useQuery({
+    queryKey: smsContactKeys.groups(params),
+    queryFn: () => listSmsContactGroups(params),
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useSmsContactGroup(groupId: number | null) {
+  return useQuery({
+    queryKey: smsContactKeys.group(groupId ?? 0),
+    queryFn: () => getSmsContactGroup(groupId as number),
+    enabled: groupId != null,
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useGroupContacts(
+  groupId: number | null,
+  params: SmsContactListParams = {},
+) {
+  return useQuery({
+    queryKey: smsContactKeys.groupContacts(groupId ?? 0, params),
+    queryFn: () => listGroupContacts(groupId as number, params),
+    enabled: groupId != null,
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useSmsContacts(params: SmsContactListParams = {}) {
+  return useQuery({
+    queryKey: smsContactKeys.contacts(params),
+    queryFn: () => listSmsContacts(params),
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useConsentEvents(contactId: number | null) {
+  return useQuery({
+    queryKey: smsContactKeys.consentEvents(contactId ?? 0),
+    queryFn: () => listConsentEvents(contactId as number, { limit: 100 }),
+    enabled: contactId != null,
+    staleTime: 30 * 1000,
+  })
+}
+
+// ---------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------
+export function useCreateContactGroup() {
+  const qc = useQueryClient()
+  return useMutation<unknown, ApiError, SmsContactGroupCreateInput>({
+    mutationFn: createSmsContactGroup,
+    onSuccess: () => {
+      toast.success("Đã tạo nhóm liên hệ.")
+      invalidateContacts(qc)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Không thể tạo nhóm.")),
+  })
+}
+
+export function useUpdateContactGroup() {
+  const qc = useQueryClient()
+  return useMutation<
+    unknown,
+    ApiError,
+    { id: number; data: SmsContactGroupUpdateInput }
+  >({
+    mutationFn: ({ id, data }) => updateSmsContactGroup(id, data),
+    onSuccess: () => {
+      toast.success("Đã cập nhật nhóm.")
+      invalidateContacts(qc)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Không thể cập nhật nhóm.")),
+  })
+}
+
+export function useUploadContacts() {
+  const qc = useQueryClient()
+  return useMutation<
+    Awaited<ReturnType<typeof uploadContactsToGroup>>,
+    ApiError,
+    { groupId: number; payload: UploadContactsPayload }
+  >({
+    mutationFn: ({ groupId, payload }) =>
+      uploadContactsToGroup(groupId, payload),
+    onSuccess: () => {
+      // Toast chi tiết do component hiển thị (counts); chỉ invalidate ở đây.
+      invalidateContacts(qc)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Import thất bại.")),
+  })
+}
+
+export function useCreateContact() {
+  const qc = useQueryClient()
+  return useMutation<unknown, ApiError, SmsContactCreateInput>({
+    mutationFn: createSmsContact,
+    onSuccess: () => {
+      toast.success("Đã tạo liên hệ.")
+      invalidateContacts(qc)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Không thể tạo liên hệ.")),
+  })
+}
+
+export function useUpdateContact() {
+  const qc = useQueryClient()
+  return useMutation<
+    unknown,
+    ApiError,
+    { id: number; data: SmsContactUpdateInput }
+  >({
+    mutationFn: ({ id, data }) => updateSmsContact(id, data),
+    onSuccess: () => {
+      toast.success("Đã cập nhật liên hệ.")
+      invalidateContacts(qc)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Không thể cập nhật liên hệ.")),
+  })
+}
+
+export function useAppendConsentEvent() {
+  const qc = useQueryClient()
+  return useMutation<
+    unknown,
+    ApiError,
+    { contactId: number; data: SmsConsentEventCreateInput }
+  >({
+    mutationFn: ({ contactId, data }) => appendConsentEvent(contactId, data),
+    onSuccess: () => {
+      toast.success("Đã ghi sự kiện consent.")
+      invalidateContacts(qc)
+    },
+    onError: (e) =>
+      toast.error(parseApiError(e, "Không thể ghi sự kiện consent.")),
+  })
+}
+
+export function useAddContactToGroup() {
+  const qc = useQueryClient()
+  return useMutation<
+    unknown,
+    ApiError,
+    { contactId: number; group_id: number; note?: string }
+  >({
+    mutationFn: ({ contactId, group_id, note }) =>
+      addContactToGroup(contactId, { group_id, note }),
+    onSuccess: () => {
+      toast.success("Đã thêm vào nhóm.")
+      invalidateContacts(qc)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Không thể thêm vào nhóm.")),
+  })
+}
+
+export function useRemoveContactFromGroup() {
+  const qc = useQueryClient()
+  return useMutation<
+    unknown,
+    ApiError,
+    { contactId: number; groupId: number }
+  >({
+    mutationFn: ({ contactId, groupId }) =>
+      removeContactFromGroup(contactId, groupId),
+    onSuccess: () => {
+      toast.success("Đã gỡ khỏi nhóm.")
+      invalidateContacts(qc)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Không thể gỡ khỏi nhóm.")),
+  })
+}

--- a/frontend/src/hooks/useSmsContacts.ts
+++ b/frontend/src/hooks/useSmsContacts.ts
@@ -4,6 +4,7 @@
  * Tiêu thụ router PR-2 (sms_contacts.py). Tất cả `require_admin` ở BE.
  */
 import {
+  keepPreviousData,
   useMutation,
   useQuery,
   useQueryClient,
@@ -73,6 +74,7 @@ export function useSmsContactGroups(
     queryKey: smsContactKeys.groups(params),
     queryFn: () => listSmsContactGroups(params),
     enabled: options.enabled ?? true,
+    placeholderData: keepPreviousData,
     staleTime: 30 * 1000,
   })
 }
@@ -94,6 +96,7 @@ export function useGroupContacts(
     queryKey: smsContactKeys.groupContacts(groupId ?? 0, params),
     queryFn: () => listGroupContacts(groupId as number, params),
     enabled: groupId != null,
+    placeholderData: keepPreviousData,
     staleTime: 30 * 1000,
   })
 }
@@ -102,6 +105,7 @@ export function useSmsContacts(params: SmsContactListParams = {}) {
   return useQuery({
     queryKey: smsContactKeys.contacts(params),
     queryFn: () => listSmsContacts(params),
+    placeholderData: keepPreviousData,
     staleTime: 30 * 1000,
   })
 }

--- a/frontend/src/lib/api/sms.ts
+++ b/frontend/src/lib/api/sms.ts
@@ -13,6 +13,13 @@ import {
   smsCampaignDashboardSchema,
   smsCampaignListSchema,
   smsClickReportSchema,
+  smsConsentEventListSchema,
+  smsConsentEventSchema,
+  smsContactGroupListSchema,
+  smsContactGroupSchema,
+  smsContactListSchema,
+  smsContactSchema,
+  smsImportResultSchema,
   smsLandingResponseSchema,
   smsOptOutListSchema,
   smsOptOutSchema,
@@ -20,7 +27,19 @@ import {
   type SmsCampaignDashboard,
   type SmsCampaignList,
   type SmsClickReport,
+  type SmsConsentEvent,
+  type SmsConsentEventCreateInput,
+  type SmsConsentEventList,
+  type SmsContact,
+  type SmsContactCreateInput,
+  type SmsContactGroup,
+  type SmsContactGroupCreateInput,
+  type SmsContactGroupList,
+  type SmsContactGroupUpdateInput,
+  type SmsContactList,
+  type SmsContactUpdateInput,
   type SmsGranularity,
+  type SmsImportResult,
   type SmsLandingResponse,
   type SmsManualOptOutSource,
   type SmsOptOut,
@@ -131,4 +150,171 @@ export async function createManualOptOut(
 ): Promise<SmsOptOut> {
   const res = await api.post<SmsOptOut>(`/api/sms/opt-out/manual`, payload)
   return smsOptOutSchema.parse(res.data)
+}
+
+// =====================================================================
+// Admin — Contact groups / Contacts / Consent (PR-6b, require_admin)
+// =====================================================================
+
+export interface SmsContactGroupListParams {
+  skip?: number
+  limit?: number
+  group_type?: string
+  is_active?: boolean
+  search?: string
+}
+
+export async function listSmsContactGroups(
+  params: SmsContactGroupListParams = {},
+): Promise<SmsContactGroupList> {
+  const res = await api.get<SmsContactGroupList>(`/api/sms/contact-groups`, {
+    params,
+  })
+  return smsContactGroupListSchema.parse(res.data)
+}
+
+export async function getSmsContactGroup(
+  groupId: number,
+): Promise<SmsContactGroup> {
+  const res = await api.get<SmsContactGroup>(
+    `/api/sms/contact-groups/${groupId}`,
+  )
+  return smsContactGroupSchema.parse(res.data)
+}
+
+export async function createSmsContactGroup(
+  payload: SmsContactGroupCreateInput,
+): Promise<SmsContactGroup> {
+  const res = await api.post<SmsContactGroup>(
+    `/api/sms/contact-groups`,
+    payload,
+  )
+  return smsContactGroupSchema.parse(res.data)
+}
+
+export async function updateSmsContactGroup(
+  groupId: number,
+  payload: SmsContactGroupUpdateInput,
+): Promise<SmsContactGroup> {
+  const res = await api.patch<SmsContactGroup>(
+    `/api/sms/contact-groups/${groupId}`,
+    payload,
+  )
+  return smsContactGroupSchema.parse(res.data)
+}
+
+export interface UploadContactsPayload {
+  file: File
+  source_label?: string
+  consent_basis?: string
+  consent_disclosure_version?: string
+  consent_proof_ref?: string
+  /** ISO tz-aware datetime; thời điểm đồng ý cho cả lô. */
+  consent_obtained_at?: string
+}
+
+/** Import CSV/XLSX vào nhóm (multipart). `api` tự set header multipart. */
+export async function uploadContactsToGroup(
+  groupId: number,
+  payload: UploadContactsPayload,
+): Promise<SmsImportResult> {
+  const form = new FormData()
+  form.append("file", payload.file)
+  if (payload.source_label) form.append("source_label", payload.source_label)
+  if (payload.consent_basis) form.append("consent_basis", payload.consent_basis)
+  if (payload.consent_disclosure_version)
+    form.append("consent_disclosure_version", payload.consent_disclosure_version)
+  if (payload.consent_proof_ref)
+    form.append("consent_proof_ref", payload.consent_proof_ref)
+  if (payload.consent_obtained_at)
+    form.append("consent_obtained_at", payload.consent_obtained_at)
+  const res = await api.post<SmsImportResult>(
+    `/api/sms/contact-groups/${groupId}/contacts/upload`,
+    form,
+  )
+  return smsImportResultSchema.parse(res.data)
+}
+
+export interface SmsContactListParams {
+  skip?: number
+  limit?: number
+  search?: string
+  consent_status?: string
+}
+
+export async function listGroupContacts(
+  groupId: number,
+  params: SmsContactListParams = {},
+): Promise<SmsContactList> {
+  const res = await api.get<SmsContactList>(
+    `/api/sms/contact-groups/${groupId}/contacts`,
+    { params },
+  )
+  return smsContactListSchema.parse(res.data)
+}
+
+export async function listSmsContacts(
+  params: SmsContactListParams = {},
+): Promise<SmsContactList> {
+  const res = await api.get<SmsContactList>(`/api/sms/contacts`, { params })
+  return smsContactListSchema.parse(res.data)
+}
+
+export async function createSmsContact(
+  payload: SmsContactCreateInput,
+): Promise<SmsContact> {
+  const res = await api.post<SmsContact>(`/api/sms/contacts`, payload)
+  return smsContactSchema.parse(res.data)
+}
+
+export async function updateSmsContact(
+  contactId: number,
+  payload: SmsContactUpdateInput,
+): Promise<SmsContact> {
+  const res = await api.patch<SmsContact>(
+    `/api/sms/contacts/${contactId}`,
+    payload,
+  )
+  return smsContactSchema.parse(res.data)
+}
+
+export async function appendConsentEvent(
+  contactId: number,
+  payload: SmsConsentEventCreateInput,
+): Promise<SmsConsentEvent> {
+  const res = await api.post<SmsConsentEvent>(
+    `/api/sms/contacts/${contactId}/consent-events`,
+    payload,
+  )
+  return smsConsentEventSchema.parse(res.data)
+}
+
+export async function listConsentEvents(
+  contactId: number,
+  params: { skip?: number; limit?: number } = {},
+): Promise<SmsConsentEventList> {
+  const res = await api.get<SmsConsentEventList>(
+    `/api/sms/contacts/${contactId}/consent-events`,
+    { params },
+  )
+  return smsConsentEventListSchema.parse(res.data)
+}
+
+/** Thêm contact vào nhóm; BE trả contact (trạng thái mới). */
+export async function addContactToGroup(
+  contactId: number,
+  payload: { group_id: number; note?: string },
+): Promise<SmsContact> {
+  const res = await api.post<SmsContact>(
+    `/api/sms/contacts/${contactId}/groups`,
+    payload,
+  )
+  return smsContactSchema.parse(res.data)
+}
+
+export async function removeContactFromGroup(
+  contactId: number,
+  groupId: number,
+): Promise<void> {
+  await api.delete(`/api/sms/contacts/${contactId}/groups/${groupId}`)
 }

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -261,6 +261,12 @@ export const navigationConfig: NavigationConfig = {
       title: "SMS Marketing",
       items: [
         {
+          label: "Liên hệ SMS",
+          href: "/admin/sms/contacts",
+          icon: Users,
+          roles: ["admin"], // BE require_admin trên contact/group/consent
+        },
+        {
           label: "Báo cáo SMS",
           href: "/admin/sms/reports",
           icon: MessageSquareText,

--- a/frontend/src/lib/hooks/use-debounced-value.ts
+++ b/frontend/src/lib/hooks/use-debounced-value.ts
@@ -1,0 +1,15 @@
+// src/lib/hooks/use-debounced-value.ts
+import { useEffect, useState } from "react"
+
+/**
+ * Trả về giá trị trễ `delay` ms sau lần đổi cuối — dùng cho ô tìm kiếm để
+ * không gọi API mỗi lần gõ. Timeout được dọn khi value/delay đổi.
+ */
+export function useDebouncedValue<T>(value: T, delay = 400): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(t)
+  }, [value, delay])
+  return debounced
+}

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -188,7 +188,6 @@ export type SmsGroupType = (typeof SMS_GROUP_TYPES)[number]
 
 /** Trạng thái consent marketing (CHECK chk_sms_contact_consent_status). */
 export const SMS_CONSENT_STATUSES = ["unknown", "granted", "revoked"] as const
-export type SmsConsentStatus = (typeof SMS_CONSENT_STATUSES)[number]
 
 /** Căn cứ consent GRANT (mirror ConsentBasis). */
 export const SMS_CONSENT_BASES = [
@@ -210,7 +209,6 @@ export const SMS_REVOKE_SOURCES = [
 export type SmsRevokeSource = (typeof SMS_REVOKE_SOURCES)[number]
 
 export const SMS_CONSENT_EVENT_TYPES = ["granted", "revoked"] as const
-export type SmsConsentEventType = (typeof SMS_CONSENT_EVENT_TYPES)[number]
 
 // --- Contact group ---
 export const smsContactGroupSchema = z.object({

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -170,3 +170,245 @@ export const smsManualOptOutSchema = z.object({
     .optional(),
 })
 export type SmsManualOptOutInput = z.infer<typeof smsManualOptOutSchema>
+
+// =====================================================================
+// Admin — Contact / Group / Consent (PR-6b; mirror app/schemas/sms.py
+// SmsContactGroup*, SmsContact*, SmsConsentEvent*, SmsImportResult).
+// =====================================================================
+
+/** Loại nhóm liên hệ (mirror GroupType). */
+export const SMS_GROUP_TYPES = [
+  "parent",
+  "student",
+  "teacher",
+  "lead",
+  "custom",
+] as const
+export type SmsGroupType = (typeof SMS_GROUP_TYPES)[number]
+
+/** Trạng thái consent marketing (CHECK chk_sms_contact_consent_status). */
+export const SMS_CONSENT_STATUSES = ["unknown", "granted", "revoked"] as const
+export type SmsConsentStatus = (typeof SMS_CONSENT_STATUSES)[number]
+
+/** Căn cứ consent GRANT (mirror ConsentBasis). */
+export const SMS_CONSENT_BASES = [
+  "explicit_form",
+  "signed_form",
+  "recorded_call",
+  "imported_proof",
+] as const
+export type SmsConsentBasis = (typeof SMS_CONSENT_BASES)[number]
+
+/** Nguồn REVOKE (mirror RevokeSource). */
+export const SMS_REVOKE_SOURCES = [
+  "sms_reply",
+  "landing_optout",
+  "manual",
+  "phone_call",
+  "external_suppression",
+] as const
+export type SmsRevokeSource = (typeof SMS_REVOKE_SOURCES)[number]
+
+export const SMS_CONSENT_EVENT_TYPES = ["granted", "revoked"] as const
+export type SmsConsentEventType = (typeof SMS_CONSENT_EVENT_TYPES)[number]
+
+// --- Contact group ---
+export const smsContactGroupSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  code: z.string(),
+  group_type: z.string(),
+  description: z.string().nullable().optional(),
+  is_active: z.boolean(),
+  created_by_id: z.number().nullable().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  member_count: z.number().nullable().optional(),
+})
+export type SmsContactGroup = z.infer<typeof smsContactGroupSchema>
+
+export const smsContactGroupListSchema = z.object({
+  total: z.number(),
+  items: z.array(smsContactGroupSchema),
+})
+export type SmsContactGroupList = z.infer<typeof smsContactGroupListSchema>
+
+/** Form tạo nhóm. `code` để trống → BE tự slugify từ name. */
+export const smsContactGroupCreateSchema = z.object({
+  name: z.string().trim().min(1, "Bắt buộc nhập tên").max(200),
+  code: z
+    .string()
+    .trim()
+    .max(50)
+    .regex(/^[a-z0-9][a-z0-9-]*$/, "Chỉ a-z, 0-9, dấu gạch; bắt đầu bằng chữ/số")
+    .optional()
+    .or(z.literal("")),
+  group_type: z.enum(SMS_GROUP_TYPES),
+  description: z.string().trim().max(2000).optional().or(z.literal("")),
+})
+export type SmsContactGroupCreateInput = z.infer<
+  typeof smsContactGroupCreateSchema
+>
+
+/** Form sửa nhóm — không đổi `code`. */
+export const smsContactGroupUpdateSchema = z.object({
+  name: z.string().trim().min(1, "Bắt buộc nhập tên").max(200),
+  group_type: z.enum(SMS_GROUP_TYPES),
+  description: z.string().trim().max(2000).optional().or(z.literal("")),
+  is_active: z.boolean(),
+})
+export type SmsContactGroupUpdateInput = z.infer<
+  typeof smsContactGroupUpdateSchema
+>
+
+// --- Contact ---
+export const smsContactSchema = z.object({
+  id: z.number(),
+  full_name: z.string(),
+  phone_raw: z.string().nullable().optional(),
+  phone_normalized: z.string(),
+  phone_international: z.string(),
+  note: z.string().nullable().optional(),
+  source_label: z.string().nullable().optional(),
+  marketing_consent_status: z.string(),
+  marketing_consented_at: z.string().nullable().optional(),
+  marketing_consent_basis: z.string().nullable().optional(),
+  marketing_consent_proof_ref: z.string().nullable().optional(),
+  consent_disclosure_version: z.string().nullable().optional(),
+  last_handed_off_at: z.string().nullable().optional(),
+  created_by_id: z.number().nullable().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+export type SmsContact = z.infer<typeof smsContactSchema>
+
+export const smsContactListSchema = z.object({
+  total: z.number(),
+  items: z.array(smsContactSchema),
+})
+export type SmsContactList = z.infer<typeof smsContactListSchema>
+
+export const smsContactCreateSchema = z.object({
+  full_name: z.string().trim().min(1, "Bắt buộc nhập họ tên").max(255),
+  phone: z
+    .string()
+    .trim()
+    .min(1, "Bắt buộc nhập số điện thoại")
+    .max(32),
+  note: z.string().trim().max(2000).optional().or(z.literal("")),
+  source_label: z.string().trim().max(255).optional().or(z.literal("")),
+})
+export type SmsContactCreateInput = z.infer<typeof smsContactCreateSchema>
+
+/** Sửa identity/note — KHÔNG đổi phone (identity), KHÔNG đụng consent. */
+export const smsContactUpdateSchema = z.object({
+  full_name: z.string().trim().min(1, "Bắt buộc nhập họ tên").max(255),
+  note: z.string().trim().max(2000).optional().or(z.literal("")),
+  source_label: z.string().trim().max(255).optional().or(z.literal("")),
+})
+export type SmsContactUpdateInput = z.infer<typeof smsContactUpdateSchema>
+
+export const smsGroupMembershipAddSchema = z.object({
+  group_id: z.number().int().min(1),
+  note: z.string().trim().max(2000).optional().or(z.literal("")),
+})
+export type SmsGroupMembershipAddInput = z.infer<
+  typeof smsGroupMembershipAddSchema
+>
+
+// --- Consent event (append-only ledger) ---
+export const smsConsentEventSchema = z.object({
+  id: z.number(),
+  contact_id: z.number().nullable().optional(),
+  phone_normalized_snapshot: z.string(),
+  event_type: z.string(),
+  basis: z.string().nullable().optional(),
+  revoke_source: z.string().nullable().optional(),
+  disclosure_version: z.string().nullable().optional(),
+  proof_reference: z.string().nullable().optional(),
+  occurred_at: z.string(),
+  recorded_by_id: z.number().nullable().optional(),
+  import_batch_id: z.number().nullable().optional(),
+  metadata_json: z.record(z.string(), z.unknown()).nullable().optional(),
+  created_at: z.string(),
+})
+export type SmsConsentEvent = z.infer<typeof smsConsentEventSchema>
+
+export const smsConsentEventListSchema = z.object({
+  total: z.number(),
+  items: z.array(smsConsentEventSchema),
+})
+export type SmsConsentEventList = z.infer<typeof smsConsentEventListSchema>
+
+/**
+ * Form ghi consent. Mirror cross-field của BE model_validator:
+ * GRANT → cần basis + disclosure_version + proof_reference (không rỗng), cấm
+ * revoke_source. REVOKE → cần revoke_source, cấm grant-data.
+ * `occurred_at` = ISO tz-aware (form gửi datetime-local + offset).
+ */
+export const smsConsentEventCreateSchema = z
+  .object({
+    event_type: z.enum(SMS_CONSENT_EVENT_TYPES),
+    occurred_at: z.string().min(1, "Bắt buộc chọn thời điểm"),
+    basis: z.enum(SMS_CONSENT_BASES).optional(),
+    disclosure_version: z.string().trim().max(50).optional().or(z.literal("")),
+    proof_reference: z.string().trim().max(512).optional().or(z.literal("")),
+    revoke_source: z.enum(SMS_REVOKE_SOURCES).optional(),
+  })
+  .superRefine((v, ctx) => {
+    if (v.event_type === "granted") {
+      if (!v.basis)
+        ctx.addIssue({
+          code: "custom",
+          path: ["basis"],
+          message: "GRANT cần căn cứ consent",
+        })
+      if (!v.disclosure_version?.trim())
+        ctx.addIssue({
+          code: "custom",
+          path: ["disclosure_version"],
+          message: "GRANT cần phiên bản công bố",
+        })
+      if (!v.proof_reference?.trim())
+        ctx.addIssue({
+          code: "custom",
+          path: ["proof_reference"],
+          message: "GRANT cần tham chiếu bằng chứng",
+        })
+    } else {
+      if (!v.revoke_source)
+        ctx.addIssue({
+          code: "custom",
+          path: ["revoke_source"],
+          message: "REVOKE cần nguồn từ chối",
+        })
+    }
+  })
+export type SmsConsentEventCreateInput = z.infer<
+  typeof smsConsentEventCreateSchema
+>
+
+// --- Import result (upload contacts vào nhóm) ---
+export const smsImportRowErrorSchema = z.object({
+  row_number: z.number(),
+  phone_raw: z.string().nullable().optional(),
+  reason: z.string(),
+})
+export type SmsImportRowError = z.infer<typeof smsImportRowErrorSchema>
+
+export const smsImportResultSchema = z.object({
+  batch_id: z.number(),
+  group_id: z.number().nullable().optional(),
+  file_name: z.string().nullable().optional(),
+  row_count: z.number(),
+  valid_count: z.number(),
+  invalid_count: z.number(),
+  duplicate_contact_count: z.number(),
+  existing_member_count: z.number(),
+  inserted_contact_count: z.number(),
+  added_member_count: z.number(),
+  skipped_count: z.number(),
+  consent_applied: z.boolean(),
+  errors: z.array(smsImportRowErrorSchema),
+})
+export type SmsImportResult = z.infer<typeof smsImportResultSchema>

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -308,14 +308,6 @@ export const smsContactUpdateSchema = z.object({
 })
 export type SmsContactUpdateInput = z.infer<typeof smsContactUpdateSchema>
 
-export const smsGroupMembershipAddSchema = z.object({
-  group_id: z.number().int().min(1),
-  note: z.string().trim().max(2000).optional().or(z.literal("")),
-})
-export type SmsGroupMembershipAddInput = z.infer<
-  typeof smsGroupMembershipAddSchema
->
-
 // --- Consent event (append-only ledger) ---
 export const smsConsentEventSchema = z.object({
   id: z.number(),


### PR DESCRIPTION
## Mục tiêu
FE vận hành Contact/Nhóm/Consent — tiêu thụ router PR-2 (`sms_contacts.py`):
contact-groups CRUD + upload, contacts CRUD, consent-events ledger, membership.
Nền để (PR sau) dựng campaign builder.

## Thay đổi (trang `/admin/sms/contacts`, 2 tab)
- **Nhóm**: list (search/loại/trạng thái) + tạo/sửa + chi tiết (liên hệ trong
  nhóm) + **import CSV/XLSX kèm bằng chứng consent** (đủ 4 trường → BE áp granted
  cả lô; hiển thị counts + dòng lỗi).
- **Liên hệ**: list toàn cục (search + lọc consent) + tạo/sửa (không đổi phone) +
  chi tiết (badge + **ledger consent** + ghi granted/revoked field-điều-kiện +
  gán nhóm).
- Zod mirror + API client + hooks (`useSmsContacts`); nav "Liên hệ SMS" admin-only;
  tách hook chung `use-debounced-value`.
- Thin-client: mirror Zod (cross-field consent superRefine khớp BE), fallback đủ
  enum, reset dialog qua onOpenChange (không setState-trong-effect).

## Kiểm thử
- **fe-check**: type-check ✅ · lint **0 error** ✅ · test **1752** ✅ · build ✅
- **/code-review max ×2**: 0 bug contract/convention; vá bug thật (Sửa không xoá
  được field → gửi `""`) + stale-snapshot + keepPreviousData + max-datetime +
  gỡ `.xls`/dead-code.
- **Chrome-smoke**: tạo nhóm (auto-slug) + liên hệ + **consent GRANT → badge/ledger
  cập nhật** PASS; fix Sửa-xoá-field verify BE-level (`""` xoá được, unset giữ).

Không migration/Casbin (FE thuần). Phụ thuộc PR-2..5 (đã trên main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)