### PR TITLE
feat(sms): PR-6d FE Campaign CRUD + gắn nhóm + Build/Preflight (+BE list-groups)

### DIFF
--- a/Backend_FastAPI/app/repositories/sms_contact_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_contact_repository.py
@@ -51,6 +51,20 @@ class SmsContactRepository:
         )
         return res.scalars().first()
 
+    async def get_groups_by_ids(
+        self, group_ids: Sequence[int]
+    ) -> List[SmsContactGroup]:
+        """Lấy các nhóm theo danh sách id (giữ thứ tự tên) — cho endpoint
+        list nhóm đã gắn của campaign. Tránh N+1 (1 query IN)."""
+        if not group_ids:
+            return []
+        res = await self.db.execute(
+            select(SmsContactGroup)
+            .where(SmsContactGroup.id.in_(set(group_ids)))
+            .order_by(SmsContactGroup.name)
+        )
+        return list(res.scalars().all())
+
     async def list_groups(
         self,
         skip: int = 0,

--- a/Backend_FastAPI/app/routers/sms_campaigns.py
+++ b/Backend_FastAPI/app/routers/sms_campaigns.py
@@ -85,6 +85,20 @@ async def update_campaign(
 # =====================================================================
 # Campaign ↔ group
 # =====================================================================
+@router.get(
+    "/campaigns/{campaign_id}/groups",
+    response_model=sms_schemas.SmsContactGroupList,
+)
+async def list_campaign_groups(
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    """Danh sách nhóm đã gắn vào campaign (kèm member_count) — FE liệt kê + bỏ."""
+    total, items = await SmsCampaignService(db).list_campaign_groups(campaign_id)
+    return {"total": total, "items": items}
+
+
 @router.post(
     "/campaigns/{campaign_id}/groups",
     response_model=sms_schemas.SmsCampaignOut,

--- a/Backend_FastAPI/app/services/sms_campaign_service.py
+++ b/Backend_FastAPI/app/services/sms_campaign_service.py
@@ -201,6 +201,23 @@ class SmsCampaignService:
             self._with_computed(c, group_count=counts.get(c.id, 0))
         return total, items
 
+    async def list_campaign_groups(
+        self, campaign_id: int
+    ) -> Tuple[int, List]:
+        """Danh sách nhóm ĐÃ GẮN vào campaign (kèm member_count) — cho FE
+        liệt kê + bỏ nhóm. 404 nếu campaign không tồn tại."""
+        campaign = await self.repo.get_campaign(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        gids = await self.repo.get_campaign_group_ids(campaign_id)
+        if not gids:
+            return 0, []
+        groups = await self.contact_repo.get_groups_by_ids(gids)
+        counts = await self.contact_repo.count_members_by_group(gids)
+        for g in groups:
+            g.member_count = counts.get(g.id, 0)
+        return len(groups), groups
+
     async def update_campaign(
         self, campaign_id: int, data: sms_schemas.SmsCampaignUpdate
     ) -> SmsCampaign:

--- a/Backend_FastAPI/app/services/sms_campaign_service.py
+++ b/Backend_FastAPI/app/services/sms_campaign_service.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import SMS_OPTOUT_INSTRUCTION_DEFAULT, settings
-from app.models.sms import SmsCampaign
+from app.models.sms import SmsCampaign, SmsContactGroup
 from app.repositories.sms_campaign_repository import SmsCampaignRepository
 from app.repositories.sms_contact_repository import SmsContactRepository
 from app.schemas import sms as sms_schemas
@@ -203,7 +203,7 @@ class SmsCampaignService:
 
     async def list_campaign_groups(
         self, campaign_id: int
-    ) -> Tuple[int, List]:
+    ) -> Tuple[int, List[SmsContactGroup]]:
         """Danh sách nhóm ĐÃ GẮN vào campaign (kèm member_count) — cho FE
         liệt kê + bỏ nhóm. 404 nếu campaign không tồn tại."""
         campaign = await self.repo.get_campaign(campaign_id)

--- a/Backend_FastAPI/tests/integration/test_sms_campaign_build.py
+++ b/Backend_FastAPI/tests/integration/test_sms_campaign_build.py
@@ -179,6 +179,46 @@ async def test_campaign_group_attach_detach(
     assert res.status_code == 404
 
 
+async def test_campaign_list_groups(
+    client: AsyncClient, admin_token_headers: dict
+):
+    """GET /campaigns/{id}/groups liệt kê nhóm đã gắn + member_count (PR-6d)."""
+    h = admin_token_headers
+    g1 = await _mk_group(client, h, "LG Nhom 1")
+    g2 = await _mk_group(client, h, "LG Nhom 2")
+    c1 = await _mk_contact(client, h, "LG A", "0987000201")
+    await _add_to_group(client, h, c1, g1)  # g1 có 1 thành viên
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="CLG")).json()["id"]
+
+    # chưa gắn → rỗng
+    res = await client.get(f"{API}/campaigns/{cid}/groups", headers=h)
+    assert res.status_code == 200, res.text
+    assert res.json()["total"] == 0
+
+    for g in (g1, g2):
+        await client.post(
+            f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+        )
+
+    res = await client.get(f"{API}/campaigns/{cid}/groups", headers=h)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == 2
+    by_id = {g["id"]: g for g in body["items"]}
+    assert set(by_id) == {g1, g2}
+    assert by_id[g1]["member_count"] == 1
+    assert by_id[g2]["member_count"] == 0
+
+    # detach g2 → còn 1
+    await client.delete(f"{API}/campaigns/{cid}/groups/{g2}", headers=h)
+    res = await client.get(f"{API}/campaigns/{cid}/groups", headers=h)
+    assert res.json()["total"] == 1
+
+    # campaign không tồn tại → 404
+    res = await client.get(f"{API}/campaigns/999999999/groups", headers=h)
+    assert res.status_code == 404
+
+
 # ---------------------------------------------------------------------
 # BUILD — dedupe + snapshot + fail-closed + token + skeleton
 # ---------------------------------------------------------------------

--- a/frontend/src/app/(dashboard)/admin/sms/campaigns/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/sms/campaigns/[id]/page.tsx
@@ -1,0 +1,27 @@
+// src/app/(dashboard)/admin/sms/campaigns/[id]/page.tsx
+/**
+ * SMS Marketing — Workspace 1 chiến dịch (admin, PR-6d).
+ * Gate: proxy /admin/* + sidebar roles:["admin"]; BE require_admin.
+ */
+import { notFound } from "next/navigation"
+
+import { PageContainer } from "@/components/layouts/PageContainer"
+import { SmsCampaignWorkspace } from "@/components/sms/admin/campaigns/SmsCampaignWorkspace"
+
+export default async function SmsCampaignDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const campaignId = Number(id)
+  if (!Number.isInteger(campaignId) || campaignId < 1) {
+    notFound()
+  }
+
+  return (
+    <PageContainer maxWidth="full">
+      <SmsCampaignWorkspace campaignId={campaignId} />
+    </PageContainer>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/sms/campaigns/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/sms/campaigns/page.tsx
@@ -1,0 +1,23 @@
+// src/app/(dashboard)/admin/sms/campaigns/page.tsx
+/**
+ * SMS Marketing — Danh sách chiến dịch (admin, PR-6d).
+ * Gate: proxy /admin/* + sidebar roles:["admin"]; BE require_admin.
+ */
+import { Send } from "lucide-react"
+
+import { PageContainer } from "@/components/layouts/PageContainer"
+import { PageHeader } from "@/components/layouts/PageHeader"
+import { SmsCampaignsListClient } from "@/components/sms/admin/campaigns/SmsCampaignsListClient"
+
+export default function SmsCampaignsPage() {
+  return (
+    <PageContainer maxWidth="full">
+      <PageHeader
+        title="Chiến dịch SMS"
+        description="Tạo chiến dịch, gắn nhóm và build danh sách gửi (preflight)."
+        icon={<Send className="h-6 w-6" />}
+      />
+      <SmsCampaignsListClient />
+    </PageContainer>
+  )
+}

--- a/frontend/src/components/sms/admin/campaigns/SmsBuildPreflightSection.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsBuildPreflightSection.tsx
@@ -1,0 +1,233 @@
+// src/components/sms/admin/campaigns/SmsBuildPreflightSection.tsx
+"use client"
+
+import { AlertTriangle, Hammer, Loader2 } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  useBuildSmsCampaign,
+  useSmsCampaignPreflight,
+} from "@/hooks/useSmsCampaigns"
+import type { SmsPreflightReport } from "@/lib/zod/sms"
+
+import {
+  carrierLabel,
+  excludedReasonLabel,
+  formatInt,
+} from "../labels"
+
+interface Props {
+  campaignId: number
+  hasBuild: boolean
+  /** Build được khi draft/ready. */
+  canBuild: boolean
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border p-3">
+      <p className="text-muted-foreground text-xs">{label}</p>
+      <p className="mt-0.5 text-xl font-bold tabular-nums">{value}</p>
+    </div>
+  )
+}
+
+export function SmsBuildPreflightSection({
+  campaignId,
+  hasBuild,
+  canBuild,
+}: Props) {
+  const buildMut = useBuildSmsCampaign()
+  const { data: preflightData, isLoading } = useSmsCampaignPreflight(
+    campaignId,
+    { enabled: hasBuild },
+  )
+  // Ưu tiên kết quả build vừa chạy (tức thời), fallback query (reload).
+  const preflight: SmsPreflightReport | undefined =
+    buildMut.data ?? preflightData
+
+  const carrierEntries = preflight
+    ? Object.entries(preflight.carrier_distribution).sort((a, b) => b[1] - a[1])
+    : []
+  const excludedEntries = preflight
+    ? Object.entries(preflight.excluded_by_reason).filter(([, n]) => n > 0)
+    : []
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle className="text-base">Build &amp; Preflight</CardTitle>
+        {canBuild && (
+          <Button
+            size="sm"
+            onClick={() => buildMut.mutate(campaignId)}
+            disabled={buildMut.isPending}
+          >
+            {buildMut.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Hammer className="mr-2 h-4 w-4" />
+            )}
+            {hasBuild ? "Build lại" : "Build"}
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!hasBuild && !preflight ? (
+          <p className="text-muted-foreground py-4 text-center text-sm">
+            Chưa build. Gắn nhóm rồi bấm “Build” để chốt danh sách gửi + kiểm tra
+            độ dài tin.
+          </p>
+        ) : isLoading && !preflight ? (
+          <div className="space-y-3">
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </div>
+        ) : preflight ? (
+          <>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <StatCard
+                label="Tổng người nhận"
+                value={formatInt(preflight.total)}
+              />
+              <StatCard
+                label="Gửi được"
+                value={formatInt(preflight.exportable)}
+              />
+              <StatCard
+                label="Bản dựng"
+                value={`#${preflight.build_revision}`}
+              />
+              <StatCard
+                label="Đo click"
+                value={preflight.has_link ? "Có" : "Không"}
+              />
+            </div>
+
+            {preflight.over_limit.length > 0 && (
+              <div className="rounded border border-amber-300 bg-amber-50 p-3">
+                <p className="flex items-center gap-1.5 text-sm font-medium text-amber-800">
+                  <AlertTriangle className="h-4 w-4" />
+                  {formatInt(preflight.over_limit.length)} người nhận có tin vượt
+                  1 đoạn — phải rút gọn nội dung trước khi export.
+                </p>
+                <div className="mt-2 max-h-40 space-y-1 overflow-y-auto text-xs">
+                  {preflight.over_limit.map((r, i) => (
+                    <div key={i} className="text-amber-800">
+                      {r.full_name} ({r.phone_normalized})
+                      {r.segments != null ? ` — ${r.segments} đoạn` : ""}
+                      {r.encoding ? ` · ${r.encoding}` : ""}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {preflight.warnings.length > 0 && (
+              <div className="space-y-1">
+                {preflight.warnings.map((w, i) => (
+                  <p
+                    key={i}
+                    className="flex items-center gap-1.5 text-xs text-amber-600"
+                  >
+                    <AlertTriangle className="h-3.5 w-3.5" /> {w}
+                  </p>
+                ))}
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div>
+                <p className="mb-1.5 text-sm font-medium">Loại theo lý do</p>
+                {excludedEntries.length === 0 ? (
+                  <p className="text-muted-foreground text-sm">
+                    Không loại ai.
+                  </p>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Lý do</TableHead>
+                        <TableHead className="text-right">Số lượng</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {excludedEntries.map(([reason, n]) => (
+                        <TableRow key={reason}>
+                          <TableCell>{excludedReasonLabel(reason)}</TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {formatInt(n)}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </div>
+
+              <div>
+                <p className="mb-1.5 text-sm font-medium">
+                  Phân bố nhà mạng (gửi được)
+                </p>
+                {carrierEntries.length === 0 ? (
+                  <p className="text-muted-foreground text-sm">
+                    Chưa có dữ liệu.
+                  </p>
+                ) : (
+                  <div className="space-y-1">
+                    {carrierEntries.map(([bucket, n]) => (
+                      <div
+                        key={bucket}
+                        className="flex items-center justify-between border-b py-1 text-sm last:border-0"
+                      >
+                        <span>{carrierLabel(bucket)}</span>
+                        <span className="font-semibold tabular-nums">
+                          {formatInt(n)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {preflight.preview.length > 0 && (
+              <div>
+                <p className="mb-1.5 text-sm font-medium">
+                  Xem trước tin cuối (mẫu)
+                </p>
+                <div className="space-y-2">
+                  {preflight.preview.map((msg, i) => (
+                    <div
+                      key={i}
+                      className="bg-muted/40 rounded border p-2 text-xs whitespace-pre-line"
+                    >
+                      {msg}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <Badge variant="secondary">
+              {preflight.exportable > 0 && preflight.over_limit.length === 0
+                ? "Sẵn sàng cho bước attestation + export (PR-6e)"
+                : "Chưa đủ điều kiện export — xem cảnh báo ở trên"}
+            </Badge>
+          </>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/sms/admin/campaigns/SmsBuildPreflightSection.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsBuildPreflightSection.tsx
@@ -1,7 +1,7 @@
 // src/components/sms/admin/campaigns/SmsBuildPreflightSection.tsx
 "use client"
 
-import { AlertTriangle, Hammer, Loader2 } from "lucide-react"
+import { AlertCircle, AlertTriangle, Hammer, Loader2 } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -30,7 +30,7 @@ import {
 interface Props {
   campaignId: number
   hasBuild: boolean
-  /** Build được khi draft/ready. */
+  /** Build được khi draft/ready/exported (chưa bàn giao/đóng). */
   canBuild: boolean
 }
 
@@ -49,10 +49,12 @@ export function SmsBuildPreflightSection({
   canBuild,
 }: Props) {
   const buildMut = useBuildSmsCampaign()
-  const { data: preflightData, isLoading } = useSmsCampaignPreflight(
-    campaignId,
-    { enabled: hasBuild },
-  )
+  const {
+    data: preflightData,
+    isLoading,
+    isError,
+    refetch,
+  } = useSmsCampaignPreflight(campaignId, { enabled: hasBuild })
   // Ưu tiên kết quả build vừa chạy (tức thời), fallback query (reload).
   const preflight: SmsPreflightReport | undefined =
     buildMut.data ?? preflightData
@@ -89,6 +91,16 @@ export function SmsBuildPreflightSection({
             Chưa build. Gắn nhóm rồi bấm “Build” để chốt danh sách gửi + kiểm tra
             độ dài tin.
           </p>
+        ) : isError && !preflight ? (
+          <div className="flex flex-col items-center gap-3 py-6 text-center">
+            <AlertCircle className="text-destructive h-7 w-7" />
+            <p className="text-muted-foreground text-sm">
+              Không tải được kết quả preflight.
+            </p>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              Thử lại
+            </Button>
+          </div>
         ) : isLoading && !preflight ? (
           <div className="space-y-3">
             <Skeleton className="h-20 w-full" />

--- a/frontend/src/components/sms/admin/campaigns/SmsBuildPreflightSection.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsBuildPreflightSection.tsx
@@ -32,6 +32,8 @@ interface Props {
   hasBuild: boolean
   /** Build được khi draft/ready/exported (chưa bàn giao/đóng). */
   canBuild: boolean
+  /** Đã build nhưng đổi nhóm sau đó → preflight hiển thị là của bản dựng CŨ. */
+  staleBuild: boolean
 }
 
 function StatCard({ label, value }: { label: string; value: string }) {
@@ -47,6 +49,7 @@ export function SmsBuildPreflightSection({
   campaignId,
   hasBuild,
   canBuild,
+  staleBuild,
 }: Props) {
   const buildMut = useBuildSmsCampaign()
   const {
@@ -108,6 +111,15 @@ export function SmsBuildPreflightSection({
           </div>
         ) : preflight ? (
           <>
+            {staleBuild && (
+              <div className="rounded border border-amber-400 bg-amber-50 p-3">
+                <p className="flex items-center gap-1.5 text-sm font-medium text-amber-900">
+                  <AlertTriangle className="h-4 w-4" />
+                  Danh sách nhóm đã đổi sau khi build — số liệu dưới đây là của
+                  bản dựng CŨ. Bấm “Build lại” để cập nhật trước khi export.
+                </p>
+              </div>
+            )}
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
               <StatCard
                 label="Tổng người nhận"
@@ -233,9 +245,12 @@ export function SmsBuildPreflightSection({
             )}
 
             <Badge variant="secondary">
-              {preflight.exportable > 0 && preflight.over_limit.length === 0
-                ? "Sẵn sàng cho bước attestation + export (PR-6e)"
-                : "Chưa đủ điều kiện export — xem cảnh báo ở trên"}
+              {staleBuild
+                ? "Cần build lại — danh sách nhóm đã thay đổi"
+                : preflight.exportable > 0 &&
+                    preflight.over_limit.length === 0
+                  ? "Sẵn sàng cho bước attestation + export (PR-6e)"
+                  : "Chưa đủ điều kiện export — xem cảnh báo ở trên"}
             </Badge>
           </>
         ) : null}

--- a/frontend/src/components/sms/admin/campaigns/SmsCampaignFormDialog.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsCampaignFormDialog.tsx
@@ -1,0 +1,427 @@
+// src/components/sms/admin/campaigns/SmsCampaignFormDialog.tsx
+"use client"
+
+import { useEffect } from "react"
+import { useForm, type Resolver } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Loader2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  useCreateSmsCampaign,
+  useUpdateSmsCampaign,
+} from "@/hooks/useSmsCampaigns"
+import {
+  smsCampaignCreateSchema,
+  smsCampaignUpdateSchema,
+  type SmsCampaign,
+  type SmsCampaignCreateInput,
+} from "@/lib/zod/sms"
+
+import { LANDING_TYPE_OPTIONS } from "../labels"
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Có giá trị → sửa (chỉ khi draft); null → tạo. */
+  campaign?: SmsCampaign | null
+  onCreated?: (c: SmsCampaign) => void
+}
+
+type FormData = SmsCampaignCreateInput
+
+const DEFAULTS: FormData = {
+  name: "",
+  code: "",
+  sms_template: "",
+  landing_type: "qlts_hosted",
+  landing_url: "",
+  landing_headline: "",
+  landing_body: "",
+  landing_cta_label: "",
+  landing_cta_url: "",
+  frequency_cap_days: undefined,
+  link_expires_at: "",
+}
+
+export function SmsCampaignFormDialog({
+  open,
+  onOpenChange,
+  campaign,
+  onCreated,
+}: Props) {
+  const isEdit = !!campaign
+  const createMut = useCreateSmsCampaign()
+  const updateMut = useUpdateSmsCampaign()
+  const isPending = createMut.isPending || updateMut.isPending
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(
+      isEdit ? smsCampaignUpdateSchema : smsCampaignCreateSchema,
+    ) as unknown as Resolver<FormData>,
+    defaultValues: DEFAULTS,
+  })
+  const landingType = form.watch("landing_type")
+
+  useEffect(() => {
+    if (!open) return
+    if (campaign) {
+      form.reset({
+        name: campaign.name,
+        code: campaign.code,
+        sms_template: campaign.sms_template,
+        landing_type: campaign.landing_type as FormData["landing_type"],
+        landing_url: campaign.landing_url ?? "",
+        landing_headline: campaign.landing_headline ?? "",
+        landing_body: campaign.landing_body ?? "",
+        landing_cta_label: campaign.landing_cta_label ?? "",
+        landing_cta_url: campaign.landing_cta_url ?? "",
+        frequency_cap_days: campaign.frequency_cap_days ?? undefined,
+        link_expires_at: campaign.link_expires_at
+          ? campaign.link_expires_at.slice(0, 16)
+          : "",
+      })
+    } else {
+      form.reset(DEFAULTS)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, campaign?.id])
+
+  function onSubmit(values: FormData) {
+    // "" → undefined cho optional; datetime-local → ISO tz-aware.
+    const shared = {
+      name: values.name,
+      sms_template: values.sms_template,
+      landing_type: values.landing_type,
+      landing_url: values.landing_url?.trim() || undefined,
+      landing_headline: values.landing_headline?.trim() || undefined,
+      landing_body: values.landing_body?.trim() || undefined,
+      landing_cta_label: values.landing_cta_label?.trim() || undefined,
+      landing_cta_url: values.landing_cta_url?.trim() || undefined,
+      frequency_cap_days: values.frequency_cap_days ?? undefined,
+      link_expires_at: values.link_expires_at
+        ? new Date(values.link_expires_at).toISOString()
+        : undefined,
+    }
+    if (isEdit && campaign) {
+      updateMut.mutate(
+        { id: campaign.id, data: shared },
+        { onSuccess: () => onOpenChange(false) },
+      )
+    } else {
+      createMut.mutate(
+        { ...shared, code: values.code?.trim() || undefined },
+        {
+          onSuccess: (c) => {
+            onOpenChange(false)
+            onCreated?.(c)
+          },
+        },
+      )
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit ? "Sửa chiến dịch" : "Tạo chiến dịch SMS"}
+          </DialogTitle>
+          <DialogDescription>
+            Nội dung tin có thể dùng biến {"{full_name}"} và {"{link}"} (link
+            rút gọn). Thiếu {"{link}"} → không đo được click.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Tên chiến dịch *</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="VD: Tuyển sinh khối 10 — đợt 1"
+                      disabled={isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {!isEdit && (
+              <FormField
+                control={form.control}
+                name="code"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Mã (slug) — tùy chọn</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="bỏ trống để tự sinh"
+                        disabled={isPending}
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="sms_template"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nội dung tin *</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={4}
+                      maxLength={2000}
+                      placeholder="Chào {full_name}, … Xem chi tiết: {link}"
+                      disabled={isPending}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Hệ thống tự thêm tiền tố [QC] + hướng dẫn từ chối khi gửi.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="landing_type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Loại trang đích</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    disabled={isPending}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {LANDING_TYPE_OPTIONS.map((o) => (
+                        <SelectItem key={o.value} value={o.value}>
+                          {o.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {landingType === "external" ? (
+              <FormField
+                control={form.control}
+                name="landing_url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>URL ngoài</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="https://…"
+                        disabled={isPending}
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Host phải thuộc allowlist (BE kiểm). Cần có {"{link}"}
+                      trong tin.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ) : (
+              <>
+                <FormField
+                  control={form.control}
+                  name="landing_headline"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Tiêu đề trang đích</FormLabel>
+                      <FormControl>
+                        <Input
+                          maxLength={200}
+                          disabled={isPending}
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="landing_body"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Nội dung trang đích</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          rows={3}
+                          maxLength={10000}
+                          disabled={isPending}
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="landing_cta_label"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Nhãn nút CTA</FormLabel>
+                        <FormControl>
+                          <Input
+                            maxLength={100}
+                            placeholder="Đăng ký tư vấn"
+                            disabled={isPending}
+                            {...field}
+                            value={field.value ?? ""}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="landing_cta_url"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>URL nút CTA</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="https://…"
+                            disabled={isPending}
+                            {...field}
+                            value={field.value ?? ""}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </>
+            )}
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="frequency_cap_days"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Chặn gửi lại (ngày)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={0}
+                        max={3650}
+                        placeholder="vd 30"
+                        disabled={isPending}
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value === ""
+                              ? undefined
+                              : Number(e.target.value),
+                          )
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="link_expires_at"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Link hết hạn</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="datetime-local"
+                        disabled={isPending}
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+              >
+                Hủy
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isEdit ? "Lưu" : "Tạo"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/sms/admin/campaigns/SmsCampaignFormDialog.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsCampaignFormDialog.tsx
@@ -44,7 +44,7 @@ import {
   type SmsCampaignCreateInput,
 } from "@/lib/zod/sms"
 
-import { LANDING_TYPE_OPTIONS } from "../labels"
+import { LANDING_TYPE_OPTIONS, isoToDatetimeLocal } from "../labels"
 
 interface Props {
   open: boolean
@@ -103,9 +103,8 @@ export function SmsCampaignFormDialog({
         landing_cta_label: campaign.landing_cta_label ?? "",
         landing_cta_url: campaign.landing_cta_url ?? "",
         frequency_cap_days: campaign.frequency_cap_days ?? undefined,
-        link_expires_at: campaign.link_expires_at
-          ? campaign.link_expires_at.slice(0, 16)
-          : "",
+        // BE trả UTC → đổi sang giờ local cho datetime-local (tránh lệch offset).
+        link_expires_at: isoToDatetimeLocal(campaign.link_expires_at),
       })
     } else {
       form.reset(DEFAULTS)
@@ -114,29 +113,54 @@ export function SmsCampaignFormDialog({
   }, [open, campaign?.id])
 
   function onSubmit(values: FormData) {
-    // "" → undefined cho optional; datetime-local → ISO tz-aware.
-    const shared = {
-      name: values.name,
-      sms_template: values.sms_template,
-      landing_type: values.landing_type,
-      landing_url: values.landing_url?.trim() || undefined,
-      landing_headline: values.landing_headline?.trim() || undefined,
-      landing_body: values.landing_body?.trim() || undefined,
-      landing_cta_label: values.landing_cta_label?.trim() || undefined,
-      landing_cta_url: values.landing_cta_url?.trim() || undefined,
-      frequency_cap_days: values.frequency_cap_days ?? undefined,
-      link_expires_at: values.link_expires_at
-        ? new Date(values.link_expires_at).toISOString()
-        : undefined,
+    const isExternal = values.landing_type === "external"
+    // Chỉ giữ field landing đúng loại (external→url; hosted→headline/body/cta);
+    // field không thuộc loại → "" để không lưu dữ liệu chéo cũ (finding #3).
+    const t = (v?: string | null) => (v ?? "").trim()
+    const landing = {
+      landing_url: isExternal ? t(values.landing_url) : "",
+      landing_headline: isExternal ? "" : t(values.landing_headline),
+      landing_body: isExternal ? "" : t(values.landing_body),
+      landing_cta_label: isExternal ? "" : t(values.landing_cta_label),
+      landing_cta_url: isExternal ? "" : t(values.landing_cta_url),
     }
+    const linkIso = values.link_expires_at
+      ? new Date(values.link_expires_at).toISOString()
+      : null
+
     if (isEdit && campaign) {
+      // Update: gửi "" / null (KHÔNG undefined) để CHO PHÉP xoá field — BE
+      // exclude_unset bỏ qua undefined = không xoá được (finding #2).
       updateMut.mutate(
-        { id: campaign.id, data: shared },
+        {
+          id: campaign.id,
+          data: {
+            name: values.name,
+            sms_template: values.sms_template,
+            landing_type: values.landing_type,
+            ...landing,
+            frequency_cap_days: values.frequency_cap_days ?? null,
+            link_expires_at: linkIso,
+          },
+        },
         { onSuccess: () => onOpenChange(false) },
       )
     } else {
+      // Create: field trống → undefined (BE default None); code tự sinh.
       createMut.mutate(
-        { ...shared, code: values.code?.trim() || undefined },
+        {
+          name: values.name,
+          code: values.code?.trim() || undefined,
+          sms_template: values.sms_template,
+          landing_type: values.landing_type,
+          landing_url: landing.landing_url || undefined,
+          landing_headline: landing.landing_headline || undefined,
+          landing_body: landing.landing_body || undefined,
+          landing_cta_label: landing.landing_cta_label || undefined,
+          landing_cta_url: landing.landing_cta_url || undefined,
+          frequency_cap_days: values.frequency_cap_days ?? undefined,
+          link_expires_at: linkIso ?? undefined,
+        },
         {
           onSuccess: (c) => {
             onOpenChange(false)

--- a/frontend/src/components/sms/admin/campaigns/SmsCampaignGroupsSection.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsCampaignGroupsSection.tsx
@@ -1,0 +1,150 @@
+// src/components/sms/admin/campaigns/SmsCampaignGroupsSection.tsx
+"use client"
+
+import { useMemo, useState } from "react"
+import { Plus, X } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  useAttachCampaignGroup,
+  useCampaignGroups,
+  useDetachCampaignGroup,
+} from "@/hooks/useSmsCampaigns"
+import { useSmsContactGroups } from "@/hooks/useSmsContacts"
+
+import { formatInt, groupTypeLabel } from "../labels"
+
+interface Props {
+  campaignId: number
+  /** Cho sửa audience (draft/ready/exported) — handed_off/closed → khóa. */
+  editable: boolean
+}
+
+export function SmsCampaignGroupsSection({ campaignId, editable }: Props) {
+  const [toAdd, setToAdd] = useState<string>("")
+  const { data, isLoading } = useCampaignGroups(campaignId)
+  const { data: allGroups } = useSmsContactGroups(
+    { limit: 200, is_active: true },
+    { enabled: editable },
+  )
+  const attachMut = useAttachCampaignGroup()
+  const detachMut = useDetachCampaignGroup()
+
+  const attachedIds = useMemo(
+    () => new Set((data?.items ?? []).map((g) => g.id)),
+    [data],
+  )
+  const available = (allGroups?.items ?? []).filter(
+    (g) => !attachedIds.has(g.id),
+  )
+
+  const attached = data?.items ?? []
+
+  const handleAttach = () => {
+    if (!toAdd) return
+    attachMut.mutate(
+      { campaignId, groupId: Number(toAdd) },
+      { onSuccess: () => setToAdd("") },
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          Nhóm liên hệ ({attached.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {editable && (
+          <div className="flex gap-2">
+            <Select
+              value={toAdd}
+              onValueChange={setToAdd}
+              disabled={attachMut.isPending}
+            >
+              <SelectTrigger className="flex-1">
+                <SelectValue placeholder="— Chọn nhóm để gắn —" />
+              </SelectTrigger>
+              <SelectContent>
+                {available.length === 0 ? (
+                  <div className="text-muted-foreground px-2 py-1.5 text-sm">
+                    Không còn nhóm để gắn.
+                  </div>
+                ) : (
+                  available.map((g) => (
+                    <SelectItem key={g.id} value={String(g.id)}>
+                      {g.name}
+                      {g.member_count != null
+                        ? ` (${formatInt(g.member_count)})`
+                        : ""}
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+            <Button
+              onClick={handleAttach}
+              disabled={!toAdd || attachMut.isPending}
+            >
+              <Plus className="mr-2 h-4 w-4" /> Gắn
+            </Button>
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <Skeleton key={i} className="h-9 w-full" />
+            ))}
+          </div>
+        ) : attached.length === 0 ? (
+          <p className="text-muted-foreground py-4 text-center text-sm">
+            Chưa gắn nhóm nào. Cần ít nhất 1 nhóm để build.
+          </p>
+        ) : (
+          <div className="divide-y">
+            {attached.map((g) => (
+              <div
+                key={g.id}
+                className="flex items-center justify-between py-2"
+              >
+                <div>
+                  <span className="text-sm font-medium">{g.name}</span>
+                  <span className="text-muted-foreground ml-2 text-xs">
+                    {groupTypeLabel(g.group_type)}
+                    {g.member_count != null
+                      ? ` · ${formatInt(g.member_count)} liên hệ`
+                      : ""}
+                  </span>
+                </div>
+                {editable && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label="Bỏ nhóm"
+                    disabled={detachMut.isPending}
+                    onClick={() =>
+                      detachMut.mutate({ campaignId, groupId: g.id })
+                    }
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
@@ -1,0 +1,105 @@
+// src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
+"use client"
+
+import { useState } from "react"
+import { AlertCircle, Link2Off, LinkIcon, Pencil } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { PageHeader } from "@/components/layouts/PageHeader"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useSmsCampaign } from "@/hooks/useSmsCampaigns"
+
+import { campaignStatusLabel } from "../labels"
+import { SmsBuildPreflightSection } from "./SmsBuildPreflightSection"
+import { SmsCampaignFormDialog } from "./SmsCampaignFormDialog"
+import { SmsCampaignGroupsSection } from "./SmsCampaignGroupsSection"
+
+const CLOSED_STATUSES = ["handed_off", "closed"]
+
+export function SmsCampaignWorkspace({ campaignId }: { campaignId: number }) {
+  const [editOpen, setEditOpen] = useState(false)
+  const { data: campaign, isLoading, isError, refetch } =
+    useSmsCampaign(campaignId)
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-72" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-56 w-full" />
+      </div>
+    )
+  }
+
+  if (isError || !campaign) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+          <AlertCircle className="text-destructive h-8 w-8" />
+          <p className="text-muted-foreground text-sm">
+            Không tải được chiến dịch (không tồn tại hoặc lỗi).
+          </p>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            Thử lại
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const canEdit = campaign.status === "draft"
+  const audienceEditable = !CLOSED_STATUSES.includes(campaign.status)
+  const hasBuild = campaign.build_revision > 0
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title={campaign.name}
+        description={campaign.code}
+        backButton={{ href: "/admin/sms/campaigns", label: "Danh sách chiến dịch" }}
+        actions={
+          canEdit ? (
+            <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
+              <Pencil className="mr-2 h-4 w-4" /> Sửa
+            </Button>
+          ) : undefined
+        }
+      />
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge>{campaignStatusLabel(campaign.status)}</Badge>
+        {campaign.build_revision > 0 && (
+          <Badge variant="secondary">Bản dựng #{campaign.build_revision}</Badge>
+        )}
+        {campaign.has_link ? (
+          <Badge variant="outline" className="gap-1">
+            <LinkIcon className="h-3 w-3" /> Có short-link
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="gap-1 text-amber-600">
+            <Link2Off className="h-3 w-3" /> Không đo click
+          </Badge>
+        )}
+      </div>
+
+      <SmsCampaignGroupsSection
+        campaignId={campaignId}
+        editable={audienceEditable}
+      />
+
+      <SmsBuildPreflightSection
+        campaignId={campaignId}
+        hasBuild={hasBuild}
+        canBuild={audienceEditable}
+      />
+
+      <SmsCampaignFormDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        campaign={campaign}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
@@ -52,6 +52,9 @@ export function SmsCampaignWorkspace({ campaignId }: { campaignId: number }) {
   const canEdit = campaign.status === "draft"
   const audienceEditable = !CLOSED_STATUSES.includes(campaign.status)
   const hasBuild = campaign.build_revision > 0
+  // Đã build rồi nhưng status quay lại draft = đổi nhóm sau build → snapshot +
+  // preflight cũ đã stale, buộc build lại (BE _mark_audience_changed).
+  const staleBuild = campaign.status === "draft" && hasBuild
 
   return (
     <div className="space-y-4">
@@ -93,6 +96,7 @@ export function SmsCampaignWorkspace({ campaignId }: { campaignId: number }) {
         campaignId={campaignId}
         hasBuild={hasBuild}
         canBuild={audienceEditable}
+        staleBuild={staleBuild}
       />
 
       <SmsCampaignFormDialog

--- a/frontend/src/components/sms/admin/campaigns/SmsCampaignsListClient.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsCampaignsListClient.tsx
@@ -1,0 +1,250 @@
+// src/components/sms/admin/campaigns/SmsCampaignsListClient.tsx
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import {
+  AlertCircle,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  Search,
+} from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useSmsCampaignsFull } from "@/hooks/useSmsCampaigns"
+import { useDebouncedValue } from "@/lib/hooks/use-debounced-value"
+import type { SmsCampaign } from "@/lib/zod/sms"
+
+import {
+  campaignStatusLabel,
+  formatDateTimeVN,
+  formatInt,
+  landingTypeLabel,
+} from "../labels"
+import { SmsCampaignFormDialog } from "./SmsCampaignFormDialog"
+
+const ALL = "all"
+const PAGE_SIZE = 50
+const STATUSES = ["draft", "ready", "exported", "handed_off", "closed"]
+
+function statusVariant(
+  s: string,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (s === "closed") return "secondary"
+  if (s === "handed_off" || s === "exported") return "default"
+  return "outline"
+}
+
+export function SmsCampaignsListClient() {
+  const router = useRouter()
+  const [searchInput, setSearchInput] = useState("")
+  const [status, setStatus] = useState<string>(ALL)
+  const [page, setPage] = useState(0)
+  const [createOpen, setCreateOpen] = useState(false)
+
+  const search = useDebouncedValue(searchInput.trim())
+
+  const onSearch = (v: string) => {
+    setSearchInput(v)
+    setPage(0)
+  }
+  const onStatus = (v: string) => {
+    setStatus(v)
+    setPage(0)
+  }
+
+  const { data, isLoading, isError, refetch, isFetching } = useSmsCampaignsFull({
+    skip: page * PAGE_SIZE,
+    limit: PAGE_SIZE,
+    search: search || undefined,
+    status: status === ALL ? undefined : status,
+  })
+
+  const total = data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const items = data?.items ?? []
+
+  const openCampaign = (c: SmsCampaign) =>
+    router.push(`/admin/sms/campaigns/${c.id}`)
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="grid flex-1 grid-cols-1 gap-4 sm:grid-cols-2 lg:max-w-xl">
+              <div className="space-y-1.5">
+                <Label htmlFor="cp-search">Tìm chiến dịch</Label>
+                <div className="relative">
+                  <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+                  <Input
+                    id="cp-search"
+                    className="pl-8"
+                    placeholder="Tên / mã…"
+                    value={searchInput}
+                    onChange={(e) => onSearch(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="cp-status">Trạng thái</Label>
+                <Select value={status} onValueChange={onStatus}>
+                  <SelectTrigger id="cp-status">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ALL}>Tất cả</SelectItem>
+                    {STATUSES.map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {campaignStatusLabel(s)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" /> Tạo chiến dịch
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6">
+          {isError ? (
+            <div className="flex flex-col items-center gap-3 py-10 text-center">
+              <AlertCircle className="text-destructive h-8 w-8" />
+              <p className="text-muted-foreground text-sm">
+                Không thể tải danh sách chiến dịch.
+              </p>
+              <Button variant="outline" size="sm" onClick={() => refetch()}>
+                Thử lại
+              </Button>
+            </div>
+          ) : isLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : items.length === 0 ? (
+            <div className="space-y-3 py-10 text-center">
+              <p className="text-muted-foreground text-sm">
+                {page > 0
+                  ? "Trang này không còn dữ liệu."
+                  : search || status !== ALL
+                    ? "Không có chiến dịch khớp bộ lọc."
+                    : "Chưa có chiến dịch nào."}
+              </p>
+              {page > 0 && (
+                <Button variant="outline" size="sm" onClick={() => setPage(0)}>
+                  Về trang đầu
+                </Button>
+              )}
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Tên</TableHead>
+                      <TableHead>Trạng thái</TableHead>
+                      <TableHead>Trang đích</TableHead>
+                      <TableHead className="text-right">Nhóm</TableHead>
+                      <TableHead>Tạo lúc</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {items.map((c) => (
+                      <TableRow
+                        key={c.id}
+                        className="hover:bg-muted/50 cursor-pointer"
+                        onClick={() => openCampaign(c)}
+                      >
+                        <TableCell>
+                          <div className="font-medium">{c.name}</div>
+                          <div className="text-muted-foreground text-xs">
+                            {c.code}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={statusVariant(c.status)}>
+                            {campaignStatusLabel(c.status)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>{landingTypeLabel(c.landing_type)}</TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {c.group_count != null ? formatInt(c.group_count) : "—"}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground text-xs whitespace-nowrap">
+                          {formatDateTimeVN(c.created_at)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+
+              <div className="mt-4 flex items-center justify-between">
+                <p className="text-muted-foreground text-sm">
+                  Tổng {formatInt(total)} chiến dịch · Trang {page + 1}/
+                  {totalPages}
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    disabled={page === 0 || isFetching}
+                  >
+                    <ChevronLeft className="h-4 w-4" /> Trước
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      setPage((p) => Math.min(totalPages - 1, p + 1))
+                    }
+                    disabled={page >= totalPages - 1 || isFetching}
+                  >
+                    Sau <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <SmsCampaignFormDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        campaign={null}
+        onCreated={openCampaign}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/sms/admin/labels.ts
+++ b/frontend/src/components/sms/admin/labels.ts
@@ -129,6 +129,20 @@ export function nowDatetimeLocal(): string {
     .slice(0, 16)
 }
 
+/**
+ * ISO tz-aware (UTC) → value cho <input type="datetime-local"> theo GIỜ ĐỊA
+ * PHƯƠNG. Dùng khi nạp lại form sửa: BE trả UTC, input hiểu giờ local → phải
+ * đổi UTC→local trước khi slice, nếu không sẽ lệch offset (bug link_expires_at).
+ */
+export function isoToDatetimeLocal(iso: string | null | undefined): string {
+  if (!iso) return ""
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ""
+  return new Date(d.getTime() - d.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, 16)
+}
+
 // =====================================================================
 // Campaign / Preflight (PR-6d)
 // =====================================================================

--- a/frontend/src/components/sms/admin/labels.ts
+++ b/frontend/src/components/sms/admin/labels.ts
@@ -13,12 +13,14 @@ import {
   SMS_CARRIER_BUCKETS,
   SMS_CONSENT_BASES,
   SMS_GROUP_TYPES,
+  SMS_LANDING_TYPES,
   SMS_MANUAL_OPT_OUT_SOURCES,
   SMS_REVOKE_SOURCES,
   type SmsCarrierBucket,
   type SmsConsentBasis,
   type SmsGranularity,
   type SmsGroupType,
+  type SmsLandingType,
   type SmsManualOptOutSource,
   type SmsRevokeSource,
 } from "@/lib/zod/sms"
@@ -125,6 +127,32 @@ export function nowDatetimeLocal(): string {
   return new Date(now.getTime() - now.getTimezoneOffset() * 60000)
     .toISOString()
     .slice(0, 16)
+}
+
+// =====================================================================
+// Campaign / Preflight (PR-6d)
+// =====================================================================
+export const LANDING_TYPE_LABELS: Record<string, string> = {
+  qlts_hosted: "Trang đích QLTS",
+  external: "Liên kết ngoài",
+}
+export function landingTypeLabel(v: string): string {
+  return LANDING_TYPE_LABELS[v] ?? v
+}
+export const LANDING_TYPE_OPTIONS: { value: SmsLandingType; label: string }[] =
+  SMS_LANDING_TYPES.map((value) => ({ value, label: LANDING_TYPE_LABELS[value] }))
+
+/** Lý do recipient bị loại ở build/preflight (excluded_by_reason keys). */
+export const EXCLUDED_REASON_LABELS: Record<string, string> = {
+  no_consent: "Chưa đồng ý",
+  opted_out: "Đã từ chối nhận tin",
+  dnc_suppressed: "Trong danh sách chặn (DNC)",
+  frequency_capped: "Vượt tần suất gửi",
+  over_limit: "Tin vượt 1 đoạn",
+  missing_data: "Thiếu dữ liệu",
+}
+export function excludedReasonLabel(v: string): string {
+  return EXCLUDED_REASON_LABELS[v] ?? v
 }
 
 // =====================================================================

--- a/frontend/src/hooks/useSmsCampaigns.ts
+++ b/frontend/src/hooks/useSmsCampaigns.ts
@@ -1,0 +1,177 @@
+// src/hooks/useSmsCampaigns.ts
+/**
+ * React Query hooks cho SMS Marketing — Campaign CRUD + Build/Preflight (PR-6d).
+ * Tiêu thụ router PR-3 (sms_campaigns.py). Tất cả `require_admin` ở BE.
+ */
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+import { AxiosError } from "axios"
+import { toast } from "sonner"
+
+import {
+  attachCampaignGroup,
+  buildSmsCampaign,
+  createSmsCampaign,
+  detachCampaignGroup,
+  getSmsCampaign,
+  getSmsCampaignPreflight,
+  listCampaignGroups,
+  listSmsCampaignsFull,
+  updateSmsCampaign,
+  type SmsCampaignListParams,
+} from "@/lib/api/sms"
+import { parseApiError } from "@/lib/utils/api-errors"
+import type {
+  SmsCampaignCreateInput,
+  SmsCampaignUpdateInput,
+} from "@/lib/zod/sms"
+import type { ApiErrorResponse } from "@/types/api.types"
+
+type ApiError = AxiosError<ApiErrorResponse>
+
+export const smsCampaignKeys = {
+  all: ["sms-campaigns"] as const,
+  list: (p: SmsCampaignListParams) =>
+    [...smsCampaignKeys.all, "list", p] as const,
+  detail: (id: number) => [...smsCampaignKeys.all, "detail", id] as const,
+  groups: (id: number) => [...smsCampaignKeys.all, "groups", id] as const,
+  preflight: (id: number) => [...smsCampaignKeys.all, "preflight", id] as const,
+}
+
+function invalidateCampaigns(qc: ReturnType<typeof useQueryClient>) {
+  qc.invalidateQueries({ queryKey: smsCampaignKeys.all })
+}
+
+// ---------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------
+export function useSmsCampaignsFull(params: SmsCampaignListParams = {}) {
+  return useQuery({
+    queryKey: smsCampaignKeys.list(params),
+    queryFn: () => listSmsCampaignsFull(params),
+    placeholderData: keepPreviousData,
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useSmsCampaign(campaignId: number | null) {
+  return useQuery({
+    queryKey: smsCampaignKeys.detail(campaignId ?? 0),
+    queryFn: () => getSmsCampaign(campaignId as number),
+    enabled: campaignId != null,
+    staleTime: 30 * 1000,
+  })
+}
+
+/** Nhóm đã gắn vào campaign (liệt kê + bỏ). */
+export function useCampaignGroups(campaignId: number | null) {
+  return useQuery({
+    queryKey: smsCampaignKeys.groups(campaignId ?? 0),
+    queryFn: () => listCampaignGroups(campaignId as number),
+    enabled: campaignId != null,
+    staleTime: 30 * 1000,
+  })
+}
+
+/** Preflight bản build hiện tại — chỉ tải khi campaign đã build (enabled). */
+export function useSmsCampaignPreflight(
+  campaignId: number | null,
+  options: { enabled?: boolean } = {},
+) {
+  return useQuery({
+    queryKey: smsCampaignKeys.preflight(campaignId ?? 0),
+    queryFn: () => getSmsCampaignPreflight(campaignId as number),
+    enabled: campaignId != null && (options.enabled ?? true),
+    staleTime: 30 * 1000,
+  })
+}
+
+// ---------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------
+export function useCreateSmsCampaign() {
+  const qc = useQueryClient()
+  return useMutation<
+    Awaited<ReturnType<typeof createSmsCampaign>>,
+    ApiError,
+    SmsCampaignCreateInput
+  >({
+    mutationFn: createSmsCampaign,
+    onSuccess: () => {
+      toast.success("Đã tạo chiến dịch.")
+      invalidateCampaigns(qc)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Không thể tạo chiến dịch.")),
+  })
+}
+
+export function useUpdateSmsCampaign() {
+  const qc = useQueryClient()
+  return useMutation<
+    unknown,
+    ApiError,
+    { id: number; data: SmsCampaignUpdateInput }
+  >({
+    mutationFn: ({ id, data }) => updateSmsCampaign(id, data),
+    onSuccess: () => {
+      toast.success("Đã cập nhật chiến dịch.")
+      invalidateCampaigns(qc)
+    },
+    onError: (e) =>
+      toast.error(parseApiError(e, "Không thể cập nhật chiến dịch.")),
+  })
+}
+
+export function useAttachCampaignGroup() {
+  const qc = useQueryClient()
+  return useMutation<
+    unknown,
+    ApiError,
+    { campaignId: number; groupId: number }
+  >({
+    mutationFn: ({ campaignId, groupId }) =>
+      attachCampaignGroup(campaignId, groupId),
+    onSuccess: () => {
+      toast.success("Đã gắn nhóm vào chiến dịch.")
+      invalidateCampaigns(qc)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Không thể gắn nhóm.")),
+  })
+}
+
+export function useDetachCampaignGroup() {
+  const qc = useQueryClient()
+  return useMutation<
+    unknown,
+    ApiError,
+    { campaignId: number; groupId: number }
+  >({
+    mutationFn: ({ campaignId, groupId }) =>
+      detachCampaignGroup(campaignId, groupId),
+    onSuccess: () => {
+      toast.success("Đã bỏ nhóm khỏi chiến dịch.")
+      invalidateCampaigns(qc)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Không thể bỏ nhóm.")),
+  })
+}
+
+export function useBuildSmsCampaign() {
+  const qc = useQueryClient()
+  return useMutation<
+    Awaited<ReturnType<typeof buildSmsCampaign>>,
+    ApiError,
+    number
+  >({
+    mutationFn: buildSmsCampaign,
+    onSuccess: () => {
+      // Preflight + campaign (build_revision/status) đổi → làm mới cả cụm.
+      invalidateCampaigns(qc)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Không thể build chiến dịch.")),
+  })
+}

--- a/frontend/src/lib/api/sms.ts
+++ b/frontend/src/lib/api/sms.ts
@@ -11,8 +11,11 @@
 import { api } from "@/lib/api/client"
 import {
   smsCampaignDashboardSchema,
+  smsCampaignFullListSchema,
   smsCampaignListSchema,
+  smsCampaignSchema,
   smsClickReportSchema,
+  smsPreflightReportSchema,
   smsConsentEventListSchema,
   smsConsentEventSchema,
   smsContactGroupListSchema,
@@ -24,9 +27,14 @@ import {
   smsOptOutListSchema,
   smsOptOutSchema,
   smsPublicOptOutResponseSchema,
+  type SmsCampaign,
+  type SmsCampaignCreateInput,
   type SmsCampaignDashboard,
+  type SmsCampaignFullList,
   type SmsCampaignList,
+  type SmsCampaignUpdateInput,
   type SmsClickReport,
+  type SmsPreflightReport,
   type SmsConsentEvent,
   type SmsConsentEventCreateInput,
   type SmsConsentEventList,
@@ -317,4 +325,90 @@ export async function removeContactFromGroup(
   groupId: number,
 ): Promise<void> {
   await api.delete(`/api/sms/contacts/${contactId}/groups/${groupId}`)
+}
+
+// =====================================================================
+// Admin — Campaign CRUD + groups + Build/Preflight (PR-6d, require_admin)
+// =====================================================================
+
+/** Danh sách campaign đầy đủ (PR-6d list). */
+export async function listSmsCampaignsFull(
+  params: SmsCampaignListParams = {},
+): Promise<SmsCampaignFullList> {
+  const res = await api.get<SmsCampaignFullList>(`/api/sms/campaigns`, {
+    params,
+  })
+  return smsCampaignFullListSchema.parse(res.data)
+}
+
+export async function getSmsCampaign(campaignId: number): Promise<SmsCampaign> {
+  const res = await api.get<SmsCampaign>(`/api/sms/campaigns/${campaignId}`)
+  return smsCampaignSchema.parse(res.data)
+}
+
+export async function createSmsCampaign(
+  payload: SmsCampaignCreateInput,
+): Promise<SmsCampaign> {
+  const res = await api.post<SmsCampaign>(`/api/sms/campaigns`, payload)
+  return smsCampaignSchema.parse(res.data)
+}
+
+export async function updateSmsCampaign(
+  campaignId: number,
+  payload: SmsCampaignUpdateInput,
+): Promise<SmsCampaign> {
+  const res = await api.patch<SmsCampaign>(
+    `/api/sms/campaigns/${campaignId}`,
+    payload,
+  )
+  return smsCampaignSchema.parse(res.data)
+}
+
+/** Danh sách nhóm đã gắn vào campaign (kèm member_count). */
+export async function listCampaignGroups(
+  campaignId: number,
+): Promise<SmsContactGroupList> {
+  const res = await api.get<SmsContactGroupList>(
+    `/api/sms/campaigns/${campaignId}/groups`,
+  )
+  return smsContactGroupListSchema.parse(res.data)
+}
+
+/** Gắn nhóm vào campaign; BE trả campaign (cập nhật group_count). */
+export async function attachCampaignGroup(
+  campaignId: number,
+  groupId: number,
+): Promise<SmsCampaign> {
+  const res = await api.post<SmsCampaign>(
+    `/api/sms/campaigns/${campaignId}/groups`,
+    { group_id: groupId },
+  )
+  return smsCampaignSchema.parse(res.data)
+}
+
+export async function detachCampaignGroup(
+  campaignId: number,
+  groupId: number,
+): Promise<void> {
+  await api.delete(`/api/sms/campaigns/${campaignId}/groups/${groupId}`)
+}
+
+/** Build snapshot + preflight (chỉ khi draft/ready). */
+export async function buildSmsCampaign(
+  campaignId: number,
+): Promise<SmsPreflightReport> {
+  const res = await api.post<SmsPreflightReport>(
+    `/api/sms/campaigns/${campaignId}/build`,
+  )
+  return smsPreflightReportSchema.parse(res.data)
+}
+
+/** Xem lại preflight của bản build hiện tại (read-only). */
+export async function getSmsCampaignPreflight(
+  campaignId: number,
+): Promise<SmsPreflightReport> {
+  const res = await api.get<SmsPreflightReport>(
+    `/api/sms/campaigns/${campaignId}/preflight`,
+  )
+  return smsPreflightReportSchema.parse(res.data)
 }

--- a/frontend/src/lib/api/sms.ts
+++ b/frontend/src/lib/api/sms.ts
@@ -393,7 +393,7 @@ export async function detachCampaignGroup(
   await api.delete(`/api/sms/campaigns/${campaignId}/groups/${groupId}`)
 }
 
-/** Build snapshot + preflight (chỉ khi draft/ready). */
+/** Build snapshot + preflight (chỉ khi draft/ready/exported — chưa bàn giao). */
 export async function buildSmsCampaign(
   campaignId: number,
 ): Promise<SmsPreflightReport> {

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -267,6 +267,12 @@ export const navigationConfig: NavigationConfig = {
           roles: ["admin"], // BE require_admin trên contact/group/consent
         },
         {
+          label: "Chiến dịch SMS",
+          href: "/admin/sms/campaigns",
+          icon: Send,
+          roles: ["admin"], // BE require_admin
+        },
+        {
           label: "Báo cáo SMS",
           href: "/admin/sms/reports",
           icon: MessageSquareText,

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -402,3 +402,125 @@ export const smsImportResultSchema = z.object({
   errors: z.array(smsImportRowErrorSchema),
 })
 export type SmsImportResult = z.infer<typeof smsImportResultSchema>
+
+// =====================================================================
+// Admin — Campaign (full) + Build/Preflight (PR-6d; mirror SmsCampaignOut/
+// Create/Update, SmsPreflightReport, SmsOverLimitRow ở app/schemas/sms.py).
+// =====================================================================
+
+/** Loại landing (mirror SmsLandingType). */
+export const SMS_LANDING_TYPES = ["qlts_hosted", "external"] as const
+export type SmsLandingType = (typeof SMS_LANDING_TYPES)[number]
+
+/** Lý do recipient bị loại (mirror SmsExcludedReason / CHECK). */
+export const SMS_EXCLUDED_REASONS = [
+  "no_consent",
+  "opted_out",
+  "dnc_suppressed",
+  "frequency_capped",
+  "over_limit",
+  "missing_data",
+] as const
+export type SmsExcludedReason = (typeof SMS_EXCLUDED_REASONS)[number]
+
+/** Campaign đầy đủ (mirror SmsCampaignOut). Datetime = ISO string. */
+export const smsCampaignSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  code: z.string(),
+  status: z.string(),
+  sms_template: z.string(),
+  frequency_cap_days: z.number().nullable().optional(),
+  landing_type: z.string(),
+  landing_url: z.string().nullable().optional(),
+  landing_headline: z.string().nullable().optional(),
+  landing_body: z.string().nullable().optional(),
+  landing_cta_label: z.string().nullable().optional(),
+  landing_cta_url: z.string().nullable().optional(),
+  build_revision: z.number(),
+  link_expires_at: z.string().nullable().optional(),
+  optout_instruction_snapshot: z.string().nullable().optional(),
+  // Attestation (dùng ở PR-6e; hợp lệ khi *_checked_build_revision === build_revision)
+  consent_checked_at: z.string().nullable().optional(),
+  consent_checked_by_id: z.number().nullable().optional(),
+  consent_reference: z.string().nullable().optional(),
+  consent_checked_build_revision: z.number().nullable().optional(),
+  dnc_checked_at: z.string().nullable().optional(),
+  dnc_checked_by_id: z.number().nullable().optional(),
+  dnc_reference: z.string().nullable().optional(),
+  dnc_checked_build_revision: z.number().nullable().optional(),
+  optout_channel_checked_at: z.string().nullable().optional(),
+  optout_channel_checked_by_id: z.number().nullable().optional(),
+  optout_channel_reference: z.string().nullable().optional(),
+  optout_channel_checked_build_revision: z.number().nullable().optional(),
+  created_by_id: z.number().nullable().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  handed_off_marked_at: z.string().nullable().optional(),
+  has_link: z.boolean().nullable().optional(),
+  group_count: z.number().nullable().optional(),
+})
+export type SmsCampaign = z.infer<typeof smsCampaignSchema>
+
+export const smsCampaignFullListSchema = z.object({
+  total: z.number(),
+  items: z.array(smsCampaignSchema),
+})
+export type SmsCampaignFullList = z.infer<typeof smsCampaignFullListSchema>
+
+/** Form tạo campaign. Cross-field (biến template, external+{link}) do BE gate. */
+export const smsCampaignCreateSchema = z.object({
+  name: z.string().trim().min(1, "Bắt buộc nhập tên").max(200),
+  code: z
+    .string()
+    .trim()
+    .max(50)
+    .regex(/^[a-z0-9][a-z0-9-]*$/, "Chỉ a-z, 0-9, dấu gạch; bắt đầu bằng chữ/số")
+    .optional()
+    .or(z.literal("")),
+  sms_template: z
+    .string()
+    .trim()
+    .min(1, "Bắt buộc nhập nội dung tin")
+    .max(2000),
+  landing_type: z.enum(SMS_LANDING_TYPES),
+  landing_url: z.string().trim().max(2000).optional().or(z.literal("")),
+  landing_headline: z.string().trim().max(200).optional().or(z.literal("")),
+  landing_body: z.string().trim().max(10000).optional().or(z.literal("")),
+  landing_cta_label: z.string().trim().max(100).optional().or(z.literal("")),
+  landing_cta_url: z.string().trim().max(2000).optional().or(z.literal("")),
+  frequency_cap_days: z.number().int().min(0).max(3650).nullable().optional(),
+  link_expires_at: z.string().optional().or(z.literal("")),
+})
+export type SmsCampaignCreateInput = z.infer<typeof smsCampaignCreateSchema>
+
+/** Form sửa campaign (chỉ khi draft; không đổi code). */
+export const smsCampaignUpdateSchema = smsCampaignCreateSchema.omit({
+  code: true,
+})
+export type SmsCampaignUpdateInput = z.infer<typeof smsCampaignUpdateSchema>
+
+// --- Build / Preflight ---
+export const smsOverLimitRowSchema = z.object({
+  phone_normalized: z.string(),
+  full_name: z.string(),
+  encoding: z.string().nullable().optional(),
+  length: z.number().nullable().optional(),
+  segments: z.number().nullable().optional(),
+})
+export type SmsOverLimitRow = z.infer<typeof smsOverLimitRowSchema>
+
+export const smsPreflightReportSchema = z.object({
+  campaign_id: z.number(),
+  build_revision: z.number(),
+  status: z.string(),
+  has_link: z.boolean(),
+  total: z.number(),
+  exportable: z.number(),
+  excluded_by_reason: z.record(z.string(), z.number()),
+  carrier_distribution: z.record(z.string(), z.number()),
+  over_limit: z.array(smsOverLimitRowSchema),
+  warnings: z.array(z.string()),
+  preview: z.array(z.string()),
+})
+export type SmsPreflightReport = z.infer<typeof smsPreflightReportSchema>

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -490,7 +490,7 @@ export const smsCampaignCreateSchema = z.object({
   landing_cta_label: z.string().trim().max(100).optional().or(z.literal("")),
   landing_cta_url: z.string().trim().max(2000).optional().or(z.literal("")),
   frequency_cap_days: z.number().int().min(0).max(3650).nullable().optional(),
-  link_expires_at: z.string().optional().or(z.literal("")),
+  link_expires_at: z.string().nullable().optional(),
 })
 export type SmsCampaignCreateInput = z.infer<typeof smsCampaignCreateSchema>
 


### PR DESCRIPTION
PR-6d cụm SMS Marketing FE — tiêu thụ router PR-3 (`sms_campaigns.py`). Tách 2 PR: **6d = Campaign + Build/Preflight**, 6e = Attestation + Export (sau).

## FE
- Trang `/admin/sms/campaigns` (list + filter status + tạo) + `/[id]` workspace (theo status).
- Form tạo/sửa campaign: name/code(slug)/template (biến `{full_name}`/`{link}`)/landing `qlts_hosted`|`external`/frequency_cap/link_expires.
- **Groups section**: liệt kê + gắn + bỏ nhóm (dùng BE endpoint mới).
- **Build/Preflight section**: nút Build → report (tổng/gửi-được/bản-dựng/đo-click · danh sách over-limit · loại theo lý do · phân bố nhà mạng · preview tin cuối) + cảnh báo stale khi đổi nhóm sau build.
- Nav "Chiến dịch SMS" admin-only; zod/api/hooks/labels mở rộng (mirror `SmsCampaignOut`/`SmsPreflightReport`).

## BE (code-only, no migration/Casbin)
- `GET /api/sms/campaigns/{id}/groups` → danh sách nhóm đã gắn + `member_count` (repo `get_groups_by_ids` + service `list_campaign_groups`; `require_admin`). Lý do: `SmsCampaignOut` chỉ có `group_count`, thiếu list → FE không bỏ nhóm được. +1 integration test.

## Review (đã vá)
- `/code-review max` (3 finder FE/BE/cleanup): link_expires_at TZ-drift, không-xoá-được optional field khi sửa, đổi landing_type lọt field ẩn, preflight thiếu nhánh lỗi + cleanup.
- Review ngoài P2: preflight stale sau đổi nhóm → banner + badge "Cần build lại".

## Kiểm thử
FE type-check + lint(0) + test(1782) + build PASS · BE 48/48 SMS campaign (gồm test mới).

🤖 Generated with [Claude Code](https://claude.com/claude-code)