### PR TITLE
feat(admissions): Admission List v2 — cột Học phí HK1 + filter điều phối

### DIFF
--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -14,6 +14,7 @@ Benefits:
 
 import logging
 from datetime import date, datetime
+from decimal import Decimal
 from typing import List, Optional, Tuple
 import unicodedata
 
@@ -85,6 +86,102 @@ def _choices_eager_load_options() -> tuple:
             AdmissionProfileChoice.scores
         ).selectinload(ProfileChoiceScore.subject),
     )
+
+
+# =============================================================================
+# Học phí HK1 aggregate (Admission List v2)
+# =============================================================================
+# Dùng chung cho: cột tiền "Đã đóng / Còn lại" + filter "Quá hạn" + sort "Còn lại".
+# HK1-predicate mirror ``fee_calculation_service.is_hk1_settled_fee``:
+#   tuition + semester_no == 1 + status != cancelled.
+# Correlate tới AdmissionProfile (outer) để chạy như scalar subquery / EXISTS
+# trong query list — KHÔNG N+1 (aggregate, không phải relationship eager-load).
+def _hk1_fee_predicate():
+    """Correlated predicate: fee HK1 của AdmissionProfile (outer)."""
+    from app.models.finance import Fee, FeeStatusEnum
+    return and_(
+        Fee.admission_profile_id == models.AdmissionProfile.id,
+        Fee.fee_type == "tuition",
+        Fee.semester_no == 1,
+        Fee.status != FeeStatusEnum.cancelled,
+    )
+
+
+def _hk1_paid_subquery():
+    """Σ paid_amount fee HK1. coalesce→0 BẮT BUỘC (chưa có HK1 → SUM NULL)."""
+    from app.models.finance import Fee
+    return (
+        select(func.coalesce(func.sum(Fee.paid_amount), 0))
+        .where(_hk1_fee_predicate())
+        .correlate(models.AdmissionProfile)
+        .scalar_subquery()
+    )
+
+
+def _hk1_remaining_subquery():
+    """Σ (final − paid − waived) fee HK1. coalesce→0 (cùng lý do)."""
+    from app.models.finance import Fee
+    return (
+        select(
+            func.coalesce(
+                func.sum(Fee.final_amount - Fee.paid_amount - Fee.waived_amount), 0
+            )
+        )
+        .where(_hk1_fee_predicate())
+        .correlate(models.AdmissionProfile)
+        .scalar_subquery()
+    )
+
+
+def _hk1_final_subquery():
+    """Σ final_amount fee HK1. coalesce→0. Dùng để phân biệt 'có fee HK1' (final>0,
+    kể cả miễn 100%) với 'chưa có HK1' (final=0) trong _hk1_status."""
+    from app.models.finance import Fee
+    return (
+        select(func.coalesce(func.sum(Fee.final_amount), 0))
+        .where(_hk1_fee_predicate())
+        .correlate(models.AdmissionProfile)
+        .scalar_subquery()
+    )
+
+
+def _hk1_overdue_exists(today: date):
+    """EXISTS hóa đơn HK1 quá hạn — mirror ``routers/invoices._invoice_is_overdue``
+    (status IN OVERDUE_DERIVED_STATUSES AND due_date < today)."""
+    from app.models.finance import Fee, Invoice, OVERDUE_DERIVED_STATUSES
+    return (
+        select(Invoice.id)
+        .join(Fee, Invoice.fee_id == Fee.id)
+        .where(
+            _hk1_fee_predicate(),
+            Invoice.status.in_(OVERDUE_DERIVED_STATUSES),
+            Invoice.due_date < today,
+        )
+        .correlate(models.AdmissionProfile)
+        .exists()
+    )
+
+
+def _hk1_status(paid, remaining, overdue, final) -> str:
+    """(paid, remaining, overdue, final) → trạng thái hiển thị. BE emit, FE chỉ map
+    màu (thin-client). Normalize None→0 phòng hồ sơ chưa có HK1 (tránh None>0 → 500).
+
+    ``final`` = Σ final_amount HK1: phân biệt 'có fee HK1' (final>0, KỂ CẢ miễn
+    100% với paid=0/remaining=0) khỏi 'chưa có HK1' (final=0 → "none"). Nếu chỉ
+    xét paid/remaining thì fee miễn-toàn-phần (paid=0, remaining=0) bị gán nhầm
+    "none" thay vì đã tất toán."""
+    paid = paid or Decimal("0")
+    remaining = remaining or Decimal("0")
+    final = final or Decimal("0")
+    if final <= 0:
+        return "none"            # chưa có fee HK1 (hoặc chỉ có fee đã hủy)
+    if overdue:
+        return "overdue"
+    if remaining <= 0:
+        return "paid"            # tất toán: đóng đủ HOẶC miễn 100%
+    if paid > 0:
+        return "partial"
+    return "unpaid"              # remaining > 0, chưa đóng đồng nào
 
 
 class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
@@ -219,6 +316,11 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         date_to: Optional[datetime] = None,
         sort_by: str = "created_at",
         order: str = "desc",
+        assigned_officer_ids: Optional[List[int]] = None,
+        assigned_reviewer_ids: Optional[List[int]] = None,
+        unassigned: bool = False,
+        today: Optional[date] = None,
+        with_hk1: bool = False,
         **filters
     ) -> Tuple[List[models.AdmissionProfile], int]:
         """
@@ -244,6 +346,11 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         Returns:
             Tuple of (List of AdmissionProfile instances, total_count)
         """
+        # Resolve "today" ONCE per request (passed from service). Default here is a
+        # fallback only — service computes per-request so HK1 overdue predicate /
+        # sort / column never straddle midnight (mirror routers/invoices.py:139).
+        today = today or date.today()
+
         # Base query for filtering
         base_conditions = []
 
@@ -256,6 +363,19 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             base_conditions.append(models.Lead.assigned_officer_id == assigned_officer_id)
         if unit_id is not None:
             base_conditions.append(models.Lead.unit_id == unit_id)
+
+        # Coordination filters (admin/manager) — narrowing ONLY, layered on top of
+        # the IDOR scope above (service intersects via _resolve_coordination_filters).
+        if assigned_officer_ids:
+            base_conditions.append(
+                models.Lead.assigned_officer_id.in_(assigned_officer_ids)
+            )
+        if unassigned:
+            base_conditions.append(models.Lead.assigned_officer_id.is_(None))
+        if assigned_reviewer_ids:
+            base_conditions.append(
+                models.AdmissionProfile.assigned_reviewer_id.in_(assigned_reviewer_ids)
+            )
 
         # Multi-status filter (new)
         if statuses and len(statuses) > 0:
@@ -288,7 +408,7 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
 
         # Payment status filter (subquery EXISTS pattern - no JOIN needed)
         if payment_status:
-            self._apply_payment_status_filter(base_conditions, payment_status)
+            self._apply_payment_status_filter(base_conditions, payment_status, today)
 
         # Date range filter
         if date_from:
@@ -313,6 +433,20 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         count_result = await self.db.execute(count_query)
         total_count = count_result.scalar() or 0
 
+        # Học phí HK1 aggregate columns (Admission List v2) — labeled scalar
+        # subqueries reused both as SELECT columns (cột tiền) AND as the sort key
+        # (single source, no drift). coalesce→0 inside the helpers.
+        # Chỉ build khi with_hk1=True (list path): tránh 4 correlated subquery/row
+        # trên /export (10k) + /stats (toàn bộ hồ sơ) vốn KHÔNG dùng cột HK1.
+        hk1_cols: list = []
+        remaining_col = None
+        if with_hk1:
+            paid_col = _hk1_paid_subquery().label("tuition_paid_hk1")
+            remaining_col = _hk1_remaining_subquery().label("tuition_remaining_hk1")
+            overdue_col = _hk1_overdue_exists(today).label("tuition_overdue_hk1")
+            final_col = _hk1_final_subquery().label("tuition_final_hk1")
+            hk1_cols = [paid_col, remaining_col, overdue_col, final_col]
+
         # Determine sort column and order
         sort_column = models.AdmissionProfile.created_at  # default
         if sort_by == "updated_at":
@@ -321,12 +455,14 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             sort_column = models.Lead.full_name
         elif sort_by == "status":
             sort_column = models.AdmissionProfile.status
+        elif sort_by == "remaining_hk1" and remaining_col is not None:
+            sort_column = remaining_col
 
         order_func = desc if order == "desc" else asc
 
         # Data query with pagination
         data_query = (
-            select(models.AdmissionProfile)
+            select(models.AdmissionProfile, *hk1_cols)
             .join(models.Lead)
         )
         if needs_program_join:
@@ -335,7 +471,8 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             ).join(
                 models.MajorProgram, models.ProgramOffering.program_id == models.MajorProgram.id
             )
-        data_query = data_query.options(
+        data_query = (
+            data_query.options(
                 selectinload(models.AdmissionProfile.assigned_reviewer),
                 selectinload(models.AdmissionProfile.lead).options(
                     selectinload(models.Lead.assigned_officer),
@@ -354,28 +491,71 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
                 # for multi-NV eligibility/completion. Without this the per-row
                 # sync access lazy-loads → MissingGreenlet (N-row 500).
                 *_choices_eager_load_options(),
-            ).order_by(order_func(sort_column)).offset(skip).limit(limit)
+            )
+            # Stable secondary key: ties on the primary sort (esp. remaining_hk1 where
+            # many profiles share a value, or no-HK1 rows all = 0) would otherwise
+            # duplicate/skip across LIMIT/OFFSET pages (mirror Invoice.id tiebreaker
+            # in fee_repository).
+            .order_by(order_func(sort_column), asc(models.AdmissionProfile.id))
+            .offset(skip).limit(limit)
+        )
         if base_conditions:
             data_query = data_query.where(and_(*base_conditions))
 
-        result = await self.db.execute(data_query)
-        profiles = list(result.scalars().all())
-
-        # Extract program_name while in async context (avoids MissingGreenlet during serialization)
-        for profile in profiles:
+        def _set_program_name(profile):
+            # Extract program_name while in async context (avoids MissingGreenlet
+            # during serialization).
             program_name = None
             if profile.lead and profile.lead.offering and profile.lead.offering.program:
                 program_name = profile.lead.offering.program.name
-            # Set as transient attribute for Pydantic serialization
-            object.__setattr__(profile, 'program_name', program_name)
+            object.__setattr__(profile, "program_name", program_name)
+
+        result = await self.db.execute(data_query)
+        profiles = []
+        if with_hk1:
+            # Rows are tuples (AdmissionProfile, paid, remaining, overdue, final)
+            # because of the HK1 columns — unpack instead of .scalars().
+            for profile, paid_hk1, remaining_hk1, overdue_hk1, final_hk1 in result.all():
+                overdue_hk1 = bool(overdue_hk1)
+                object.__setattr__(profile, "tuition_paid_hk1", paid_hk1)
+                object.__setattr__(profile, "tuition_remaining_hk1", remaining_hk1)
+                object.__setattr__(profile, "tuition_overdue_hk1", overdue_hk1)
+                object.__setattr__(
+                    profile, "tuition_hk1_status",
+                    _hk1_status(paid_hk1, remaining_hk1, overdue_hk1, final_hk1),
+                )
+                _set_program_name(profile)
+                profiles.append(profile)
+        else:
+            # No HK1 columns (export / stats) — plain entity rows.
+            for profile in result.scalars().all():
+                _set_program_name(profile)
+                profiles.append(profile)
 
         return profiles, total_count
 
     @staticmethod
-    def _apply_payment_status_filter(base_conditions: list, payment_status: str) -> None:
-        """Apply payment status subquery filter to base_conditions."""
+    def _apply_payment_status_filter(
+        base_conditions: list,
+        payment_status: str,
+        today: Optional[date] = None,
+    ) -> None:
+        """Apply payment status subquery filter to base_conditions.
+
+        ``overdue`` (Admission List v2) = có hóa đơn HK1 quá hạn chưa thanh toán
+        (mirror cột ``tuition_overdue_hk1``). ``today`` truyền từ caller (per-request)
+        để không lệch qua nửa đêm; fallback ``date.today()`` nếu None.
+        """
         from app.models import Fee, FeeStatusEnum
 
+        today = today or date.today()
+
+        if payment_status == "overdue":
+            # CỐ Ý chỉ xét HK1 (khớp cột "Học phí HK1"/sort của Admission List v2),
+            # KHÁC các nhánh paid/unpaid/partial/no_fee bên dưới (xét MỌI fee). Đừng
+            # "đồng bộ" nhánh này sang all-fees — sẽ phá parity với cột HK1.
+            base_conditions.append(_hk1_overdue_exists(today))
+            return
         if payment_status == "paid":
             # All fees are paid/waived (no unpaid fees exist) AND has at least one fee
             unpaid_exists = select(Fee.id).where(
@@ -441,12 +621,20 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         payment_status: Optional[str] = None,
         date_from: Optional[datetime] = None,
         date_to: Optional[datetime] = None,
+        assigned_officer_ids: Optional[List[int]] = None,
+        assigned_reviewer_ids: Optional[List[int]] = None,
+        unassigned: bool = False,
+        today: Optional[date] = None,
     ) -> Tuple[list, bool]:
         """Build shared filter conditions for aggregate queries.
+
+        Keeps status-counts in lockstep with the list query (same coordination
+        filters + payment_status incl. "overdue").
 
         Returns:
             Tuple of (conditions list, needs_program_join bool)
         """
+        today = today or date.today()
         conditions = []
         # Exclude soft-deleted leads' profiles (parity with list + aggregate).
         conditions.append(models.Lead.deleted_at.is_(None))
@@ -454,6 +642,15 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             conditions.append(models.Lead.assigned_officer_id == assigned_officer_id)
         if unit_id is not None:
             conditions.append(models.Lead.unit_id == unit_id)
+        # Coordination filters (parity with get_filtered_with_count).
+        if assigned_officer_ids:
+            conditions.append(models.Lead.assigned_officer_id.in_(assigned_officer_ids))
+        if unassigned:
+            conditions.append(models.Lead.assigned_officer_id.is_(None))
+        if assigned_reviewer_ids:
+            conditions.append(
+                models.AdmissionProfile.assigned_reviewer_id.in_(assigned_reviewer_ids)
+            )
         if search:
             # Same diacritic-insensitive search as the list query (parity).
             conditions.append(self._name_search_condition(search))
@@ -465,7 +662,7 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         if degree_level:
             conditions.append(models.MajorProgram.degree_level == degree_level)
         if payment_status:
-            self._apply_payment_status_filter(conditions, payment_status)
+            self._apply_payment_status_filter(conditions, payment_status, today)
         if date_from:
             conditions.append(models.AdmissionProfile.created_at >= date_from)
         if date_to:
@@ -483,6 +680,10 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         payment_status: Optional[str] = None,
         date_from: Optional[datetime] = None,
         date_to: Optional[datetime] = None,
+        assigned_officer_ids: Optional[List[int]] = None,
+        assigned_reviewer_ids: Optional[List[int]] = None,
+        unassigned: bool = False,
+        today: Optional[date] = None,
     ) -> dict:
         """
         Get count of profiles grouped by status.
@@ -496,6 +697,9 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             search=search, major_ids=major_ids,
             academic_year=academic_year, degree_level=degree_level,
             payment_status=payment_status, date_from=date_from, date_to=date_to,
+            assigned_officer_ids=assigned_officer_ids,
+            assigned_reviewer_ids=assigned_reviewer_ids,
+            unassigned=unassigned, today=today,
         )
 
         query = (

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -68,7 +68,7 @@ router = APIRouter(prefix="/admissions", tags=["Admissions"])
 # list, status-counts, and export endpoints. Repository helper silently
 # drops anything outside this set, so router-level validation is required
 # to keep the contract honest.
-ALLOWED_PAYMENT_STATUSES = ("paid", "unpaid", "partial", "no_fee")
+ALLOWED_PAYMENT_STATUSES = ("paid", "unpaid", "partial", "no_fee", "overdue")
 
 
 def _validate_payment_status(value: Optional[str]) -> None:
@@ -81,6 +81,27 @@ def _validate_payment_status(value: Optional[str]) -> None:
                 + ", ".join(ALLOWED_PAYMENT_STATUSES)
             ),
         )
+
+
+def _parse_id_csv(value: Optional[str], field: str) -> Optional[List[int]]:
+    """Parse a comma-separated id list → list[int]; raise 400 on non-integer or
+    out-of-int4-range value. Returns None when ``value`` is empty.
+
+    Range-guard [1, 2147483647]: these ids are compared against int4 columns
+    (Lead.assigned_officer_id / AdmissionProfile.assigned_reviewer_id /
+    ProgramOffering.program_id). A value beyond int4 makes Postgres raise
+    "integer out of range" → 500 — the same class as the prod incident fixed in
+    ``_build_invoice_list_conditions`` (#437). Reject as 400 instead.
+    """
+    if not value:
+        return None
+    try:
+        ids = [int(x.strip()) for x in value.split(",") if x.strip()]
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Invalid {field} format")
+    if any(not (1 <= i <= 2147483647) for i in ids):
+        raise HTTPException(status_code=400, detail=f"Invalid {field} format")
+    return ids
 
 
 # Hotfix R8: import the X-Forwarded-For aware helper so the
@@ -107,16 +128,29 @@ async def list_admission_profiles(
     major_id: str | None = Query(None, description="Filter by major/program ID (comma-separated)"),
     academic_year: int | None = Query(None, description="Filter by academic year"),
     degree_level: str | None = Query(None, description="Filter by degree level"),
-    payment_status: str | None = Query(None, description="Filter by payment status (paid/unpaid/partial/no_fee)"),
+    payment_status: str | None = Query(None, description="Filter by payment status (paid/unpaid/partial/no_fee/overdue)"),
     date_from: datetime | None = Query(None, description="Filter from date (created_at)"),
     date_to: datetime | None = Query(None, description="Filter to date (created_at)"),
-    sort_by: Literal["created_at", "updated_at", "full_name", "status"] = Query(
+    sort_by: Literal["created_at", "updated_at", "full_name", "status", "remaining_hk1"] = Query(
         "created_at",
         description="Sort field — repo silently fell back to created_at for invalid values until 2026-05-16 (Q-INFO-1 fix). Mirror FE Zod `AdmissionListParams.sort_by`.",
     ),
     order: Literal["asc", "desc"] = Query(
         "desc",
         description="Sort order — repo defaulted to asc for any non-`desc` value until 2026-05-16. Mirror FE Zod `AdmissionListParams.order`.",
+    ),
+    assigned_officer_id: str | None = Query(
+        None,
+        description="Coordination filter (admin/manager): officer IDs (comma-separated). Intersected with IDOR scope server-side.",
+    ),
+    unit_id: int | None = Query(
+        None, description="Coordination filter (admin): unit ID. Managers are forced to own unit."
+    ),
+    assigned_reviewer_id: str | None = Query(
+        None, description="Coordination filter (admin/manager): reviewer IDs (comma-separated)."
+    ),
+    unassigned: bool = Query(
+        False, description="Coordination filter (admin/manager): only profiles with no assigned officer."
     ),
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(20, ge=1, le=100, description="Items per page"),
@@ -142,12 +176,10 @@ async def list_admission_profiles(
     if status:
         statuses = [s.strip() for s in status.split(",") if s.strip()]
 
-    major_ids: Optional[List[int]] = None
-    if major_id:
-        try:
-            major_ids = [int(m.strip()) for m in major_id.split(",") if m.strip()]
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid major_id format")
+    major_ids = _parse_id_csv(major_id, "major_id")
+
+    officer_ids = _parse_id_csv(assigned_officer_id, "assigned_officer_id")
+    reviewer_ids = _parse_id_csv(assigned_reviewer_id, "assigned_reviewer_id")
 
     # Validate payment_status (ADM-010: shared helper)
     _validate_payment_status(payment_status)
@@ -167,6 +199,10 @@ async def list_admission_profiles(
         date_to=date_to,
         sort_by=sort_by,
         order=order,
+        officer_ids=officer_ids,
+        unit_id=unit_id,
+        reviewer_ids=reviewer_ids,
+        unassigned=unassigned,
     )
 
     return schemas.AdmissionsPage(
@@ -206,19 +242,22 @@ async def get_status_counts(
     payment_status: str | None = Query(None),
     date_from: datetime | None = Query(None),
     date_to: datetime | None = Query(None),
+    assigned_officer_id: str | None = Query(None),
+    unit_id: int | None = Query(None),
+    assigned_reviewer_id: str | None = Query(None),
+    unassigned: bool = Query(False),
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = CasbinAuth,
 ):
     """
     Get admission profile counts grouped by status.
     Applies all filters EXCEPT status (to populate tab badges).
+    Coordination filters mirror the list endpoint so tab counts match rows.
     """
-    major_ids: Optional[List[int]] = None
-    if major_id:
-        try:
-            major_ids = [int(m.strip()) for m in major_id.split(",") if m.strip()]
-        except ValueError:
-            raise HTTPException(status_code=400, detail="Invalid major_id format")
+    major_ids = _parse_id_csv(major_id, "major_id")
+
+    officer_ids = _parse_id_csv(assigned_officer_id, "assigned_officer_id")
+    reviewer_ids = _parse_id_csv(assigned_reviewer_id, "assigned_reviewer_id")
 
     # Validate payment_status (ADM-010: keep parity with list/export)
     _validate_payment_status(payment_status)
@@ -233,6 +272,10 @@ async def get_status_counts(
         payment_status=payment_status,
         date_from=date_from,
         date_to=date_to,
+        officer_ids=officer_ids,
+        unit_id=unit_id,
+        reviewer_ids=reviewer_ids,
+        unassigned=unassigned,
     )
 
 
@@ -554,6 +597,10 @@ async def export_admissions_csv(
     payment_status: str | None = Query(None, description="Filter by payment status"),
     date_from: datetime | None = Query(None, description="Filter from date"),
     date_to: datetime | None = Query(None, description="Filter to date"),
+    assigned_officer_id: str | None = Query(None, description="comma-separated officer IDs"),
+    unit_id: int | None = Query(None),
+    assigned_reviewer_id: str | None = Query(None, description="comma-separated reviewer IDs"),
+    unassigned: bool = Query(False),
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = CasbinAuth,
 ):
@@ -564,12 +611,15 @@ async def export_admissions_csv(
 
     # Parse filters
     statuses = [s.strip() for s in status.split(",")] if status else None
-    major_ids = [int(m.strip()) for m in major_id.split(",") if m.strip().isdigit()] if major_id else None
+    major_ids = _parse_id_csv(major_id, "major_id")
+    officer_ids = _parse_id_csv(assigned_officer_id, "assigned_officer_id")
+    reviewer_ids = _parse_id_csv(assigned_reviewer_id, "assigned_reviewer_id")
 
     # Validate payment_status (ADM-010: keep parity with list/status-counts)
     _validate_payment_status(payment_status)
 
-    # Export path: no page cap, lightweight hydration (only completion_percent)
+    # Export path: no page cap, lightweight hydration (only completion_percent).
+    # Same coordination filters as list so the CSV matches the on-screen rows.
     profiles = await admission_service.get_profiles_for_export(
         db=db,
         current_user=current_user,
@@ -581,6 +631,10 @@ async def export_admissions_csv(
         payment_status=payment_status,
         date_from=date_from,
         date_to=date_to,
+        officer_ids=officer_ids,
+        unit_id=unit_id,
+        reviewer_ids=reviewer_ids,
+        unassigned=unassigned,
     )
 
     # Create CSV in memory

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -144,7 +144,10 @@ async def list_admission_profiles(
         description="Coordination filter (admin/manager): officer IDs (comma-separated). Intersected with IDOR scope server-side.",
     ),
     unit_id: int | None = Query(
-        None, description="Coordination filter (admin): unit ID. Managers are forced to own unit."
+        None,
+        ge=1,
+        le=2147483647,
+        description="Coordination filter (admin): unit ID. Managers are forced to own unit.",
     ),
     assigned_reviewer_id: str | None = Query(
         None, description="Coordination filter (admin/manager): reviewer IDs (comma-separated)."
@@ -243,7 +246,7 @@ async def get_status_counts(
     date_from: datetime | None = Query(None),
     date_to: datetime | None = Query(None),
     assigned_officer_id: str | None = Query(None),
-    unit_id: int | None = Query(None),
+    unit_id: int | None = Query(None, ge=1, le=2147483647),
     assigned_reviewer_id: str | None = Query(None),
     unassigned: bool = Query(False),
     db: AsyncSession = Depends(database.get_db),
@@ -598,7 +601,7 @@ async def export_admissions_csv(
     date_from: datetime | None = Query(None, description="Filter from date"),
     date_to: datetime | None = Query(None, description="Filter to date"),
     assigned_officer_id: str | None = Query(None, description="comma-separated officer IDs"),
-    unit_id: int | None = Query(None),
+    unit_id: int | None = Query(None, ge=1, le=2147483647),
     assigned_reviewer_id: str | None = Query(None, description="comma-separated reviewer IDs"),
     unassigned: bool = Query(False),
     db: AsyncSession = Depends(database.get_db),

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1195,6 +1195,26 @@ class AdmissionProfileResponse(BaseModel):
     )
 
     # =========================================================================
+    # Học phí HK1 (Admission List v2) — denormalized aggregate cho cột danh sách.
+    # Set transient ở admission_repository.get_filtered_with_count (scalar
+    # subquery, coalesce→0). Decimal → Pydantic v2 serialize JSON string; FE
+    # normalize string→number ở API client listAdmissions (list không .parse()).
+    # `tuition_hk1_status` do BE tính (_hk1_status) — FE chỉ map màu (thin-client).
+    # =========================================================================
+    tuition_paid_hk1: Optional[Decimal] = Field(
+        None, description="Σ học phí HK1 đã đóng (fee tuition semester_no=1 non-cancelled)"
+    )
+    tuition_remaining_hk1: Optional[Decimal] = Field(
+        None, description="Σ học phí HK1 còn lại (final − paid − waived)"
+    )
+    tuition_overdue_hk1: bool = Field(
+        default=False, description="Có hóa đơn HK1 quá hạn chưa thanh toán đủ"
+    )
+    tuition_hk1_status: Optional[str] = Field(
+        None, description="Trạng thái HK1: paid|partial|unpaid|overdue|none (BE emit, FE map màu)"
+    )
+
+    # =========================================================================
     # Phase 7: Frontend Thin Client Compliance Fields
     # =========================================================================
     

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -395,6 +395,55 @@ def _resolve_idor_filters(current_user: models.User) -> tuple[Optional[int], Opt
         )
 
 
+def _resolve_coordination_filters(
+    current_user: models.User,
+    officer_ids: Optional[List[int]] = None,
+    unit_id_param: Optional[int] = None,
+    reviewer_ids: Optional[List[int]] = None,
+    unassigned: bool = False,
+) -> dict:
+    """Layer user-supplied coordination filters ON TOP of the role IDOR scope.
+
+    Admission List v2 — lets admin/manager filter by officer/đơn vị/người
+    duyệt/chưa-giao. NEVER widens beyond ``_resolve_idor_filters``:
+
+    - OFFICER: hard-locked to self (idor_officer). ALL coordination inputs are
+      DROPPED — a crafted ``?assigned_officer_id=99&unassigned=true`` is ignored.
+    - MANAGER: always scoped to own unit (``unit_id_param`` IGNORED); may narrow
+      by officer/reviewer/unassigned WITHIN that unit (AND-ed → a cross-unit
+      officer yields 0 rows, never a leak / 500).
+    - ADMIN: free ``unit_id_param`` + officer/reviewer/unassigned.
+
+    Returns repo kwargs: {unit_id, assigned_officer_id, assigned_officer_ids,
+    assigned_reviewer_ids, unassigned}.
+    """
+    idor_unit, idor_officer = _resolve_idor_filters(current_user)  # fail-closed inside
+
+    # OFFICER: self-lock, ignore every coordination input (no widening).
+    if idor_officer is not None:
+        return {
+            "unit_id": idor_unit,
+            "assigned_officer_id": idor_officer,
+            "assigned_officer_ids": None,
+            "assigned_reviewer_ids": None,
+            "unassigned": False,
+        }
+
+    # ADMIN or MANAGER
+    is_admin = current_user.role == UserRole.ADMIN
+    eff_unit = unit_id_param if is_admin else idor_unit  # manager forced to own unit
+    # XOR: "unassigned" drops the officer-IN list (else IS NULL AND IN(...) = empty).
+    eff_officer_ids = None if unassigned else (officer_ids or None)
+
+    return {
+        "unit_id": eff_unit,
+        "assigned_officer_id": None,
+        "assigned_officer_ids": eff_officer_ids,
+        "assigned_reviewer_ids": (reviewer_ids or None),
+        "unassigned": bool(unassigned),
+    }
+
+
 def _check_idor_access(
     profile: models.AdmissionProfile,
     current_user: Optional[models.User],
@@ -4377,25 +4426,49 @@ async def get_profiles(
     date_to: Optional[datetime] = None,
     sort_by: str = "created_at",
     order: str = "desc",
+    officer_ids: Optional[List[int]] = None,
+    reviewer_ids: Optional[List[int]] = None,
+    unassigned: bool = False,
 ) -> Tuple[List[models.AdmissionProfile], int]:
     """
     Get filtered list of admission profiles with total count.
 
     Security:
     - IDOR: Automatically filters by unit_id for non-admin users.
+    - Coordination filters (officer_ids/unit_id/reviewer_ids/unassigned) are
+      layered ON TOP of the IDOR scope via _resolve_coordination_filters and can
+      only narrow, never widen (officer self-locked, manager forced to own unit).
     """
     from app.repositories import AdmissionRepository
     admission_repo = AdmissionRepository(db)
 
-    # IDOR: 3-tier filtering (Admin=all, Manager=unit, Officer=assigned+unit)
-    unit_filter, officer_filter = _resolve_idor_filters(current_user) if current_user else (unit_id, None)
+    # Per-request "today" so the HK1 overdue column / filter / sort never straddle
+    # midnight (passed explicitly to the repo — mirror routers/invoices.py).
+    today = date.today()
+
+    # IDOR + coordination (Admin=all, Manager=unit, Officer=assigned+unit).
+    if current_user:
+        coord = _resolve_coordination_filters(
+            current_user,
+            officer_ids=officer_ids,
+            unit_id_param=unit_id,
+            reviewer_ids=reviewer_ids,
+            unassigned=unassigned,
+        )
+    else:
+        # System/internal caller (no auth context) — legacy fallback, no coordination.
+        coord = {
+            "unit_id": unit_id,
+            "assigned_officer_id": None,
+            "assigned_officer_ids": None,
+            "assigned_reviewer_ids": None,
+            "unassigned": False,
+        }
 
     # Get profiles using repository with count
     profiles, total_count = await admission_repo.get_filtered_with_count(
         skip=skip,
         limit=min(limit, 100),
-        unit_id=unit_filter,
-        assigned_officer_id=officer_filter,
         search=search,
         statuses=statuses,
         major_ids=major_ids,
@@ -4406,6 +4479,9 @@ async def get_profiles(
         date_to=date_to,
         sort_by=sort_by,
         order=order,
+        today=today,
+        with_hk1=True,  # list path needs HK1 money columns + remaining_hk1 sort
+        **coord,
     )
 
     # ADM-031 round 10: pre-resolve verifier names ACROSS all profiles in
@@ -4463,23 +4539,37 @@ async def get_profiles_for_export(
     payment_status: Optional[str] = None,
     date_from: Optional[datetime] = None,
     date_to: Optional[datetime] = None,
+    officer_ids: Optional[List[int]] = None,
+    unit_id: Optional[int] = None,
+    reviewer_ids: Optional[List[int]] = None,
+    unassigned: bool = False,
 ) -> List[models.AdmissionProfile]:
     """
     Get profiles for CSV export — no page cap, lightweight hydration.
 
     Only computes completion_percent (needed by CSV) via _calculate_and_update_totals.
     Skips full _compute_frontend_fields (permissions, actions, step_status, etc.).
+
+    Honors the SAME coordination filters as the list (officer/unit/reviewer/
+    unassigned) so the exported set matches the on-screen filtered rows.
+    with_hk1=False (default): export doesn't render HK1 money columns, so skip the
+    aggregate subqueries.
     """
     from app.repositories import AdmissionRepository
     admission_repo = AdmissionRepository(db)
 
-    unit_filter, officer_filter = _resolve_idor_filters(current_user)
+    today = date.today()
+    coord = _resolve_coordination_filters(
+        current_user,
+        officer_ids=officer_ids,
+        unit_id_param=unit_id,
+        reviewer_ids=reviewer_ids,
+        unassigned=unassigned,
+    )
 
     profiles, _ = await admission_repo.get_filtered_with_count(
         skip=0,
         limit=10_000,  # export cap
-        unit_id=unit_filter,
-        assigned_officer_id=officer_filter,
         search=search,
         statuses=statuses,
         major_ids=major_ids,
@@ -4490,6 +4580,8 @@ async def get_profiles_for_export(
         date_to=date_to,
         sort_by="created_at",
         order="desc",
+        today=today,
+        **coord,
     )
 
     # Lightweight hydration: totals/GPA + completion_percent, no permissions/actions
@@ -4511,16 +4603,29 @@ async def get_status_counts(
     payment_status: Optional[str] = None,
     date_from: Optional[datetime] = None,
     date_to: Optional[datetime] = None,
+    officer_ids: Optional[List[int]] = None,
+    unit_id: Optional[int] = None,
+    reviewer_ids: Optional[List[int]] = None,
+    unassigned: bool = False,
 ) -> dict:
-    """Get status counts for admission profiles (all filters except status)."""
+    """Get status counts for admission profiles (all filters except status).
+
+    Coordination filters mirror get_profiles (same _resolve_coordination_filters)
+    so tab badge counts stay in lockstep with the filtered rows.
+    """
     from app.repositories import AdmissionRepository
     admission_repo = AdmissionRepository(db)
 
-    unit_filter, officer_filter = _resolve_idor_filters(current_user)
+    today = date.today()
+    coord = _resolve_coordination_filters(
+        current_user,
+        officer_ids=officer_ids,
+        unit_id_param=unit_id,
+        reviewer_ids=reviewer_ids,
+        unassigned=unassigned,
+    )
 
     return await admission_repo.get_status_counts(
-        unit_id=unit_filter,
-        assigned_officer_id=officer_filter,
         search=search,
         major_ids=major_ids,
         academic_year=academic_year,
@@ -4528,6 +4633,8 @@ async def get_status_counts(
         payment_status=payment_status,
         date_from=date_from,
         date_to=date_to,
+        today=today,
+        **coord,
     )
 
 

--- a/Backend_FastAPI/tests/api/test_admission_list_hk1.py
+++ b/Backend_FastAPI/tests/api/test_admission_list_hk1.py
@@ -308,6 +308,31 @@ class TestQueryValidation:
         )
         assert resp.status_code == 400, resp.text
 
+    @pytest.mark.parametrize("path", [
+        "/api/admissions",
+        "/api/admissions/status-counts",
+        "/api/admissions/export",
+    ])
+    async def test_out_of_int4_unit_id_rejected_not_500(
+        self, client: AsyncClient, admin_token_headers: dict, path: str
+    ):
+        # unit_id is compared against Lead.unit_id (int4); an out-of-int4 value
+        # would make asyncpg raise "integer out of range" → 500 (the #437 class).
+        # The Query(ge=1, le=2147483647) guard must reject it as 422, on ALL three
+        # endpoints that accept the coordination filter.
+        resp = await client.get(
+            f"{path}?unit_id=99999999999", headers=admin_token_headers
+        )
+        assert resp.status_code == 422, resp.text
+
+    async def test_valid_unit_id_accepted(
+        self, client: AsyncClient, admin_token_headers: dict
+    ):
+        resp = await client.get(
+            "/api/admissions?unit_id=3", headers=admin_token_headers
+        )
+        assert resp.status_code == 200, resp.text
+
     @pytest.mark.parametrize("payment_status", ["paid", "unpaid", "partial", "no_fee", "overdue"])
     async def test_payment_status_accepted(
         self, client: AsyncClient, admin_token_headers: dict, payment_status: str

--- a/Backend_FastAPI/tests/api/test_admission_list_hk1.py
+++ b/Backend_FastAPI/tests/api/test_admission_list_hk1.py
@@ -1,0 +1,329 @@
+"""Integration tests — Admission List v2 (cột Học phí HK1 + filter điều phối).
+
+Covers the BE additions in ``get_filtered_with_count`` / router:
+  * HK1 tuition aggregate columns (paid / remaining / overdue / status) scoped to
+    fee_type='tuition' AND semester_no=1 AND status != cancelled.
+  * no-HK1 profile → status "none", paid/remaining 0, no 500.
+  * payment_status=overdue filter.
+  * sort_by=remaining_hk1 (with stable id tiebreaker).
+  * coordination filters: assigned_officer_id / unassigned / assigned_reviewer_id.
+  * query validation: non-int officer id → 400; new sort/payment values accepted.
+
+conftest truncates all tables per test, so each test controls the full dataset.
+"""
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.models.finance import Fee, Invoice, FeeStatusEnum, InvoiceStatusEnum
+
+pytestmark = pytest.mark.asyncio
+
+_CCCD_SEQ = iter(range(1, 10_000))
+
+
+def _next_cccd() -> str:
+    return f"0790000{next(_CCCD_SEQ):05d}"
+
+
+async def _make_profile(unit_id: int, *, officer_id=None, reviewer_id=None, status="submitted") -> int:
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            lead = models.Lead(
+                full_name="HK1 Test Lead",
+                phone="0901234567",
+                email=f"hk1_{_next_cccd()}@test.com",
+                source="website",
+                unit_id=unit_id,
+                assigned_officer_id=officer_id,
+            )
+            session.add(lead)
+            await session.flush()
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                status=status,
+                citizen_id=_next_cccd(),
+                academic_year=2026,
+                version=1,
+                applied_rules={"min_gpa": 0, "mandatory_docs": []},
+                assigned_reviewer_id=reviewer_id,
+            )
+            session.add(profile)
+            await session.flush()
+            return profile.id
+
+
+async def _add_fee(
+    profile_id: int,
+    *,
+    fee_type="tuition",
+    semester_no=1,
+    final="9200000",
+    paid="0",
+    waived="0",
+    status=FeeStatusEnum.invoiced.value,
+    invoice_status=None,
+    invoice_due=None,
+) -> int:
+    """Add a Fee (+ optional Invoice) to a profile. Returns fee id."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            fee = Fee(
+                admission_profile_id=profile_id,
+                fee_type=fee_type,
+                academic_year=2026,
+                semester_no=semester_no if fee_type == "tuition" else None,
+                base_amount=Decimal(final),
+                total_discount=Decimal("0"),
+                final_amount=Decimal(final),
+                paid_amount=Decimal(paid),
+                waived_amount=Decimal(waived),
+                status=status,
+                version=1,
+            )
+            session.add(fee)
+            await session.flush()
+            if invoice_status is not None:
+                session.add(
+                    Invoice(
+                        fee_id=fee.id,
+                        invoice_number=f"INV-{fee.id}",
+                        installment_no=1,
+                        amount=Decimal(final),
+                        paid_amount=Decimal(paid),
+                        status=invoice_status,
+                        due_date=invoice_due or date.today(),
+                    )
+                )
+            return fee.id
+
+
+def _find(body: dict, profile_id: int) -> dict:
+    return next(p for p in body["profiles"] if p["id"] == profile_id)
+
+
+class TestHk1Aggregate:
+    async def test_only_hk1_tuition_counts(
+        self, client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        """paid/remaining count ONLY HK1 tuition (HK2 + application excluded)."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        pid = await _make_profile(unit_id)
+        await _add_fee(pid, semester_no=1, final="9200000", paid="3000000",
+                       status=FeeStatusEnum.partial.value)
+        await _add_fee(pid, semester_no=2, final="5000000", paid="5000000",
+                       status=FeeStatusEnum.paid.value)
+        await _add_fee(pid, fee_type="application", final="70000", paid="70000",
+                       status=FeeStatusEnum.paid.value)
+
+        resp = await client.get("/api/admissions", headers=admin_token_headers)
+        assert resp.status_code == 200, resp.text
+        row = _find(resp.json(), pid)
+        assert Decimal(row["tuition_paid_hk1"]) == Decimal("3000000")
+        assert Decimal(row["tuition_remaining_hk1"]) == Decimal("6200000")
+        assert row["tuition_hk1_status"] == "partial"
+        assert row["tuition_overdue_hk1"] is False
+
+    async def test_cancelled_hk1_excluded_status_none(
+        self, client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        """A profile whose only HK1 fee is cancelled → treated as no-HK1 ("none")."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        pid = await _make_profile(unit_id)
+        await _add_fee(pid, semester_no=1, final="9200000", paid="0",
+                       status=FeeStatusEnum.cancelled.value)
+
+        resp = await client.get("/api/admissions", headers=admin_token_headers)
+        row = _find(resp.json(), pid)
+        assert Decimal(row["tuition_paid_hk1"]) == Decimal("0")
+        assert Decimal(row["tuition_remaining_hk1"]) == Decimal("0")
+        assert row["tuition_hk1_status"] == "none"
+
+    async def test_no_fee_profile_status_none_no_500(
+        self, client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        """Profile with NO fees at all → status none, paid/remaining 0, no crash."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        pid = await _make_profile(unit_id)
+
+        resp = await client.get("/api/admissions", headers=admin_token_headers)
+        assert resp.status_code == 200, resp.text
+        row = _find(resp.json(), pid)
+        assert row["tuition_hk1_status"] == "none"
+        assert Decimal(row["tuition_paid_hk1"]) == Decimal("0")
+        assert Decimal(row["tuition_remaining_hk1"]) == Decimal("0")
+
+    async def test_fully_waived_hk1_is_paid_not_none(
+        self, client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        """HK1 miễn 100% (waived=final, paid=0, remaining=0) → 'paid', KHÔNG 'none'."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        pid = await _make_profile(unit_id)
+        await _add_fee(pid, semester_no=1, final="9200000", paid="0",
+                       waived="9200000", status=FeeStatusEnum.waived.value)
+
+        resp = await client.get("/api/admissions", headers=admin_token_headers)
+        row = _find(resp.json(), pid)
+        assert row["tuition_hk1_status"] == "paid"
+        assert Decimal(row["tuition_remaining_hk1"]) == Decimal("0")
+
+
+class TestOverdueFilter:
+    async def test_overdue_filter_and_status(
+        self, client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        overdue_pid = await _make_profile(unit_id)
+        await _add_fee(
+            overdue_pid, semester_no=1, final="1000000", paid="0",
+            status=FeeStatusEnum.invoiced.value,
+            invoice_status=InvoiceStatusEnum.issued.value,
+            invoice_due=date.today() - timedelta(days=3),
+        )
+        # A non-overdue profile (invoice due in the future) that must be filtered out.
+        ok_pid = await _make_profile(unit_id)
+        await _add_fee(
+            ok_pid, semester_no=1, final="1000000", paid="0",
+            status=FeeStatusEnum.invoiced.value,
+            invoice_status=InvoiceStatusEnum.issued.value,
+            invoice_due=date.today() + timedelta(days=30),
+        )
+
+        # status column flags overdue
+        resp = await client.get("/api/admissions", headers=admin_token_headers)
+        assert _find(resp.json(), overdue_pid)["tuition_overdue_hk1"] is True
+        assert _find(resp.json(), overdue_pid)["tuition_hk1_status"] == "overdue"
+
+        # filter returns only the overdue profile
+        resp2 = await client.get(
+            "/api/admissions?payment_status=overdue", headers=admin_token_headers
+        )
+        assert resp2.status_code == 200, resp2.text
+        ids = {p["id"] for p in resp2.json()["profiles"]}
+        assert overdue_pid in ids
+        assert ok_pid not in ids
+
+    async def test_overdue_counts_match_list(
+        self, client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        """status-counts total with payment_status=overdue == list total_count."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        pid = await _make_profile(unit_id)
+        await _add_fee(
+            pid, semester_no=1, final="1000000", paid="0",
+            status=FeeStatusEnum.invoiced.value,
+            invoice_status=InvoiceStatusEnum.issued.value,
+            invoice_due=date.today() - timedelta(days=1),
+        )
+        list_resp = await client.get(
+            "/api/admissions?payment_status=overdue", headers=admin_token_headers
+        )
+        counts_resp = await client.get(
+            "/api/admissions/status-counts?payment_status=overdue", headers=admin_token_headers
+        )
+        assert list_resp.status_code == 200 and counts_resp.status_code == 200
+        assert counts_resp.json()["total"] == list_resp.json()["total_count"]
+
+
+class TestSortRemainingHk1:
+    async def test_sort_desc_with_tiebreaker(
+        self, client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        big = await _make_profile(unit_id)
+        await _add_fee(big, semester_no=1, final="9000000", paid="0",
+                       status=FeeStatusEnum.invoiced.value)
+        small = await _make_profile(unit_id)
+        await _add_fee(small, semester_no=1, final="1000000", paid="700000",
+                       status=FeeStatusEnum.partial.value)  # remaining 300k
+
+        resp = await client.get(
+            "/api/admissions?sort_by=remaining_hk1&order=desc", headers=admin_token_headers
+        )
+        assert resp.status_code == 200, resp.text
+        order = [p["id"] for p in resp.json()["profiles"]]
+        # big (9M) before small (300k)
+        assert order.index(big) < order.index(small)
+
+
+class TestCoordinationFilters:
+    async def test_officer_and_unassigned(
+        self, client: AsyncClient, admin_token_headers: dict,
+        officer_user_in_db: dict, seed_lead_dependencies: dict
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        officer_id = officer_user_in_db["id"]
+        assigned = await _make_profile(unit_id, officer_id=officer_id)
+        free = await _make_profile(unit_id, officer_id=None)
+
+        by_officer = await client.get(
+            f"/api/admissions?assigned_officer_id={officer_id}", headers=admin_token_headers
+        )
+        ids = {p["id"] for p in by_officer.json()["profiles"]}
+        assert assigned in ids and free not in ids
+
+        unassigned = await client.get(
+            "/api/admissions?unassigned=true", headers=admin_token_headers
+        )
+        ids2 = {p["id"] for p in unassigned.json()["profiles"]}
+        assert free in ids2 and assigned not in ids2
+
+    async def test_filter_by_admin_reviewer(
+        self, client: AsyncClient, admin_token_headers: dict,
+        admin_user_in_db: dict, seed_lead_dependencies: dict
+    ):
+        """Admin can be assigned_reviewer → filtering by that reviewer returns it."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        reviewer_id = admin_user_in_db["id"]
+        reviewed = await _make_profile(unit_id, reviewer_id=reviewer_id)
+        other = await _make_profile(unit_id, reviewer_id=None)
+
+        resp = await client.get(
+            f"/api/admissions?assigned_reviewer_id={reviewer_id}", headers=admin_token_headers
+        )
+        assert resp.status_code == 200, resp.text
+        ids = {p["id"] for p in resp.json()["profiles"]}
+        assert reviewed in ids and other not in ids
+
+
+class TestQueryValidation:
+    async def test_non_int_officer_id_400(
+        self, client: AsyncClient, admin_token_headers: dict
+    ):
+        resp = await client.get(
+            "/api/admissions?assigned_officer_id=abc", headers=admin_token_headers
+        )
+        assert resp.status_code == 400, resp.text
+
+    async def test_non_int_reviewer_id_400(
+        self, client: AsyncClient, admin_token_headers: dict
+    ):
+        resp = await client.get(
+            "/api/admissions?assigned_reviewer_id=x,y", headers=admin_token_headers
+        )
+        assert resp.status_code == 400, resp.text
+
+    @pytest.mark.parametrize("payment_status", ["paid", "unpaid", "partial", "no_fee", "overdue"])
+    async def test_payment_status_accepted(
+        self, client: AsyncClient, admin_token_headers: dict, payment_status: str
+    ):
+        resp = await client.get(
+            f"/api/admissions?payment_status={payment_status}", headers=admin_token_headers
+        )
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.parametrize(
+        "sort_by", ["created_at", "updated_at", "full_name", "status", "remaining_hk1"]
+    )
+    async def test_sort_by_accepted(
+        self, client: AsyncClient, admin_token_headers: dict, sort_by: str
+    ):
+        resp = await client.get(
+            f"/api/admissions?sort_by={sort_by}", headers=admin_token_headers
+        )
+        assert resp.status_code == 200, resp.text

--- a/Backend_FastAPI/tests/unit/test_admission_coordination_filters.py
+++ b/Backend_FastAPI/tests/unit/test_admission_coordination_filters.py
@@ -1,0 +1,153 @@
+# tests/unit/test_admission_coordination_filters.py
+"""
+Unit tests for the Admission List v2 coordination layer — pure functions, no DB,
+no Casbin, no HTTP (mirrors ``test_admission_idor_filters.py``):
+
+- ``admission_service._resolve_coordination_filters`` — layers the user-supplied
+  officer/unit/reviewer/unassigned filters ON TOP of the role IDOR scope. The
+  security contract: officer is self-locked (cannot widen), manager is forced to
+  its own unit (``unit_id`` param ignored), admin is free, and "unassigned" is
+  mutually exclusive with the officer-IN list.
+- ``admission_repository._hk1_status`` — maps (paid, remaining, overdue) → the
+  HK1 display status; MUST normalize ``None`` (a profile with no HK1 fee) to 0 so
+  it never raises ``None > 0`` (the no-HK1 → "none", not a 500).
+"""
+from decimal import Decimal
+
+import pytest
+
+from app import models
+from app.core.constants import UserRole
+from app.services.admission_service import _resolve_coordination_filters
+from app.repositories.admission_repository import _hk1_status
+from app.utils.exceptions import PermissionDeniedError
+
+pytestmark = pytest.mark.unit
+
+
+def _user(role, unit_id, uid=1):
+    return models.User(id=uid, username=f"u{uid}", role=role, unit_id=unit_id)
+
+
+class TestCoordinationFiltersAdmin:
+    """Admin: free officer / unit / reviewer / unassigned."""
+
+    def test_admin_free_officer_unit_reviewer(self):
+        out = _resolve_coordination_filters(
+            _user(UserRole.ADMIN, None),
+            officer_ids=[5, 7],
+            unit_id_param=3,
+            reviewer_ids=[9],
+            unassigned=False,
+        )
+        assert out == {
+            "unit_id": 3,
+            "assigned_officer_id": None,
+            "assigned_officer_ids": [5, 7],
+            "assigned_reviewer_ids": [9],
+            "unassigned": False,
+        }
+
+    def test_admin_unassigned_drops_officer_list_xor(self):
+        out = _resolve_coordination_filters(
+            _user(UserRole.ADMIN, None),
+            officer_ids=[5],
+            unit_id_param=None,
+            reviewer_ids=None,
+            unassigned=True,
+        )
+        assert out["unassigned"] is True
+        assert out["assigned_officer_ids"] is None  # XOR: officer list dropped
+
+
+class TestCoordinationFiltersManager:
+    """Manager: ALWAYS scoped to own unit; may narrow within it."""
+
+    def test_manager_forced_own_unit_ignores_unit_param(self):
+        out = _resolve_coordination_filters(
+            _user(UserRole.MANAGER, 7),
+            officer_ids=[5],
+            unit_id_param=3,  # must be IGNORED — manager cannot pick another unit
+            reviewer_ids=None,
+            unassigned=False,
+        )
+        assert out["unit_id"] == 7
+        assert out["assigned_officer_ids"] == [5]
+        assert out["assigned_officer_id"] is None
+
+    def test_manager_unassigned_within_own_unit(self):
+        out = _resolve_coordination_filters(
+            _user(UserRole.MANAGER, 7),
+            officer_ids=[5],
+            unit_id_param=None,
+            reviewer_ids=None,
+            unassigned=True,
+        )
+        assert out["unit_id"] == 7
+        assert out["unassigned"] is True
+        assert out["assigned_officer_ids"] is None  # XOR
+
+    def test_manager_without_unit_denied(self):
+        with pytest.raises(PermissionDeniedError):
+            _resolve_coordination_filters(
+                _user(UserRole.MANAGER, None), officer_ids=[5]
+            )
+
+
+class TestCoordinationFiltersOfficerSelfLock:
+    """Officer: hard-locked to self; ALL coordination inputs dropped (no widen)."""
+
+    def test_officer_self_lock_ignores_all_inputs(self):
+        out = _resolve_coordination_filters(
+            _user(UserRole.OFFICER, 7, uid=3),
+            officer_ids=[99],       # crafted — must be ignored
+            unit_id_param=3,        # ignored
+            reviewer_ids=[9],       # ignored
+            unassigned=True,        # ignored
+        )
+        assert out == {
+            "unit_id": 7,
+            "assigned_officer_id": 3,       # forced self
+            "assigned_officer_ids": None,
+            "assigned_reviewer_ids": None,
+            "unassigned": False,
+        }
+
+    def test_officer_without_unit_denied(self):
+        with pytest.raises(PermissionDeniedError):
+            _resolve_coordination_filters(_user(UserRole.OFFICER, None, uid=3))
+
+
+class TestHk1Status:
+    """_hk1_status(paid, remaining, overdue, final) mapping + None-normalization.
+
+    ``final`` (Σ final_amount HK1) distinguishes 'has a HK1 fee' (final>0) from
+    'no HK1 fee' (final<=0 → none), so a fully-waived fee reads as settled.
+    """
+
+    def test_overdue_wins(self):
+        assert _hk1_status(Decimal("1"), Decimal("1"), True, Decimal("9200000")) == "overdue"
+
+    def test_paid_full(self):
+        assert _hk1_status(Decimal("9200000"), Decimal("0"), False, Decimal("9200000")) == "paid"
+
+    def test_fully_waived_is_paid_not_none(self):
+        # Miễn 100%: final=9.2M, paid=0, remaining=0 → đã tất toán ("paid"), KHÔNG "none".
+        assert _hk1_status(Decimal("0"), Decimal("0"), False, Decimal("9200000")) == "paid"
+
+    def test_partial(self):
+        assert _hk1_status(Decimal("3000000"), Decimal("6200000"), False, Decimal("9200000")) == "partial"
+
+    def test_unpaid(self):
+        assert _hk1_status(Decimal("0"), Decimal("9200000"), False, Decimal("9200000")) == "unpaid"
+
+    def test_none_when_no_fee(self):
+        # final<=0 = chưa có fee HK1 (hoặc chỉ có fee đã hủy → bị loại khỏi subquery).
+        assert _hk1_status(Decimal("0"), Decimal("0"), False, Decimal("0")) == "none"
+
+    def test_none_inputs_do_not_crash(self):
+        # SUM trên 0 hàng → NULL (None). Normalize → "none", not 500.
+        assert _hk1_status(None, None, False, None) == "none"
+
+    def test_none_paid_with_remaining(self):
+        assert _hk1_status(None, Decimal("9200000"), False, Decimal("9200000")) == "unpaid"

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -345,6 +345,9 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
   )
 
   const handleExport = useCallback(() => {
+    // Guard unit_id like apiFilters/countFilters — a crafted ?unit_id=abc must not
+    // send unit_id=NaN (→ BE 422) from the export path.
+    const parsedUnitId = state.unitId ? parseInt(state.unitId, 10) : NaN
     exportCsv.mutate({
       status: state.statusFilters.length > 0 ? state.statusFilters.join(",") : undefined,
       search: state.search || undefined,
@@ -361,7 +364,7 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
           ? state.officerFilters.join(",")
           : undefined,
       unassigned: state.unassigned || undefined,
-      unit_id: state.unitId ? parseInt(state.unitId, 10) : undefined,
+      unit_id: Number.isFinite(parsedUnitId) ? parsedUnitId : undefined,
       assigned_reviewer_id:
         state.reviewerFilters.length > 0 ? state.reviewerFilters.join(",") : undefined,
     })

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -53,6 +53,7 @@ import {
 } from "@/hooks/admissions"
 import {
   areAdmissionsListParamsEqual,
+  buildCoordinationParams,
   CURRENT_ADMISSIONS_YEAR,
   ADMISSION_STATUS_TABS as STATUS_TABS,
 } from "@/hooks/admissions/filterDefaults"
@@ -345,9 +346,6 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
   )
 
   const handleExport = useCallback(() => {
-    // Guard unit_id like apiFilters/countFilters — a crafted ?unit_id=abc must not
-    // send unit_id=NaN (→ BE 422) from the export path.
-    const parsedUnitId = state.unitId ? parseInt(state.unitId, 10) : NaN
     exportCsv.mutate({
       status: state.statusFilters.length > 0 ? state.statusFilters.join(",") : undefined,
       search: state.search || undefined,
@@ -357,16 +355,14 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
       payment_status: state.paymentStatusFilter || undefined,
       date_from: state.dateFrom || undefined,
       date_to: state.dateTo || undefined,
-      // Coordination filters — keep the CSV in sync with the on-screen list
-      // (same XOR officer/unassigned as apiFilters).
-      assigned_officer_id:
-        state.officerFilters.length > 0 && !state.unassigned
-          ? state.officerFilters.join(",")
-          : undefined,
-      unassigned: state.unassigned || undefined,
-      unit_id: Number.isFinite(parsedUnitId) ? parsedUnitId : undefined,
-      assigned_reviewer_id:
-        state.reviewerFilters.length > 0 ? state.reviewerFilters.join(",") : undefined,
+      // Coordination filters — same helper as apiFilters/countFilters (officer XOR
+      // unassigned, unit_id int4-guard) so the CSV matches the on-screen list.
+      ...buildCoordinationParams({
+        officerFilters: state.officerFilters,
+        unitId: state.unitId,
+        reviewerFilters: state.reviewerFilters,
+        unassigned: state.unassigned,
+      }),
     })
   }, [exportCsv, state])
 

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -67,7 +67,7 @@ import { BulkAssignDialog } from "./dialogs/BulkAssignDialog"
 import { AdmissionsMetricRail, type MetricItem } from "./AdmissionsMetricRail"
 import { AdmissionsFilterBar } from "./AdmissionsFilterBar"
 import { AdmissionsStatusTabs } from "./AdmissionsStatusTabs"
-import { Monogram, StatusDot, ProgressBar, EligibilityToken, RowActionsMenu } from "./roster-parts"
+import { Monogram, StatusDot, ProgressBar, EligibilityToken, RowActionsMenu, TuitionHk1 } from "./roster-parts"
 
 const CURRENT_YEAR = CURRENT_ADMISSIONS_YEAR
 const DENSITY_STORAGE_KEY = "admissions:density"
@@ -354,6 +354,16 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
       payment_status: state.paymentStatusFilter || undefined,
       date_from: state.dateFrom || undefined,
       date_to: state.dateTo || undefined,
+      // Coordination filters — keep the CSV in sync with the on-screen list
+      // (same XOR officer/unassigned as apiFilters).
+      assigned_officer_id:
+        state.officerFilters.length > 0 && !state.unassigned
+          ? state.officerFilters.join(",")
+          : undefined,
+      unassigned: state.unassigned || undefined,
+      unit_id: state.unitId ? parseInt(state.unitId, 10) : undefined,
+      assigned_reviewer_id:
+        state.reviewerFilters.length > 0 ? state.reviewerFilters.join(",") : undefined,
     })
   }, [exportCsv, state])
 
@@ -432,6 +442,14 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
           sortBy={state.sortBy}
           sortOrder={state.sortOrder}
           onSortChange={handlers.handleSortChange}
+          officerFilters={state.officerFilters}
+          onOfficerChange={handlers.handleOfficerChange}
+          unitId={state.unitId}
+          onUnitIdChange={handlers.handleUnitIdChange}
+          reviewerFilters={state.reviewerFilters}
+          onReviewerChange={handlers.handleReviewerChange}
+          unassigned={state.unassigned}
+          onUnassignedChange={handlers.handleUnassignedChange}
           onReset={handlers.resetFilters}
         />
 
@@ -716,6 +734,17 @@ function AdmissionCard({ profile, isSelected, onSelect, onClaim, onApprove, onRe
               {formatDate(profile.created_at)}
             </span>
           </div>
+
+          {/* Học phí HK1 — chỉ hiện khi có (none → ẩn hàng cho card gọn) */}
+          {profile.tuition_hk1_status && profile.tuition_hk1_status !== "none" && (
+            <div className="mt-2">
+              <TuitionHk1
+                paid={profile.tuition_paid_hk1}
+                remaining={profile.tuition_remaining_hk1}
+                status={profile.tuition_hk1_status}
+              />
+            </div>
+          )}
         </div>
       </div>
     </article>

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.test.tsx
@@ -1,8 +1,50 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import type { ReactNode } from "react"
 import { render, screen } from "@/test/utils/test-utils"
-import { fireEvent } from "@testing-library/react"
+import { fireEvent, within } from "@testing-library/react"
 import { AdmissionsFilterBar, type AdmissionsFilterBarProps } from "./AdmissionsFilterBar"
 import { CURRENT_ADMISSIONS_YEAR } from "@/hooks/admissions/filterDefaults"
+
+// Role drives the assignment-group gating (UX-only; backend enforces real scope).
+const mockAuthState = vi.hoisted(() => ({ role: "admin" as string }))
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: 1, username: "u", role: mockAuthState.role } }),
+}))
+// Role-aware so officer vs reviewer sections render DISTINCT users (else the same
+// aria-label appears twice → getByLabelText is ambiguous).
+vi.mock("@/hooks/useAdminUsers", () => ({
+  useAdminUsersList: (params: { role?: string }) => ({
+    data:
+      params?.role === "officer"
+        ? { users: [{ id: 10, full_name: "Nguyễn Văn A" }], total_count: 1 }
+        : { users: [{ id: 20, full_name: "Trần Thị B" }], total_count: 1 },
+  }),
+}))
+vi.mock("@/hooks/useOrganization", () => ({
+  useOrganizationUnits: () => ({
+    data: [{ id: 5, name: "Phòng Tuyển Sinh", children: [] }],
+  }),
+}))
+
+// Render Popover / DropdownMenu content always-open in tests (repo pattern, see
+// ProfileActionMenu.test) so assertions don't depend on Radix pointer-event open.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}))
+
+beforeEach(() => {
+  mockAuthState.role = "admin"
+})
 
 function setup(overrides: Partial<AdmissionsFilterBarProps> = {}) {
   const props: AdmissionsFilterBarProps = {
@@ -28,11 +70,23 @@ function setup(overrides: Partial<AdmissionsFilterBarProps> = {}) {
     sortBy: "created_at",
     sortOrder: "desc",
     onSortChange: vi.fn(),
+    officerFilters: [],
+    onOfficerChange: vi.fn(),
+    unitId: "",
+    onUnitIdChange: vi.fn(),
+    reviewerFilters: [],
+    onReviewerChange: vi.fn(),
+    unassigned: false,
+    onUnassignedChange: vi.fn(),
     onReset: vi.fn(),
     ...overrides,
   }
   render(<AdmissionsFilterBar {...props} />)
   return props
+}
+
+function openFilters() {
+  fireEvent.click(screen.getByRole("button", { name: /bộ lọc nâng cao/i }))
 }
 
 describe("AdmissionsFilterBar", () => {
@@ -44,7 +98,9 @@ describe("AdmissionsFilterBar", () => {
 
   it("renders a chip per active status filter; removing it calls onStatusChange", () => {
     const props = setup({ statusFilters: ["submitted"] })
-    expect(screen.getByText("Chờ duyệt")).toBeInTheDocument()
+    // "Chờ duyệt" appears as both a chip AND a status checkbox (popover content is
+    // always-rendered under the mock) → assert ≥1 + target the chip's remove button.
+    expect(screen.getAllByText("Chờ duyệt").length).toBeGreaterThan(0)
     fireEvent.click(screen.getByRole("button", { name: /bỏ lọc chờ duyệt/i }))
     expect(props.onStatusChange).toHaveBeenCalledWith([])
   })
@@ -52,7 +108,10 @@ describe("AdmissionsFilterBar", () => {
   it("counts active filter GROUPS on the Bộ lọc badge (status = 1 group)", () => {
     // status group (1) + payment group (1) = 2
     setup({ statusFilters: ["submitted", "approved"], paymentStatusFilter: "paid" })
-    expect(screen.getByText("2")).toBeInTheDocument()
+    // Scope to the Bộ lọc trigger so the badge "2" isn't confused with other "2"s
+    // now that the popover content renders under the mock.
+    const filterButton = screen.getByRole("button", { name: /bộ lọc nâng cao/i })
+    expect(within(filterButton).getByText("2")).toBeInTheDocument()
   })
 
   it("shows a Năm chip for a non-default year; removing it resets to current year", () => {
@@ -68,5 +127,64 @@ describe("AdmissionsFilterBar", () => {
     const props = setup({ statusFilters: ["submitted"] })
     fireEvent.click(screen.getByRole("button", { name: /xóa tất cả/i }))
     expect(props.onReset).toHaveBeenCalled()
+  })
+
+  describe("Phân công group — role gating", () => {
+    it("admin sees Cán bộ + Người duyệt + Đơn vị", () => {
+      mockAuthState.role = "admin"
+      setup()
+      openFilters()
+      expect(screen.getByText("Cán bộ phụ trách")).toBeInTheDocument()
+      expect(screen.getByText("Người duyệt")).toBeInTheDocument()
+      expect(screen.getByText("Đơn vị")).toBeInTheDocument()
+    })
+
+    it("manager sees Cán bộ but NOT Đơn vị", () => {
+      mockAuthState.role = "manager"
+      setup()
+      openFilters()
+      expect(screen.getByText("Cán bộ phụ trách")).toBeInTheDocument()
+      expect(screen.queryByText("Đơn vị")).not.toBeInTheDocument()
+    })
+
+    it("officer does NOT see the Phân công group at all", () => {
+      mockAuthState.role = "officer"
+      setup()
+      openFilters()
+      expect(screen.queryByText("Phân công")).not.toBeInTheDocument()
+      expect(screen.queryByText("Cán bộ phụ trách")).not.toBeInTheDocument()
+    })
+
+    it("toggling an officer checkbox calls onOfficerChange with the id", () => {
+      mockAuthState.role = "admin"
+      const props = setup()
+      openFilters()
+      fireEvent.click(screen.getByLabelText("Nguyễn Văn A"))
+      expect(props.onOfficerChange).toHaveBeenCalledWith(["10"])
+    })
+
+    it('renders an officer chip and a "Chưa giao" chip', () => {
+      const props = setup({ officerFilters: ["10"], unassigned: true })
+      // officer chip resolves the name from the fetched list
+      expect(screen.getByText(/Cán bộ: Nguyễn Văn A/)).toBeInTheDocument()
+      const chuaGiao = screen.getByText("Chưa giao")
+      expect(chuaGiao).toBeInTheDocument()
+      fireEvent.click(screen.getByRole("button", { name: /bỏ lọc chưa giao/i }))
+      expect(props.onUnassignedChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe("payment + sort options", () => {
+    it('offers a "Quá hạn" payment option', () => {
+      setup()
+      openFilters()
+      expect(screen.getByText("Quá hạn")).toBeInTheDocument()
+    })
+
+    it('offers "Còn lại nhiều nhất" sort option', () => {
+      setup()
+      fireEvent.click(screen.getByRole("button", { name: /sắp xếp/i }))
+      expect(screen.getByText("Còn lại nhiều nhất")).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.tsx
@@ -13,7 +13,7 @@
 
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react"
 import { format } from "date-fns"
 import { vi } from "date-fns/locale"
 import { ArrowUpDown, Check, ChevronDown, Search, SlidersHorizontal, X } from "lucide-react"
@@ -89,6 +89,9 @@ function toggleId(arr: string[], value: string): string[] {
 
 const NATIVE_SELECT_CLASS =
   "h-10 w-full rounded-md border border-border bg-card px-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring md:h-9"
+
+// Stable no-op subscribe for the hydration flag below (useSyncExternalStore).
+const emptySubscribe = () => () => {}
 
 function parseDate(str: string): Date | undefined {
   if (!str) return undefined
@@ -178,8 +181,11 @@ export function AdmissionsFilterBar(props: AdmissionsFilterBarProps) {
   //    LeadFilterPanel so chip labels resolve here. UX-only role gates; backend
   //    enforces real scope via _resolve_coordination_filters.
   const { user } = useAuth()
-  const [isMounted, setIsMounted] = useState(false)
-  useEffect(() => setIsMounted(true), [])
+  // Hydration-safe client flag: false on SSR + first client render, true after
+  // hydration. useSyncExternalStore instead of a `useEffect(() => setState(true))`
+  // that trips react-hooks/set-state-in-effect (LeadFilterPanel uses the older
+  // React.useEffect form which the rule doesn't detect).
+  const isMounted = useSyncExternalStore(emptySubscribe, () => true, () => false)
   const isAdminFlag = isMounted && checkIsAdmin(user)
   const canFilterByOfficerFlag = isMounted && checkCanFilterByOfficer(user)
   const showAssignmentGroup = canFilterByOfficerFlag || isAdminFlag

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.tsx
@@ -13,6 +13,7 @@
 
 "use client"
 
+import { useEffect, useMemo, useState } from "react"
 import { format } from "date-fns"
 import { vi } from "date-fns/locale"
 import { ArrowUpDown, Check, ChevronDown, Search, SlidersHorizontal, X } from "lucide-react"
@@ -31,6 +32,13 @@ import {
 import { cn } from "@/lib/utils"
 import { ADMISSION_STATUS_CONFIG, getStatusDotColor } from "@/lib/status-config"
 import { CURRENT_ADMISSIONS_YEAR } from "@/hooks/admissions/filterDefaults"
+import { useAuth } from "@/hooks/useAuth"
+import { useAdminUsersList } from "@/hooks/useAdminUsers"
+import { useOrganizationUnits } from "@/hooks/useOrganization"
+import {
+  isAdmin as checkIsAdmin,
+  canFilterByOfficer as checkCanFilterByOfficer,
+} from "@/lib/utils/permissions"
 
 // Workflow order; LABELS đến từ ADMISSION_STATUS_CONFIG (single source) nên nhãn
 // checkbox không bao giờ lệch nhãn chip lọc (statusLabel cũng đọc cùng config).
@@ -62,6 +70,7 @@ const PAYMENT_OPTIONS: readonly { value: string; label: string }[] = [
   { value: "unpaid", label: "Chưa thanh toán" },
   { value: "partial", label: "Thanh toán một phần" },
   { value: "no_fee", label: "Chưa có học phí" },
+  { value: "overdue", label: "Quá hạn" },
 ]
 
 const SORT_OPTIONS: readonly { by: string; order: "asc" | "desc"; label: string }[] = [
@@ -69,7 +78,14 @@ const SORT_OPTIONS: readonly { by: string; order: "asc" | "desc"; label: string 
   { by: "created_at", order: "asc", label: "Cũ nhất" },
   { by: "full_name", order: "asc", label: "Tên A → Z" },
   { by: "full_name", order: "desc", label: "Tên Z → A" },
+  { by: "remaining_hk1", order: "desc", label: "Còn lại nhiều nhất" },
+  { by: "remaining_hk1", order: "asc", label: "Còn lại ít nhất" },
 ]
+
+/** Toggle a value in a string[] (copy of LeadFilterPanel helper). */
+function toggleId(arr: string[], value: string): string[] {
+  return arr.includes(value) ? arr.filter((v) => v !== value) : [...arr, value]
+}
 
 const NATIVE_SELECT_CLASS =
   "h-10 w-full rounded-md border border-border bg-card px-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring md:h-9"
@@ -111,6 +127,15 @@ export interface AdmissionsFilterBarProps {
   sortBy: string
   sortOrder: "asc" | "desc"
   onSortChange: (sortBy: string, sortOrder: "asc" | "desc") => void
+  // Coordination filters (admin/manager) — Admission List v2
+  officerFilters: string[]
+  onOfficerChange: (officerIds: string[]) => void
+  unitId: string
+  onUnitIdChange: (unitId: string) => void
+  reviewerFilters: string[]
+  onReviewerChange: (reviewerIds: string[]) => void
+  unassigned: boolean
+  onUnassignedChange: (unassigned: boolean) => void
   onReset: () => void
 }
 
@@ -138,8 +163,84 @@ export function AdmissionsFilterBar(props: AdmissionsFilterBarProps) {
     sortBy,
     sortOrder,
     onSortChange,
+    officerFilters,
+    onOfficerChange,
+    unitId,
+    onUnitIdChange,
+    reviewerFilters,
+    onReviewerChange,
+    unassigned,
+    onUnassignedChange,
     onReset,
   } = props
+
+  // ── Coordination filter data (admin/manager) — fetched internally like
+  //    LeadFilterPanel so chip labels resolve here. UX-only role gates; backend
+  //    enforces real scope via _resolve_coordination_filters.
+  const { user } = useAuth()
+  const [isMounted, setIsMounted] = useState(false)
+  useEffect(() => setIsMounted(true), [])
+  const isAdminFlag = isMounted && checkIsAdmin(user)
+  const canFilterByOfficerFlag = isMounted && checkCanFilterByOfficer(user)
+  const showAssignmentGroup = canFilterByOfficerFlag || isAdminFlag
+
+  const [officerSearch, setOfficerSearch] = useState("")
+  const [debouncedOfficerSearch, setDebouncedOfficerSearch] = useState("")
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedOfficerSearch(officerSearch), 300)
+    return () => clearTimeout(t)
+  }, [officerSearch])
+  const { data: officersData } = useAdminUsersList(
+    {
+      page: 1,
+      page_size: 100,
+      status: "active",
+      role: "officer",
+      // Manager chỉ lọc trong đơn vị mình (BE cũng AND own-unit) → chỉ liệt kê
+      // officer cùng đơn vị, tránh chọn officer khác unit ra 0 dòng khó hiểu.
+      // Admin (không unit) thấy toàn bộ.
+      ...(!isAdminFlag && user?.unit_id ? { unit_id: user.unit_id } : {}),
+      ...(debouncedOfficerSearch && { search: debouncedOfficerSearch }),
+    },
+    { enabled: canFilterByOfficerFlag },
+  )
+  const officers = officersData?.users || []
+  const officersTotalCount = officersData?.total_count ?? 0
+  const officersTruncated = officersTotalCount > officers.length
+
+  const [reviewerSearch, setReviewerSearch] = useState("")
+  const [debouncedReviewerSearch, setDebouncedReviewerSearch] = useState("")
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedReviewerSearch(reviewerSearch), 300)
+    return () => clearTimeout(t)
+  }, [reviewerSearch])
+  // Reviewers = manager + admin (admin can also be assigned_reviewer_id).
+  const { data: reviewersData } = useAdminUsersList(
+    {
+      page: 1,
+      page_size: 100,
+      status: "active",
+      role: "manager,admin",
+      ...(debouncedReviewerSearch && { search: debouncedReviewerSearch }),
+    },
+    { enabled: canFilterByOfficerFlag },
+  )
+  const reviewers = reviewersData?.users || []
+  const reviewersTotalCount = reviewersData?.total_count ?? 0
+  const reviewersTruncated = reviewersTotalCount > reviewers.length
+
+  const { data: organizationUnits = [] } = useOrganizationUnits()
+  const flatUnits = useMemo(() => {
+    const result: { id: number; name: string; depth: number }[] = []
+    function walk(units: typeof organizationUnits, depth: number) {
+      for (const unit of units) {
+        result.push({ id: unit.id, name: unit.name, depth })
+        if (unit.children?.length) walk(unit.children, depth + 1)
+      }
+    }
+    walk(organizationUnits, 0)
+    return result
+  }, [organizationUnits])
 
   const toggleStatus = (value: string) =>
     onStatusChange(
@@ -147,14 +248,25 @@ export function AdmissionsFilterBar(props: AdmissionsFilterBarProps) {
     )
 
   // Đếm theo NHÓM lọc đang bật (Trạng thái = 1 nhóm, không phải số status).
+  const assignmentActive =
+    (officerFilters.length > 0 ? 1 : 0) +
+    (reviewerFilters.length > 0 ? 1 : 0) +
+    (unitId ? 1 : 0) +
+    (unassigned ? 1 : 0)
   const filterCount =
     (statusFilters.length > 0 ? 1 : 0) +
     (majorFilter ? 1 : 0) +
     (degreeLevelFilter ? 1 : 0) +
     (paymentStatusFilter ? 1 : 0) +
-    (dateFrom || dateTo ? 1 : 0)
+    (dateFrom || dateTo ? 1 : 0) +
+    assignmentActive
 
   const majorName = majorPrograms?.find((p) => String(p.id) === majorFilter)?.name ?? majorFilter
+  const officerNameOf = (id: string) =>
+    officers.find((o) => o.id.toString() === id)?.full_name ?? `#${id}`
+  const reviewerNameOf = (id: string) =>
+    reviewers.find((o) => o.id.toString() === id)?.full_name ?? `#${id}`
+  const unitName = flatUnits.find((u) => u.id.toString() === unitId)?.name ?? unitId
 
   // Active chips: gồm cả Năm (khi ≠ năm mặc định) + các lọc trong popover.
   type Chip = { key: string; label: string; dot?: string; onRemove: () => void }
@@ -183,6 +295,24 @@ export function AdmissionsFilterBar(props: AdmissionsFilterBarProps) {
         onDateToChange("")
       },
     })
+  officerFilters.forEach((id) =>
+    chips.push({
+      key: `officer-${id}`,
+      label: `Cán bộ: ${officerNameOf(id)}`,
+      onRemove: () => onOfficerChange(officerFilters.filter((o) => o !== id)),
+    }),
+  )
+  if (unassigned)
+    chips.push({ key: "unassigned", label: "Chưa giao", onRemove: () => onUnassignedChange(false) })
+  if (unitId)
+    chips.push({ key: "unit", label: `Đơn vị: ${unitName}`, onRemove: () => onUnitIdChange("") })
+  reviewerFilters.forEach((id) =>
+    chips.push({
+      key: `reviewer-${id}`,
+      label: `Người duyệt: ${reviewerNameOf(id)}`,
+      onRemove: () => onReviewerChange(reviewerFilters.filter((r) => r !== id)),
+    }),
+  )
 
   return (
     <div className="space-y-3">
@@ -320,6 +450,107 @@ export function AdmissionsFilterBar(props: AdmissionsFilterBarProps) {
                     </select>
                   </div>
                 </div>
+
+                {/* Phân công (admin/manager) — fetch nội bộ; backend enforce scope */}
+                {showAssignmentGroup && (
+                  <div className="space-y-3 border-b border-border p-3">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Phân công</p>
+
+                    {canFilterByOfficerFlag && (
+                      <div className="space-y-2">
+                        <label className="block text-xs font-medium text-muted-foreground">Cán bộ phụ trách</label>
+                        <Input
+                          placeholder="Tìm cán bộ…"
+                          value={officerSearch}
+                          onChange={(e) => setOfficerSearch(e.target.value)}
+                          className="h-9"
+                        />
+                        <div className="max-h-40 space-y-1.5 overflow-y-auto">
+                          {officers.map((officer) => (
+                            <label key={officer.id} className="flex min-h-9 cursor-pointer items-center gap-2 text-sm">
+                              <Checkbox
+                                checked={officerFilters.includes(officer.id.toString())}
+                                onCheckedChange={() => onOfficerChange(toggleId(officerFilters, officer.id.toString()))}
+                                aria-label={officer.full_name ?? undefined}
+                              />
+                              <span className="truncate">{officer.full_name}</span>
+                            </label>
+                          ))}
+                          {officers.length === 0 && (
+                            <p className="text-muted-foreground text-xs">Không có cán bộ phù hợp.</p>
+                          )}
+                        </div>
+                        {officersTruncated && (
+                          <p className="text-muted-foreground text-xs">
+                            Hiển thị {officers.length}/{officersTotalCount} — nhập tên để tìm thêm
+                          </p>
+                        )}
+                        <label className="flex min-h-9 cursor-pointer items-center gap-2 text-sm">
+                          <Checkbox
+                            checked={unassigned}
+                            onCheckedChange={(v) => onUnassignedChange(!!v)}
+                            aria-label="Chưa giao"
+                          />
+                          <span>Chưa giao (không có cán bộ)</span>
+                        </label>
+                      </div>
+                    )}
+
+                    {canFilterByOfficerFlag && (
+                      <div className="space-y-2">
+                        <label className="block text-xs font-medium text-muted-foreground">Người duyệt</label>
+                        <Input
+                          placeholder="Tìm người duyệt…"
+                          value={reviewerSearch}
+                          onChange={(e) => setReviewerSearch(e.target.value)}
+                          className="h-9"
+                        />
+                        <div className="max-h-40 space-y-1.5 overflow-y-auto">
+                          {reviewers.map((r) => (
+                            <label key={r.id} className="flex min-h-9 cursor-pointer items-center gap-2 text-sm">
+                              <Checkbox
+                                checked={reviewerFilters.includes(r.id.toString())}
+                                onCheckedChange={() => onReviewerChange(toggleId(reviewerFilters, r.id.toString()))}
+                                aria-label={r.full_name ?? undefined}
+                              />
+                              <span className="truncate">{r.full_name}</span>
+                            </label>
+                          ))}
+                          {reviewers.length === 0 && (
+                            <p className="text-muted-foreground text-xs">Không có người duyệt phù hợp.</p>
+                          )}
+                        </div>
+                        {reviewersTruncated && (
+                          <p className="text-muted-foreground text-xs">
+                            Hiển thị {reviewers.length}/{reviewersTotalCount} — nhập tên để tìm thêm
+                          </p>
+                        )}
+                      </div>
+                    )}
+
+                    {isAdminFlag && (
+                      <div className="space-y-2">
+                        <label className="block text-xs font-medium text-muted-foreground">Đơn vị</label>
+                        <div className="max-h-40 space-y-0.5 overflow-y-auto">
+                          {flatUnits.map((unit) => (
+                            <button
+                              key={unit.id}
+                              type="button"
+                              className={cn(
+                                "w-full rounded px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted",
+                                unitId === unit.id.toString() && "bg-muted font-medium",
+                              )}
+                              style={unit.depth > 0 ? { paddingLeft: `${8 + unit.depth * 12}px` } : undefined}
+                              onClick={() => onUnitIdChange(unitId === unit.id.toString() ? "" : unit.id.toString())}
+                            >
+                              {unit.name}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
 
                 {/* Khoảng ngày tạo — giữ CalendarComponent */}
                 <div className="p-3">

--- a/frontend/src/app/(dashboard)/admissions/_components/columns.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/columns.tsx
@@ -24,6 +24,7 @@ import {
   ProgressBar,
   RowActionsMenu,
   StatusDot,
+  TuitionHk1,
 } from "./roster-parts"
 
 type Density = "comfortable" | "compact"
@@ -143,6 +144,22 @@ export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileR
       cell: ({ getValue }) => <EligibilityToken status={getValue()} />,
       enableSorting: false,
       size: 120,
+    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+
+    // Học phí HK1 (Admission List v2) — sortable theo "Còn lại". id="remaining_hk1"
+    // khớp state.sortBy → BE sort end-to-end; accessor là number (normalize ở
+    // listAdmissions) nên client getSortedRowModel cũng đúng số.
+    columnHelper.accessor((row) => Number(row.tuition_remaining_hk1 ?? 0), {
+      id: "remaining_hk1",
+      header: ({ column }) => <SortableHeader column={column} label="Học phí HK1" />,
+      cell: ({ row }) => (
+        <TuitionHk1
+          paid={row.original.tuition_paid_hk1}
+          remaining={row.original.tuition_remaining_hk1}
+          status={row.original.tuition_hk1_status}
+        />
+      ),
+      size: 170,
     }) as ColumnDef<AdmissionProfileResponse, unknown>,
 
     // Assignees (officer + reviewer — luôn hiện cả hai, mọi density)

--- a/frontend/src/app/(dashboard)/admissions/_components/roster-parts.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/roster-parts.test.tsx
@@ -1,0 +1,46 @@
+// src/app/(dashboard)/admissions/_components/roster-parts.test.tsx
+import { describe, it, expect } from "vitest"
+import { render } from "@/test/utils/test-utils"
+import { TuitionHk1 } from "./roster-parts"
+
+describe("TuitionHk1", () => {
+  it('renders "—" when status is "none"', () => {
+    const { container } = render(<TuitionHk1 paid={0} remaining={0} status="none" />)
+    expect(container.textContent).toContain("—")
+    expect(container.textContent).not.toContain("Đã đóng")
+  })
+
+  it('renders "—" when status is null (no HK1 fee)', () => {
+    const { container } = render(<TuitionHk1 paid={null} remaining={null} status={null} />)
+    expect(container.textContent).toContain("—")
+  })
+
+  it("shows Đã đóng / Còn lại with formatted VND", () => {
+    const { container } = render(
+      <TuitionHk1 paid={3000000} remaining={6200000} status="partial" />,
+    )
+    expect(container.textContent).toContain("Đã đóng")
+    expect(container.textContent).toContain("Còn lại")
+    expect(container.textContent).toContain("3.000.000")
+    expect(container.textContent).toContain("6.200.000")
+  })
+
+  it("maps status → dot color (BE emits status, FE only colors)", () => {
+    expect(
+      render(<TuitionHk1 paid={9200000} remaining={0} status="paid" />)
+        .container.querySelector(".bg-success-500"),
+    ).not.toBeNull()
+    expect(
+      render(<TuitionHk1 paid={3000000} remaining={6200000} status="partial" />)
+        .container.querySelector(".bg-amber-500"),
+    ).not.toBeNull()
+    expect(
+      render(<TuitionHk1 paid={0} remaining={9200000} status="unpaid" />)
+        .container.querySelector(".bg-gray-400"),
+    ).not.toBeNull()
+    expect(
+      render(<TuitionHk1 paid={0} remaining={1000000} status="overdue" />)
+        .container.querySelector(".bg-error-500"),
+    ).not.toBeNull()
+  })
+})

--- a/frontend/src/app/(dashboard)/admissions/_components/roster-parts.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/roster-parts.tsx
@@ -21,6 +21,7 @@ import {
 import { cn } from "@/lib/utils"
 import { ADMISSION_STATUS_CONFIG, getStatusDotColor } from "@/lib/status-config"
 import { hasAction } from "@/lib/admission/permissions"
+import { formatVND } from "@/lib/zod/finance"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
 export function getInitials(name: string): string {
@@ -68,6 +69,42 @@ export function EligibilityToken({ status }: { status: string }) {
       <span className={cn("size-1.5 shrink-0 rounded-full", m.dot)} />
       {m.label}
     </span>
+  )
+}
+
+// Học phí HK1 (Admission List v2). Chấm màu map TĨNH từ `tuition_hk1_status`
+// (BE emit — thin client, FE chỉ map màu). status "none"/undefined = hồ sơ chưa
+// có học phí HK1 → "—".
+const HK1_DOT: Record<string, string> = {
+  paid: "bg-success-500",
+  partial: "bg-amber-500",
+  unpaid: "bg-gray-400",
+  overdue: "bg-error-500",
+}
+
+export function TuitionHk1({
+  paid,
+  remaining,
+  status,
+}: {
+  paid: number | null | undefined
+  remaining: number | null | undefined
+  status: string | null | undefined
+}) {
+  if (!status || status === "none") {
+    return <span className="text-sm text-muted-foreground">—</span>
+  }
+  const dot = HK1_DOT[status] ?? "bg-gray-400"
+  return (
+    <div className="flex items-center gap-2 whitespace-nowrap">
+      <span className={cn("size-1.5 shrink-0 rounded-full", dot)} aria-hidden="true" />
+      <div className="text-xs leading-tight tabular-nums">
+        <div className="text-foreground">Đã đóng {formatVND(paid ?? 0)}</div>
+        <div className={cn(status === "overdue" ? "text-error-700" : "text-muted-foreground")}>
+          Còn lại {formatVND(remaining ?? 0)}
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/frontend/src/hooks/admissions/filterDefaults.test.ts
+++ b/frontend/src/hooks/admissions/filterDefaults.test.ts
@@ -1,0 +1,66 @@
+// src/hooks/admissions/filterDefaults.test.ts
+import { describe, it, expect } from "vitest"
+import {
+  parseAdmissionsSearchParamsToApiParams,
+  areAdmissionsListParamsEqual,
+} from "./filterDefaults"
+
+// Regression guard for the SSR coordination-filter drift (Admission List v2 #1):
+// the SSR parser + equality key-set MUST know the officer/unit_id/reviewer/
+// unassigned params, else a ?officer=5 deep-link reuses the UNFILTERED SSR
+// initialData (list shows all rows while badges show the filtered count).
+
+describe("parseAdmissionsSearchParamsToApiParams — coordination filters", () => {
+  it("parses officer / unit_id / reviewer / unassigned from the URL", () => {
+    const p = parseAdmissionsSearchParamsToApiParams({
+      officer: "5,7",
+      unit_id: "3",
+      reviewer: "9",
+      unassigned: "1",
+    })
+    expect(p.assigned_officer_id).toBe("5,7")
+    expect(p.unit_id).toBe(3)
+    expect(p.assigned_reviewer_id).toBe("9")
+    expect(p.unassigned).toBe(true)
+  })
+
+  it("omits coordination params when absent", () => {
+    const p = parseAdmissionsSearchParamsToApiParams({})
+    expect(p.assigned_officer_id).toBeUndefined()
+    expect(p.unit_id).toBeUndefined()
+    expect(p.assigned_reviewer_id).toBeUndefined()
+    expect(p.unassigned).toBeUndefined()
+  })
+
+  it("treats unassigned only for '1' / 'true'", () => {
+    expect(parseAdmissionsSearchParamsToApiParams({ unassigned: "true" }).unassigned).toBe(true)
+    expect(parseAdmissionsSearchParamsToApiParams({ unassigned: "0" }).unassigned).toBeUndefined()
+  })
+})
+
+describe("areAdmissionsListParamsEqual — coordination keys (SSR-drift guard)", () => {
+  const base = parseAdmissionsSearchParamsToApiParams({})
+
+  it("detects an officer-only difference → SSR initialData must NOT be reused", () => {
+    const client = parseAdmissionsSearchParamsToApiParams({ officer: "5" })
+    expect(areAdmissionsListParamsEqual(client, base)).toBe(false)
+  })
+
+  it("detects unit_id / reviewer / unassigned differences", () => {
+    expect(
+      areAdmissionsListParamsEqual(parseAdmissionsSearchParamsToApiParams({ unit_id: "3" }), base),
+    ).toBe(false)
+    expect(
+      areAdmissionsListParamsEqual(parseAdmissionsSearchParamsToApiParams({ reviewer: "9" }), base),
+    ).toBe(false)
+    expect(
+      areAdmissionsListParamsEqual(parseAdmissionsSearchParamsToApiParams({ unassigned: "1" }), base),
+    ).toBe(false)
+  })
+
+  it("returns true when coordination params match", () => {
+    const a = parseAdmissionsSearchParamsToApiParams({ officer: "5", unit_id: "3" })
+    const b = parseAdmissionsSearchParamsToApiParams({ officer: "5", unit_id: "3" })
+    expect(areAdmissionsListParamsEqual(a, b)).toBe(true)
+  })
+})

--- a/frontend/src/hooks/admissions/filterDefaults.test.ts
+++ b/frontend/src/hooks/admissions/filterDefaults.test.ts
@@ -3,6 +3,9 @@ import { describe, it, expect } from "vitest"
 import {
   parseAdmissionsSearchParamsToApiParams,
   areAdmissionsListParamsEqual,
+  buildCoordinationParams,
+  parseUnitId,
+  ADMISSIONS_INT4_MAX,
 } from "./filterDefaults"
 
 // Regression guard for the SSR coordination-filter drift (Admission List v2 #1):
@@ -62,5 +65,69 @@ describe("areAdmissionsListParamsEqual — coordination keys (SSR-drift guard)",
     const a = parseAdmissionsSearchParamsToApiParams({ officer: "5", unit_id: "3" })
     const b = parseAdmissionsSearchParamsToApiParams({ officer: "5", unit_id: "3" })
     expect(areAdmissionsListParamsEqual(a, b)).toBe(true)
+  })
+})
+
+// int4-guard for unit_id (Admission List v2 review #1): a value beyond int4 must
+// be DROPPED, never forwarded to the wire — else `Lead.unit_id == <huge>` makes
+// asyncpg raise "integer out of range" → 500 (the #437 incident class).
+describe("parseUnitId — int4 range guard", () => {
+  it("parses a valid unit id", () => {
+    expect(parseUnitId("3")).toBe(3)
+    expect(parseUnitId(String(ADMISSIONS_INT4_MAX))).toBe(ADMISSIONS_INT4_MAX)
+  })
+
+  it("drops an out-of-int4 / non-positive / non-numeric value", () => {
+    expect(parseUnitId("99999999999")).toBeUndefined() // > int4 max
+    expect(parseUnitId(String(ADMISSIONS_INT4_MAX + 1))).toBeUndefined()
+    expect(parseUnitId("0")).toBeUndefined()
+    expect(parseUnitId("-4")).toBeUndefined()
+    expect(parseUnitId("abc")).toBeUndefined()
+    expect(parseUnitId(undefined)).toBeUndefined()
+    expect(parseUnitId("")).toBeUndefined()
+  })
+
+  it("SSR parser drops an out-of-int4 unit_id deep-link (no SSR 500)", () => {
+    const p = parseAdmissionsSearchParamsToApiParams({ unit_id: "99999999999" })
+    expect(p.unit_id).toBeUndefined()
+  })
+})
+
+// Shared coordination-param builder (apiFilters + countFilters + export) — one
+// source so the three never drift (officer XOR unassigned, unit int4-guard).
+describe("buildCoordinationParams", () => {
+  const empty = { officerFilters: [], unitId: "", reviewerFilters: [], unassigned: false }
+
+  it("maps officer / unit_id / reviewer", () => {
+    const p = buildCoordinationParams({
+      officerFilters: ["5", "7"],
+      unitId: "3",
+      reviewerFilters: ["9"],
+      unassigned: false,
+    })
+    expect(p.assigned_officer_id).toBe("5,7")
+    expect(p.unit_id).toBe(3)
+    expect(p.assigned_reviewer_id).toBe("9")
+    expect(p.unassigned).toBeUndefined()
+  })
+
+  it("XOR: 'unassigned' drops the officer-IN list (avoids IS NULL AND IN = ∅)", () => {
+    const p = buildCoordinationParams({
+      officerFilters: ["5"],
+      unitId: "",
+      reviewerFilters: [],
+      unassigned: true,
+    })
+    expect(p.assigned_officer_id).toBeUndefined()
+    expect(p.unassigned).toBe(true)
+  })
+
+  it("drops an out-of-int4 unit_id (never 500s the backend)", () => {
+    const p = buildCoordinationParams({ ...empty, unitId: "99999999999" })
+    expect(p.unit_id).toBeUndefined()
+  })
+
+  it("returns an empty object when nothing is set", () => {
+    expect(buildCoordinationParams(empty)).toEqual({})
   })
 })

--- a/frontend/src/hooks/admissions/filterDefaults.ts
+++ b/frontend/src/hooks/admissions/filterDefaults.ts
@@ -54,6 +54,12 @@ const ADMISSIONS_LIST_PARAM_KEYS = [
   "date_to",
   "sort_by",
   "order",
+  // Coordination filters (Admission List v2) — MUST be here so the SSR/initialData
+  // equality check detects them; else a ?officer=5 deep-link reuses unfiltered SSR.
+  "assigned_officer_id",
+  "unit_id",
+  "assigned_reviewer_id",
+  "unassigned",
 ] as const satisfies readonly (keyof AdmissionListParams)[]
 
 function getFirstParam(
@@ -114,6 +120,23 @@ export function parseAdmissionsSearchParamsToApiParams(
 
   const to = getFirstParam(searchParams, "to")
   if (to) params.date_to = to
+
+  // Coordination filters (Admission List v2) — URL keys mirror useAdmissionsFilter's
+  // URL-write (officer / unit_id / reviewer / unassigned). Must match the client
+  // apiFilters shape (assigned_officer_id / unit_id / assigned_reviewer_id /
+  // unassigned) so areAdmissionsListParamsEqual sees the SSR + client as equal.
+  // officer XOR unassigned (the hook never writes both), so no conflict here.
+  const officer = getFirstParam(searchParams, "officer")
+  if (officer) params.assigned_officer_id = officer
+
+  const unitId = parseIntegerParam(getFirstParam(searchParams, "unit_id"))
+  if (unitId !== undefined) params.unit_id = unitId
+
+  const reviewer = getFirstParam(searchParams, "reviewer")
+  if (reviewer) params.assigned_reviewer_id = reviewer
+
+  const unassigned = getFirstParam(searchParams, "unassigned")
+  if (unassigned === "1" || unassigned === "true") params.unassigned = true
 
   return params
 }

--- a/frontend/src/hooks/admissions/filterDefaults.ts
+++ b/frontend/src/hooks/admissions/filterDefaults.ts
@@ -41,6 +41,15 @@ export const ADMISSIONS_DEFAULT_SORT_BY: NonNullable<AdmissionListParams["sort_b
 export const ADMISSIONS_DEFAULT_SORT_ORDER: NonNullable<AdmissionListParams["order"]> = "desc"
 export const CURRENT_ADMISSIONS_YEAR = new Date().getFullYear()
 
+/**
+ * Postgres int4 upper bound. `unit_id` / officer / reviewer ids are compared
+ * against int4 columns; SQLAlchemy binds the value with the COLUMN's type, so a
+ * value beyond int4 makes asyncpg raise "integer out of range" → 500 (the #437
+ * incident class the backend `_parse_id_csv` guards). A plain `Number.isFinite`
+ * check passes 99999999999, so any int forwarded to the wire must clamp here.
+ */
+export const ADMISSIONS_INT4_MAX = 2147483647
+
 const ADMISSIONS_LIST_PARAM_KEYS = [
   "page",
   "page_size",
@@ -74,6 +83,57 @@ function parseIntegerParam(value: string | undefined): number | undefined {
   if (!value) return undefined
   const parsed = Number.parseInt(value, 10)
   return Number.isFinite(parsed) ? parsed : undefined
+}
+
+/**
+ * Parse a `unit_id` (URL/state string) → number, dropping anything outside the
+ * int4 range. Unlike {@link parseIntegerParam}, an out-of-int4 value (e.g.
+ * `?unit_id=99999999999`) is DROPPED rather than forwarded, so it never reaches
+ * `Lead.unit_id == <huge>` and 500s the backend. Mirrors `_parse_id_csv`.
+ */
+export function parseUnitId(value: string | undefined): number | undefined {
+  const parsed = parseIntegerParam(value)
+  if (parsed === undefined) return undefined
+  if (parsed < 1 || parsed > ADMISSIONS_INT4_MAX) return undefined
+  return parsed
+}
+
+/** Coordination-filter state (officer / unit / reviewer / unassigned). */
+export interface AdmissionsCoordinationState {
+  officerFilters: string[]
+  unitId: string
+  reviewerFilters: string[]
+  unassigned: boolean
+}
+
+export type AdmissionsCoordinationParams = Pick<
+  AdmissionListParams,
+  "assigned_officer_id" | "unit_id" | "assigned_reviewer_id" | "unassigned"
+>
+
+/**
+ * Map coordination-filter state → wire params. SINGLE source shared by
+ * `useAdmissionsFilter` (apiFilters + countFilters) and the CSV export, so the
+ * three never drift — the exact class of SSR/list/count divergence this list
+ * already had to patch. Encodes the two invariants once:
+ *  - officer XOR unassigned: an active "unassigned" DROPS the officer-IN list
+ *    (else `IS NULL AND IN(...)` = ∅, an always-empty result).
+ *  - `unit_id` int4-guarded (see {@link parseUnitId}) so a huge value never 500s.
+ */
+export function buildCoordinationParams(
+  state: AdmissionsCoordinationState,
+): AdmissionsCoordinationParams {
+  const params: AdmissionsCoordinationParams = {}
+  if (state.officerFilters.length > 0 && !state.unassigned) {
+    params.assigned_officer_id = state.officerFilters.join(",")
+  }
+  if (state.unassigned) params.unassigned = true
+  const unitId = parseUnitId(state.unitId)
+  if (unitId !== undefined) params.unit_id = unitId
+  if (state.reviewerFilters.length > 0) {
+    params.assigned_reviewer_id = state.reviewerFilters.join(",")
+  }
+  return params
 }
 
 export function getDefaultAdmissionsListParams(
@@ -129,7 +189,9 @@ export function parseAdmissionsSearchParamsToApiParams(
   const officer = getFirstParam(searchParams, "officer")
   if (officer) params.assigned_officer_id = officer
 
-  const unitId = parseIntegerParam(getFirstParam(searchParams, "unit_id"))
+  // int4-guard: a deep-link ?unit_id=99999999999 must not reach the SSR list
+  // fetch (→ Lead.unit_id == <huge> → asyncpg int4 overflow → SSR 500).
+  const unitId = parseUnitId(getFirstParam(searchParams, "unit_id"))
   if (unitId !== undefined) params.unit_id = unitId
 
   const reviewer = getFirstParam(searchParams, "reviewer")

--- a/frontend/src/hooks/admissions/useAdmissions.ts
+++ b/frontend/src/hooks/admissions/useAdmissions.ts
@@ -67,6 +67,12 @@ export function useListAdmissions(
       date_to: filters?.date_to,
       sort_by: filters?.sort_by,
       order: filters?.order,
+      // Coordination filters (Admission List v2) — forwarded EXPLICITLY (this hook
+      // does not spread `filters`), else they never reach the wire.
+      assigned_officer_id: filters?.assigned_officer_id,
+      unit_id: filters?.unit_id,
+      assigned_reviewer_id: filters?.assigned_reviewer_id,
+      unassigned: filters?.unassigned,
     }),
     staleTime: 15000, // 15 seconds
     gcTime: 5 * 60 * 1000, // 5 min — keep cached pages for back-navigation

--- a/frontend/src/hooks/admissions/useAdmissionsFilter.test.ts
+++ b/frontend/src/hooks/admissions/useAdmissionsFilter.test.ts
@@ -76,7 +76,7 @@ describe("useAdmissionsFilter", () => {
     it("restores localStorage filters after hydration", async () => {
       vi.spyOn(Storage.prototype, "getItem").mockReturnValue(
         JSON.stringify({
-          version: 1,
+          version: 2,
           data: {
             page: 2,
             search: "Nguyen",
@@ -195,6 +195,70 @@ describe("useAdmissionsFilter", () => {
         result.current.handlers.handleTabClick("pending")
       })
       expect(result.current.state.page).toBe(1)
+    })
+  })
+
+  describe("Coordination filters (Admission List v2)", () => {
+    it("officer ↔ unassigned are mutually exclusive (XOR)", () => {
+      const { result } = renderHook(() => useAdmissionsFilter())
+
+      act(() => result.current.handlers.handleUnassignedChange(true))
+      expect(result.current.state.unassigned).toBe(true)
+
+      // Selecting officers clears "unassigned"
+      act(() => result.current.handlers.handleOfficerChange(["5", "7"]))
+      expect(result.current.state.officerFilters).toEqual(["5", "7"])
+      expect(result.current.state.unassigned).toBe(false)
+
+      // Turning "unassigned" back on clears the officer list
+      act(() => result.current.handlers.handleUnassignedChange(true))
+      expect(result.current.state.unassigned).toBe(true)
+      expect(result.current.state.officerFilters).toEqual([])
+    })
+
+    it("apiFilters maps officer (comma-join), unit_id (int), reviewer", () => {
+      const { result } = renderHook(() => useAdmissionsFilter())
+
+      act(() => {
+        result.current.handlers.handleOfficerChange(["5", "7"])
+        result.current.handlers.handleUnitIdChange("3")
+        result.current.handlers.handleReviewerChange(["9"])
+      })
+
+      expect(result.current.apiFilters.assigned_officer_id).toBe("5,7")
+      expect(result.current.apiFilters.unit_id).toBe(3)
+      expect(result.current.apiFilters.assigned_reviewer_id).toBe("9")
+      expect(result.current.apiFilters.unassigned).toBeUndefined()
+    })
+
+    it("apiFilters drops officer list and sets unassigned when unassigned is on", () => {
+      const { result } = renderHook(() => useAdmissionsFilter())
+
+      act(() => result.current.handlers.handleOfficerChange(["5"]))
+      act(() => result.current.handlers.handleUnassignedChange(true))
+
+      expect(result.current.apiFilters.unassigned).toBe(true)
+      expect(result.current.apiFilters.assigned_officer_id).toBeUndefined()
+    })
+  })
+
+  describe("STORAGE_VERSION bump", () => {
+    it("discards stale v1 localStorage (no restore)", async () => {
+      vi.spyOn(Storage.prototype, "getItem").mockReturnValue(
+        JSON.stringify({
+          version: 1,
+          data: { page: 9, search: "STALE", statusFilters: ["draft"], activeTab: "draft" },
+        }),
+      )
+
+      const { result } = renderHook(() => useAdmissionsFilter())
+
+      // Give the post-hydration restore effect a chance to (not) run.
+      await waitFor(() => {
+        expect(result.current.state.page).toBe(1)
+      })
+      expect(result.current.state.search).toBe("")
+      expect(result.current.state.activeTab).toBe("all")
     })
   })
 })

--- a/frontend/src/hooks/admissions/useAdmissionsFilter.ts
+++ b/frontend/src/hooks/admissions/useAdmissionsFilter.ts
@@ -38,6 +38,11 @@ export interface StoredFilters {
   dateFrom: string
   dateTo: string
   activeTab: string
+  // Coordination filters (admin/manager) — Admission List v2
+  officerFilters: string[]   // multi-select officer IDs (as strings)
+  unitId: string             // single unit ID (as string)
+  reviewerFilters: string[]  // multi-select reviewer IDs (as strings)
+  unassigned: boolean        // only profiles with no assigned officer
 }
 
 export interface AdmissionsFilterState extends StoredFilters {
@@ -58,6 +63,10 @@ export interface AdmissionsFilterHandlers {
   handleDateToChange: (date: string) => void
   handleSortChange: (sortBy: string, sortOrder: "asc" | "desc") => void
   handleTabClick: (tabKey: string) => void
+  handleOfficerChange: (officerIds: string[]) => void
+  handleUnitIdChange: (unitId: string) => void
+  handleReviewerChange: (reviewerIds: string[]) => void
+  handleUnassignedChange: (unassigned: boolean) => void
   resetFilters: () => void
 }
 
@@ -74,7 +83,9 @@ export interface UseAdmissionsFilterReturn {
 // =============================================================================
 
 const STORAGE_KEY = "admissions_filters"
-const STORAGE_VERSION = 1
+// v2 (Admission List v2): added officer/unit/reviewer/unassigned coordination
+// filters → bump so stale v1 localStorage (without these keys) is discarded.
+const STORAGE_VERSION = 2
 
 interface VersionedStorage {
   version: number
@@ -97,6 +108,10 @@ const DEFAULT_FILTERS: StoredFilters = {
   dateFrom: "",
   dateTo: "",
   activeTab: "all",
+  officerFilters: [],
+  unitId: "",
+  reviewerFilters: [],
+  unassigned: false,
 }
 
 // =============================================================================
@@ -149,6 +164,8 @@ function normalizeStoredFilters(filters: StoredFilters): StoredFilters {
     ...DEFAULT_FILTERS,
     ...filters,
     statusFilters: Array.isArray(filters.statusFilters) ? filters.statusFilters : [],
+    officerFilters: Array.isArray(filters.officerFilters) ? filters.officerFilters : [],
+    reviewerFilters: Array.isArray(filters.reviewerFilters) ? filters.reviewerFilters : [],
   }
 }
 
@@ -167,7 +184,11 @@ function hasUrlFilterParams(sp: URLSearchParams): boolean {
     sp.get("payment") ||
     sp.get("from") ||
     sp.get("to") ||
-    sp.get("tab")
+    sp.get("tab") ||
+    sp.get("officer") ||
+    sp.get("unit_id") ||
+    sp.get("reviewer") ||
+    sp.get("unassigned")
   )
 }
 
@@ -184,6 +205,10 @@ function parseSearchParams(sp: URLSearchParams): StoredFilters {
     dateFrom: sp.get("from") || "",
     dateTo: sp.get("to") || "",
     activeTab: sp.get("tab") || "all",
+    officerFilters: sp.get("officer")?.split(",").filter(Boolean) || [],
+    unitId: sp.get("unit_id") || "",
+    reviewerFilters: sp.get("reviewer")?.split(",").filter(Boolean) || [],
+    unassigned: sp.get("unassigned") === "1" || sp.get("unassigned") === "true",
   }
 }
 
@@ -223,6 +248,10 @@ export function useAdmissionsFilter(
   const [dateFrom, setDateFrom] = useState(initialValues.dateFrom)
   const [dateTo, setDateTo] = useState(initialValues.dateTo)
   const [activeTab, setActiveTab] = useState(initialValues.activeTab)
+  const [officerFilters, setOfficerFilters] = useState<string[]>(initialValues.officerFilters)
+  const [unitId, setUnitId] = useState(initialValues.unitId)
+  const [reviewerFilters, setReviewerFilters] = useState<string[]>(initialValues.reviewerFilters)
+  const [unassigned, setUnassigned] = useState(initialValues.unassigned)
   const [sortBy, setSortBy] = useState("created_at")
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc")
 
@@ -254,6 +283,14 @@ export function useAdmissionsFilter(
     setDateFrom((current) => (current === restored.dateFrom ? current : restored.dateFrom))
     setDateTo((current) => (current === restored.dateTo ? current : restored.dateTo))
     setActiveTab((current) => (current === restored.activeTab ? current : restored.activeTab))
+    setOfficerFilters((current) =>
+      arraysEqual(current, restored.officerFilters) ? current : [...restored.officerFilters],
+    )
+    setUnitId((current) => (current === restored.unitId ? current : restored.unitId))
+    setReviewerFilters((current) =>
+      arraysEqual(current, restored.reviewerFilters) ? current : [...restored.reviewerFilters],
+    )
+    setUnassigned((current) => (current === restored.unassigned ? current : restored.unassigned))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -282,6 +319,10 @@ export function useAdmissionsFilter(
     if (url.dateFrom !== dateFrom) setDateFrom(url.dateFrom)
     if (url.dateTo !== dateTo) setDateTo(url.dateTo)
     if (url.activeTab !== activeTab) setActiveTab(url.activeTab)
+    if (JSON.stringify(url.officerFilters) !== JSON.stringify(officerFilters)) setOfficerFilters(url.officerFilters)
+    if (url.unitId !== unitId) setUnitId(url.unitId)
+    if (JSON.stringify(url.reviewerFilters) !== JSON.stringify(reviewerFilters)) setReviewerFilters(url.reviewerFilters)
+    if (url.unassigned !== unassigned) setUnassigned(url.unassigned)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams])
 
@@ -309,6 +350,10 @@ export function useAdmissionsFilter(
       if (dateFrom) params.set("from", dateFrom)
       if (dateTo) params.set("to", dateTo)
       if (activeTab !== "all") params.set("tab", activeTab)
+      if (officerFilters.length > 0) params.set("officer", officerFilters.join(","))
+      if (unitId) params.set("unit_id", unitId)
+      if (reviewerFilters.length > 0) params.set("reviewer", reviewerFilters.join(","))
+      if (unassigned) params.set("unassigned", "1")
 
       const qs = params.toString()
       const newUrl = qs ? `${pathname}?${qs}` : pathname
@@ -323,6 +368,7 @@ export function useAdmissionsFilter(
   }, [
     page, search, statusFilters, majorFilter, academicYear,
     degreeLevelFilter, paymentStatusFilter, dateFrom, dateTo, activeTab,
+    officerFilters, unitId, reviewerFilters, unassigned,
     pathname,
   ])
 
@@ -331,6 +377,7 @@ export function useAdmissionsFilter(
     const data: StoredFilters = {
       page, search, statusFilters, majorFilter, academicYear,
       degreeLevelFilter, paymentStatusFilter, dateFrom, dateTo, activeTab,
+      officerFilters, unitId, reviewerFilters, unassigned,
     }
 
     const shouldSave =
@@ -343,7 +390,11 @@ export function useAdmissionsFilter(
       paymentStatusFilter ||
       dateFrom ||
       dateTo ||
-      activeTab !== "all"
+      activeTab !== "all" ||
+      officerFilters.length > 0 ||
+      unitId ||
+      reviewerFilters.length > 0 ||
+      unassigned
 
     if (isStorageSyncInitialMount.current) {
       isStorageSyncInitialMount.current = false
@@ -358,6 +409,7 @@ export function useAdmissionsFilter(
   }, [
     page, search, statusFilters, majorFilter, academicYear,
     degreeLevelFilter, paymentStatusFilter, dateFrom, dateTo, activeTab,
+    officerFilters, unitId, reviewerFilters, unassigned,
   ])
 
   // ── HANDLERS (all reset page to 1) ────────────────────────────────────
@@ -415,6 +467,30 @@ export function useAdmissionsFilter(
     setPage(1)
   }, [])
 
+  const handleOfficerChange = useCallback((officerIds: string[]) => {
+    setOfficerFilters(officerIds)
+    // XOR: selecting officers clears "unassigned" (else IS NULL AND IN = empty).
+    if (officerIds.length > 0) setUnassigned(false)
+    setPage(1)
+  }, [])
+
+  const handleUnitIdChange = useCallback((nextUnitId: string) => {
+    setUnitId(nextUnitId)
+    setPage(1)
+  }, [])
+
+  const handleReviewerChange = useCallback((reviewerIds: string[]) => {
+    setReviewerFilters(reviewerIds)
+    setPage(1)
+  }, [])
+
+  const handleUnassignedChange = useCallback((next: boolean) => {
+    setUnassigned(next)
+    // XOR: "unassigned" clears the officer selection.
+    if (next) setOfficerFilters([])
+    setPage(1)
+  }, [])
+
   const resetFilters = useCallback(() => {
     setSearch("")
     setStatusFilters([])
@@ -425,6 +501,10 @@ export function useAdmissionsFilter(
     setDateFrom("")
     setDateTo("")
     setActiveTab("all")
+    setOfficerFilters([])
+    setUnitId("")
+    setReviewerFilters([])
+    setUnassigned(false)
     setSortBy("created_at")
     setSortOrder("desc")
     setPage(1)
@@ -441,11 +521,16 @@ export function useAdmissionsFilter(
       paymentStatusFilter ||
       dateFrom ||
       dateTo ||
-      (academicYear !== undefined && academicYear !== CURRENT_ADMISSIONS_YEAR)
+      (academicYear !== undefined && academicYear !== CURRENT_ADMISSIONS_YEAR) ||
+      officerFilters.length > 0 ||
+      unitId ||
+      reviewerFilters.length > 0 ||
+      unassigned
     )
   }, [
     search, statusFilters, majorFilter, degreeLevelFilter,
     paymentStatusFilter, dateFrom, dateTo, academicYear,
+    officerFilters, unitId, reviewerFilters, unassigned,
   ])
 
   /** Params sent to useListAdmissions */
@@ -465,11 +550,20 @@ export function useAdmissionsFilter(
     if (paymentStatusFilter) params.payment_status = paymentStatusFilter
     if (dateFrom) params.date_from = dateFrom
     if (dateTo) params.date_to = dateTo
+    // Coordination filters — XOR: drop officer list when "unassigned" is on.
+    if (officerFilters.length > 0 && !unassigned) params.assigned_officer_id = officerFilters.join(",")
+    if (unassigned) params.unassigned = true
+    if (unitId) {
+      const parsedUnitId = parseInt(unitId, 10)
+      if (Number.isFinite(parsedUnitId)) params.unit_id = parsedUnitId
+    }
+    if (reviewerFilters.length > 0) params.assigned_reviewer_id = reviewerFilters.join(",")
 
     return params
   }, [
     page, pageSize, search, statusFilters, majorFilter, academicYear,
     degreeLevelFilter, paymentStatusFilter, dateFrom, dateTo, sortBy, sortOrder,
+    officerFilters, unitId, reviewerFilters, unassigned,
   ])
 
   /** Params for useAdmissionStatusCounts (excludes page/status/sort) */
@@ -483,15 +577,27 @@ export function useAdmissionsFilter(
     if (paymentStatusFilter) params.payment_status = paymentStatusFilter
     if (dateFrom) params.date_from = dateFrom
     if (dateTo) params.date_to = dateTo
+    // Coordination filters (parity with apiFilters → tab counts match rows).
+    if (officerFilters.length > 0 && !unassigned) params.assigned_officer_id = officerFilters.join(",")
+    if (unassigned) params.unassigned = true
+    if (unitId) {
+      const parsedUnitId = parseInt(unitId, 10)
+      if (Number.isFinite(parsedUnitId)) params.unit_id = parsedUnitId
+    }
+    if (reviewerFilters.length > 0) params.assigned_reviewer_id = reviewerFilters.join(",")
 
     return params
-  }, [search, majorFilter, academicYear, degreeLevelFilter, paymentStatusFilter, dateFrom, dateTo])
+  }, [
+    search, majorFilter, academicYear, degreeLevelFilter, paymentStatusFilter,
+    dateFrom, dateTo, officerFilters, unitId, reviewerFilters, unassigned,
+  ])
 
   // ── RETURN ────────────────────────────────────────────────────────────
   return {
     state: {
       page, pageSize, search, statusFilters, majorFilter, academicYear,
       degreeLevelFilter, paymentStatusFilter, dateFrom, dateTo, activeTab,
+      officerFilters, unitId, reviewerFilters, unassigned,
       sortBy, sortOrder,
     },
     handlers: {
@@ -506,6 +612,10 @@ export function useAdmissionsFilter(
       handleDateToChange,
       handleSortChange,
       handleTabClick,
+      handleOfficerChange,
+      handleUnitIdChange,
+      handleReviewerChange,
+      handleUnassignedChange,
       resetFilters,
     },
     hasActiveFilters,

--- a/frontend/src/hooks/admissions/useAdmissionsFilter.ts
+++ b/frontend/src/hooks/admissions/useAdmissionsFilter.ts
@@ -21,6 +21,7 @@ import {
   ADMISSIONS_DEFAULT_PAGE_SIZE,
   CURRENT_ADMISSIONS_YEAR,
   ADMISSION_STATUS_TABS as STATUS_TABS,
+  buildCoordinationParams,
 } from "./filterDefaults"
 
 // =============================================================================
@@ -550,14 +551,9 @@ export function useAdmissionsFilter(
     if (paymentStatusFilter) params.payment_status = paymentStatusFilter
     if (dateFrom) params.date_from = dateFrom
     if (dateTo) params.date_to = dateTo
-    // Coordination filters — XOR: drop officer list when "unassigned" is on.
-    if (officerFilters.length > 0 && !unassigned) params.assigned_officer_id = officerFilters.join(",")
-    if (unassigned) params.unassigned = true
-    if (unitId) {
-      const parsedUnitId = parseInt(unitId, 10)
-      if (Number.isFinite(parsedUnitId)) params.unit_id = parsedUnitId
-    }
-    if (reviewerFilters.length > 0) params.assigned_reviewer_id = reviewerFilters.join(",")
+    // Coordination filters (officer XOR unassigned, unit_id int4-guard, reviewer)
+    // — one helper shared with countFilters + export so all three stay in lockstep.
+    Object.assign(params, buildCoordinationParams({ officerFilters, unitId, reviewerFilters, unassigned }))
 
     return params
   }, [
@@ -578,13 +574,7 @@ export function useAdmissionsFilter(
     if (dateFrom) params.date_from = dateFrom
     if (dateTo) params.date_to = dateTo
     // Coordination filters (parity with apiFilters → tab counts match rows).
-    if (officerFilters.length > 0 && !unassigned) params.assigned_officer_id = officerFilters.join(",")
-    if (unassigned) params.unassigned = true
-    if (unitId) {
-      const parsedUnitId = parseInt(unitId, 10)
-      if (Number.isFinite(parsedUnitId)) params.unit_id = parsedUnitId
-    }
-    if (reviewerFilters.length > 0) params.assigned_reviewer_id = reviewerFilters.join(",")
+    Object.assign(params, buildCoordinationParams({ officerFilters, unitId, reviewerFilters, unassigned }))
 
     return params
   }, [

--- a/frontend/src/lib/api/admissions.test.ts
+++ b/frontend/src/lib/api/admissions.test.ts
@@ -1,0 +1,78 @@
+// src/lib/api/admissions.test.ts
+import { describe, it, expect, beforeEach } from "vitest"
+import { server } from "@/test/mocks/server"
+import { http, HttpResponse } from "msw"
+import { listAdmissions } from "./admissions"
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000"
+
+describe("listAdmissions — Admission List v2", () => {
+  beforeEach(() => server.resetHandlers())
+
+  it("normalizes HK1 Decimal-string money to numbers; null stays null", async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/api/admissions`, () =>
+        HttpResponse.json({
+          total_count: 2,
+          page: 1,
+          page_size: 20,
+          profiles: [
+            {
+              id: 1,
+              status: "submitted",
+              // BE serializes Decimal → JSON string (Pydantic v2)
+              tuition_paid_hk1: "3000000.00",
+              tuition_remaining_hk1: "6200000.00",
+              tuition_hk1_status: "partial",
+              tuition_overdue_hk1: false,
+            },
+            {
+              id: 2,
+              status: "submitted",
+              tuition_paid_hk1: null,
+              tuition_remaining_hk1: null,
+              tuition_hk1_status: "none",
+              tuition_overdue_hk1: false,
+            },
+          ],
+        }),
+      ),
+    )
+
+    const page = await listAdmissions()
+    const [a, b] = page.profiles
+
+    // listAdmissions does the runtime conversion (the response is NOT zod-parsed).
+    expect(typeof a.tuition_paid_hk1).toBe("number")
+    expect(a.tuition_paid_hk1).toBe(3000000)
+    expect(a.tuition_remaining_hk1).toBe(6200000)
+    expect(b.tuition_paid_hk1).toBeNull()
+    expect(b.tuition_remaining_hk1).toBeNull()
+  })
+
+  it("forwards coordination filters in the query string", async () => {
+    let captured: URLSearchParams | null = null
+    server.use(
+      http.get(`${API_BASE_URL}/api/admissions`, ({ request }) => {
+        captured = new URL(request.url).searchParams
+        return HttpResponse.json({ total_count: 0, page: 1, page_size: 20, profiles: [] })
+      }),
+    )
+
+    await listAdmissions({
+      assigned_officer_id: "5,7",
+      unit_id: 3,
+      unassigned: true,
+      assigned_reviewer_id: "9",
+      sort_by: "remaining_hk1",
+      payment_status: "overdue",
+    })
+
+    expect(captured!.get("assigned_officer_id")).toBe("5,7")
+    expect(captured!.get("unit_id")).toBe("3")
+    expect(captured!.get("unassigned")).toBe("true")
+    expect(captured!.get("assigned_reviewer_id")).toBe("9")
+    expect(captured!.get("sort_by")).toBe("remaining_hk1")
+    expect(captured!.get("payment_status")).toBe("overdue")
+  })
+})

--- a/frontend/src/lib/api/admissions.ts
+++ b/frontend/src/lib/api/admissions.ts
@@ -25,14 +25,32 @@ import type {
 // ADMISSION CRUD OPERATIONS
 // ============================================
 
+/** Coerce a money field (BE Decimal → JSON string) to number for display + sort. */
+function toNum(v: unknown): number | null {
+  return v == null ? null : Number(v)
+}
+
 /**
- * Get list of admissions with pagination and filters
+ * Get list of admissions with pagination and filters.
+ *
+ * NOTE (Admission List v2): the response is NOT zod-parsed, so the HK1 money
+ * fields arrive as Decimal JSON strings. Normalize them to numbers HERE — the
+ * single boundary every consumer reads — so `formatVND` + the TanStack column
+ * sort (getSortedRowModel) operate on numbers, not lexicographic strings.
  */
 export async function listAdmissions(
   params?: AdmissionListParams
 ): Promise<AdmissionsPage> {
   const response = await api.get<AdmissionsPage>('/api/admissions', { params })
-  return response.data
+  const page = response.data
+  return {
+    ...page,
+    profiles: page.profiles.map((p) => ({
+      ...p,
+      tuition_paid_hk1: toNum(p.tuition_paid_hk1),
+      tuition_remaining_hk1: toNum(p.tuition_remaining_hk1),
+    })),
+  }
 }
 
 /**

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -943,7 +943,17 @@ export const admissionProfileResponseSchema = z.object({
 
   // Denormalized fields for list display
   program_name: z.string().optional().nullable(),
-  
+
+  // Học phí HK1 (Admission List v2). NOTE: listAdmissions does NOT .parse() the
+  // response — these z.number() declarations are TYPE-ONLY (no runtime coercion).
+  // BE sends Decimal as JSON string; the string→number conversion happens in the
+  // listAdmissions API client (normalize step). tuition_hk1_status is BE-computed
+  // (FE only maps status→dot color — thin client).
+  tuition_paid_hk1: z.number().optional().nullable(),
+  tuition_remaining_hk1: z.number().optional().nullable(),
+  tuition_overdue_hk1: z.boolean().optional().default(false),
+  tuition_hk1_status: z.string().optional().nullable(),
+
   // =========================================================================
   // Phase 7: Frontend Thin Client Fields (computed by backend)
   // =========================================================================
@@ -1606,11 +1616,16 @@ export interface AdmissionListParams {
   major_id?: string     // comma-separated
   academic_year?: number
   degree_level?: string
-  payment_status?: string  // paid | unpaid | partial | no_fee
+  payment_status?: string  // paid | unpaid | partial | no_fee | overdue
   date_from?: string    // ISO date string
   date_to?: string      // ISO date string
-  sort_by?: 'created_at' | 'updated_at' | 'full_name' | 'status'
+  sort_by?: 'created_at' | 'updated_at' | 'full_name' | 'status' | 'remaining_hk1'
   order?: 'asc' | 'desc'
+  // Coordination filters (admin/manager) — Admission List v2
+  assigned_officer_id?: string   // comma-separated officer IDs
+  unit_id?: number
+  assigned_reviewer_id?: string  // comma-separated reviewer IDs
+  unassigned?: boolean
 }
 
 /**


### PR DESCRIPTION
## Mục tiêu

Nâng cấp danh sách hồ sơ tuyển sinh giải quyết 2 pain point:
1. **Officer** không thấy được tiền học phí đã đóng / công nợ từng hồ sơ ngay trên list.
2. **Admin/Manager** không lọc được danh sách theo officer / đơn vị / người duyệt / chưa giao.

Nghiệp vụ đã chốt với chủ dự án qua AskUserQuestion (30-06).

## Phần 1 — Officer thấy tiền/công nợ

- **Cột "Học phí HK1"**: hiển thị `Đã đóng / Còn lại` dạng số tiền (vd `3.000.000 / còn 6.200.000`) + chấm màu trạng thái (đủ · một phần · chưa · **quá hạn = đỏ**).
- **Phạm vi CHỈ HK1** (`fee_type=tuition`, `semester_no=1`, non-cancelled) — đồng nhất với mốc nhập học và nhãn lead `sts10` (`is_hk1_cleared`). Đã đóng = `paid_amount`; Còn lại = `final − paid − waived`. Miễn 100% (waived=final, paid=0) tính là **đủ**, không phải "chưa".
- **Filter Học phí** thêm option **"Quá hạn"** (HK1 invoice past-due, remaining > 0).
- **Sort theo "Còn lại"**.

## Phần 2 — Admin/Manager điều phối

- Filter **Officer (multi)** + **"Chưa giao" (unassigned)** + **Đơn vị** + **Người duyệt (reviewer)** — reuse endpoint nhân sự & pattern UI từ Lead-list.
- Officer dropdown scope theo đơn vị cho manager.

## Backend

- `admission_repository.py`: subquery aggregate học phí HK1 theo profile (tránh N+1, nền `Fee.resolved_*` denormalize #438) + filter điều phối; cờ `with_hk1` để export/stats **không** build subquery HK1 (perf).
- `admission_service.py` / `routers/admissions.py`: parse filter điều phối (officer multi / unassigned / unit / reviewer), int32 range-guard cho `_parse_id_csv`, truyền coord filter vào export.
- `schemas/admission.py`: thêm field học phí HK1 vào response.
- **Code-only, KHÔNG migration, KHÔNG thay đổi Casbin** → deploy chỉ cần restart backend.

## Frontend

- Cột mới + filter điều phối/quá hạn/sort; SSR coordination parse ở `filterDefaults.ts` (fix drift deep-link `?officer=5`); export truyền đủ filter; guard `unit_id` NaN.

## Kiểm thử

- **BE**: 36 test (15 unit `test_admission_coordination_filters` + 21 integration `test_admission_list_hk1`) — XANH.
- **FE**: 36 vitest (5 file, gồm `filterDefaults.test.ts` chặn tái regress SSR) + type-check `src/` sạch.
- **/code-review max ×2** — đã vá 11 finding thật (SSR drift, int32 guard, HK1 miễn-100%, export bỏ coord filter, perf `with_hk1`, officer scope unit…).

## Ghi chú

- Rebase sạch lên `main@9630bedb` (thuần domain admission, không đụng file SMS).
- **Chưa Chrome smoke** — defer post-merge để dev stack tự phục vụ code mới.

🤖 Generated with [Claude Code](https://claude.com/claude-code)