### PR TITLE
feat(sms): PR-7 Phase 2 BE — schema + deep tracking (đo quan tâm ngành)

### DIFF
--- a/Backend_FastAPI/alembic/versions/smsp2eng20260702001_sms_phase2_deep_engagement.py
+++ b/Backend_FastAPI/alembic/versions/smsp2eng20260702001_sms_phase2_deep_engagement.py
@@ -1,0 +1,209 @@
+"""sms phase2 deep engagement schema (3 bảng đo quan tâm ngành)
+
+Viết TAY (không autogenerate) — autogenerate bị nhiễm drift dev DB (đòi drop
+archive/casbin + alter comment hàng trăm cột). Chỉ tạo 3 bảng Phase 2 §16.4:
+sms_landing_session, sms_program_view, sms_contact_program_interest.
+
+Revision ID: smsp2eng20260702001
+Revises: mta20260628001
+Create Date: 2026-07-02
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "smsp2eng20260702001"
+down_revision: Union[str, Sequence[str], None] = "mta20260628001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. sms_landing_session (program_view phụ thuộc → tạo trước)
+    op.create_table(
+        "sms_landing_session",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("contact_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "source_type", sa.String(length=20),
+            server_default="campaign", nullable=False,
+        ),
+        sa.Column("recipient_id", sa.Integer(), nullable=True),
+        sa.Column("campaign_id", sa.Integer(), nullable=True),
+        sa.Column("session_token_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "started_at", sa.DateTime(timezone=True),
+            server_default=sa.text("now()"), nullable=False,
+        ),
+        sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "active_seconds", sa.Integer(),
+            server_default="0", nullable=False,
+        ),
+        sa.Column("ip_hash", sa.String(length=64), nullable=True),
+        sa.Column("user_agent", sa.String(length=512), nullable=True),
+        sa.Column(
+            "is_suspected_bot", sa.Boolean(),
+            server_default="false", nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["contact_id"], ["sms_contact.id"], ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["recipient_id"], ["sms_campaign_recipient.id"], ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["campaign_id"], ["sms_campaign.id"], ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("session_token_hash"),
+    )
+    op.create_index(
+        op.f("ix_sms_landing_session_contact_id"),
+        "sms_landing_session", ["contact_id"], unique=False,
+    )
+    op.create_index(
+        op.f("ix_sms_landing_session_recipient_id"),
+        "sms_landing_session", ["recipient_id"], unique=False,
+    )
+    op.create_index(
+        op.f("ix_sms_landing_session_campaign_id"),
+        "sms_landing_session", ["campaign_id"], unique=False,
+    )
+
+    # 2. sms_program_view (FK → session)
+    op.create_table(
+        "sms_program_view",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("session_id", sa.Integer(), nullable=False),
+        sa.Column("contact_id", sa.Integer(), nullable=False),
+        sa.Column("major_program_id", sa.Integer(), nullable=True),
+        sa.Column("program_offering_id", sa.Integer(), nullable=True),
+        sa.Column("program_name_snapshot", sa.String(length=255), nullable=False),
+        sa.Column(
+            "viewed_at", sa.DateTime(timezone=True),
+            server_default=sa.text("now()"), nullable=False,
+        ),
+        sa.Column(
+            "dwell_seconds", sa.Integer(),
+            server_default="0", nullable=False,
+        ),
+        sa.Column(
+            "sequence_no", sa.Integer(),
+            server_default="1", nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["session_id"], ["sms_landing_session.id"], ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["contact_id"], ["sms_contact.id"], ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["major_program_id"], ["major_program.id"], ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_sms_program_view_session_id"),
+        "sms_program_view", ["session_id"], unique=False,
+    )
+    op.create_index(
+        op.f("ix_sms_program_view_contact_id"),
+        "sms_program_view", ["contact_id"], unique=False,
+    )
+    op.create_index(
+        op.f("ix_sms_program_view_major_program_id"),
+        "sms_program_view", ["major_program_id"], unique=False,
+    )
+
+    # 3. sms_contact_program_interest (aggregate; UNIQUE(contact, program))
+    op.create_table(
+        "sms_contact_program_interest",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("contact_id", sa.Integer(), nullable=False),
+        sa.Column("major_program_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "view_count", sa.Integer(),
+            server_default="0", nullable=False,
+        ),
+        sa.Column(
+            "total_dwell_seconds", sa.Integer(),
+            server_default="0", nullable=False,
+        ),
+        sa.Column("first_interest_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_interest_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "interest_score", sa.Float(),
+            server_default="0", nullable=False,
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True),
+            server_default=sa.text("now()"), nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["contact_id"], ["sms_contact.id"], ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["major_program_id"], ["major_program.id"], ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_sms_contact_program_interest_contact_id"),
+        "sms_contact_program_interest", ["contact_id"], unique=False,
+    )
+    op.create_index(
+        op.f("ix_sms_contact_program_interest_major_program_id"),
+        "sms_contact_program_interest", ["major_program_id"], unique=False,
+    )
+    op.create_index(
+        "uq_sms_contact_program_interest",
+        "sms_contact_program_interest",
+        ["contact_id", "major_program_id"], unique=True,
+    )
+
+
+def downgrade() -> None:
+    # Thứ tự ngược FK: program_view (→ session) trước, rồi session; interest độc lập.
+    op.drop_index(
+        op.f("ix_sms_program_view_major_program_id"),
+        table_name="sms_program_view",
+    )
+    op.drop_index(
+        op.f("ix_sms_program_view_contact_id"), table_name="sms_program_view",
+    )
+    op.drop_index(
+        op.f("ix_sms_program_view_session_id"), table_name="sms_program_view",
+    )
+    op.drop_table("sms_program_view")
+
+    op.drop_index(
+        "uq_sms_contact_program_interest",
+        table_name="sms_contact_program_interest",
+    )
+    op.drop_index(
+        op.f("ix_sms_contact_program_interest_major_program_id"),
+        table_name="sms_contact_program_interest",
+    )
+    op.drop_index(
+        op.f("ix_sms_contact_program_interest_contact_id"),
+        table_name="sms_contact_program_interest",
+    )
+    op.drop_table("sms_contact_program_interest")
+
+    op.drop_index(
+        op.f("ix_sms_landing_session_campaign_id"),
+        table_name="sms_landing_session",
+    )
+    op.drop_index(
+        op.f("ix_sms_landing_session_recipient_id"),
+        table_name="sms_landing_session",
+    )
+    op.drop_index(
+        op.f("ix_sms_landing_session_contact_id"),
+        table_name="sms_landing_session",
+    )
+    op.drop_table("sms_landing_session")

--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -293,6 +293,23 @@ class Settings(BaseSettings):
         ),
         validation_alias="SMS_LANDING_CONSENT_NOTICE",
     )  # câu thông báo cơ sở xử lý dữ liệu trên landing (§19.2)
+    # -- Phase 2 (§16) deep engagement / đo quan tâm ngành --
+    SMS_SESSION_TOKEN_HASH_SECRET: str = Field(
+        default="dev-sms-session-token-hash-secret-change-in-prod",
+        validation_alias="SMS_SESSION_TOKEN_HASH_SECRET",
+    )  # HMAC session token landing (bearer) — secret riêng, prod đặt thật ≥32
+    SMS_INTEREST_DWELL_CAP: int = Field(
+        default=180, ge=1, le=86400,
+        validation_alias="SMS_INTEREST_DWELL_CAP",
+    )  # trần dwell/lượt (giây) cho dwell_factor=min(s/CAP,1) — chống gian lận
+    SMS_INTEREST_HALF_LIFE: int = Field(
+        default=14, ge=1, le=3650,
+        validation_alias="SMS_INTEREST_HALF_LIFE",
+    )  # bán rã (ngày) cho recency_weight=exp(-Δdays/HALF_LIFE)
+    SMS_INTEREST_K: float = Field(
+        default=3.0, gt=0,
+        validation_alias="SMS_INTEREST_K",
+    )  # hệ số normalize(x)=x/(x+K); cosmetic (không đổi thứ hạng)
 
     # -- Docker self-hosted deployment --
     # When True, skip TLS enforcement for DB/Redis connections.

--- a/Backend_FastAPI/app/models/__init__.py
+++ b/Backend_FastAPI/app/models/__init__.py
@@ -165,6 +165,10 @@ from .sms import (
     SmsClickEvent,
     SmsOptOut,
     SmsMarketingConsentEvent,
+    # Phase 2 (§16) — deep engagement / đo quan tâm ngành
+    SmsLandingSession,
+    SmsProgramView,
+    SmsContactProgramInterest,
 )
 
 # Import tất cả các model để chúng được đăng ký với Base
@@ -302,4 +306,8 @@ __all__ = [
     "SmsClickEvent",
     "SmsOptOut",
     "SmsMarketingConsentEvent",
+    # SMS Marketing Module (Phase 2 §16: deep engagement)
+    "SmsLandingSession",
+    "SmsProgramView",
+    "SmsContactProgramInterest",
 ]

--- a/Backend_FastAPI/app/models/sms/__init__.py
+++ b/Backend_FastAPI/app/models/sms/__init__.py
@@ -1,5 +1,6 @@
 # app/models/sms/__init__.py
-"""SMS Marketing models (Phase 1 — 12 model). Xem SMS_MARKETING_MODULE_DESIGN.md §4."""
+"""SMS Marketing models (Phase 1 — 12 model + Phase 2 §16 — 3 model deep engagement).
+Xem SMS_MARKETING_MODULE_DESIGN.md §4 + §16."""
 from .contact_group import SmsContactGroup
 from .contact import SmsContact
 from .contact_group_member import SmsContactGroupMember
@@ -12,6 +13,10 @@ from .campaign_export_batch import SmsCampaignExportBatch
 from .click_event import SmsClickEvent
 from .opt_out import SmsOptOut
 from .marketing_consent_event import SmsMarketingConsentEvent
+# Phase 2 (§16) — deep engagement / đo quan tâm ngành
+from .landing_session import SmsLandingSession
+from .program_view import SmsProgramView
+from .contact_program_interest import SmsContactProgramInterest
 
 __all__ = [
     "SmsContactGroup",
@@ -26,4 +31,8 @@ __all__ = [
     "SmsClickEvent",
     "SmsOptOut",
     "SmsMarketingConsentEvent",
+    # Phase 2
+    "SmsLandingSession",
+    "SmsProgramView",
+    "SmsContactProgramInterest",
 ]

--- a/Backend_FastAPI/app/models/sms/contact_program_interest.py
+++ b/Backend_FastAPI/app/models/sms/contact_program_interest.py
@@ -1,0 +1,72 @@
+# app/models/sms/contact_program_interest.py
+"""
+SMS contact ↔ program interest (Phase 2 §16.4) — hồ sơ sở thích TỔNG HỢP per
+contact per ngành (giá trị nghiệp vụ chính). Trả lời "liên hệ X quan tâm ngành
+gì nhất" xuyên mọi phiên/nguồn. Cập nhật khi chốt dwell 1 program_view.
+
+`interest_score` (§16.10-P2-Q2): normalize(Σ dwell_factor × recency_weight),
+config `SMS_INTEREST_DWELL_CAP/_HALF_LIFE/_K`. Ranking theo `total_dwell_seconds`
+(hoặc score) desc. UNIQUE(contact_id, major_program_id) = 1 hàng/ngành/contact.
+"""
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    DateTime, Float, ForeignKey, Index, Integer,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+
+
+class SmsContactProgramInterest(Base):
+    """Sở thích tổng hợp 1 contact với 1 ngành (aggregate qua mọi phiên)."""
+
+    __tablename__ = "sms_contact_program_interest"
+
+    __table_args__ = (
+        Index(
+            "uq_sms_contact_program_interest",
+            "contact_id", "major_program_id",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    contact_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("sms_contact.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    major_program_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("major_program.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    view_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+    )
+    total_dwell_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+        comment="tổng dwell mọi phiên — tín hiệu quan tâm chính (rank desc)",
+    )
+    first_interest_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    last_interest_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    interest_score: Mapped[float] = mapped_column(
+        Float, nullable=False, default=0.0, server_default="0",
+        comment="normalize(Σ dwell_factor×recency) ∈ [0,1); config-driven",
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+        server_default=func.now(), onupdate=func.now(),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<SmsContactProgramInterest contact={self.contact_id} "
+            f"program={self.major_program_id} dwell={self.total_dwell_seconds}s "
+            f"score={self.interest_score:.3f}>"
+        )

--- a/Backend_FastAPI/app/models/sms/landing_session.py
+++ b/Backend_FastAPI/app/models/sms/landing_session.py
@@ -1,0 +1,79 @@
+# app/models/sms/landing_session.py
+"""
+SMS landing session (Phase 2 §16.4) — 1 lượt xem landing để đo deep engagement.
+Khóa thống nhất gắn interest = `contact_id`. Session token là bearer token →
+CHỈ lưu `session_token_hash` = HMAC-SHA256(token, SMS_SESSION_TOKEN_HASH_SECRET),
+KHÔNG lưu raw (chống giả lập engagement nếu DB/log lộ — P1-2 §16.7).
+
+MVP đo-quan-tâm: source_type luôn 'campaign' (resolve qua recipient); trường
+consult (`consult_link_id`) DEFER tới khi làm P2-3. IP luôn `ip_hash`, không thô.
+Xem `Documents/SMS_MARKETING_MODULE_DESIGN.md` §16.4 + `SMS_PHASE2_PR7_SCOPE.md`.
+"""
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    Boolean, DateTime, ForeignKey, Integer, String,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+
+
+class SmsLandingSession(Base):
+    """1 phiên xem landing (đo dwell qua heartbeat); token lưu hash."""
+
+    __tablename__ = "sms_landing_session"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    contact_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("sms_contact.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+        comment="khóa thống nhất gắn interest (campaign & consult resolve về contact)",
+    )
+    source_type: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="campaign",
+        comment="campaign / consult (MVP chỉ campaign)",
+    )
+    recipient_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("sms_campaign_recipient.id", ondelete="SET NULL"),
+        nullable=True, index=True,
+        comment="nguồn campaign (NULL nếu consult — Phase 2 sau)",
+    )
+    campaign_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("sms_campaign.id", ondelete="SET NULL"),
+        nullable=True, index=True,
+    )
+    session_token_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False, unique=True,
+        comment="HMAC-SHA256(session_token, SMS_SESSION_TOKEN_HASH_SECRET); no raw",
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(),
+    )
+    last_heartbeat_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    ended_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    active_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+        comment="tổng dwell toàn phiên (cộng dồn từ heartbeat các trang)",
+    )
+    ip_hash: Mapped[Optional[str]] = mapped_column(
+        String(64), nullable=True,
+        comment="HMAC-SHA256(ip, SMS_IP_HASH_SECRET); KHÔNG lưu IP thô",
+    )
+    user_agent: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    is_suspected_bot: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<SmsLandingSession {self.id} contact={self.contact_id} "
+            f"active={self.active_seconds}s bot={self.is_suspected_bot}>"
+        )

--- a/Backend_FastAPI/app/models/sms/program_view.py
+++ b/Backend_FastAPI/app/models/sms/program_view.py
@@ -1,0 +1,62 @@
+# app/models/sms/program_view.py
+"""
+SMS program view (Phase 2 §16.4) — mỗi lượt xem 1 trang ngành `/lp/{code}/nganh/{id}`.
+`dwell_seconds` chốt từ heartbeat của trang ngành → tín hiệu chính "quan tâm".
+`program_name_snapshot` giữ tên ngành tại thời điểm xem (ngành có thể đổi/xóa).
+Xem `Documents/SMS_MARKETING_MODULE_DESIGN.md` §16.4.
+"""
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+
+
+class SmsProgramView(Base):
+    """1 lượt xem trang 1 ngành trong 1 phiên landing (đo dwell)."""
+
+    __tablename__ = "sms_program_view"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    session_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("sms_landing_session.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    contact_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("sms_contact.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    major_program_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("major_program.id", ondelete="SET NULL"),
+        nullable=True, index=True,
+        comment="ngành xem (SET NULL nếu ngành bị xóa — giữ snapshot)",
+    )
+    program_offering_id: Mapped[Optional[int]] = mapped_column(
+        Integer, nullable=True,
+        comment="loại hình (chính quy/liên thông) — ngữ cảnh, không FK cứng",
+    )
+    program_name_snapshot: Mapped[str] = mapped_column(
+        String(255), nullable=False,
+        comment="tên ngành lúc xem (audit khi ngành đổi/xóa)",
+    )
+    viewed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(),
+    )
+    dwell_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+        comment="thời gian ở lại trang ngành (cộng dồn từ heartbeat)",
+    )
+    sequence_no: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1",
+        comment="thứ tự xem trong phiên (1,2,3…)",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<SmsProgramView {self.id} session={self.session_id} "
+            f"program={self.major_program_id} dwell={self.dwell_seconds}s>"
+        )

--- a/Backend_FastAPI/app/repositories/sms_engagement_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_engagement_repository.py
@@ -107,15 +107,33 @@ class SmsEngagementRepository:
     async def views_for_interest(
         self, contact_id: int, major_program_id: int
     ) -> List[Tuple[int, datetime]]:
-        """(dwell_seconds, viewed_at) MỌI view của cặp (contact, ngành) — để
-        tính lại interest_score (Σ dwell_factor×recency)."""
+        """(dwell_seconds, viewed_at) view NGƯỜI-THẬT của cặp (contact, ngành)
+        — để tính lại interest_score (Σ dwell_factor×recency). JOIN session +
+        LOẠI phiên bot: bot vẫn ghi program_view (audit) nhưng KHÔNG được lẫn
+        vào interest aggregate (khớp report program-interest cũng lọc bot)."""
         res = await self.db.execute(
-            select(SmsProgramView.dwell_seconds, SmsProgramView.viewed_at).where(
+            select(SmsProgramView.dwell_seconds, SmsProgramView.viewed_at)
+            .join(
+                SmsLandingSession,
+                SmsLandingSession.id == SmsProgramView.session_id,
+            )
+            .where(
                 SmsProgramView.contact_id == contact_id,
                 SmsProgramView.major_program_id == major_program_id,
+                SmsLandingSession.is_suspected_bot.is_(False),
             )
         )
         return [(int(d), v) for d, v in res.all()]
+
+    async def session_total_dwell(self, session_id: int) -> int:
+        """Σ dwell mọi program_view của phiên — DERIVE active_seconds (nguồn sự
+        thật) thay vì cộng dồn delta (chống lost-update khi heartbeat // 2 tab)."""
+        total = await self.db.scalar(
+            select(func.coalesce(func.sum(SmsProgramView.dwell_seconds), 0)).where(
+                SmsProgramView.session_id == session_id
+            )
+        )
+        return int(total or 0)
 
     # ---------------------------------------------------------------
     # Aggregate interest (upsert atomic)
@@ -180,6 +198,12 @@ class SmsEngagementRepository:
         conds = [SmsLandingSession.is_suspected_bot.is_(False)]
         if campaign_id is not None:
             conds.append(SmsLandingSession.campaign_id == campaign_id)
+        if group_id is not None:
+            # group_ids_snapshot ở recipient → caller phải JOIN recipient
+            # (_report_from cùng group_id) để cột này có mặt trong FROM.
+            conds.append(
+                SmsCampaignRecipient.group_ids_snapshot.contains([group_id])
+            )
         if major_program_id is not None:
             conds.append(SmsProgramView.major_program_id == major_program_id)
         if date_from is not None:
@@ -213,8 +237,9 @@ class SmsEngagementRepository:
         limit: int = 200,
     ) -> List[Tuple[Optional[int], str, int, int, int]]:
         """(major_program_id, program_name, distinct_contacts, view_count,
-        total_dwell) theo ngành, rank total_dwell desc. Ngành bị xoá →
-        major_program_id NULL, name = snapshot gần nhất."""
+        total_dwell) theo ngành, rank total_dwell desc. Tên = tên HIỆN TẠI của
+        ngành (LEFT JOIN major_program) — ngành đổi tên hiện tên mới; ngành đã
+        xoá (major_program_id NULL) → fallback snapshot."""
         conds = self._report_conds(
             campaign_id=campaign_id,
             group_id=group_id,
@@ -222,22 +247,28 @@ class SmsEngagementRepository:
             date_from=date_from,
             date_to=date_to,
         )
-        if group_id is not None:
-            conds.append(
-                SmsCampaignRecipient.group_ids_snapshot.contains([group_id])
-            )
+        # LEFT JOIN major_program lấy tên hiện tại (max() vì group theo id →
+        # 1 tên/nhóm; coalesce fallback snapshot khi ngành đã xoá = NULL name).
+        from_clause = self._report_from(group_id=group_id).outerjoin(
+            MajorProgram.__table__,
+            MajorProgram.id == SmsProgramView.major_program_id,
+        )
+        name_expr = func.coalesce(
+            func.max(MajorProgram.name),
+            func.max(SmsProgramView.program_name_snapshot),
+        ).label("name")
         total_dwell = func.coalesce(func.sum(SmsProgramView.dwell_seconds), 0)
         res = await self.db.execute(
             select(
                 SmsProgramView.major_program_id.label("program_id"),
-                func.max(SmsProgramView.program_name_snapshot).label("name"),
+                name_expr,
                 func.count(func.distinct(SmsProgramView.contact_id)).label(
                     "distinct_contacts"
                 ),
                 func.count().label("view_count"),
                 total_dwell.label("total_dwell"),
             )
-            .select_from(self._report_from(group_id=group_id))
+            .select_from(from_clause)
             .where(and_(*conds))
             .group_by(SmsProgramView.major_program_id)
             .order_by(total_dwell.desc())
@@ -267,10 +298,6 @@ class SmsEngagementRepository:
             date_from=date_from,
             date_to=date_to,
         )
-        if group_id is not None:
-            conds.append(
-                SmsCampaignRecipient.group_ids_snapshot.contains([group_id])
-            )
         res = await self.db.execute(
             select(
                 func.count(func.distinct(SmsProgramView.contact_id)),

--- a/Backend_FastAPI/app/repositories/sms_engagement_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_engagement_repository.py
@@ -14,7 +14,7 @@ Standalone repository. Service flush, router commit. Xem SMS §16.
 from datetime import datetime
 from typing import List, Optional, Tuple
 
-from sqlalchemy import and_, func, select
+from sqlalchemy import String, and_, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -238,8 +238,12 @@ class SmsEngagementRepository:
     ) -> List[Tuple[Optional[int], str, int, int, int]]:
         """(major_program_id, program_name, distinct_contacts, view_count,
         total_dwell) theo ngành, rank total_dwell desc. Tên = tên HIỆN TẠI của
-        ngành (LEFT JOIN major_program) — ngành đổi tên hiện tên mới; ngành đã
-        xoá (major_program_id NULL) → fallback snapshot."""
+        ngành (LEFT JOIN major_program) — ngành đổi tên hiện tên mới.
+
+        Ngành đã xoá cứng → major_program_id NULL: KHÔNG gộp mọi ngành-xoá vào
+        1 hàng NULL (sẽ trộn số liệu 2 ngành khác nhau); group theo KEY =
+        coalesce(id, snapshot) → ngành sống gộp theo id (bất kể đổi tên), ngành
+        xoá tách theo tên snapshot. program_id trả NULL cho nhóm ngành-xoá."""
         conds = self._report_conds(
             campaign_id=campaign_id,
             group_id=group_id,
@@ -247,11 +251,17 @@ class SmsEngagementRepository:
             date_from=date_from,
             date_to=date_to,
         )
-        # LEFT JOIN major_program lấy tên hiện tại (max() vì group theo id →
+        # LEFT JOIN major_program lấy tên hiện tại (max() vì group theo key →
         # 1 tên/nhóm; coalesce fallback snapshot khi ngành đã xoá = NULL name).
         from_clause = self._report_from(group_id=group_id).outerjoin(
             MajorProgram.__table__,
             MajorProgram.id == SmsProgramView.major_program_id,
+        )
+        # Key nhóm: id (ngành sống, ổn định qua đổi tên) HOẶC snapshot có tiền tố
+        # (ngành đã xoá — tách từng ngành, không dồn chung NULL).
+        group_key = func.coalesce(
+            func.cast(SmsProgramView.major_program_id, String),
+            func.concat("name::", SmsProgramView.program_name_snapshot),
         )
         name_expr = func.coalesce(
             func.max(MajorProgram.name),
@@ -260,7 +270,7 @@ class SmsEngagementRepository:
         total_dwell = func.coalesce(func.sum(SmsProgramView.dwell_seconds), 0)
         res = await self.db.execute(
             select(
-                SmsProgramView.major_program_id.label("program_id"),
+                func.max(SmsProgramView.major_program_id).label("program_id"),
                 name_expr,
                 func.count(func.distinct(SmsProgramView.contact_id)).label(
                     "distinct_contacts"
@@ -270,7 +280,7 @@ class SmsEngagementRepository:
             )
             .select_from(from_clause)
             .where(and_(*conds))
-            .group_by(SmsProgramView.major_program_id)
+            .group_by(group_key)
             .order_by(total_dwell.desc())
             .limit(limit)
         )

--- a/Backend_FastAPI/app/repositories/sms_engagement_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_engagement_repository.py
@@ -1,0 +1,303 @@
+# app/repositories/sms_engagement_repository.py
+"""
+Data-access Phase 2 (§16) deep engagement — 3 bảng đo quan tâm ngành:
+sms_landing_session, sms_program_view, sms_contact_program_interest + danh mục
+ngành (major_program active) cho landing 2 tầng.
+
+Chức năng: tạo/tra session (theo token_hash), mở program-view + sequence, cộng
+dwell, aggregate interest (upsert atomic pg on_conflict), report 'ngành nóng'
+(JOIN view↔session[+recipient] theo campaign/nhóm/thời gian, loại bot), và hồ
+sơ sở thích 1 contact.
+
+Standalone repository. Service flush, router commit. Xem SMS §16.
+"""
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.major_program import MajorProgram
+from app.models.sms import (
+    SmsCampaignRecipient,
+    SmsContactProgramInterest,
+    SmsLandingSession,
+    SmsProgramView,
+)
+
+
+class SmsEngagementRepository:
+    """Repository session/view/interest Phase 2 + danh mục ngành."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    # ---------------------------------------------------------------
+    # Danh mục ngành (landing 2 tầng — tái dùng major_program active)
+    # ---------------------------------------------------------------
+    async def list_active_programs(self) -> List[MajorProgram]:
+        res = await self.db.execute(
+            select(MajorProgram)
+            .where(MajorProgram.is_active.is_(True))
+            .order_by(MajorProgram.degree_level, MajorProgram.name)
+        )
+        return list(res.scalars().all())
+
+    async def get_active_program(
+        self, major_program_id: int
+    ) -> Optional[MajorProgram]:
+        res = await self.db.execute(
+            select(MajorProgram).where(
+                MajorProgram.id == major_program_id,
+                MajorProgram.is_active.is_(True),
+            )
+        )
+        return res.scalars().first()
+
+    # ---------------------------------------------------------------
+    # Session
+    # ---------------------------------------------------------------
+    async def create_session(self, fields: dict) -> SmsLandingSession:
+        row = SmsLandingSession(**fields)
+        self.db.add(row)
+        await self.db.flush()
+        return row
+
+    async def get_session_by_token_hash(
+        self, token_hash: str
+    ) -> Optional[SmsLandingSession]:
+        res = await self.db.execute(
+            select(SmsLandingSession).where(
+                SmsLandingSession.session_token_hash == token_hash
+            )
+        )
+        return res.scalars().first()
+
+    # ---------------------------------------------------------------
+    # Program view
+    # ---------------------------------------------------------------
+    async def next_sequence_no(self, session_id: int) -> int:
+        cur = await self.db.scalar(
+            select(func.coalesce(func.max(SmsProgramView.sequence_no), 0)).where(
+                SmsProgramView.session_id == session_id
+            )
+        )
+        return int(cur or 0) + 1
+
+    async def create_program_view(self, fields: dict) -> SmsProgramView:
+        row = SmsProgramView(**fields)
+        self.db.add(row)
+        await self.db.flush()
+        return row
+
+    async def get_program_view(
+        self, view_id: int, session_id: int
+    ) -> Optional[SmsProgramView]:
+        """Lấy view PHẢI thuộc session (chống dùng token phiên khác đẩy dwell
+        vào view lạ)."""
+        res = await self.db.execute(
+            select(SmsProgramView).where(
+                SmsProgramView.id == view_id,
+                SmsProgramView.session_id == session_id,
+            )
+        )
+        return res.scalars().first()
+
+    async def views_for_interest(
+        self, contact_id: int, major_program_id: int
+    ) -> List[Tuple[int, datetime]]:
+        """(dwell_seconds, viewed_at) MỌI view của cặp (contact, ngành) — để
+        tính lại interest_score (Σ dwell_factor×recency)."""
+        res = await self.db.execute(
+            select(SmsProgramView.dwell_seconds, SmsProgramView.viewed_at).where(
+                SmsProgramView.contact_id == contact_id,
+                SmsProgramView.major_program_id == major_program_id,
+            )
+        )
+        return [(int(d), v) for d, v in res.all()]
+
+    # ---------------------------------------------------------------
+    # Aggregate interest (upsert atomic)
+    # ---------------------------------------------------------------
+    async def upsert_interest(
+        self,
+        *,
+        contact_id: int,
+        major_program_id: int,
+        view_count: int,
+        total_dwell_seconds: int,
+        first_interest_at: Optional[datetime],
+        last_interest_at: Optional[datetime],
+        interest_score: float,
+        now: datetime,
+    ) -> None:
+        """INSERT ... ON CONFLICT(contact,program) DO UPDATE — atomic, last
+        writer wins. Giá trị tính lại từ view (nguồn sự thật) nên tự lành khi
+        2 heartbeat đua. first_interest giữ min (không lùi khi update)."""
+        stmt = (
+            pg_insert(SmsContactProgramInterest)
+            .values(
+                contact_id=contact_id,
+                major_program_id=major_program_id,
+                view_count=view_count,
+                total_dwell_seconds=total_dwell_seconds,
+                first_interest_at=first_interest_at,
+                last_interest_at=last_interest_at,
+                interest_score=interest_score,
+                updated_at=now,
+            )
+            .on_conflict_do_update(
+                index_elements=["contact_id", "major_program_id"],
+                set_={
+                    "view_count": view_count,
+                    "total_dwell_seconds": total_dwell_seconds,
+                    "first_interest_at": func.least(
+                        SmsContactProgramInterest.first_interest_at,
+                        first_interest_at,
+                    ),
+                    "last_interest_at": last_interest_at,
+                    "interest_score": interest_score,
+                    "updated_at": now,
+                },
+            )
+        )
+        await self.db.execute(stmt)
+
+    # ---------------------------------------------------------------
+    # Report 'ngành nóng' (§16.7) — JOIN view↔session[+recipient]
+    # ---------------------------------------------------------------
+    def _report_conds(
+        self,
+        *,
+        campaign_id: Optional[int],
+        group_id: Optional[int],
+        major_program_id: Optional[int],
+        date_from: Optional[datetime],
+        date_to: Optional[datetime],
+    ):
+        # Loại session bot khỏi số liệu 'quan tâm' (chỉ đo người thật chạy JS).
+        conds = [SmsLandingSession.is_suspected_bot.is_(False)]
+        if campaign_id is not None:
+            conds.append(SmsLandingSession.campaign_id == campaign_id)
+        if major_program_id is not None:
+            conds.append(SmsProgramView.major_program_id == major_program_id)
+        if date_from is not None:
+            conds.append(SmsProgramView.viewed_at >= date_from)
+        if date_to is not None:
+            conds.append(SmsProgramView.viewed_at <= date_to)
+        return conds
+
+    def _report_from(self, *, group_id: Optional[int]):
+        """FROM view JOIN session; JOIN recipient khi lọc theo nhóm (group_ids
+        snapshot ở recipient, không ở session)."""
+        j = SmsProgramView.__table__.join(
+            SmsLandingSession.__table__,
+            SmsLandingSession.id == SmsProgramView.session_id,
+        )
+        if group_id is not None:
+            j = j.join(
+                SmsCampaignRecipient.__table__,
+                SmsCampaignRecipient.id == SmsLandingSession.recipient_id,
+            )
+        return j
+
+    async def program_interest_report(
+        self,
+        *,
+        campaign_id: Optional[int] = None,
+        group_id: Optional[int] = None,
+        major_program_id: Optional[int] = None,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+        limit: int = 200,
+    ) -> List[Tuple[Optional[int], str, int, int, int]]:
+        """(major_program_id, program_name, distinct_contacts, view_count,
+        total_dwell) theo ngành, rank total_dwell desc. Ngành bị xoá →
+        major_program_id NULL, name = snapshot gần nhất."""
+        conds = self._report_conds(
+            campaign_id=campaign_id,
+            group_id=group_id,
+            major_program_id=major_program_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        if group_id is not None:
+            conds.append(
+                SmsCampaignRecipient.group_ids_snapshot.contains([group_id])
+            )
+        total_dwell = func.coalesce(func.sum(SmsProgramView.dwell_seconds), 0)
+        res = await self.db.execute(
+            select(
+                SmsProgramView.major_program_id.label("program_id"),
+                func.max(SmsProgramView.program_name_snapshot).label("name"),
+                func.count(func.distinct(SmsProgramView.contact_id)).label(
+                    "distinct_contacts"
+                ),
+                func.count().label("view_count"),
+                total_dwell.label("total_dwell"),
+            )
+            .select_from(self._report_from(group_id=group_id))
+            .where(and_(*conds))
+            .group_by(SmsProgramView.major_program_id)
+            .order_by(total_dwell.desc())
+            .limit(limit)
+        )
+        return [
+            (r.program_id, r.name, int(r.distinct_contacts), int(r.view_count),
+             int(r.total_dwell))
+            for r in res.all()
+        ]
+
+    async def program_interest_totals(
+        self,
+        *,
+        campaign_id: Optional[int] = None,
+        group_id: Optional[int] = None,
+        major_program_id: Optional[int] = None,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+    ) -> Tuple[int, int, int]:
+        """(distinct_contacts_total, view_count_total, total_dwell) toàn dải —
+        distinct contact tính riêng (không sum row-level distinct)."""
+        conds = self._report_conds(
+            campaign_id=campaign_id,
+            group_id=group_id,
+            major_program_id=major_program_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        if group_id is not None:
+            conds.append(
+                SmsCampaignRecipient.group_ids_snapshot.contains([group_id])
+            )
+        res = await self.db.execute(
+            select(
+                func.count(func.distinct(SmsProgramView.contact_id)),
+                func.count(),
+                func.coalesce(func.sum(SmsProgramView.dwell_seconds), 0),
+            )
+            .select_from(self._report_from(group_id=group_id))
+            .where(and_(*conds))
+        )
+        r = res.first()
+        return int(r[0]), int(r[1]), int(r[2])
+
+    # ---------------------------------------------------------------
+    # Hồ sơ sở thích 1 contact
+    # ---------------------------------------------------------------
+    async def contact_interests(
+        self, contact_id: int
+    ) -> List[Tuple[SmsContactProgramInterest, str]]:
+        """(interest_row, program_name) của contact, rank total_dwell desc.
+        JOIN major_program lấy tên (FK CASCADE → ngành xoá thì row cũng xoá)."""
+        res = await self.db.execute(
+            select(SmsContactProgramInterest, MajorProgram.name)
+            .join(
+                MajorProgram,
+                MajorProgram.id == SmsContactProgramInterest.major_program_id,
+            )
+            .where(SmsContactProgramInterest.contact_id == contact_id)
+            .order_by(SmsContactProgramInterest.total_dwell_seconds.desc())
+        )
+        return [(row[0], row[1]) for row in res.all()]

--- a/Backend_FastAPI/app/routers/sms_public.py
+++ b/Backend_FastAPI/app/routers/sms_public.py
@@ -2,7 +2,8 @@
 """
 SMS Marketing — public surface (no auth, CSRF-exempt dưới /api/public/). PR-5:
 GET landing/{code} (read-only, no-store, noindex, no-referrer) + POST opt-out
-(idempotent). Router "dumb": commit (opt-out) rồi trả. KHÔNG sửa main.py.
+(idempotent). PR-7 P2-2: session/program-view/heartbeat đo deep engagement
+(§16). Router "dumb": commit (mutation) rồi trả. KHÔNG sửa main.py.
 """
 from fastapi import APIRouter, Depends, Path, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,9 +12,18 @@ from app import database
 from app.core.client_ip import get_client_ip
 from app.core.rate_limits import RateLimits, limiter
 from app.schemas import sms as sms_schemas
+from app.services.sms_engagement_service import SmsEngagementService
 from app.services.sms_landing_service import SmsLandingService
 
 router = APIRouter(prefix="/api/public/sms", tags=["SMS Public"])
+
+# Deep-engagement là traffic người thật từ landing → nhà mạng VN CGNAT chia IP
+# egress cho nhiều thuê bao → trần rộng + key theo get_client_ip (XFF-aware,
+# X-Real-IP nginx overwrite non-spoofable) chứ KHÔNG get_remote_address (=IP
+# nginx → khoá global). nginx limit_req là lớp chặn DoS thật.
+_SESSION_LIMIT = "600/hour"   # ~1 phiên/lượt xem landing
+_VIEW_LIMIT = "2000/hour"     # khách mở nhiều trang ngành
+_HEARTBEAT_LIMIT = "6000/hour"  # heartbeat ~15s × nhiều phiên/IP
 
 
 def _set_public_headers(response: Response) -> None:
@@ -47,6 +57,72 @@ async def public_opt_out(
 ):
     """Opt-out công khai từ landing — idempotent (UNIQUE phone)."""
     result = await SmsLandingService(db).public_opt_out(payload.code)
+    await db.commit()
+    _set_public_headers(response)
+    return result
+
+
+# ---------------------------------------------------------------------
+# Phase 2 (§16) — deep engagement tracking (session / view / heartbeat)
+# ---------------------------------------------------------------------
+@router.post(
+    "/landing/{code}/session",
+    response_model=sms_schemas.SmsSessionStartResponse,
+)
+@limiter.limit(_SESSION_LIMIT, key_func=get_client_ip)
+async def start_session(
+    request: Request,  # required by slowapi rate limiter + IP/UA
+    response: Response,
+    code: str = Path(..., max_length=64),
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Tạo phiên xem landing → sinh session_token raw TRẢ 1 LẦN (server lưu
+    hash). Không tạo ở GET landing (tránh crawler/prefetch tạo phiên rác)."""
+    result = await SmsEngagementService(db).start_session(
+        code,
+        ip=get_client_ip(request),
+        user_agent=request.headers.get("user-agent"),
+        headers=request.headers,
+    )
+    await db.commit()
+    _set_public_headers(response)
+    return result
+
+
+@router.post(
+    "/landing/{code}/program-view",
+    response_model=sms_schemas.SmsProgramViewResponse,
+)
+@limiter.limit(_VIEW_LIMIT, key_func=get_client_ip)
+async def record_program_view(
+    request: Request,  # required by slowapi rate limiter
+    response: Response,
+    payload: sms_schemas.SmsProgramViewRequest,
+    code: str = Path(..., max_length=64),
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Mở 1 lượt xem trang ngành (snapshot tên ngành) — trả program_view_id để
+    client đính vào heartbeat của trang đó."""
+    result = await SmsEngagementService(db).record_program_view(code, payload)
+    await db.commit()
+    _set_public_headers(response)
+    return result
+
+
+@router.post(
+    "/landing/{code}/heartbeat",
+    response_model=sms_schemas.SmsHeartbeatResponse,
+)
+@limiter.limit(_HEARTBEAT_LIMIT, key_func=get_client_ip)
+async def heartbeat(
+    request: Request,  # required by slowapi rate limiter
+    response: Response,
+    payload: sms_schemas.SmsHeartbeatRequest,
+    code: str = Path(..., max_length=64),
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Cộng dwell trang ngành (clamp wall-clock) → cập nhật interest_score."""
+    result = await SmsEngagementService(db).heartbeat(code, payload)
     await db.commit()
     _set_public_headers(response)
     return result

--- a/Backend_FastAPI/app/routers/sms_reports.py
+++ b/Backend_FastAPI/app/routers/sms_reports.py
@@ -84,3 +84,43 @@ async def manual_opt_out(
     result = await SmsReportService(db).manual_opt_out(payload, current_user)
     await db.commit()
     return result
+
+
+# ---------------------------------------------------------------------
+# Phase 2 (§16.7) — report ngành nóng + hồ sơ sở thích 1 contact
+# ---------------------------------------------------------------------
+@router.get(
+    "/reports/program-interest",
+    response_model=sms_schemas.SmsProgramInterestReport,
+)
+async def report_program_interest(
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+    campaign_id: Optional[int] = Query(None, ge=1, le=_MAX_ID),
+    group_id: Optional[int] = Query(None, ge=1, le=_MAX_ID),
+    major_program_id: Optional[int] = Query(None, ge=1, le=_MAX_ID),
+    date_from: Optional[datetime] = Query(None),
+    date_to: Optional[datetime] = Query(None),
+):
+    """Ngành 'nóng' theo campaign/nhóm/thời gian (rank tổng dwell desc; loại
+    phiên bot). Tín hiệu quan tâm chính = tổng dwell/ngành (§16.2)."""
+    return await SmsReportService(db).program_interest_report(
+        campaign_id=campaign_id,
+        group_id=group_id,
+        major_program_id=major_program_id,
+        date_from=date_from,
+        date_to=date_to,
+    )
+
+
+@router.get(
+    "/contacts/{contact_id}/interests",
+    response_model=sms_schemas.SmsContactInterestList,
+)
+async def contact_interests(
+    contact_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    """Hồ sơ 'quan tâm ngành' của 1 contact (rank tổng dwell desc)."""
+    return await SmsReportService(db).contact_interests(contact_id)

--- a/Backend_FastAPI/app/schemas/sms.py
+++ b/Backend_FastAPI/app/schemas/sms.py
@@ -551,9 +551,19 @@ SmsManualOptOutSource = Literal[
 ]
 
 
+class SmsLandingProgram(BaseModel):
+    """1 ngành trong danh mục landing 2 tầng (Phase 2 §16.1). Public — chỉ
+    trường hiển thị (id/tên/mã/trình độ), KHÔNG PII."""
+
+    id: int
+    name: str
+    code: str
+    degree_level: str
+
+
 class SmsLandingResponse(BaseModel):
     """Nội dung landing `/lp/{code}` — read-only, KHÔNG lộ PII recipient
-    (phòng code bị chia sẻ). §19.4."""
+    (phòng code bị chia sẻ). §19.4. Phase 2: +danh mục ngành (no session)."""
 
     school_name: str
     headline: Optional[str] = None
@@ -562,6 +572,93 @@ class SmsLandingResponse(BaseModel):
     cta_url: Optional[str] = None
     consent_notice: str
     already_opted_out: bool = False
+    # Phase 2 (§16.1) — danh mục ngành để render landing 2 tầng; rỗng nếu
+    # chưa có ngành active (FE ẩn khối "chọn ngành").
+    programs: List[SmsLandingProgram] = Field(default_factory=list)
+
+
+# =====================================================================
+# Phase 2 (§16) — deep engagement tracking (session / view / heartbeat)
+# =====================================================================
+class SmsSessionStartResponse(BaseModel):
+    """Trả sau `POST /landing/{code}/session` — session_token raw TRẢ 1 LẦN
+    (server chỉ lưu hash). Client giữ token để gửi program-view/heartbeat."""
+
+    session_token: str
+    session_id: int
+
+
+class SmsProgramViewRequest(BaseModel):
+    """Body `POST /landing/{code}/program-view` — mở 1 lượt xem trang ngành."""
+
+    session_token: str = Field(..., min_length=16, max_length=128)
+    major_program_id: int = Field(..., ge=1, le=2147483647)
+    program_offering_id: Optional[int] = Field(None, ge=1, le=2147483647)
+
+
+class SmsProgramViewResponse(BaseModel):
+    """Trả program_view_id để client đính vào heartbeat của trang ngành đó."""
+
+    program_view_id: int
+    sequence_no: int
+
+
+class SmsHeartbeatRequest(BaseModel):
+    """Body `POST /landing/{code}/heartbeat` — báo dwell tích luỹ (giây) trên
+    trang ngành đang xem. Server clamp theo wall-clock chống thổi phồng."""
+
+    session_token: str = Field(..., min_length=16, max_length=128)
+    program_view_id: int = Field(..., ge=1, le=2147483647)
+    # dwell tích luỹ client đo (không delta) — server tự clamp trần theo thời
+    # gian thực đã trôi kể từ khi mở view. le lớn = 24h an toàn (server vẫn cap).
+    dwell_seconds: int = Field(..., ge=0, le=86400)
+
+
+class SmsHeartbeatResponse(BaseModel):
+    """Xác nhận dwell đã ghi (đã clamp) + tổng active của phiên."""
+
+    ok: bool = True
+    dwell_seconds: int = 0
+    active_seconds: int = 0
+
+
+class SmsProgramInterestRow(BaseModel):
+    """1 ngành trong report 'ngành nóng' (admin) — aggregate qua program_view."""
+
+    major_program_id: Optional[int] = None
+    program_name: str
+    distinct_contacts: int = 0
+    view_count: int = 0
+    total_dwell_seconds: int = 0
+    avg_dwell_seconds: float = 0.0
+
+
+class SmsProgramInterestReport(BaseModel):
+    """Report ngành nóng theo campaign/nhóm/thời gian (§16.7). Rank dwell desc."""
+
+    items: List[SmsProgramInterestRow] = Field(default_factory=list)
+    distinct_contacts_total: int = 0
+    view_count_total: int = 0
+    total_dwell_seconds: int = 0
+
+
+class SmsContactInterestRow(BaseModel):
+    """1 ngành trong hồ sơ sở thích 1 contact (rank total_dwell_seconds desc)."""
+
+    major_program_id: int
+    program_name: str
+    view_count: int = 0
+    total_dwell_seconds: int = 0
+    interest_score: float = 0.0
+    first_interest_at: Optional[datetime] = None
+    last_interest_at: Optional[datetime] = None
+
+
+class SmsContactInterestList(BaseModel):
+    """Hồ sơ 'quan tâm ngành' của 1 contact (§16.7 admin / P2-4b lead tab)."""
+
+    contact_id: int
+    items: List[SmsContactInterestRow] = Field(default_factory=list)
 
 
 class SmsPublicOptOutRequest(BaseModel):

--- a/Backend_FastAPI/app/services/sms_engagement_service.py
+++ b/Backend_FastAPI/app/services/sms_engagement_service.py
@@ -172,11 +172,13 @@ class SmsEngagementService:
         elapsed = int((now - _aware(view.viewed_at)).total_seconds())
         wall_cap = max(elapsed, 0) + _HEARTBEAT_GRACE_SECONDS
         new_dwell = max(view.dwell_seconds, min(payload.dwell_seconds, wall_cap))
-        delta = new_dwell - view.dwell_seconds
         view.dwell_seconds = new_dwell
-        session.active_seconds = session.active_seconds + delta
         session.last_heartbeat_at = now
         await self.db.flush()
+        # active_seconds = Σ dwell mọi view của phiên (DERIVE sau flush, nguồn
+        # sự thật) → chống lost-update khi 2 tab heartbeat // (không cộng delta).
+        active_seconds = await self.repo.session_total_dwell(session.id)
+        session.active_seconds = active_seconds
         # Cập nhật aggregate interest — chỉ session người thật + ngành còn sống.
         if not session.is_suspected_bot and view.major_program_id is not None:
             await self._recompute_interest(
@@ -184,11 +186,11 @@ class SmsEngagementService:
                 major_program_id=view.major_program_id,
                 now=now,
             )
-            await self.db.flush()
+        await self.db.flush()
         return sms_schemas.SmsHeartbeatResponse(
             ok=True,
             dwell_seconds=new_dwell,
-            active_seconds=session.active_seconds,
+            active_seconds=active_seconds,
         )
 
     async def _recompute_interest(
@@ -199,10 +201,11 @@ class SmsEngagementService:
         views = await self.repo.views_for_interest(contact_id, major_program_id)
         if not views:
             return
-        total_dwell = sum(d for d, _ in views)
-        viewed_ats = [_aware(v) for _, v in views]
+        # Build 1 lần (normalize tz), rồi derive total_dwell/first/last từ đó.
+        aware_views = [(d, _aware(v)) for d, v in views]
+        viewed_ats = [v for _, v in aware_views]
         score = compute_interest_score(
-            [(d, _aware(v)) for d, v in views],
+            aware_views,
             now,
             dwell_cap=settings.SMS_INTEREST_DWELL_CAP,
             half_life_days=settings.SMS_INTEREST_HALF_LIFE,
@@ -211,8 +214,8 @@ class SmsEngagementService:
         await self.repo.upsert_interest(
             contact_id=contact_id,
             major_program_id=major_program_id,
-            view_count=len(views),
-            total_dwell_seconds=total_dwell,
+            view_count=len(aware_views),
+            total_dwell_seconds=sum(d for d, _ in aware_views),
             first_interest_at=min(viewed_ats),
             last_interest_at=max(viewed_ats),
             interest_score=score,

--- a/Backend_FastAPI/app/services/sms_engagement_service.py
+++ b/Backend_FastAPI/app/services/sms_engagement_service.py
@@ -1,0 +1,220 @@
+# app/services/sms_engagement_service.py
+"""
+Business logic Phase 2 (§16) deep engagement — đo "ngành thực sự quan tâm":
+- start_session: resolve `/lp/{code}` (campaign recipient) → tạo phiên, sinh
+  session_token raw TRẢ 1 LẦN (lưu hash), gắn contact_id (khóa thống nhất).
+- record_program_view: mở 1 lượt xem trang ngành (snapshot tên ngành).
+- heartbeat: cộng dwell trang ngành (clamp wall-clock chống thổi phồng) →
+  cập nhật aggregate interest_score (§18.F) cho cặp (contact, ngành).
+
+KHÔNG import fastapi; raise domain exception; service flush (router commit).
+Bot (UA/prefetch) vẫn tạo phiên (không lộ việc phát hiện) NHƯNG bị loại khỏi
+interest + report. Xem SMS_MARKETING_MODULE_DESIGN.md §16.
+"""
+import logging
+from datetime import datetime, timezone
+from typing import Mapping, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.repositories.sms_engagement_repository import SmsEngagementRepository
+from app.repositories.sms_tracking_repository import SmsTrackingRepository
+from app.schemas import sms as sms_schemas
+from app.utils.exceptions import ResourceNotFoundError
+from app.utils.sms_bot import detect_bot
+from app.utils.sms_interest import compute_interest_score
+from app.utils.sms_token import (
+    compute_ip_hash,
+    compute_session_token_hash,
+    compute_token_hash,
+    generate_session_token,
+    is_valid_code,
+)
+
+log = logging.getLogger(__name__)
+
+_GENERIC_404 = "Liên kết không hợp lệ hoặc đã hết hạn"
+# Dung sai clamp dwell: cho phép dwell client báo vượt thời gian thực đã trôi
+# tối đa ngần này (bù lệch đồng hồ + độ trễ heartbeat cuối). Chống client gửi
+# dwell_seconds khổng lồ (thổi phồng interest).
+_HEARTBEAT_GRACE_SECONDS = 30
+
+
+def _aware(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+class SmsEngagementService:
+    """Session + program-view + heartbeat + aggregate interest (Phase 2)."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = SmsEngagementRepository(db)
+        self.tracking_repo = SmsTrackingRepository(db)
+
+    # ---------------------------------------------------------------
+    # Resolve code → recipient + campaign (mirror landing/tracking)
+    # ---------------------------------------------------------------
+    async def _resolve_recipient(self, code: str):
+        if not is_valid_code(code):
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        found = await self.tracking_repo.lookup_by_token_hash(
+            compute_token_hash(code)
+        )
+        if found is None:
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        recipient, campaign = found
+        if campaign.link_expires_at and _aware(
+            campaign.link_expires_at
+        ) <= datetime.now(timezone.utc):
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        return recipient, campaign
+
+    async def _resolve_session(self, session_token: str):
+        """Session theo token hash (bearer). None → 404 generic."""
+        token = (session_token or "").strip()
+        if not token:
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        session = await self.repo.get_session_by_token_hash(
+            compute_session_token_hash(token)
+        )
+        if session is None:
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        return session
+
+    # ---------------------------------------------------------------
+    # Start session (POST /landing/{code}/session)
+    # ---------------------------------------------------------------
+    async def start_session(
+        self,
+        code: str,
+        *,
+        ip: Optional[str],
+        user_agent: Optional[str],
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> sms_schemas.SmsSessionStartResponse:
+        recipient, campaign = await self._resolve_recipient(code)
+        # contact_id = khóa thống nhất gắn interest; NULL (contact đã xoá) →
+        # không quy được sở thích → 404 generic (measurement bỏ qua ca hiếm này).
+        if recipient.contact_id is None:
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        now = datetime.now(timezone.utc)
+        is_bot, _reason = detect_bot(
+            user_agent=user_agent, headers=headers, now=now
+        )
+        raw_token = generate_session_token()
+        session = await self.repo.create_session(
+            {
+                "contact_id": recipient.contact_id,
+                "source_type": "campaign",
+                "recipient_id": recipient.id,
+                "campaign_id": campaign.id,
+                "session_token_hash": compute_session_token_hash(raw_token),
+                "started_at": now,
+                "last_heartbeat_at": now,
+                "ip_hash": compute_ip_hash(ip),
+                "user_agent": (user_agent[:512] if user_agent else None),
+                "is_suspected_bot": is_bot,
+            }
+        )
+        return sms_schemas.SmsSessionStartResponse(
+            session_token=raw_token, session_id=session.id
+        )
+
+    # ---------------------------------------------------------------
+    # Program view (POST /landing/{code}/program-view)
+    # ---------------------------------------------------------------
+    async def record_program_view(
+        self, code: str, payload: sms_schemas.SmsProgramViewRequest
+    ) -> sms_schemas.SmsProgramViewResponse:
+        if not is_valid_code(code):
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        session = await self._resolve_session(payload.session_token)
+        program = await self.repo.get_active_program(payload.major_program_id)
+        if program is None:
+            # Ngành không tồn tại/không active → không đo (404 generic).
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        seq = await self.repo.next_sequence_no(session.id)
+        view = await self.repo.create_program_view(
+            {
+                "session_id": session.id,
+                "contact_id": session.contact_id,
+                "major_program_id": program.id,
+                "program_offering_id": payload.program_offering_id,
+                "program_name_snapshot": program.name[:255],
+                "viewed_at": datetime.now(timezone.utc),
+                "dwell_seconds": 0,
+                "sequence_no": seq,
+            }
+        )
+        return sms_schemas.SmsProgramViewResponse(
+            program_view_id=view.id, sequence_no=seq
+        )
+
+    # ---------------------------------------------------------------
+    # Heartbeat (POST /landing/{code}/heartbeat)
+    # ---------------------------------------------------------------
+    async def heartbeat(
+        self, code: str, payload: sms_schemas.SmsHeartbeatRequest
+    ) -> sms_schemas.SmsHeartbeatResponse:
+        if not is_valid_code(code):
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        session = await self._resolve_session(payload.session_token)
+        view = await self.repo.get_program_view(
+            payload.program_view_id, session.id
+        )
+        if view is None:
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        now = datetime.now(timezone.utc)
+        # Clamp: dwell ≤ thời gian thực đã trôi kể từ khi mở view + grace, và
+        # đơn điệu tăng (heartbeat trễ/trùng không làm tụt). Chống thổi phồng.
+        elapsed = int((now - _aware(view.viewed_at)).total_seconds())
+        wall_cap = max(elapsed, 0) + _HEARTBEAT_GRACE_SECONDS
+        new_dwell = max(view.dwell_seconds, min(payload.dwell_seconds, wall_cap))
+        delta = new_dwell - view.dwell_seconds
+        view.dwell_seconds = new_dwell
+        session.active_seconds = session.active_seconds + delta
+        session.last_heartbeat_at = now
+        await self.db.flush()
+        # Cập nhật aggregate interest — chỉ session người thật + ngành còn sống.
+        if not session.is_suspected_bot and view.major_program_id is not None:
+            await self._recompute_interest(
+                contact_id=session.contact_id,
+                major_program_id=view.major_program_id,
+                now=now,
+            )
+            await self.db.flush()
+        return sms_schemas.SmsHeartbeatResponse(
+            ok=True,
+            dwell_seconds=new_dwell,
+            active_seconds=session.active_seconds,
+        )
+
+    async def _recompute_interest(
+        self, *, contact_id: int, major_program_id: int, now: datetime
+    ) -> None:
+        """Tính lại interest_score từ MỌI view của (contact, ngành) — nguồn sự
+        thật là program_view (tự lành khi 2 heartbeat đua)."""
+        views = await self.repo.views_for_interest(contact_id, major_program_id)
+        if not views:
+            return
+        total_dwell = sum(d for d, _ in views)
+        viewed_ats = [_aware(v) for _, v in views]
+        score = compute_interest_score(
+            [(d, _aware(v)) for d, v in views],
+            now,
+            dwell_cap=settings.SMS_INTEREST_DWELL_CAP,
+            half_life_days=settings.SMS_INTEREST_HALF_LIFE,
+            k=settings.SMS_INTEREST_K,
+        )
+        await self.repo.upsert_interest(
+            contact_id=contact_id,
+            major_program_id=major_program_id,
+            view_count=len(views),
+            total_dwell_seconds=total_dwell,
+            first_interest_at=min(viewed_ats),
+            last_interest_at=max(viewed_ats),
+            interest_score=score,
+            now=now,
+        )

--- a/Backend_FastAPI/app/services/sms_engagement_service.py
+++ b/Backend_FastAPI/app/services/sms_engagement_service.py
@@ -72,7 +72,15 @@ class SmsEngagementService:
         return recipient, campaign
 
     async def _resolve_session(self, session_token: str):
-        """Session theo token hash (bearer). None → 404 generic."""
+        """Session theo token hash (bearer). None → 404 generic.
+
+        BEARER SỐNG-HẾT-PHIÊN (có chủ đích, /review #3): expiry của campaign
+        link CHỈ gate lúc TẠO phiên (start_session→_resolve_recipient), /r/ và
+        landing GET. Program-view/heartbeat KHÔNG re-check expiry: người dùng
+        thật vào bằng link còn hạn rồi ĐANG đọc, nếu link hết hạn giữa chừng mà
+        cắt đo dwell = làm HỎNG số liệu của chính người thật đó. Token 256-bit
+        bất khả đoán + rate-limit theo IP + interest_score có trần → không cần
+        chặn theo expiry ở đây. `code` path chỉ validate format (routing)."""
         token = (session_token or "").strip()
         if not token:
             raise ResourceNotFoundError(detail=_GENERIC_404)

--- a/Backend_FastAPI/app/services/sms_landing_service.py
+++ b/Backend_FastAPI/app/services/sms_landing_service.py
@@ -14,6 +14,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
+from app.repositories.sms_engagement_repository import SmsEngagementRepository
 from app.repositories.sms_tracking_repository import SmsTrackingRepository
 from app.schemas import sms as sms_schemas
 from app.utils.exceptions import ResourceNotFoundError
@@ -35,6 +36,7 @@ class SmsLandingService:
     def __init__(self, db: AsyncSession):
         self.db = db
         self.repo = SmsTrackingRepository(db)
+        self.engagement_repo = SmsEngagementRepository(db)
 
     async def _resolve(self, code: str, *, enforce_expiry: bool = True):
         if not is_valid_code(code):
@@ -65,6 +67,9 @@ class SmsLandingService:
                 "SMS landing: CTA url ngoài allowlist campaign_id=%s", campaign.id
             )
             cta_label = cta_url = None
+        # Phase 2 (§16.1): danh mục ngành cho landing 2 tầng (read-only, no
+        # session — session chỉ tạo qua POST để tránh crawler tạo phiên rác).
+        programs = await self.engagement_repo.list_active_programs()
         return sms_schemas.SmsLandingResponse(
             school_name=settings.SMS_LANDING_SCHOOL_NAME,
             headline=campaign.landing_headline,
@@ -73,6 +78,13 @@ class SmsLandingService:
             cta_url=cta_url,
             consent_notice=settings.SMS_LANDING_CONSENT_NOTICE,
             already_opted_out=already,
+            programs=[
+                sms_schemas.SmsLandingProgram(
+                    id=p.id, name=p.name, code=p.code,
+                    degree_level=p.degree_level,
+                )
+                for p in programs
+            ],
         )
 
     async def public_opt_out(

--- a/Backend_FastAPI/app/services/sms_report_service.py
+++ b/Backend_FastAPI/app/services/sms_report_service.py
@@ -201,6 +201,11 @@ class SmsReportService:
         date_from: Optional[datetime] = None,
         date_to: Optional[datetime] = None,
     ) -> sms_schemas.SmsProgramInterestReport:
+        # LƯU Ý ĐO LƯỜNG (/review #4): total_dwell/view_count là tín hiệu THÔ do
+        # client báo (đã lọc bot + clamp wall-clock/lượt + rate-limit per-IP);
+        # 1 người có thể tự bơm dwell CHÍNH ngành mình quan tâm. Chấp nhận: chỉ
+        # tự-ảnh-hưởng contact của họ, và tín hiệu xếp hạng cốt lõi per-contact
+        # là interest_score (CÓ TRẦN normalize), không phải dwell thô của report.
         scope = dict(
             campaign_id=campaign_id,
             group_id=group_id,

--- a/Backend_FastAPI/app/services/sms_report_service.py
+++ b/Backend_FastAPI/app/services/sms_report_service.py
@@ -14,6 +14,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.sms_campaign_repository import SmsCampaignRepository
+from app.repositories.sms_engagement_repository import SmsEngagementRepository
 from app.repositories.sms_tracking_repository import SmsTrackingRepository
 from app.schemas import sms as sms_schemas
 from app.utils.exceptions import (
@@ -49,6 +50,7 @@ class SmsReportService:
         self.db = db
         self.repo = SmsTrackingRepository(db)
         self.campaign_repo = SmsCampaignRepository(db)
+        self.engagement_repo = SmsEngagementRepository(db)
 
     # ---------------------------------------------------------------
     # Report click theo granularity
@@ -186,3 +188,65 @@ class SmsReportService:
             skip=skip, limit=limit, search=search, source=source
         )
         return sms_schemas.SmsOptOutList(total=total, items=items)
+
+    # ---------------------------------------------------------------
+    # Phase 2 (§16.7) — report ngành nóng + hồ sơ sở thích 1 contact
+    # ---------------------------------------------------------------
+    async def program_interest_report(
+        self,
+        *,
+        campaign_id: Optional[int] = None,
+        group_id: Optional[int] = None,
+        major_program_id: Optional[int] = None,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+    ) -> sms_schemas.SmsProgramInterestReport:
+        scope = dict(
+            campaign_id=campaign_id,
+            group_id=group_id,
+            major_program_id=major_program_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        rows = await self.engagement_repo.program_interest_report(**scope)
+        distinct_total, view_total, dwell_total = (
+            await self.engagement_repo.program_interest_totals(**scope)
+        )
+        return sms_schemas.SmsProgramInterestReport(
+            items=[
+                sms_schemas.SmsProgramInterestRow(
+                    major_program_id=pid,
+                    program_name=name or "(ngành đã xoá)",
+                    distinct_contacts=distinct,
+                    view_count=views,
+                    total_dwell_seconds=dwell,
+                    avg_dwell_seconds=(
+                        round(dwell / views, 1) if views else 0.0
+                    ),
+                )
+                for pid, name, distinct, views, dwell in rows
+            ],
+            distinct_contacts_total=distinct_total,
+            view_count_total=view_total,
+            total_dwell_seconds=dwell_total,
+        )
+
+    async def contact_interests(
+        self, contact_id: int
+    ) -> sms_schemas.SmsContactInterestList:
+        rows = await self.engagement_repo.contact_interests(contact_id)
+        return sms_schemas.SmsContactInterestList(
+            contact_id=contact_id,
+            items=[
+                sms_schemas.SmsContactInterestRow(
+                    major_program_id=r.major_program_id,
+                    program_name=name or "(ngành đã xoá)",
+                    view_count=r.view_count,
+                    total_dwell_seconds=r.total_dwell_seconds,
+                    interest_score=r.interest_score,
+                    first_interest_at=r.first_interest_at,
+                    last_interest_at=r.last_interest_at,
+                )
+                for r, name in rows
+            ],
+        )

--- a/Backend_FastAPI/app/utils/sms_interest.py
+++ b/Backend_FastAPI/app/utils/sms_interest.py
@@ -1,0 +1,66 @@
+# app/utils/sms_interest.py
+"""
+Công thức `interest_score` Phase 2 (§16.10-P2-Q2 / §18.F, ĐÃ CHỐT):
+
+    interest_score = normalize( Σ_view  dwell_factor(v) × recency_weight(v) )
+      dwell_factor(s)   = min(s / DWELL_CAP, 1.0)     # cap → phiên dài không vô hạn
+      recency_weight(t) = exp(-Δdays / HALF_LIFE)     # ưu tiên gần đây
+      normalize(x)      = x / (x + K)                  # squash 0–1
+
+Pure Python (KHÔNG import fastapi/sqlalchemy) — nhận list view + tham số config,
+trả float ∈ [0,1). Tần suất (frequency) tự gấp vào vì cộng dồn theo từng view;
+dwell = cường độ (capped chống gian lận); recency = độ mới.
+
+Nguồn: Dynamic Yield affinity + Dotdigital weighting curve. KHÔNG ML.
+Xem `Documents/SMS_MARKETING_MODULE_DESIGN.md` §18.F.
+"""
+import math
+from datetime import datetime, timezone
+from typing import Iterable, Tuple
+
+
+def _aware(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def dwell_factor(dwell_seconds: int, cap: int) -> float:
+    """min(s / cap, 1.0). cap ≥ 1 (config ge=1); guard chia 0 phòng lỗi cấu hình."""
+    if cap <= 0:
+        return 1.0 if dwell_seconds > 0 else 0.0
+    return min(max(dwell_seconds, 0) / cap, 1.0)
+
+
+def recency_weight(viewed_at: datetime, now: datetime, half_life_days: int) -> float:
+    """exp(-Δdays / half_life). Δdays clamp ≥ 0 (view 'tương lai' do lệch đồng
+    hồ → weight 1.0, không >1). half_life ≥ 1 (config)."""
+    delta_days = (_aware(now) - _aware(viewed_at)).total_seconds() / 86400.0
+    if delta_days <= 0:
+        return 1.0
+    hl = half_life_days if half_life_days > 0 else 1
+    return math.exp(-delta_days / hl)
+
+
+def normalize(x: float, k: float) -> float:
+    """x / (x + K); K > 0 (config gt=0). x ≥ 0 → kết quả ∈ [0,1)."""
+    denom = x + k
+    if denom <= 0:
+        return 0.0
+    return x / denom
+
+
+def compute_interest_score(
+    views: Iterable[Tuple[int, datetime]],
+    now: datetime,
+    *,
+    dwell_cap: int,
+    half_life_days: int,
+    k: float,
+) -> float:
+    """Tính interest_score từ MỌI view (dwell_seconds, viewed_at) của 1 cặp
+    (contact, ngành). now = mốc tính recency (thường thời điểm cập nhật)."""
+    raw = 0.0
+    for dwell_seconds, viewed_at in views:
+        raw += dwell_factor(dwell_seconds, dwell_cap) * recency_weight(
+            viewed_at, now, half_life_days
+        )
+    return normalize(raw, k)

--- a/Backend_FastAPI/app/utils/sms_token.py
+++ b/Backend_FastAPI/app/utils/sms_token.py
@@ -37,11 +37,16 @@ def generate_short_code() -> str:
     return "".join(secrets.choice(_BASE62) for _ in range(CODE_LENGTH))
 
 
+def _hmac_sha256_hex(secret: str, value: str) -> str:
+    """HMAC-SHA256(value, secret) → hex 64 ký tự [0-9a-f]. Primitive dùng chung
+    cho mọi hash SMS (token/session/ip) — đổi thuật toán/encoding 1 chỗ."""
+    return hmac.new(secret.encode(), value.encode(), hashlib.sha256).hexdigest()
+
+
 def compute_token_hash(code: str) -> str:
     """HMAC-SHA256(code, SMS_TOKEN_HASH_SECRET) → hex 64 ký tự [0-9a-f]
     (khớp CHECK `chk_sms_recipient_token_triplet`). Dùng để lookup /r/{code}."""
-    secret = settings.SMS_TOKEN_HASH_SECRET.encode()
-    return hmac.new(secret, code.encode(), hashlib.sha256).hexdigest()
+    return _hmac_sha256_hex(settings.SMS_TOKEN_HASH_SECRET, code)
 
 
 def generate_session_token() -> str:
@@ -55,8 +60,7 @@ def generate_session_token() -> str:
 def compute_session_token_hash(token: str) -> str:
     """HMAC-SHA256(session_token, SMS_SESSION_TOKEN_HASH_SECRET) → hex 64 ký tự.
     Secret TÁCH BIỆT short-link token-hash (§16.4) → lookup session độc lập."""
-    secret = settings.SMS_SESSION_TOKEN_HASH_SECRET.encode()
-    return hmac.new(secret, token.encode(), hashlib.sha256).hexdigest()
+    return _hmac_sha256_hex(settings.SMS_SESSION_TOKEN_HASH_SECRET, token)
 
 
 def compute_ip_hash(ip: Optional[str]) -> Optional[str]:
@@ -66,8 +70,7 @@ def compute_ip_hash(ip: Optional[str]) -> Optional[str]:
     raw = (ip or "").strip()
     if not raw:
         return None
-    secret = settings.SMS_IP_HASH_SECRET.encode()
-    return hmac.new(secret, raw.encode(), hashlib.sha256).hexdigest()
+    return _hmac_sha256_hex(settings.SMS_IP_HASH_SECRET, raw)
 
 
 def is_valid_code(code: str) -> bool:

--- a/Backend_FastAPI/app/utils/sms_token.py
+++ b/Backend_FastAPI/app/utils/sms_token.py
@@ -44,6 +44,21 @@ def compute_token_hash(code: str) -> str:
     return hmac.new(secret, code.encode(), hashlib.sha256).hexdigest()
 
 
+def generate_session_token() -> str:
+    """Sinh session bearer token (Phase 2 §16.7) — 32 byte CSPRNG → base64url
+    (~43 ký tự). Trả về client 1 LẦN; server chỉ lưu HMAC hash (chống giả lập
+    engagement nếu DB/log lộ). Khác short code (base62×9): session token dài hơn,
+    entropy cao (256-bit) vì là bearer đo dwell, không nhúng vào SMS."""
+    return secrets.token_urlsafe(32)
+
+
+def compute_session_token_hash(token: str) -> str:
+    """HMAC-SHA256(session_token, SMS_SESSION_TOKEN_HASH_SECRET) → hex 64 ký tự.
+    Secret TÁCH BIỆT short-link token-hash (§16.4) → lookup session độc lập."""
+    secret = settings.SMS_SESSION_TOKEN_HASH_SECRET.encode()
+    return hmac.new(secret, token.encode(), hashlib.sha256).hexdigest()
+
+
 def compute_ip_hash(ip: Optional[str]) -> Optional[str]:
     """HMAC-SHA256(ip, SMS_IP_HASH_SECRET) → hex 64 (click event PR-5). Secret
     TÁCH BIỆT token-hash (§2.2) → không suy ngược token↔IP. KHÔNG lưu IP thô.

--- a/Backend_FastAPI/tests/integration/test_sms_engagement.py
+++ b/Backend_FastAPI/tests/integration/test_sms_engagement.py
@@ -1,0 +1,414 @@
+# tests/integration/test_sms_engagement.py
+"""
+Integration test PR-7 P2-2 (SMS Phase 2 — deep engagement / đo quan tâm ngành).
+
+Phủ:
+- Landing GET +danh mục ngành (no session).
+- Flow session → program-view → heartbeat: ghi dwell + cập nhật aggregate
+  interest (§18.F), rồi hồ sơ sở thích contact (admin) + report ngành nóng.
+- Clamp dwell thổi phồng theo wall-clock.
+- Bot session bị loại khỏi interest + report.
+- Ranking nhiều ngành theo tổng dwell desc.
+- 404 generic: code sai, session token sai, ngành không tồn tại.
+- Admin endpoint yêu cầu auth.
+
+Lấy raw code qua decrypt token_ciphertext (dev Fernet). Handoff mô phỏng bằng
+SQL. Chạy one-off container (CLAUDE.md — suite fan-out fixture nặng).
+"""
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.database import AsyncSessionLocal
+from app.utils.sms_token import decrypt_code
+
+API = "/api/sms"
+PUB = "/api/public/sms"
+_GRANT = {
+    "event_type": "granted",
+    "occurred_at": "2026-05-01T00:00:00+07:00",
+    "basis": "signed_form",
+    "disclosure_version": "v1",
+    "proof_reference": "ho-so/ref",
+}
+_UA_HUMAN = (
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) "
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 "
+    "Safari/604.1"
+)
+_UA_BOT = "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
+_H = {"User-Agent": _UA_HUMAN}
+
+
+async def _mk_group(client, h, name="Eng Nhom"):
+    r = await client.post(
+        f"{API}/contact-groups", json={"name": name, "group_type": "custom"},
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _mk_contact(client, h, name, phone):
+    r = await client.post(
+        f"{API}/contacts", json={"full_name": name, "phone": phone}, headers=h
+    )
+    assert r.status_code == 201, r.text
+    cid = r.json()["id"]
+    rc = await client.post(
+        f"{API}/contacts/{cid}/consent-events", json=_GRANT, headers=h
+    )
+    assert rc.status_code == 201, rc.text
+    return cid
+
+
+async def _setup(client, h, phone="0981234567"):
+    """group + 1 contact granted + campaign {link} + build + handoff (past).
+    Trả (campaign_id, raw_code, contact_id)."""
+    gid = await _mk_group(client, h)
+    contact_id = await _mk_contact(client, h, "Phu huynh A", phone)
+    await client.post(
+        f"{API}/contacts/{contact_id}/groups", json={"group_id": gid}, headers=h
+    )
+    r = await client.post(
+        f"{API}/campaigns",
+        json={
+            "name": "Eng QA",
+            "sms_template": "Chao {full_name}, xem {link}",
+            "landing_headline": "Tuyển sinh 2026",
+            "landing_body": "Thông tin tuyển sinh chi tiết.",
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    cid = r.json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": gid}, headers=h
+    )
+    rb = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert rb.status_code == 200, rb.text
+    async with AsyncSessionLocal() as s:
+        row = (
+            await s.execute(
+                text(
+                    "SELECT token_ciphertext, token_key_version FROM "
+                    "sms_campaign_recipient WHERE campaign_id=:c LIMIT 1"
+                ),
+                {"c": cid},
+            )
+        ).first()
+        await s.execute(
+            text(
+                "UPDATE sms_campaign_recipient SET handed_off_at = now() - "
+                "interval '1 hour' WHERE campaign_id=:c"
+            ),
+            {"c": cid},
+        )
+        await s.commit()
+    code = decrypt_code(row[0], row[1])
+    assert code, "decrypt token thất bại"
+    return cid, code, contact_id
+
+
+async def _seed_second_major(new_id=9002):
+    """Ngành #2 active (dùng chung unit với ngành #1 seed_lead_dependencies).
+    id tường minh vì test DB dùng create_all() → sequence major_program chưa
+    sync (auto-id sẽ đụng id=1 seeded). Trả id ngành mới."""
+    async with AsyncSessionLocal() as s:
+        unit_id = (
+            await s.execute(
+                text("SELECT unit_id FROM major_program WHERE id=1")
+            )
+        ).scalar()
+        await s.execute(
+            text(
+                "INSERT INTO major_program "
+                "(id, name, code, degree_level, is_active, unit_id) VALUES "
+                "(:i, 'Test Major 2', 'TM2', 'Cao đẳng', true, :u)"
+            ),
+            {"i": new_id, "u": unit_id},
+        )
+        await s.commit()
+    return new_id
+
+
+# ---------------------------------------------------------------------
+# Landing +danh mục ngành
+# ---------------------------------------------------------------------
+async def test_landing_includes_active_programs(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    h = admin_token_headers
+    _cid, code, _contact = await _setup(client, h)
+    lr = await client.get(f"{PUB}/landing/{code}")
+    assert lr.status_code == 200, lr.text
+    body = lr.json()
+    assert body["headline"] == "Tuyển sinh 2026"
+    progs = body["programs"]
+    assert isinstance(progs, list) and len(progs) >= 1
+    assert any(p["id"] == 1 and p["code"] == "TM1" for p in progs)
+
+
+# ---------------------------------------------------------------------
+# Flow đầy đủ: session → program-view → heartbeat → interest
+# ---------------------------------------------------------------------
+async def test_session_view_heartbeat_updates_interest(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    h = admin_token_headers
+    _cid, code, contact_id = await _setup(client, h)
+
+    # 1) tạo session (UA người thật)
+    rs = await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    assert rs.status_code == 200, rs.text
+    token = rs.json()["session_token"]
+    assert token and len(token) >= 16
+    assert rs.headers.get("cache-control") == "no-store"
+
+    # 2) mở trang ngành #1
+    rv = await client.post(
+        f"{PUB}/landing/{code}/program-view",
+        json={"session_token": token, "major_program_id": 1},
+        headers=_H,
+    )
+    assert rv.status_code == 200, rv.text
+    view_id = rv.json()["program_view_id"]
+    assert rv.json()["sequence_no"] == 1
+
+    # 3) heartbeat cộng dwell (100s < cap 180) — view mới nên wall-clock cho phép
+    #    tối đa vài giây + grace(30) → 100 sẽ bị clamp về ~30. Test clamp riêng;
+    #    ở đây kiểm dwell > 0 + interest được tạo.
+    hb = await client.post(
+        f"{PUB}/landing/{code}/heartbeat",
+        json={"session_token": token, "program_view_id": view_id,
+              "dwell_seconds": 25},
+        headers=_H,
+    )
+    assert hb.status_code == 200, hb.text
+    assert hb.json()["dwell_seconds"] == 25  # ≤ grace 30 → không clamp
+    assert hb.json()["active_seconds"] == 25
+
+    # DB: program_view + aggregate interest
+    async with AsyncSessionLocal() as s:
+        pv = (
+            await s.execute(
+                text(
+                    "SELECT dwell_seconds, major_program_id, contact_id FROM "
+                    "sms_program_view WHERE id=:i"
+                ),
+                {"i": view_id},
+            )
+        ).first()
+        interest = (
+            await s.execute(
+                text(
+                    "SELECT view_count, total_dwell_seconds, interest_score "
+                    "FROM sms_contact_program_interest WHERE contact_id=:c "
+                    "AND major_program_id=1"
+                ),
+                {"c": contact_id},
+            )
+        ).first()
+    assert pv[0] == 25 and pv[1] == 1 and pv[2] == contact_id
+    assert interest is not None
+    assert interest[0] == 1 and interest[1] == 25
+    assert interest[2] > 0.0  # score dương
+
+    # 4) hồ sơ sở thích contact (admin)
+    ci = await client.get(f"{API}/contacts/{contact_id}/interests", headers=h)
+    assert ci.status_code == 200, ci.text
+    items = ci.json()["items"]
+    assert len(items) == 1
+    assert items[0]["major_program_id"] == 1
+    assert items[0]["total_dwell_seconds"] == 25
+    assert items[0]["interest_score"] > 0.0
+
+
+# ---------------------------------------------------------------------
+# Clamp dwell thổi phồng theo wall-clock
+# ---------------------------------------------------------------------
+async def test_heartbeat_clamps_inflated_dwell(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    h = admin_token_headers
+    _cid, code, _contact = await _setup(client, h)
+    token = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    ).json()["session_token"]
+    view_id = (
+        await client.post(
+            f"{PUB}/landing/{code}/program-view",
+            json={"session_token": token, "major_program_id": 1},
+            headers=_H,
+        )
+    ).json()["program_view_id"]
+    # client báo dwell khổng lồ (dưới trần schema 86400) ngay sau khi mở view
+    # → clamp về ~grace(30)s theo wall-clock
+    hb = await client.post(
+        f"{PUB}/landing/{code}/heartbeat",
+        json={"session_token": token, "program_view_id": view_id,
+              "dwell_seconds": 80000},
+        headers=_H,
+    )
+    assert hb.status_code == 200, hb.text
+    assert hb.json()["dwell_seconds"] <= 60  # wall-clock(≈0) + grace(30) + lag
+
+
+# ---------------------------------------------------------------------
+# Bot session KHÔNG cập nhật interest
+# ---------------------------------------------------------------------
+async def test_bot_session_excluded_from_interest(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    h = admin_token_headers
+    _cid, code, contact_id = await _setup(client, h)
+    bot_ua = {"User-Agent": _UA_BOT}
+    token = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=bot_ua)
+    ).json()["session_token"]
+    view_id = (
+        await client.post(
+            f"{PUB}/landing/{code}/program-view",
+            json={"session_token": token, "major_program_id": 1},
+            headers=bot_ua,
+        )
+    ).json()["program_view_id"]
+    hb = await client.post(
+        f"{PUB}/landing/{code}/heartbeat",
+        json={"session_token": token, "program_view_id": view_id,
+              "dwell_seconds": 20},
+        headers=bot_ua,
+    )
+    assert hb.status_code == 200
+    # dwell VẪN ghi (audit) nhưng interest KHÔNG được tạo cho bot
+    async with AsyncSessionLocal() as s:
+        is_bot = (
+            await s.execute(
+                text("SELECT is_suspected_bot FROM sms_landing_session LIMIT 1")
+            )
+        ).scalar()
+        interest = (
+            await s.execute(
+                text(
+                    "SELECT count(*) FROM sms_contact_program_interest "
+                    "WHERE contact_id=:c"
+                ),
+                {"c": contact_id},
+            )
+        ).scalar()
+    assert is_bot is True
+    assert interest == 0
+    # report ngành nóng cũng loại bot → rỗng
+    rep = await client.get(f"{API}/reports/program-interest", headers=h)
+    assert rep.status_code == 200
+    assert rep.json()["view_count_total"] == 0
+
+
+# ---------------------------------------------------------------------
+# Report ngành nóng — ranking theo tổng dwell desc
+# ---------------------------------------------------------------------
+async def test_program_interest_report_ranking(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    h = admin_token_headers
+    cid, code, _contact = await _setup(client, h)
+    major2 = await _seed_second_major()
+    token = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    ).json()["session_token"]
+
+    async def _view_and_beat(major_id, dwell):
+        vid = (
+            await client.post(
+                f"{PUB}/landing/{code}/program-view",
+                json={"session_token": token, "major_program_id": major_id},
+                headers=_H,
+            )
+        ).json()["program_view_id"]
+        # nới wall-clock: đẩy viewed_at về quá khứ để dwell không bị clamp
+        async with AsyncSessionLocal() as s:
+            await s.execute(
+                text(
+                    "UPDATE sms_program_view SET viewed_at = now() - "
+                    "interval '1 hour' WHERE id=:i"
+                ),
+                {"i": vid},
+            )
+            await s.commit()
+        await client.post(
+            f"{PUB}/landing/{code}/heartbeat",
+            json={"session_token": token, "program_view_id": vid,
+                  "dwell_seconds": dwell},
+            headers=_H,
+        )
+        return vid
+
+    await _view_and_beat(1, 30)        # ngành 1: 30s
+    await _view_and_beat(major2, 120)  # ngành 2: 120s (nóng hơn)
+
+    rep = await client.get(f"{API}/reports/program-interest", headers=h)
+    assert rep.status_code == 200, rep.text
+    body = rep.json()
+    assert body["view_count_total"] == 2
+    assert body["distinct_contacts_total"] == 1
+    assert body["total_dwell_seconds"] == 150
+    items = body["items"]
+    assert len(items) == 2
+    # rank tổng dwell desc → ngành 2 đứng đầu
+    assert items[0]["major_program_id"] == major2
+    assert items[0]["total_dwell_seconds"] == 120
+    assert items[1]["major_program_id"] == 1
+    # filter theo major_program_id
+    rep1 = await client.get(
+        f"{API}/reports/program-interest?major_program_id=1", headers=h
+    )
+    assert rep1.json()["view_count_total"] == 1
+    assert len(rep1.json()["items"]) == 1
+
+
+# ---------------------------------------------------------------------
+# 404 / auth
+# ---------------------------------------------------------------------
+async def test_session_invalid_code_404(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    # code sai format
+    assert (
+        await client.post(f"{PUB}/landing/xx/session", headers=_H)
+    ).status_code == 404
+    # đúng format base62×9 nhưng không khớp recipient
+    assert (
+        await client.post(f"{PUB}/landing/ABCdef123/session", headers=_H)
+    ).status_code == 404
+
+
+async def test_program_view_invalid_token_and_program_404(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    h = admin_token_headers
+    _cid, code, _contact = await _setup(client, h)
+    token = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    ).json()["session_token"]
+    # session token sai → 404
+    bad = await client.post(
+        f"{PUB}/landing/{code}/program-view",
+        json={"session_token": "wrong-token-xxxxxxxx", "major_program_id": 1},
+        headers=_H,
+    )
+    assert bad.status_code == 404
+    # ngành không tồn tại → 404
+    nope = await client.post(
+        f"{PUB}/landing/{code}/program-view",
+        json={"session_token": token, "major_program_id": 999999},
+        headers=_H,
+    )
+    assert nope.status_code == 404
+
+
+async def test_engagement_admin_endpoints_require_auth(client: AsyncClient):
+    assert (
+        await client.get(f"{API}/reports/program-interest")
+    ).status_code == 401
+    assert (
+        await client.get(f"{API}/contacts/1/interests")
+    ).status_code == 401

--- a/Backend_FastAPI/tests/integration/test_sms_engagement.py
+++ b/Backend_FastAPI/tests/integration/test_sms_engagement.py
@@ -279,7 +279,7 @@ async def test_bot_session_excluded_from_interest(
         headers=bot_ua,
     )
     assert hb.status_code == 200
-    # dwell VẪN ghi (audit) nhưng interest KHÔNG được tạo cho bot
+    # dwell bot VẪN ghi (audit) nhưng interest KHÔNG được tạo cho bot
     async with AsyncSessionLocal() as s:
         is_bot = (
             await s.execute(
@@ -301,6 +301,41 @@ async def test_bot_session_excluded_from_interest(
     rep = await client.get(f"{API}/reports/program-interest", headers=h)
     assert rep.status_code == 200
     assert rep.json()["view_count_total"] == 0
+
+    # ⭐ CHỐNG NHIỄM BOT (finding /review #1): giờ 1 phiên NGƯỜI THẬT của CÙNG
+    # contact xem CÙNG ngành 1 → recompute interest KHÔNG được cộng dwell bot.
+    htoken = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    ).json()["session_token"]
+    hview = (
+        await client.post(
+            f"{PUB}/landing/{code}/program-view",
+            json={"session_token": htoken, "major_program_id": 1},
+            headers=_H,
+        )
+    ).json()["program_view_id"]
+    assert (
+        await client.post(
+            f"{PUB}/landing/{code}/heartbeat",
+            json={"session_token": htoken, "program_view_id": hview,
+                  "dwell_seconds": 15},
+            headers=_H,
+        )
+    ).status_code == 200
+    async with AsyncSessionLocal() as s:
+        row = (
+            await s.execute(
+                text(
+                    "SELECT view_count, total_dwell_seconds FROM "
+                    "sms_contact_program_interest WHERE contact_id=:c "
+                    "AND major_program_id=1"
+                ),
+                {"c": contact_id},
+            )
+        ).first()
+    # CHỈ view người thật (15s) — KHÔNG có 20s của bot (nếu nhiễm sẽ =2 view/35s)
+    assert row is not None
+    assert row[0] == 1 and row[1] == 15
 
 
 # ---------------------------------------------------------------------

--- a/Backend_FastAPI/tests/integration/test_sms_engagement.py
+++ b/Backend_FastAPI/tests/integration/test_sms_engagement.py
@@ -440,6 +440,168 @@ async def test_program_view_invalid_token_and_program_404(
     assert nope.status_code == 404
 
 
+async def test_report_deleted_programs_not_merged(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """/review #1: 2 ngành ĐÃ XOÁ (major_program_id NULL) KHÔNG bị gộp về 1
+    hàng — group theo snapshot khi id NULL, giữ số liệu tách biệt."""
+    h = admin_token_headers
+    cid, code, _contact = await _setup(client, h)
+    major2 = await _seed_second_major()
+    token = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    ).json()["session_token"]
+    ids = []
+    for mid, dwell in ((1, 30), (major2, 90)):
+        vid = (
+            await client.post(
+                f"{PUB}/landing/{code}/program-view",
+                json={"session_token": token, "major_program_id": mid},
+                headers=_H,
+            )
+        ).json()["program_view_id"]
+        async with AsyncSessionLocal() as s:
+            await s.execute(
+                text(
+                    "UPDATE sms_program_view SET viewed_at = now() - "
+                    "interval '1 hour' WHERE id=:i"
+                ),
+                {"i": vid},
+            )
+            await s.commit()
+        await client.post(
+            f"{PUB}/landing/{code}/heartbeat",
+            json={"session_token": token, "program_view_id": vid,
+                  "dwell_seconds": dwell},
+            headers=_H,
+        )
+        ids.append(vid)
+    # Mô phỏng CẢ 2 ngành bị xoá cứng → major_program_id SET NULL (giữ snapshot).
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text(
+                "UPDATE sms_program_view SET major_program_id = NULL "
+                "WHERE id = ANY(:ids)"
+            ),
+            {"ids": ids},
+        )
+        await s.commit()
+    rep = await client.get(f"{API}/reports/program-interest", headers=h)
+    assert rep.status_code == 200, rep.text
+    items = rep.json()["items"]
+    # KHÔNG gộp: vẫn 2 hàng (tách theo snapshot), tổng dwell không đổi
+    assert len(items) == 2
+    assert all(it["major_program_id"] is None for it in items)
+    names = {it["program_name"] for it in items}
+    assert "Test Major 1" in names and "Test Major 2" in names
+    assert rep.json()["total_dwell_seconds"] == 120
+
+
+async def test_heartbeat_rejects_cross_session_view(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """/review #2a: heartbeat với view_id của PHIÊN KHÁC → 404 (guard
+    get_program_view scope theo session, chống đẩy dwell vào view phiên khác)."""
+    h = admin_token_headers
+    _cid, code, _contact = await _setup(client, h)
+    t1 = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    ).json()["session_token"]
+    t2 = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    ).json()["session_token"]
+    v1 = (
+        await client.post(
+            f"{PUB}/landing/{code}/program-view",
+            json={"session_token": t1, "major_program_id": 1},
+            headers=_H,
+        )
+    ).json()["program_view_id"]
+    # phiên 2 gửi heartbeat cho view của phiên 1 → 404
+    bad = await client.post(
+        f"{PUB}/landing/{code}/heartbeat",
+        json={"session_token": t2, "program_view_id": v1, "dwell_seconds": 10},
+        headers=_H,
+    )
+    assert bad.status_code == 404
+
+
+async def test_heartbeat_dwell_monotonic_non_decrease(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """/review #2b: heartbeat thấp hơn sau đó KHÔNG làm tụt dwell (max clamp)."""
+    h = admin_token_headers
+    _cid, code, _contact = await _setup(client, h)
+    token = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    ).json()["session_token"]
+    vid = (
+        await client.post(
+            f"{PUB}/landing/{code}/program-view",
+            json={"session_token": token, "major_program_id": 1},
+            headers=_H,
+        )
+    ).json()["program_view_id"]
+    r1 = await client.post(
+        f"{PUB}/landing/{code}/heartbeat",
+        json={"session_token": token, "program_view_id": vid,
+              "dwell_seconds": 25},
+        headers=_H,
+    )
+    assert r1.json()["dwell_seconds"] == 25
+    # heartbeat trễ/trùng báo dwell THẤP hơn → giữ 25 (không tụt về 5)
+    r2 = await client.post(
+        f"{PUB}/landing/{code}/heartbeat",
+        json={"session_token": token, "program_view_id": vid,
+              "dwell_seconds": 5},
+        headers=_H,
+    )
+    assert r2.json()["dwell_seconds"] == 25
+
+
+async def test_session_bearer_records_after_link_expiry(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """/review #3 (codify design): phiên tạo khi link CÒN hạn vẫn ghi dwell kể
+    cả sau khi link hết hạn giữa chừng — session là bearer sống-hết-phiên (cắt
+    giữa chừng sẽ hỏng số liệu người thật đang đọc). Expiry chỉ gate TẠO phiên."""
+    h = admin_token_headers
+    cid, code, contact_id = await _setup(client, h)
+    token = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    ).json()["session_token"]
+    # link hết hạn SAU khi phiên đã mở
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text(
+                "UPDATE sms_campaign SET link_expires_at = now() - "
+                "interval '1 day' WHERE id=:c"
+            ),
+            {"c": cid},
+        )
+        await s.commit()
+    # TẠO phiên mới giờ phải 404 (expiry gate lúc tạo)
+    assert (
+        await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    ).status_code == 404
+    # nhưng phiên CŨ vẫn ghi được program-view + heartbeat (bearer)
+    vid = (
+        await client.post(
+            f"{PUB}/landing/{code}/program-view",
+            json={"session_token": token, "major_program_id": 1},
+            headers=_H,
+        )
+    ).json()["program_view_id"]
+    hb = await client.post(
+        f"{PUB}/landing/{code}/heartbeat",
+        json={"session_token": token, "program_view_id": vid,
+              "dwell_seconds": 10},
+        headers=_H,
+    )
+    assert hb.status_code == 200
+    assert hb.json()["dwell_seconds"] == 10
+
+
 async def test_engagement_admin_endpoints_require_auth(client: AsyncClient):
     assert (
         await client.get(f"{API}/reports/program-interest")

--- a/Documents/SMS_HUONG_DAN_VAN_HANH_CHIEN_DICH.md
+++ b/Documents/SMS_HUONG_DAN_VAN_HANH_CHIEN_DICH.md
@@ -1,0 +1,90 @@
+# Hướng dẫn vận hành — Chạy chiến dịch SMS Marketing (Phase 1)
+
+> Dành cho người vận hành (admin). Phase 1 = **quảng cáo qua file Excel bàn giao nhà mạng** —
+> hệ thống **KHÔNG tự gửi SMS**. QLTS sinh file danh sách + nội dung đã chuẩn hoá, bạn
+> **tải file rồi upload thủ công lên cổng nhà mạng** (Viettel/VinaPhone/MobiFone…).
+
+Truy cập: **Admin → SMS** (menu bên trái, biểu tượng máy bay giấy). URL prod: `https://qlts.tnpc.edu.vn/admin/sms/...`
+
+---
+
+## Toàn cảnh luồng (8 bước)
+
+```
+1. Liên hệ + đồng ý (consent)  →  2. Nhóm liên hệ  →  3. Tạo chiến dịch
+   →  4. Gắn nhóm  →  5. Build (chốt danh sách + kiểm tra)  →  6. 3 Xác nhận
+   →  7. Export Excel (1 file/nhà mạng)  →  8. Tải file → upload nhà mạng → "Đã bàn giao"
+```
+
+---
+
+## Bước 1 — Liên hệ + Đồng ý (bắt buộc)
+`SMS → Liên hệ SMS → tab "Liên hệ"`
+- **Tạo liên hệ** (tên + số điện thoại). Số nhập dạng `09xxxxxxxx`.
+- **Ghi nhận đồng ý (consent)**: mở liên hệ → thêm sự kiện consent **"Đồng ý"** kèm căn cứ (form/phiếu/ghi âm) + tham chiếu bằng chứng.
+  - ⚠️ **Liên hệ CHƯA "Đã đồng ý" sẽ bị LOẠI khỏi danh sách gửi** (theo NĐ91). Chỉ số có consent granted mới được export.
+- Nhập số lượng lớn: dùng **Import** (CSV/xlsx) ở tab Nhóm.
+
+## Bước 2 — Nhóm liên hệ
+`SMS → Liên hệ SMS → tab "Nhóm liên hệ"`
+- **Tạo nhóm** (đặt tên rõ, vd "Phụ huynh K10 2026").
+- Đưa liên hệ vào nhóm: mở nhóm (icon người) → **Import** file danh sách.
+  - ⚠️ Ô "Tìm tên/số" trong dialog nhóm = **lọc thành viên đã có**, KHÔNG phải thêm-lẻ. Thêm liên hệ vào nhóm hiện qua **Import**.
+
+## Bước 3 — Tạo chiến dịch
+`SMS → Chiến dịch SMS → "Tạo chiến dịch"`
+- **Tên chiến dịch** (bắt buộc). Mã tự sinh.
+- **Nội dung tin** (bắt buộc): dùng biến `{full_name}` (tên) + `{link}` (link rút gọn có đo click).
+  - Ví dụ: `Chao {full_name}, xem tuyen sinh 2026: {link}`
+  - ⚠️ **Thiếu `{link}` → chiến dịch KHÔNG đo được click** (vẫn gửi được).
+  - 💡 Hệ thống tự thêm `[QC]` đầu tin + hướng dẫn từ chối cuối tin — **không cần tự gõ**.
+- **Trang đích**: "Trang đích QLTS" (điền Tiêu đề + Nội dung → hiển thị ở trang `/lp` khi khách bấm link) hoặc "Liên kết ngoài" (nhập URL trong allowlist).
+
+## Bước 4 — Gắn nhóm
+Trong trang chiến dịch → mục **Nhóm liên hệ** → chọn nhóm → **Gắn**. Cần ≥1 nhóm.
+
+## Bước 5 — Build (chốt danh sách + preflight)
+Bấm **Build**. Hệ thống chốt danh sách gửi + kiểm tra, hiện:
+- **Tổng người nhận** / **Gửi được** / **Bản dựng #** / **Đo click**.
+- **Loại theo lý do**: chưa đồng ý / đã từ chối / trong DNC / vượt tần suất / **tin vượt 1 đoạn** / thiếu dữ liệu.
+- **Phân bố nhà mạng** + **Xem trước tin cuối** (kiểm tra thực tế tin trông thế nào).
+- ⚠️ **BẪY thường gặp — "tin vượt 1 đoạn"**: tên có **dấu tiếng Việt** (ễ, ộ…) → mã hoá UCS2 (giới hạn **70 ký tự/đoạn**). Tin dài → vượt 1 đoạn → **bị chặn export**.
+  - Cách xử lý: **rút gọn nội dung tin**, hoặc chấp nhận tên không dấu, hoặc rút ngắn danh sách. Tin không dấu (GSM-7) cho **160 ký tự/đoạn** → dễ vừa 1 đoạn hơn.
+- Đổi nhóm/nội dung sau khi build → **Build lại** (số liệu cũ sẽ được đánh dấu stale).
+
+## Bước 6 — 3 Xác nhận trước export (bắt buộc)
+Mục **Xác nhận trước export**. Phải đủ **3/3**, mỗi cái nhập tham chiếu bằng chứng rồi bấm **Xác nhận**:
+1. **Đã có đồng ý (consent)** — đã kiểm danh sách có consent hợp lệ.
+2. **Đã lọc danh sách chặn (DNC)** — đã đối chiếu danh sách không-gọi/không-gửi.
+3. **Kênh từ chối hoạt động** — kênh opt-out (hotline **0906513555**) đang hoạt động.
+- ⚠️ **Build lại sẽ VÔ HIỆU cả 3 xác nhận** → phải xác nhận lại cho bản dựng mới.
+
+## Bước 7 — Export Excel
+Mục **Export & bàn giao** → **Export Excel**. Điều kiện: **đủ 3/3 xác nhận + 0 tin-vượt-đoạn + ≥1 gửi được**.
+- Sinh **1 file/nhà mạng** (Viettel, VinaPhone…). Mỗi file: cột A = số `84xxx`, cột B = nội dung tin cuối.
+- File có **hạn** (14 ngày) — tải + dùng trước khi hết hạn.
+
+## Bước 8 — Tải file → Gửi nhà mạng → Đánh dấu bàn giao
+- **Tải** từng file → **upload lên cổng nhà mạng tương ứng** (thao tác NGOÀI QLTS, theo quy trình nhà mạng).
+- Sau khi đã upload xong 1 nhà mạng → bấm **"Đã bàn giao"** cho nhà mạng đó.
+  - ⚠️ Neo người nhận (chặn build lại) + tính tần suất gửi. **Không hoàn tác.**
+  - Khi **mọi nhà mạng đã bàn giao** → chiến dịch tự chuyển **"Đã đóng"**.
+
+---
+
+## Sau chiến dịch
+- **Đo click / CTR**: `SMS → Báo cáo SMS` (theo ngày/tháng/năm + dashboard từng chiến dịch). Chỉ có số khi tin dùng `{link}`.
+- **Khách từ chối**: bấm link → trang `/lp/{code}` có nút "Huỷ nhận tin" → tự vào danh sách opt-out. Xem/thêm tay ở `SMS → Từ chối nhận tin`.
+- Số đã opt-out sẽ **tự bị loại** ở các build sau.
+
+## Nguyên tắc tuân thủ (NĐ91)
+- Chỉ gửi cho số **đã đồng ý** (consent granted).
+- Tin luôn có `[QC]` + hướng dẫn từ chối (tự động).
+- Kênh từ chối (hotline) phải **thật + hoạt động**.
+- Tôn trọng số đã từ chối (opt-out/DNC) — hệ thống tự loại.
+
+## Khi gặp lỗi
+- **"Chưa export được: còn thiếu N/3 xác nhận"** → làm đủ Bước 6.
+- **"tin vượt 1 đoạn — export bị chặn"** → rút gọn nội dung (Bước 5).
+- **Không có người gửi được** → kiểm consent (Bước 1) / nhóm rỗng / tất cả bị opt-out.
+- Lỗi mạng thoáng qua khi bấm → thử lại sau vài giây.

--- a/Documents/SMS_PHASE2_PR7_SCOPE.md
+++ b/Documents/SMS_PHASE2_PR7_SCOPE.md
@@ -1,0 +1,73 @@
+# SCOPE — PR-7 / SMS Phase 2: Deep Engagement + Đo quan tâm ngành
+
+> Nguồn thiết kế: `SMS_MARKETING_MODULE_DESIGN.md` §16 (đã chốt đầy đủ, kể cả công thức interest_score §16.10-P2-Q2 / §18.F). Đây là bản scope thực thi.
+
+## 0. Mục tiêu (khớp ý tưởng owner)
+Gắn link vào SMS → khách vào landing → **đo hành động + ngành thực sự quan tâm** → biết "ai quan tâm ngành nào" → officer tư vấn cá nhân + admin thống kê ngành hot. (Không chỉ "ai bấm link" như Phase 1.)
+
+## 1. Đã có (Phase 1) vs sẽ thêm (Phase 2)
+| | Phase 1 (đã ship) | Phase 2 (PR-7 này) |
+|---|---|---|
+| Landing | 1 trang: headline/body/1-CTA/opt-out | **2 tầng**: danh mục ngành → **trang từng ngành** |
+| Đo | click link (CTR) | **dwell (thời gian xem) từng ngành** + lượt xem |
+| Kết quả | ai bấm link | **hồ sơ "ngành quan tâm" per contact** (interest_score) |
+| Officer | — | **link tư vấn 1-1** + **tab "Quan tâm ngành" ở lead** |
+| Report | CTR ngày/tháng/năm | + **ngành nóng** theo campaign/nhóm/thời gian |
+
+## 2. Cách đo (§16.2) — KHÔNG cần ML, KHÔNG IntersectionObserver
+Mỗi ngành = **1 URL riêng** `/lp/{code}/nganh/{program_id}` → đo **time-on-page chuẩn qua heartbeat**:
+- Vào `/lp/{code}` → tạo **session** (bearer token, lưu hash).
+- Click ngành → sang trang ngành → ghi **program-view** + bắt đầu dwell.
+- Heartbeat định kỳ (JS) cộng `dwell_seconds` cho trang đang xem; rời trang → chốt.
+- Bot không chạy JS → không heartbeat → tự loại.
+- **Tín hiệu chính = tổng dwell/ngành** (click chỉ phụ).
+
+## 3. Data model (§16.4) — 4 bảng
+1. **`sms_landing_session`** — 1 lượt xem landing (contact_id, source campaign/consult, session_token_hash UNIQUE, started/heartbeat/ended, active_seconds, ip_hash, ua, is_bot).
+2. **`sms_program_view`** — 1 lượt xem trang ngành (session_id, contact_id, major_program_id, program_name_snapshot, dwell_seconds, sequence_no).
+3. **`sms_contact_program_interest`** — hồ sơ tổng hợp (UNIQUE(contact_id, major_program_id), view_count, total_dwell_seconds, first/last_interest_at, interest_score). ← **giá trị nghiệp vụ chính**.
+4. **`sms_consult_link`** — link tư vấn officer↔lead (lead_id, contact_id, created_by officer, token_hash partial-UNIQUE, click counters, expires_at).
+
+**Khóa thống nhất = `contact_id`**: campaign recipient & consult link đều resolve về 1 contact → interest gộp theo contact → lead xem qua match phone.
+
+## 4. interest_score (§16.10-P2-Q2, ĐÃ CHỐT — không cần quyết lại)
+`interest_score = normalize( Σ_view dwell_factor × recency_weight )`
+- `dwell_factor(s) = min(s/DWELL_CAP, 1)` · `recency_weight(t)=exp(-Δdays/HALF_LIFE)` · `normalize(x)=x/(x+K)`
+- Config (mặc định): `SMS_INTEREST_DWELL_CAP=180s` · `_HALF_LIFE=14 ngày` · `_K=tune`. Frequency tự cộng dồn, recency ưu tiên gần, dwell = cường độ (capped chống gian lận).
+
+## 5. API (§16.7)
+- Public: `GET /landing/{code}` (đọc, +danh mục ngành, no session) · `POST /landing/{code}/session` (tạo session, trả raw token 1 lần) · `POST /program-view` · `POST /heartbeat`.
+- Officer: `POST /leads/{id}/consult-link` (scope IDOR) · `GET /leads/{id}/interests`.
+- Admin: `GET /reports/program-interest` · `GET /contacts/{id}/interests`.
+- `/r/{code}` resolve mở rộng: tra recipient trước, không thấy → consult_link.
+
+## 6. Lộ trình PR con (§16.8) + đề xuất thứ tự
+| PR con | Nội dung | Ghi chú |
+|---|---|---|
+| **P2-1 Schema** | 4 bảng + migration + config secret `SMS_SESSION_TOKEN_HASH_SECRET`+dwell config | nền |
+| **P2-2 Deep tracking BE** | landing resolve mở rộng + session/program-view/heartbeat + aggregate interest_score + report program-interest | **lõi đo lường** |
+| **P2-4a FE tracking** | landing 2 tầng (`/lp/{code}` danh mục + `/lp/{code}/nganh/{id}` heartbeat JS) + admin report ngành | **thấy được kết quả** |
+| **P2-3 Consult BE** | officer consult-link (IDOR) + `/leads/{id}/interests` + Casbin officer | add-on tư vấn |
+| **P2-4b FE consult** | tab "Quan tâm ngành" ở lead detail + nút officer "Tạo link tư vấn" | add-on |
+
+→ **MVP đo-quan-tâm** = P2-1 + P2-2 + P2-4a (bỏ consult trước cũng chạy được thống kê ngành). Consult (P2-3/P2-4b) làm sau nếu cần.
+
+## 7. Tái dùng (§16.3, §18.E) — KHÔNG xây mới
+- Ngành: `MajorProgram`/`ProgramOffering` (đã có), catalog `GET /api/public/admissions/programs`.
+- Token/hash/Fernet, `ip_hash`, rate-limit, `/r/{code}` resolve, landing §19 (giữ header/opt-out/footer), Celery beat (dọn), KPI date-bucket (report).
+
+## 8. ⚠️ RÀO PHÁP LÝ (§16.9) — GATE trước khi BẬT prod (không phải code)
+Deep tracking đích danh = **mục đích xử lý dữ liệu RIÊNG**, KHÔNG suy diễn từ consent marketing SMS. Trước khi bật prod cần (owner/pháp lý lo):
+1. **Disclosure/consent riêng** cho việc theo dõi hành vi (thông báo trên landing + cơ sở).
+2. **Chính sách retention** rõ ràng (P2-Q3).
+3. Cập nhật **hồ sơ đánh giá tác động** (DPIA).
+→ Tôi **code được feature** ngay; nhưng **bật dùng thật** phải qua bước compliance này.
+
+## 9. Quyết định cần owner chốt
+- **D1 — Phạm vi PR-7 lần này:** (a) **MVP đo-quan-tâm** (P2-1+P2-2+P2-4a, chưa consult) — khuyến nghị; hay (b) **đầy đủ §16** (thêm consult officer + tab lead).
+- **D2 — P2-Q1 (consult link):** officer luôn thấy **danh mục đầy đủ** (đề xuất MVP) hay chọn ngành riêng? (chỉ cần nếu làm consult)
+- **D3 — P2-Q3 (retention):** giữ **aggregate profile dài hạn** + xoá **event chi tiết sau N tháng** — N = ? (đề xuất 12 tháng)
+- **D4 — Compliance §16.9:** ai lo disclosure/consent + DPIA? (owner) — code không chờ, nhưng bật prod thì chờ.
+
+---
+**Đề xuất của tôi:** làm **D1=(a) MVP đo-quan-tâm** trước (P2-1→P2-2→P2-4a) — đúng trọng tâm ý owner ("đo quan tâm ngành"), gọn, thấy kết quả nhanh; consult officer để đợt sau. Bắt đầu bằng **P2-1 (Schema)**.


### PR DESCRIPTION
## Tóm tắt
SMS Marketing **Phase 2 (§16)** — backend đo "ngành thực sự quan tâm": khách vào landing 2 tầng → đo **dwell (thời gian xem) từng trang ngành** qua heartbeat → tổng hợp **interest per contact** + report **ngành nóng**. Gộp 2 phần phụ thuộc nhau:

- **P2-1 Schema** (`97a90834`): 3 bảng (`sms_landing_session` / `sms_program_view` / `sms_contact_program_interest`) + migration viết tay `smsp2eng20260702001` + config `SMS_SESSION_TOKEN_HASH_SECRET` / `SMS_INTEREST_DWELL_CAP/_HALF_LIFE/_K`.
- **P2-2 Deep tracking BE** (`e85aed21` + fix `a5156430`): session/program-view/heartbeat + aggregate interest_score + report.

MVP đo-quan-tâm (chưa consult officer — P2-3 làm sau).

## Endpoint
**Public** (`/api/public/sms`, rate-limit key `get_client_ip`):
- `GET /landing/{code}` — mở rộng **+danh mục ngành** active (no session — tránh crawler tạo phiên rác).
- `POST /landing/{code}/session` — sinh `session_token` raw **trả 1 lần** (chỉ lưu HMAC hash, secret riêng).
- `POST /landing/{code}/program-view` — mở lượt xem trang ngành (snapshot tên).
- `POST /landing/{code}/heartbeat` — cộng dwell (**clamp wall-clock + grace 30s, đơn điệu**) → cập nhật interest.

**Admin** (`/api/sms`, `require_admin`):
- `GET /reports/program-interest` — ngành nóng theo campaign/nhóm/thời gian (rank tổng dwell desc, **loại phiên bot**, tên ngành hiện tại).
- `GET /contacts/{id}/interests` — hồ sơ sở thích 1 contact.

## Thiết kế
- `interest_score` §18.F (đã chốt P2-Q2): `normalize(Σ dwell_factor × recency_weight)`, config-driven. Upsert **atomic** `pg on_conflict`, recompute từ `program_view` (nguồn sự thật → tự lành khi heartbeat đua).
- Bot (UA/prefetch) **vẫn tạo phiên** (không lộ phát hiện) nhưng **bị loại khỏi interest + report** (JOIN session filter cả 2 mặt).
- Khóa thống nhất = `contact_id` (campaign recipient resolve về contact).

## /code-review max (4 finder hội tụ) — đã vá `a5156430`
- 🔴 **Bot contamination**: `views_for_interest` giờ lọc `is_suspected_bot=False` (trước đó dwell bot lẫn vào interest khi có phiên người thật cùng ngành) + test bot nâng cấp ca bot+người-thật-trộn.
- 🟠 `active_seconds` **derive** Σ dwell (chống lost-update 2-tab).
- 🟠 Report tên ngành **hiện tại** (LEFT JOIN, hết stale khi đổi tên).
- Cleanup: fold `group_id` vào `_report_conds` · build `aware_views` 1 lần · `_hmac_sha256_hex` helper.
- Defer (low/tradeoff): unbounded catalog + `viewed_at` index (bounded/admin) · `next_sequence_no` race (chỉ thứ tự) · debounce heartbeat (self-healing chủ đích).

## Test
- **19 integration PASS** (8 engagement: flow/clamp/bot-loại/ranking/404/auth + 11 regression `sms_tracking`) · `sms_schema` 8 PASS · **flake8 sạch**.
- Import + score sanity (0.1562) khớp tay tính.

## Deploy
- ✅ **Migration `smsp2eng20260702001`** (3 bảng) — KHÔNG code-only.
- Config Phase 2 có default dev; prod đặt `SMS_SESSION_TOKEN_HASH_SECRET` thật ≥32.
- ⚠️ **§16.9 GATE pháp lý**: deep tracking đích danh cần disclosure/consent riêng + retention + DPIA **trước khi bật prod** (owner lo; code không chờ).
- Còn **P2-4a FE** (landing 2 tầng + heartbeat JS + report ngành) — đợt sau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)