### PR TITLE
feat(sms): PR-6e FE Attestation + Export lifecycle

### DIFF
--- a/frontend/src/components/sms/admin/campaigns/SmsAttestationSection.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsAttestationSection.tsx
@@ -1,0 +1,153 @@
+// src/components/sms/admin/campaigns/SmsAttestationSection.tsx
+"use client"
+
+import { useState } from "react"
+import { CheckCircle2, Circle, Loader2 } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { useAddAttestation } from "@/hooks/useSmsExport"
+import {
+  SMS_ATTESTATION_KINDS,
+  type SmsAttestationKind,
+  type SmsCampaign,
+} from "@/lib/zod/sms"
+
+import { attestationKindLabel, formatDateTimeVN } from "../labels"
+
+interface Props {
+  campaign: SmsCampaign
+  /** Ghi attestation được khi chưa bàn giao/đóng (BE cũng gate). */
+  editable: boolean
+}
+
+interface KindState {
+  at: string | null | undefined
+  byId: number | null | undefined
+  reference: string | null | undefined
+  revision: number | null | undefined
+}
+
+/** Đọc trạng thái attestation của 1 kind từ campaign (field theo tiền tố kind). */
+function readKind(c: SmsCampaign, kind: SmsAttestationKind): KindState {
+  const g = (suffix: string) =>
+    (c as unknown as Record<string, unknown>)[`${kind}_${suffix}`] as
+      | string
+      | number
+      | null
+      | undefined
+  return {
+    at: g("checked_at") as string | null | undefined,
+    byId: g("checked_by_id") as number | null | undefined,
+    reference: g("reference") as string | null | undefined,
+    revision: g("checked_build_revision") as number | null | undefined,
+  }
+}
+
+export function SmsAttestationSection({ campaign, editable }: Props) {
+  const [drafts, setDrafts] = useState<Record<string, string>>({})
+  const addMut = useAddAttestation(campaign.id)
+
+  const submit = (kind: SmsAttestationKind) => {
+    const reference = (drafts[kind] ?? "").trim()
+    if (!reference) return
+    addMut.mutate(
+      { kind, reference },
+      { onSuccess: () => setDrafts((d) => ({ ...d, [kind]: "" })) },
+    )
+  }
+
+  const validCount = SMS_ATTESTATION_KINDS.filter((k) => {
+    const s = readKind(campaign, k)
+    return s.revision != null && s.revision === campaign.build_revision
+  }).length
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle className="text-base">Xác nhận trước export</CardTitle>
+        <Badge variant={validCount === 3 ? "default" : "outline"}>
+          {validCount}/3 đã xác nhận
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-muted-foreground text-xs">
+          Cả 3 xác nhận phải khớp bản dựng hiện tại (#{campaign.build_revision}).
+          Build lại sẽ vô hiệu các xác nhận cũ.
+        </p>
+        {SMS_ATTESTATION_KINDS.map((kind) => {
+          const s = readKind(campaign, kind)
+          const valid =
+            s.revision != null && s.revision === campaign.build_revision
+          const staleAttested = s.revision != null && !valid
+          return (
+            <div key={kind} className="rounded border p-3">
+              <div className="flex items-start gap-2">
+                {valid ? (
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+                ) : (
+                  <Circle className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium">
+                    {attestationKindLabel(kind)}
+                  </p>
+                  {valid ? (
+                    <p className="text-muted-foreground text-xs">
+                      ✓ {formatDateTimeVN(s.at)}
+                      {s.byId != null ? ` · bởi #${s.byId}` : ""} · ref:{" "}
+                      {s.reference}
+                    </p>
+                  ) : staleAttested ? (
+                    <p className="text-xs text-amber-600">
+                      Đã xác nhận cho bản dựng #{s.revision} (cũ) — cần xác nhận
+                      lại cho #{campaign.build_revision}.
+                    </p>
+                  ) : (
+                    <p className="text-muted-foreground text-xs">
+                      Chưa xác nhận.
+                    </p>
+                  )}
+
+                  {editable && (
+                    <div className="mt-2 flex gap-2">
+                      <Input
+                        className="h-8 text-sm"
+                        placeholder="Tham chiếu (link/mã hồ sơ bằng chứng)"
+                        maxLength={512}
+                        value={drafts[kind] ?? ""}
+                        disabled={addMut.isPending}
+                        onChange={(e) =>
+                          setDrafts((d) => ({ ...d, [kind]: e.target.value }))
+                        }
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault()
+                            submit(kind)
+                          }
+                        }}
+                      />
+                      <Button
+                        size="sm"
+                        variant={valid ? "outline" : "default"}
+                        disabled={!drafts[kind]?.trim() || addMut.isPending}
+                        onClick={() => submit(kind)}
+                      >
+                        {addMut.isPending && (
+                          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                        )}
+                        {valid ? "Cập nhật" : "Xác nhận"}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/sms/admin/campaigns/SmsAttestationSection.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsAttestationSection.tsx
@@ -15,7 +15,13 @@ import {
   type SmsCampaign,
 } from "@/lib/zod/sms"
 
-import { attestationKindLabel, formatDateTimeVN } from "../labels"
+import {
+  attestationKindLabel,
+  formatDateTimeVN,
+  isAttestationValid,
+} from "../labels"
+
+const REQUIRED = SMS_ATTESTATION_KINDS.length
 
 interface Props {
   campaign: SmsCampaign
@@ -30,19 +36,13 @@ interface KindState {
   revision: number | null | undefined
 }
 
-/** Đọc trạng thái attestation của 1 kind từ campaign (field theo tiền tố kind). */
+/** Đọc field hiển thị của 1 kind từ campaign (index typed theo tiền tố kind). */
 function readKind(c: SmsCampaign, kind: SmsAttestationKind): KindState {
-  const g = (suffix: string) =>
-    (c as unknown as Record<string, unknown>)[`${kind}_${suffix}`] as
-      | string
-      | number
-      | null
-      | undefined
   return {
-    at: g("checked_at") as string | null | undefined,
-    byId: g("checked_by_id") as number | null | undefined,
-    reference: g("reference") as string | null | undefined,
-    revision: g("checked_build_revision") as number | null | undefined,
+    at: c[`${kind}_checked_at`],
+    byId: c[`${kind}_checked_by_id`],
+    reference: c[`${kind}_reference`],
+    revision: c[`${kind}_checked_build_revision`],
   }
 }
 
@@ -59,17 +59,16 @@ export function SmsAttestationSection({ campaign, editable }: Props) {
     )
   }
 
-  const validCount = SMS_ATTESTATION_KINDS.filter((k) => {
-    const s = readKind(campaign, k)
-    return s.revision != null && s.revision === campaign.build_revision
-  }).length
+  const validCount = SMS_ATTESTATION_KINDS.filter((k) =>
+    isAttestationValid(campaign, k),
+  ).length
 
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0">
         <CardTitle className="text-base">Xác nhận trước export</CardTitle>
-        <Badge variant={validCount === 3 ? "default" : "outline"}>
-          {validCount}/3 đã xác nhận
+        <Badge variant={validCount === REQUIRED ? "default" : "outline"}>
+          {validCount}/{REQUIRED} đã xác nhận
         </Badge>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -79,8 +78,7 @@ export function SmsAttestationSection({ campaign, editable }: Props) {
         </p>
         {SMS_ATTESTATION_KINDS.map((kind) => {
           const s = readKind(campaign, kind)
-          const valid =
-            s.revision != null && s.revision === campaign.build_revision
+          const valid = isAttestationValid(campaign, kind)
           const staleAttested = s.revision != null && !valid
           return (
             <div key={kind} className="rounded border p-3">

--- a/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
@@ -107,11 +107,7 @@ export function SmsCampaignWorkspace({ campaignId }: { campaignId: number }) {
             campaign={campaign}
             editable={audienceEditable}
           />
-          <SmsExportSection
-            campaign={campaign}
-            hasBuild={hasBuild}
-            editable={audienceEditable}
-          />
+          <SmsExportSection campaign={campaign} editable={audienceEditable} />
         </>
       )}
 

--- a/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
@@ -12,9 +12,11 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { useSmsCampaign } from "@/hooks/useSmsCampaigns"
 
 import { campaignStatusLabel } from "../labels"
+import { SmsAttestationSection } from "./SmsAttestationSection"
 import { SmsBuildPreflightSection } from "./SmsBuildPreflightSection"
 import { SmsCampaignFormDialog } from "./SmsCampaignFormDialog"
 import { SmsCampaignGroupsSection } from "./SmsCampaignGroupsSection"
+import { SmsExportSection } from "./SmsExportSection"
 
 const CLOSED_STATUSES = ["handed_off", "closed"]
 
@@ -98,6 +100,20 @@ export function SmsCampaignWorkspace({ campaignId }: { campaignId: number }) {
         canBuild={audienceEditable}
         staleBuild={staleBuild}
       />
+
+      {hasBuild && (
+        <>
+          <SmsAttestationSection
+            campaign={campaign}
+            editable={audienceEditable}
+          />
+          <SmsExportSection
+            campaign={campaign}
+            hasBuild={hasBuild}
+            editable={audienceEditable}
+          />
+        </>
+      )}
 
       <SmsCampaignFormDialog
         open={editOpen}

--- a/frontend/src/components/sms/admin/campaigns/SmsExportSection.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsExportSection.tsx
@@ -1,0 +1,244 @@
+// src/components/sms/admin/campaigns/SmsExportSection.tsx
+"use client"
+
+import { useState } from "react"
+import { AlertTriangle, Download, FileDown, Loader2 } from "lucide-react"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useSmsCampaignPreflight } from "@/hooks/useSmsCampaigns"
+import {
+  useCampaignExports,
+  useDownloadExport,
+  useExportCampaign,
+  useMarkExportHandedOff,
+} from "@/hooks/useSmsExport"
+import { SMS_ATTESTATION_KINDS, type SmsCampaign } from "@/lib/zod/sms"
+
+import {
+  carrierLabel,
+  exportStatusLabel,
+  exportStatusVariant,
+  formatDateTimeVN,
+  formatInt,
+} from "../labels"
+
+interface Props {
+  campaign: SmsCampaign
+  hasBuild: boolean
+  /** Export/handoff được khi chưa bàn giao/đóng. */
+  editable: boolean
+}
+
+function formatBytes(n: number | null | undefined): string {
+  if (n == null) return "—"
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function attestValid(c: SmsCampaign, kind: string): boolean {
+  const rev = (c as unknown as Record<string, unknown>)[
+    `${kind}_checked_build_revision`
+  ] as number | null | undefined
+  return rev != null && rev === c.build_revision
+}
+
+export function SmsExportSection({ campaign, hasBuild, editable }: Props) {
+  const [handoffTarget, setHandoffTarget] = useState<{
+    id: number
+    carrier: string
+  } | null>(null)
+
+  const { data: preflight } = useSmsCampaignPreflight(campaign.id, {
+    enabled: hasBuild,
+  })
+  const { data: exports, isLoading } = useCampaignExports(campaign.id, hasBuild)
+  const exportMut = useExportCampaign(campaign.id)
+  const handoffMut = useMarkExportHandedOff(campaign.id)
+  const downloadMut = useDownloadExport(campaign.id)
+
+  const validCount = SMS_ATTESTATION_KINDS.filter((k) =>
+    attestValid(campaign, k),
+  ).length
+
+  // Lý do CHƯA export được (BE là gate cuối 400; đây chỉ là gợi ý hiển thị).
+  const reasons: string[] = []
+  if (validCount < 3) reasons.push(`Còn thiếu ${3 - validCount}/3 xác nhận`)
+  if (preflight && preflight.exportable <= 0)
+    reasons.push("Không có người nhận hợp lệ")
+  if (preflight && preflight.over_limit.length > 0)
+    reasons.push(`Còn ${preflight.over_limit.length} tin vượt 1 đoạn`)
+  const ready = reasons.length === 0
+
+  const batches = exports?.batches ?? []
+
+  const confirmHandoff = () => {
+    if (!handoffTarget) return
+    handoffMut.mutate(
+      { batchId: handoffTarget.id },
+      { onSuccess: () => setHandoffTarget(null) },
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle className="text-base">Export &amp; bàn giao</CardTitle>
+        {editable && (
+          <Button
+            size="sm"
+            onClick={() => exportMut.mutate()}
+            disabled={!ready || exportMut.isPending}
+          >
+            {exportMut.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <FileDown className="mr-2 h-4 w-4" />
+            )}
+            Export Excel
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {!hasBuild ? (
+          <p className="text-muted-foreground py-4 text-center text-sm">
+            Cần build trước khi export.
+          </p>
+        ) : (
+          <>
+            {editable && !ready && (
+              <div className="rounded border border-amber-300 bg-amber-50 p-2.5">
+                <p className="flex items-center gap-1.5 text-xs font-medium text-amber-800">
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  Chưa export được: {reasons.join(" · ")}.
+                </p>
+              </div>
+            )}
+
+            {isLoading ? (
+              <Skeleton className="h-16 w-full" />
+            ) : batches.length === 0 ? (
+              <p className="text-muted-foreground py-3 text-center text-sm">
+                Chưa có file export. Bấm “Export Excel” để sinh 1 file / nhà mạng.
+              </p>
+            ) : (
+              <div className="divide-y">
+                {batches.map((b) => (
+                  <div
+                    key={b.id}
+                    className="flex flex-wrap items-center justify-between gap-2 py-2.5"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium">
+                          {carrierLabel(b.carrier_bucket)}
+                        </span>
+                        <Badge variant={exportStatusVariant(b.status)}>
+                          {exportStatusLabel(b.status)}
+                        </Badge>
+                        {b.is_expired && (
+                          <Badge variant="secondary">Hết hạn</Badge>
+                        )}
+                      </div>
+                      <p className="text-muted-foreground text-xs">
+                        {formatInt(b.recipient_count)} người ·{" "}
+                        {formatBytes(b.file_size_bytes)}
+                        {b.expires_at
+                          ? ` · hết hạn ${formatDateTimeVN(b.expires_at)}`
+                          : ""}
+                      </p>
+                      {b.failure_reason && (
+                        <p className="text-destructive text-xs">
+                          {b.failure_reason}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {b.can_download && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={downloadMut.isPending}
+                          onClick={() =>
+                            downloadMut.mutate({
+                              batchId: b.id,
+                              fallbackName:
+                                b.file_name ??
+                                `${b.carrier_bucket}-export.xlsx`,
+                            })
+                          }
+                        >
+                          <Download className="mr-1.5 h-3.5 w-3.5" /> Tải
+                        </Button>
+                      )}
+                      {editable && b.can_mark_handed_off && (
+                        <Button
+                          size="sm"
+                          onClick={() =>
+                            setHandoffTarget({
+                              id: b.id,
+                              carrier: carrierLabel(b.carrier_bucket),
+                            })
+                          }
+                        >
+                          Đã bàn giao
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+
+      <AlertDialog
+        open={handoffTarget != null}
+        onOpenChange={(o) => !o && setHandoffTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Xác nhận đã bàn giao?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Đánh dấu file <b>{handoffTarget?.carrier}</b> đã upload cho nhà
+              mạng. Thao tác này neo người nhận (chặn build lại) + tính tần suất
+              gửi, và đóng chiến dịch khi mọi nhà mạng đã bàn giao. Không hoàn
+              tác được.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={handoffMut.isPending}>
+              Hủy
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={handoffMut.isPending}
+              onClick={(e) => {
+                e.preventDefault()
+                confirmHandoff()
+              }}
+            >
+              {handoffMut.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Xác nhận bàn giao
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  )
+}

--- a/frontend/src/components/sms/admin/campaigns/SmsExportSection.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsExportSection.tsx
@@ -33,12 +33,14 @@ import {
   exportStatusVariant,
   formatDateTimeVN,
   formatInt,
+  isAttestationValid,
 } from "../labels"
+
+const REQUIRED = SMS_ATTESTATION_KINDS.length
 
 interface Props {
   campaign: SmsCampaign
-  hasBuild: boolean
-  /** Export/handoff được khi chưa bàn giao/đóng. */
+  /** Export/handoff được khi chưa bàn giao/đóng. Chỉ mount khi đã build. */
   editable: boolean
 }
 
@@ -49,39 +51,32 @@ function formatBytes(n: number | null | undefined): string {
   return `${(n / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function attestValid(c: SmsCampaign, kind: string): boolean {
-  const rev = (c as unknown as Record<string, unknown>)[
-    `${kind}_checked_build_revision`
-  ] as number | null | undefined
-  return rev != null && rev === c.build_revision
-}
-
-export function SmsExportSection({ campaign, hasBuild, editable }: Props) {
+export function SmsExportSection({ campaign, editable }: Props) {
   const [handoffTarget, setHandoffTarget] = useState<{
     id: number
     carrier: string
   } | null>(null)
 
-  const { data: preflight } = useSmsCampaignPreflight(campaign.id, {
-    enabled: hasBuild,
-  })
-  const { data: exports, isLoading } = useCampaignExports(campaign.id, hasBuild)
+  const { data: preflight } = useSmsCampaignPreflight(campaign.id)
+  const { data: exports, isLoading } = useCampaignExports(campaign.id)
   const exportMut = useExportCampaign(campaign.id)
   const handoffMut = useMarkExportHandedOff(campaign.id)
   const downloadMut = useDownloadExport(campaign.id)
 
   const validCount = SMS_ATTESTATION_KINDS.filter((k) =>
-    attestValid(campaign, k),
+    isAttestationValid(campaign, k),
   ).length
 
   // Lý do CHƯA export được (BE là gate cuối 400; đây chỉ là gợi ý hiển thị).
   const reasons: string[] = []
-  if (validCount < 3) reasons.push(`Còn thiếu ${3 - validCount}/3 xác nhận`)
+  if (validCount < REQUIRED)
+    reasons.push(`Còn thiếu ${REQUIRED - validCount}/${REQUIRED} xác nhận`)
   if (preflight && preflight.exportable <= 0)
     reasons.push("Không có người nhận hợp lệ")
   if (preflight && preflight.over_limit.length > 0)
     reasons.push(`Còn ${preflight.over_limit.length} tin vượt 1 đoạn`)
-  const ready = reasons.length === 0
+  // Chưa có preflight (đang tải/lỗi) → coi như chưa sẵn sàng (không bật sớm).
+  const ready = reasons.length === 0 && preflight != null
 
   const batches = exports?.batches ?? []
 
@@ -113,96 +108,90 @@ export function SmsExportSection({ campaign, hasBuild, editable }: Props) {
         )}
       </CardHeader>
       <CardContent className="space-y-3">
-        {!hasBuild ? (
-          <p className="text-muted-foreground py-4 text-center text-sm">
-            Cần build trước khi export.
+        {editable && !ready && (
+          <div className="rounded border border-amber-300 bg-amber-50 p-2.5">
+            <p className="flex items-center gap-1.5 text-xs font-medium text-amber-800">
+              <AlertTriangle className="h-3.5 w-3.5" />
+              Chưa export được: {reasons.join(" · ")}.
+            </p>
+          </div>
+        )}
+
+        {isLoading ? (
+          <Skeleton className="h-16 w-full" />
+        ) : batches.length === 0 ? (
+          <p className="text-muted-foreground py-3 text-center text-sm">
+            Chưa có file export. Bấm “Export Excel” để sinh 1 file / nhà mạng.
           </p>
         ) : (
-          <>
-            {editable && !ready && (
-              <div className="rounded border border-amber-300 bg-amber-50 p-2.5">
-                <p className="flex items-center gap-1.5 text-xs font-medium text-amber-800">
-                  <AlertTriangle className="h-3.5 w-3.5" />
-                  Chưa export được: {reasons.join(" · ")}.
-                </p>
-              </div>
-            )}
-
-            {isLoading ? (
-              <Skeleton className="h-16 w-full" />
-            ) : batches.length === 0 ? (
-              <p className="text-muted-foreground py-3 text-center text-sm">
-                Chưa có file export. Bấm “Export Excel” để sinh 1 file / nhà mạng.
-              </p>
-            ) : (
-              <div className="divide-y">
-                {batches.map((b) => (
-                  <div
-                    key={b.id}
-                    className="flex flex-wrap items-center justify-between gap-2 py-2.5"
-                  >
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium">
-                          {carrierLabel(b.carrier_bucket)}
-                        </span>
-                        <Badge variant={exportStatusVariant(b.status)}>
-                          {exportStatusLabel(b.status)}
-                        </Badge>
-                        {b.is_expired && (
-                          <Badge variant="secondary">Hết hạn</Badge>
-                        )}
-                      </div>
-                      <p className="text-muted-foreground text-xs">
-                        {formatInt(b.recipient_count)} người ·{" "}
-                        {formatBytes(b.file_size_bytes)}
-                        {b.expires_at
-                          ? ` · hết hạn ${formatDateTimeVN(b.expires_at)}`
-                          : ""}
-                      </p>
-                      {b.failure_reason && (
-                        <p className="text-destructive text-xs">
-                          {b.failure_reason}
-                        </p>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2">
-                      {b.can_download && (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          disabled={downloadMut.isPending}
-                          onClick={() =>
-                            downloadMut.mutate({
-                              batchId: b.id,
-                              fallbackName:
-                                b.file_name ??
-                                `${b.carrier_bucket}-export.xlsx`,
-                            })
-                          }
-                        >
-                          <Download className="mr-1.5 h-3.5 w-3.5" /> Tải
-                        </Button>
-                      )}
-                      {editable && b.can_mark_handed_off && (
-                        <Button
-                          size="sm"
-                          onClick={() =>
-                            setHandoffTarget({
-                              id: b.id,
-                              carrier: carrierLabel(b.carrier_bucket),
-                            })
-                          }
-                        >
-                          Đã bàn giao
-                        </Button>
-                      )}
-                    </div>
+          <div className="divide-y">
+            {batches.map((b) => (
+              <div
+                key={b.id}
+                className="flex flex-wrap items-center justify-between gap-2 py-2.5"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">
+                      {carrierLabel(b.carrier_bucket)}
+                    </span>
+                    <Badge variant={exportStatusVariant(b.status)}>
+                      {exportStatusLabel(b.status)}
+                    </Badge>
+                    {b.is_expired && (
+                      <Badge variant="secondary">Hết hạn</Badge>
+                    )}
                   </div>
-                ))}
+                  <p className="text-muted-foreground text-xs">
+                    {formatInt(b.recipient_count)} người ·{" "}
+                    {formatBytes(b.file_size_bytes)}
+                    {b.expires_at
+                      ? ` · hết hạn ${formatDateTimeVN(b.expires_at)}`
+                      : ""}
+                  </p>
+                  {b.failure_reason && (
+                    <p className="text-destructive text-xs">
+                      {b.failure_reason}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  {b.can_download && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={
+                        downloadMut.isPending &&
+                        downloadMut.variables?.batchId === b.id
+                      }
+                      onClick={() =>
+                        downloadMut.mutate({
+                          batchId: b.id,
+                          fallbackName:
+                            b.file_name ?? `${b.carrier_bucket}-export.xlsx`,
+                        })
+                      }
+                    >
+                      <Download className="mr-1.5 h-3.5 w-3.5" /> Tải
+                    </Button>
+                  )}
+                  {editable && b.can_mark_handed_off && (
+                    <Button
+                      size="sm"
+                      onClick={() =>
+                        setHandoffTarget({
+                          id: b.id,
+                          carrier: carrierLabel(b.carrier_bucket),
+                        })
+                      }
+                    >
+                      Đã bàn giao
+                    </Button>
+                  )}
+                </div>
               </div>
-            )}
-          </>
+            ))}
+          </div>
         )}
       </CardContent>
 

--- a/frontend/src/components/sms/admin/labels.ts
+++ b/frontend/src/components/sms/admin/labels.ts
@@ -169,6 +169,36 @@ export function excludedReasonLabel(v: string): string {
   return EXCLUDED_REASON_LABELS[v] ?? v
 }
 
+// --- Attestation + Export (PR-6e) ---
+export const ATTESTATION_KIND_LABELS: Record<string, string> = {
+  consent: "Xác nhận đã có đồng ý (consent)",
+  dnc: "Xác nhận đã lọc danh sách chặn (DNC)",
+  optout_channel: "Xác nhận kênh từ chối hoạt động",
+}
+export function attestationKindLabel(v: string): string {
+  return ATTESTATION_KIND_LABELS[v] ?? v
+}
+
+export const EXPORT_STATUS_LABELS: Record<string, string> = {
+  pending: "Đang tạo",
+  generated: "Đã tạo",
+  handed_off: "Đã bàn giao",
+  failed: "Thất bại",
+  purged: "Đã xoá file",
+  invalidated: "Vô hiệu (đã build lại)",
+}
+export function exportStatusLabel(v: string): string {
+  return EXPORT_STATUS_LABELS[v] ?? v
+}
+export function exportStatusVariant(
+  v: string,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (v === "handed_off") return "default"
+  if (v === "failed") return "destructive"
+  if (v === "purged" || v === "invalidated") return "secondary"
+  return "outline"
+}
+
 // =====================================================================
 // Contact / Group / Consent (PR-6b)
 // =====================================================================

--- a/frontend/src/components/sms/admin/labels.ts
+++ b/frontend/src/components/sms/admin/labels.ts
@@ -16,6 +16,8 @@ import {
   SMS_LANDING_TYPES,
   SMS_MANUAL_OPT_OUT_SOURCES,
   SMS_REVOKE_SOURCES,
+  type SmsAttestationKind,
+  type SmsCampaign,
   type SmsCarrierBucket,
   type SmsConsentBasis,
   type SmsGranularity,
@@ -197,6 +199,18 @@ export function exportStatusVariant(
   if (v === "failed") return "destructive"
   if (v === "purged" || v === "invalidated") return "secondary"
   return "outline"
+}
+
+/**
+ * Attestation của `kind` hợp lệ khi khớp bản dựng hiện tại (build lại → vô
+ * hiệu). Index typed theo `${kind}_checked_build_revision` (không cast unknown).
+ */
+export function isAttestationValid(
+  c: SmsCampaign,
+  kind: SmsAttestationKind,
+): boolean {
+  const rev = c[`${kind}_checked_build_revision`]
+  return rev != null && rev === c.build_revision
 }
 
 // =====================================================================

--- a/frontend/src/hooks/useSmsExport.ts
+++ b/frontend/src/hooks/useSmsExport.ts
@@ -16,6 +16,7 @@ import {
   markSmsExportHandedOff,
 } from "@/lib/api/sms"
 import { parseApiError } from "@/lib/utils/api-errors"
+import { blobErrorMessage } from "@/lib/utils/download-blob"
 import type { SmsAttestationCreateInput } from "@/lib/zod/sms"
 import type { ApiErrorResponse } from "@/types/api.types"
 
@@ -99,6 +100,8 @@ export function useDownloadExport(campaignId: number) {
   >({
     mutationFn: ({ batchId, fallbackName }) =>
       downloadSmsExport(campaignId, batchId, fallbackName),
-    onError: (e) => toast.error(parseApiError(e, "Không thể tải file.")),
+    // responseType:'blob' → body lỗi là Blob; blobErrorMessage đọc .text() ra detail.
+    onError: async (e) =>
+      toast.error(await blobErrorMessage(e, "Không thể tải file.")),
   })
 }

--- a/frontend/src/hooks/useSmsExport.ts
+++ b/frontend/src/hooks/useSmsExport.ts
@@ -1,0 +1,104 @@
+// src/hooks/useSmsExport.ts
+/**
+ * React Query hooks — SMS Attestation + Export lifecycle (PR-6e).
+ * Attestation/export/handed-off đổi campaign (status + attestation fields) →
+ * invalidate cả cụm sms-campaigns + danh sách export. require_admin ở BE.
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { AxiosError } from "axios"
+import { toast } from "sonner"
+
+import {
+  addCampaignAttestation,
+  downloadSmsExport,
+  exportSmsCampaign,
+  listSmsCampaignExports,
+  markSmsExportHandedOff,
+} from "@/lib/api/sms"
+import { parseApiError } from "@/lib/utils/api-errors"
+import type { SmsAttestationCreateInput } from "@/lib/zod/sms"
+import type { ApiErrorResponse } from "@/types/api.types"
+
+import { smsCampaignKeys } from "./useSmsCampaigns"
+
+type ApiError = AxiosError<ApiErrorResponse>
+
+export const smsExportKeys = {
+  all: ["sms-exports"] as const,
+  list: (campaignId: number) =>
+    [...smsExportKeys.all, "list", campaignId] as const,
+}
+
+function invalidateAfterMutation(
+  qc: ReturnType<typeof useQueryClient>,
+  campaignId: number,
+) {
+  // Campaign (status/attestation/build) + danh sách batch đều có thể đổi.
+  qc.invalidateQueries({ queryKey: smsCampaignKeys.all })
+  qc.invalidateQueries({ queryKey: smsExportKeys.list(campaignId) })
+}
+
+// ---------------------------------------------------------------------
+export function useCampaignExports(campaignId: number | null, enabled = true) {
+  return useQuery({
+    queryKey: smsExportKeys.list(campaignId ?? 0),
+    queryFn: () => listSmsCampaignExports(campaignId as number),
+    enabled: campaignId != null && enabled,
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useAddAttestation(campaignId: number) {
+  const qc = useQueryClient()
+  return useMutation<unknown, ApiError, SmsAttestationCreateInput>({
+    mutationFn: (payload) => addCampaignAttestation(campaignId, payload),
+    onSuccess: () => {
+      toast.success("Đã ghi xác nhận.")
+      invalidateAfterMutation(qc, campaignId)
+    },
+    onError: (e) =>
+      toast.error(parseApiError(e, "Không thể ghi xác nhận.")),
+  })
+}
+
+export function useExportCampaign(campaignId: number) {
+  const qc = useQueryClient()
+  return useMutation<
+    Awaited<ReturnType<typeof exportSmsCampaign>>,
+    ApiError,
+    void
+  >({
+    mutationFn: () => exportSmsCampaign(campaignId),
+    onSuccess: (res) => {
+      toast.success(res.message || "Đã tạo file export.")
+      invalidateAfterMutation(qc, campaignId)
+    },
+    onError: (e) => toast.error(parseApiError(e, "Không thể export.")),
+  })
+}
+
+export function useMarkExportHandedOff(campaignId: number) {
+  const qc = useQueryClient()
+  return useMutation<unknown, ApiError, { batchId: number }>({
+    mutationFn: ({ batchId }) => markSmsExportHandedOff(campaignId, batchId),
+    onSuccess: () => {
+      toast.success("Đã đánh dấu bàn giao.")
+      invalidateAfterMutation(qc, campaignId)
+    },
+    onError: (e) =>
+      toast.error(parseApiError(e, "Không thể đánh dấu bàn giao.")),
+  })
+}
+
+/** Tải file export (imperative, có loading state per lần bấm). */
+export function useDownloadExport(campaignId: number) {
+  return useMutation<
+    void,
+    ApiError,
+    { batchId: number; fallbackName: string }
+  >({
+    mutationFn: ({ batchId, fallbackName }) =>
+      downloadSmsExport(campaignId, batchId, fallbackName),
+    onError: (e) => toast.error(parseApiError(e, "Không thể tải file.")),
+  })
+}

--- a/frontend/src/lib/api/sms.ts
+++ b/frontend/src/lib/api/sms.ts
@@ -10,6 +10,10 @@
  */
 import { api } from "@/lib/api/client"
 import {
+  downloadBlob,
+  filenameFromDisposition,
+} from "@/lib/utils/download-blob"
+import {
   smsCampaignDashboardSchema,
   smsCampaignFullListSchema,
   smsCampaignListSchema,
@@ -469,7 +473,7 @@ export async function markSmsExportHandedOff(
 /**
  * Tải file export. Endpoint trả FileResponse (binary) + YÊU CẦU auth (JWT) →
  * phải fetch blob qua axios (giữ Authorization header), KHÔNG mở URL trần.
- * Kích hoạt tải trong trình duyệt qua <a download> tạm rồi thu hồi objectURL.
+ * Dùng util chung download-blob (tránh lặp regex/createObjectURL).
  */
 export async function downloadSmsExport(
   campaignId: number,
@@ -480,17 +484,9 @@ export async function downloadSmsExport(
     `/api/sms/campaigns/${campaignId}/exports/${batchId}/download`,
     { responseType: "blob" },
   )
-  // Lấy tên file từ Content-Disposition nếu có, else fallback (batch.file_name).
-  const cd = res.headers["content-disposition"] as string | undefined
-  const match = cd?.match(/filename\*?=(?:UTF-8'')?["']?([^"';]+)/i)
-  const filename = match ? decodeURIComponent(match[1]) : fallbackName
-
-  const url = URL.createObjectURL(res.data)
-  const a = document.createElement("a")
-  a.href = url
-  a.download = filename
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
+  const filename = filenameFromDisposition(
+    res.headers["content-disposition"] as string | undefined,
+    fallbackName,
+  )
+  downloadBlob(res.data, filename)
 }

--- a/frontend/src/lib/api/sms.ts
+++ b/frontend/src/lib/api/sms.ts
@@ -15,6 +15,9 @@ import {
   smsCampaignListSchema,
   smsCampaignSchema,
   smsClickReportSchema,
+  smsExportBatchListSchema,
+  smsExportBatchSchema,
+  smsExportResultSchema,
   smsPreflightReportSchema,
   smsConsentEventListSchema,
   smsConsentEventSchema,
@@ -33,7 +36,11 @@ import {
   type SmsCampaignFullList,
   type SmsCampaignList,
   type SmsCampaignUpdateInput,
+  type SmsAttestationCreateInput,
   type SmsClickReport,
+  type SmsExportBatch,
+  type SmsExportBatchList,
+  type SmsExportResult,
   type SmsPreflightReport,
   type SmsConsentEvent,
   type SmsConsentEventCreateInput,
@@ -411,4 +418,79 @@ export async function getSmsCampaignPreflight(
     `/api/sms/campaigns/${campaignId}/preflight`,
   )
   return smsPreflightReportSchema.parse(res.data)
+}
+
+// =====================================================================
+// Admin — Attestation + Export lifecycle (PR-6e, require_admin)
+// =====================================================================
+
+/** Ghi attestation (consent/dnc/optout_channel) cho build hiện tại. */
+export async function addCampaignAttestation(
+  campaignId: number,
+  payload: SmsAttestationCreateInput,
+): Promise<SmsCampaign> {
+  const res = await api.post<SmsCampaign>(
+    `/api/sms/campaigns/${campaignId}/attestations`,
+    payload,
+  )
+  return smsCampaignSchema.parse(res.data)
+}
+
+/** Sinh file Excel per nhà mạng (gate fail-closed ở BE → 400 nếu chưa đủ). */
+export async function exportSmsCampaign(
+  campaignId: number,
+): Promise<SmsExportResult> {
+  const res = await api.post<SmsExportResult>(
+    `/api/sms/campaigns/${campaignId}/export`,
+  )
+  return smsExportResultSchema.parse(res.data)
+}
+
+/** Danh sách batch export của bản build hiện tại (hiển thị lại sau reload). */
+export async function listSmsCampaignExports(
+  campaignId: number,
+): Promise<SmsExportBatchList> {
+  const res = await api.get<SmsExportBatchList>(
+    `/api/sms/campaigns/${campaignId}/exports`,
+  )
+  return smsExportBatchListSchema.parse(res.data)
+}
+
+export async function markSmsExportHandedOff(
+  campaignId: number,
+  batchId: number,
+): Promise<SmsExportBatch> {
+  const res = await api.post<SmsExportBatch>(
+    `/api/sms/campaigns/${campaignId}/exports/${batchId}/mark-handed-off`,
+  )
+  return smsExportBatchSchema.parse(res.data)
+}
+
+/**
+ * Tải file export. Endpoint trả FileResponse (binary) + YÊU CẦU auth (JWT) →
+ * phải fetch blob qua axios (giữ Authorization header), KHÔNG mở URL trần.
+ * Kích hoạt tải trong trình duyệt qua <a download> tạm rồi thu hồi objectURL.
+ */
+export async function downloadSmsExport(
+  campaignId: number,
+  batchId: number,
+  fallbackName: string,
+): Promise<void> {
+  const res = await api.get<Blob>(
+    `/api/sms/campaigns/${campaignId}/exports/${batchId}/download`,
+    { responseType: "blob" },
+  )
+  // Lấy tên file từ Content-Disposition nếu có, else fallback (batch.file_name).
+  const cd = res.headers["content-disposition"] as string | undefined
+  const match = cd?.match(/filename\*?=(?:UTF-8'')?["']?([^"';]+)/i)
+  const filename = match ? decodeURIComponent(match[1]) : fallbackName
+
+  const url = URL.createObjectURL(res.data)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
 }

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -524,3 +524,77 @@ export const smsPreflightReportSchema = z.object({
   preview: z.array(z.string()),
 })
 export type SmsPreflightReport = z.infer<typeof smsPreflightReportSchema>
+
+// =====================================================================
+// Admin — Attestation + Export lifecycle (PR-6e; mirror SmsAttestationCreate,
+// SmsExportBatchOut/Result/List ở app/schemas/sms.py).
+// =====================================================================
+
+/** Loại attestation gate export (mirror SmsAttestationKind). */
+export const SMS_ATTESTATION_KINDS = [
+  "consent",
+  "dnc",
+  "optout_channel",
+] as const
+export type SmsAttestationKind = (typeof SMS_ATTESTATION_KINDS)[number]
+
+/** Form ghi attestation cho build_revision hiện tại. */
+export const smsAttestationCreateSchema = z.object({
+  kind: z.enum(SMS_ATTESTATION_KINDS),
+  reference: z.string().trim().min(1, "Bắt buộc nhập tham chiếu").max(512),
+})
+export type SmsAttestationCreateInput = z.infer<
+  typeof smsAttestationCreateSchema
+>
+
+/** Trạng thái vòng đời batch export (mirror SmsExportStatus / CHECK). */
+export const SMS_EXPORT_STATUSES = [
+  "pending",
+  "generated",
+  "handed_off",
+  "failed",
+  "purged",
+  "invalidated",
+] as const
+export type SmsExportStatus = (typeof SMS_EXPORT_STATUSES)[number]
+
+/** 1 file Excel / nhà mạng / build_revision (mirror SmsExportBatchOut). */
+export const smsExportBatchSchema = z.object({
+  id: z.number(),
+  campaign_id: z.number(),
+  build_revision: z.number(),
+  group_id: z.number().nullable().optional(),
+  group_name_snapshot: z.string().nullable().optional(),
+  carrier_bucket: z.string(),
+  recipient_count: z.number(),
+  file_name: z.string().nullable().optional(),
+  file_size_bytes: z.number().nullable().optional(),
+  status: z.string(),
+  failure_reason: z.string().nullable().optional(),
+  expires_at: z.string().nullable().optional(),
+  generated_at: z.string().nullable().optional(),
+  generated_by_id: z.number().nullable().optional(),
+  marked_handed_off_at: z.string().nullable().optional(),
+  invalidated_at: z.string().nullable().optional(),
+  // Cờ do BE điền — thin-client đọc cờ, KHÔNG tự suy trạng thái.
+  can_download: z.boolean(),
+  can_mark_handed_off: z.boolean(),
+  is_expired: z.boolean(),
+})
+export type SmsExportBatch = z.infer<typeof smsExportBatchSchema>
+
+export const smsExportResultSchema = z.object({
+  campaign_id: z.number(),
+  build_revision: z.number(),
+  total_exportable: z.number(),
+  batches: z.array(smsExportBatchSchema),
+  message: z.string().nullable().optional(),
+})
+export type SmsExportResult = z.infer<typeof smsExportResultSchema>
+
+export const smsExportBatchListSchema = z.object({
+  campaign_id: z.number(),
+  build_revision: z.number(),
+  batches: z.array(smsExportBatchSchema),
+})
+export type SmsExportBatchList = z.infer<typeof smsExportBatchListSchema>


### PR DESCRIPTION
PR-6e — hoàn tất cụm SMS Marketing FE. Tiêu thụ router PR-3/PR-4 (attestation + export đã có ở BE; **FE-only, không đụng BE**). Nối tiếp PR-6d (#454): thêm 2 section vào workspace campaign.

## FE
- **SmsAttestationSection**: 3 gate `consent`/`dnc`/`optout_channel`. Hợp lệ khi `{kind}_checked_build_revision === build_revision` (helper typed `isAttestationValid`; rebuild → invalidate, cảnh báo "xác nhận cho bản dựng cũ"). Form reference → `POST /attestations`.
- **SmsExportSection**: nút Export gated (gợi ý lý do chưa đủ: `<3` xác nhận / over-limit / 0 người nhận — **BE 400 là gate cuối** fail-closed) + danh sách batch per nhà mạng (status/recipient/size/expiry; nút **Tải** [`can_download`, disable đúng hàng] + **"Đã bàn giao"** [`can_mark_handed_off`] có AlertDialog cảnh báo đóng campaign).
- **Download**: fetch BLOB giữ auth (JWT) qua axios + `filenameFromDisposition` + `downloadBlob` (util chung; KHÔNG mở URL trần); lỗi dùng `blobErrorMessage` (đọc `detail` từ blob).
- `zod`/`api`/`hooks(useSmsExport)`/`labels` mở rộng (mirror `SmsAttestationCreate`, `SmsExportBatchOut`/`Result`/`List`; thin-client đọc cờ `can_*`).

## Review
`/code-review max` (2 finder): contract zod↔Pydantic CLEAN, không bug data-integrity (BE fail-closed). Vá 8 UX/cleanup (reuse util download-blob, `blobErrorMessage`, typed `isAttestationValid`, `REQUIRED=length`, gate preflight-loaded, per-row download, bỏ prop thừa).

## Kiểm thử
FE type-check + lint(0) + test(1782) + build PASS. Không đụng BE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)