### PR TITLE
feat(sms): PR-7 P2-4a FE — landing 2 tầng + heartbeat dwell + report ngành

### DIFF
--- a/frontend/src/app/lp/[code]/nganh/[programId]/page.tsx
+++ b/frontend/src/app/lp/[code]/nganh/[programId]/page.tsx
@@ -1,0 +1,46 @@
+import { Suspense } from "react"
+import { notFound } from "next/navigation"
+import type { Metadata } from "next"
+
+import { SmsProgramClient } from "@/components/sms/SmsProgramClient"
+
+// Trang ngành công khai mang bearer code (§16.1) — KHÔNG cho index.
+export const metadata: Metadata = {
+  title: "Thông tin ngành tuyển sinh",
+  robots: { index: false, follow: false },
+}
+
+export function generateStaticParams() {
+  return [{ code: "__placeholder__", programId: "0" }]
+}
+
+export default async function SmsProgramPage({
+  params,
+}: {
+  params: Promise<{ code: string; programId: string }>
+}) {
+  const { code, programId } = await params
+  const majorProgramId = Number(programId)
+
+  if (code === "__placeholder__" || !Number.isInteger(majorProgramId) || majorProgramId < 1) {
+    notFound()
+  }
+
+  return (
+    <div className="bg-muted/40 flex min-h-screen items-start justify-center p-4">
+      <Suspense
+        fallback={
+          <div
+            role="status"
+            aria-live="polite"
+            className="text-muted-foreground mt-16"
+          >
+            Đang tải…
+          </div>
+        }
+      >
+        <SmsProgramClient code={code} majorProgramId={majorProgramId} />
+      </Suspense>
+    </div>
+  )
+}

--- a/frontend/src/components/sms/SmsLandingClient.tsx
+++ b/frontend/src/components/sms/SmsLandingClient.tsx
@@ -2,9 +2,17 @@
 "use client"
 
 import { useState } from "react"
+import Link from "next/link"
 import { useMutation, useQuery } from "@tanstack/react-query"
-import { BellOff, CheckCircle2, Loader2 } from "lucide-react"
+import {
+  BellOff,
+  CheckCircle2,
+  ChevronRight,
+  GraduationCap,
+  Loader2,
+} from "lucide-react"
 
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   AlertDialog,
@@ -94,6 +102,33 @@ export function SmsLandingClient({ code }: { code: string }) {
         <a href={data.cta_url} rel="noreferrer" target="_blank">
           <Button className="w-full">{data.cta_label}</Button>
         </a>
+      )}
+
+      {data.programs.length > 0 && (
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold">Chọn ngành bạn quan tâm</h2>
+          <ul className="space-y-2">
+            {data.programs.map((p) => (
+              <li key={p.id}>
+                <Link
+                  href={`/lp/${encodeURIComponent(code)}/nganh/${p.id}`}
+                  className="hover:bg-accent focus-visible:ring-ring flex items-center gap-3 rounded border p-3 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                >
+                  <GraduationCap className="text-primary h-5 w-5 shrink-0" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">
+                      {p.name}
+                    </span>
+                    <Badge variant="secondary" className="mt-1">
+                      {p.degree_level}
+                    </Badge>
+                  </span>
+                  <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
       )}
 
       <hr className="border-border" />

--- a/frontend/src/components/sms/SmsProgramClient.tsx
+++ b/frontend/src/components/sms/SmsProgramClient.tsx
@@ -61,11 +61,11 @@ export function SmsProgramClient({
         <h1 className="text-lg font-semibold">
           Không tìm thấy ngành hoặc liên kết đã hết hạn
         </h1>
-        <Link href={`/lp/${encodeURIComponent(code)}`}>
-          <Button variant="outline" className="w-full">
+        <Button asChild variant="outline" className="w-full">
+          <Link href={`/lp/${encodeURIComponent(code)}`}>
             <ArrowLeft className="mr-2 h-4 w-4" /> Về danh mục ngành
-          </Button>
-        </Link>
+          </Link>
+        </Button>
       </Shell>
     )
   }
@@ -97,11 +97,11 @@ export function SmsProgramClient({
 
       <hr className="border-border" />
 
-      <Link href={`/lp/${encodeURIComponent(code)}`}>
-        <Button variant="outline" className="w-full">
+      <Button asChild variant="outline" className="w-full">
+        <Link href={`/lp/${encodeURIComponent(code)}`}>
           <ArrowLeft className="mr-2 h-4 w-4" /> Xem ngành khác
-        </Button>
-      </Link>
+        </Link>
+      </Button>
 
       <p className="text-muted-foreground text-center text-xs">
         {data.consent_notice}

--- a/frontend/src/components/sms/SmsProgramClient.tsx
+++ b/frontend/src/components/sms/SmsProgramClient.tsx
@@ -1,0 +1,110 @@
+// src/components/sms/SmsProgramClient.tsx
+"use client"
+
+import Link from "next/link"
+import { useQuery } from "@tanstack/react-query"
+import { ArrowLeft, GraduationCap, Loader2 } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { getSmsLanding } from "@/lib/api/sms"
+import { useSmsDwellTracker } from "@/hooks/useSmsDwellTracker"
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-card mt-8 w-full max-w-md space-y-4 rounded border p-6 shadow-md md:p-8">
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Trang 1 ngành (§16.1) — nơi ĐO CHÍNH dwell. Tái dùng landing response để lấy
+ * tên trường + thông tin ngành (id/tên/mã/trình độ), KHÔNG gọi thêm endpoint.
+ * `useSmsDwellTracker` tự mở session/program-view + heartbeat khi xem trang.
+ * Thin-client: chỉ render + gửi tín hiệu, KHÔNG suy luận nghiệp vụ.
+ */
+export function SmsProgramClient({
+  code,
+  majorProgramId,
+}: {
+  code: string
+  majorProgramId: number
+}) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["sms-landing", code],
+    queryFn: () => getSmsLanding(code),
+    retry: false,
+  })
+
+  const program = data?.programs.find((p) => p.id === majorProgramId)
+
+  // Chỉ bắt đầu đo khi ngành hợp lệ (có trong danh mục landing).
+  useSmsDwellTracker(code, program ? majorProgramId : 0)
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="text-muted-foreground mt-16 flex items-center gap-2"
+      >
+        <Loader2 className="h-4 w-4 animate-spin" /> Đang tải…
+      </div>
+    )
+  }
+
+  if (isError || !data || !program) {
+    return (
+      <Shell>
+        <h1 className="text-lg font-semibold">
+          Không tìm thấy ngành hoặc liên kết đã hết hạn
+        </h1>
+        <Link href={`/lp/${encodeURIComponent(code)}`}>
+          <Button variant="outline" className="w-full">
+            <ArrowLeft className="mr-2 h-4 w-4" /> Về danh mục ngành
+          </Button>
+        </Link>
+      </Shell>
+    )
+  }
+
+  return (
+    <Shell>
+      <header className="text-center">
+        <p className="text-primary text-sm font-semibold">{data.school_name}</p>
+      </header>
+
+      <div className="flex items-start gap-3">
+        <GraduationCap className="text-primary mt-1 h-6 w-6 shrink-0" />
+        <div className="space-y-1">
+          <h1 className="text-xl font-bold">{program.name}</h1>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">{program.degree_level}</Badge>
+            <span className="text-muted-foreground text-xs">
+              Mã ngành: {program.code}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <p className="text-muted-foreground text-sm leading-relaxed">
+        Bạn đang xem thông tin ngành <strong>{program.name}</strong>. Để được tư
+        vấn chi tiết về chương trình, học phí và hồ sơ, vui lòng liên hệ{" "}
+        {data.school_name} hoặc để lại thông tin đăng ký.
+      </p>
+
+      <hr className="border-border" />
+
+      <Link href={`/lp/${encodeURIComponent(code)}`}>
+        <Button variant="outline" className="w-full">
+          <ArrowLeft className="mr-2 h-4 w-4" /> Xem ngành khác
+        </Button>
+      </Link>
+
+      <p className="text-muted-foreground text-center text-xs">
+        {data.consent_notice}
+      </p>
+    </Shell>
+  )
+}

--- a/frontend/src/components/sms/SmsProgramClient.tsx
+++ b/frontend/src/components/sms/SmsProgramClient.tsx
@@ -39,8 +39,9 @@ export function SmsProgramClient({
 
   const program = data?.programs.find((p) => p.id === majorProgramId)
 
-  // Chỉ bắt đầu đo khi ngành hợp lệ (có trong danh mục landing).
-  useSmsDwellTracker(code, program ? majorProgramId : 0)
+  // Chỉ đo khi ngành ĐÃ resolve hợp lệ (enabled) — cold/deep-load data chưa
+  // về → no-op, tránh session/program-view rác (major_program_id=0 → 422).
+  useSmsDwellTracker(code, majorProgramId, Boolean(program))
 
   if (isLoading) {
     return (

--- a/frontend/src/components/sms/admin/SmsProgramInterestPanel.tsx
+++ b/frontend/src/components/sms/admin/SmsProgramInterestPanel.tsx
@@ -1,0 +1,260 @@
+// src/components/sms/admin/SmsProgramInterestPanel.tsx
+"use client"
+
+import { useMemo, useState } from "react"
+import { AlertCircle, RotateCcw } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  useSmsCampaignList,
+  useSmsProgramInterest,
+} from "@/hooks/useSmsAdmin"
+import type { SmsProgramInterestParams } from "@/lib/api/sms"
+
+import { campaignStatusLabel, formatDwell, formatInt } from "./labels"
+import { SmsSummaryCard } from "./SmsSummaryCard"
+
+const ALL = "all"
+
+function toIsoStart(d: string): string | undefined {
+  if (!d) return undefined
+  const parsed = new Date(`${d}T00:00:00`)
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString()
+}
+function toIsoEnd(d: string): string | undefined {
+  if (!d) return undefined
+  const parsed = new Date(`${d}T23:59:59.999`)
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString()
+}
+
+/**
+ * Report "ngành nóng" (§16.7) — tín hiệu chính = TỔNG dwell/ngành (rank desc,
+ * BE loại phiên bot + tên ngành hiện tại). Filter chiến dịch + khoảng ngày.
+ * Thin-client: render đúng số BE trả.
+ */
+export function SmsProgramInterestPanel() {
+  const [campaignId, setCampaignId] = useState<string>(ALL)
+  const [dateFrom, setDateFrom] = useState<string>("")
+  const [dateTo, setDateTo] = useState<string>("")
+
+  const { data: campaignData } = useSmsCampaignList({ limit: 200 })
+
+  const params = useMemo<SmsProgramInterestParams>(
+    () => ({
+      campaign_id: campaignId === ALL ? undefined : Number(campaignId),
+      date_from: toIsoStart(dateFrom),
+      date_to: toIsoEnd(dateTo),
+    }),
+    [campaignId, dateFrom, dateTo],
+  )
+
+  const { data, isLoading, isError, refetch, isFetching } =
+    useSmsProgramInterest(params)
+
+  const invalidRange = dateFrom !== "" && dateTo !== "" && dateFrom > dateTo
+
+  const resetFilters = () => {
+    setCampaignId(ALL)
+    setDateFrom("")
+    setDateTo("")
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Bộ lọc */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Bộ lọc</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="sms-interest-campaign">Chiến dịch</Label>
+              <Select value={campaignId} onValueChange={setCampaignId}>
+                <SelectTrigger id="sms-interest-campaign">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL}>Tất cả chiến dịch</SelectItem>
+                  {campaignData?.items.map((c) => (
+                    <SelectItem key={c.id} value={String(c.id)}>
+                      {c.name} ({campaignStatusLabel(c.status)})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="sms-interest-from">Từ ngày</Label>
+              <Input
+                id="sms-interest-from"
+                type="date"
+                value={dateFrom}
+                max={dateTo || undefined}
+                onChange={(e) => setDateFrom(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="sms-interest-to">Đến ngày</Label>
+              <Input
+                id="sms-interest-to"
+                type="date"
+                value={dateTo}
+                min={dateFrom || undefined}
+                onChange={(e) => setDateTo(e.target.value)}
+              />
+            </div>
+
+            <div className="flex items-end">
+              <Button
+                variant="outline"
+                onClick={resetFilters}
+                className="w-full sm:w-auto"
+              >
+                <RotateCcw className="mr-2 h-4 w-4" /> Xóa lọc
+              </Button>
+            </div>
+          </div>
+
+          {invalidRange && (
+            <p className="text-destructive mt-3 text-xs">
+              Mốc bắt đầu đang muộn hơn mốc kết thúc — vui lòng chọn lại khoảng
+              ngày hợp lệ.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Trạng thái lỗi */}
+      {isError && (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+            <AlertCircle className="text-destructive h-8 w-8" />
+            <p className="text-muted-foreground text-sm">
+              Không thể tải báo cáo. Vui lòng thử lại.
+            </p>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              Thử lại
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Thẻ tổng hợp */}
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full" />
+          ))}
+        </div>
+      ) : data ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <SmsSummaryCard
+            label="Số người quan tâm"
+            value={formatInt(data.distinct_contacts_total)}
+          />
+          <SmsSummaryCard
+            label="Tổng lượt xem ngành"
+            value={formatInt(data.view_count_total)}
+          />
+          <SmsSummaryCard
+            label="Tổng thời gian xem"
+            value={formatDwell(data.total_dwell_seconds)}
+          />
+        </div>
+      ) : null}
+
+      {/* Bảng ngành nóng */}
+      {!isError && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              Ngành được quan tâm (theo tổng thời gian xem)
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-3">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-10 w-full" />
+                ))}
+              </div>
+            ) : !data || data.items.length === 0 ? (
+              <p className="text-muted-foreground py-8 text-center text-sm">
+                {isFetching
+                  ? "Đang tải…"
+                  : "Chưa có lượt xem ngành nào trong phạm vi đã chọn."}
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-10 text-right">#</TableHead>
+                      <TableHead>Ngành</TableHead>
+                      <TableHead className="text-right">
+                        Số người quan tâm
+                      </TableHead>
+                      <TableHead className="text-right">Lượt xem</TableHead>
+                      <TableHead className="text-right">
+                        Tổng thời gian
+                      </TableHead>
+                      <TableHead className="text-right">TB/lượt</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {data.items.map((row, i) => (
+                      <TableRow
+                        key={row.major_program_id ?? `deleted-${i}`}
+                      >
+                        <TableCell className="text-muted-foreground text-right tabular-nums">
+                          {i + 1}
+                        </TableCell>
+                        <TableCell className="font-medium">
+                          {row.program_name}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatInt(row.distinct_contacts)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatInt(row.view_count)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatDwell(row.total_dwell_seconds)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatDwell(Math.round(row.avg_dwell_seconds))}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/sms/admin/SmsReportsClient.tsx
+++ b/frontend/src/components/sms/admin/SmsReportsClient.tsx
@@ -10,11 +10,13 @@ import {
 
 import { SmsCampaignDashboardPanel } from "./SmsCampaignDashboardPanel"
 import { SmsClickReportPanel } from "./SmsClickReportPanel"
+import { SmsProgramInterestPanel } from "./SmsProgramInterestPanel"
 
 /**
- * Trang báo cáo SMS Marketing (admin). 2 tab:
+ * Trang báo cáo SMS Marketing (admin). 3 tab:
  * - "Tổng hợp click": báo cáo click theo ngày/tháng/năm + CTR (§9).
  * - "Theo chiến dịch": dashboard 1 chiến dịch (CTR + nhà mạng + danh sách).
+ * - "Quan tâm ngành": ngành nóng theo tổng dwell (Phase 2 §16.7).
  */
 export function SmsReportsClient() {
   return (
@@ -22,12 +24,16 @@ export function SmsReportsClient() {
       <TabsList>
         <TabsTrigger value="overview">Tổng hợp click</TabsTrigger>
         <TabsTrigger value="campaign">Theo chiến dịch</TabsTrigger>
+        <TabsTrigger value="interest">Quan tâm ngành</TabsTrigger>
       </TabsList>
       <TabsContent value="overview">
         <SmsClickReportPanel />
       </TabsContent>
       <TabsContent value="campaign">
         <SmsCampaignDashboardPanel />
+      </TabsContent>
+      <TabsContent value="interest">
+        <SmsProgramInterestPanel />
       </TabsContent>
     </Tabs>
   )

--- a/frontend/src/components/sms/admin/labels.ts
+++ b/frontend/src/components/sms/admin/labels.ts
@@ -105,6 +105,15 @@ export function formatPercent(n: number): string {
   return `${n.toLocaleString("vi-VN", { maximumFractionDigits: 1 })}%`
 }
 
+/** Định dạng dwell (giây) → "M phút S giây" / "S giây" (Phase 2 report). */
+export function formatDwell(seconds: number): string {
+  const s = Math.max(0, Math.round(seconds))
+  if (s < 60) return `${s} giây`
+  const m = Math.floor(s / 60)
+  const rem = s % 60
+  return rem === 0 ? `${m} phút` : `${m} phút ${rem} giây`
+}
+
 /**
  * Định dạng ISO datetime → "dd/MM/yyyy HH:mm" (giờ trình duyệt). An toàn,
  * không crash render: giá trị rỗng (null/undefined/"") → "—"; chuỗi không

--- a/frontend/src/hooks/useSmsAdmin.ts
+++ b/frontend/src/hooks/useSmsAdmin.ts
@@ -18,11 +18,13 @@ import {
   createManualOptOut,
   getSmsCampaignDashboard,
   getSmsClickReport,
+  getSmsProgramInterestReport,
   listSmsCampaigns,
   listSmsOptOuts,
   type ManualOptOutPayload,
   type SmsCampaignListParams,
   type SmsClickReportParams,
+  type SmsProgramInterestParams,
   type SmsOptOutListParams,
 } from "@/lib/api/sms"
 import { parseApiError } from "@/lib/utils/api-errors"
@@ -41,6 +43,8 @@ export const smsAdminKeys = {
     [...smsAdminKeys.all, "campaigns", params] as const,
   optOuts: (params: SmsOptOutListParams) =>
     [...smsAdminKeys.all, "opt-outs", params] as const,
+  programInterest: (params: SmsProgramInterestParams) =>
+    [...smsAdminKeys.all, "program-interest", params] as const,
 }
 
 // ---------------------------------------------------------------------
@@ -67,6 +71,14 @@ export function useSmsCampaignList(params: SmsCampaignListParams = {}) {
   return useQuery({
     queryKey: smsAdminKeys.campaigns(params),
     queryFn: () => listSmsCampaigns(params),
+    staleTime: 60 * 1000,
+  })
+}
+
+export function useSmsProgramInterest(params: SmsProgramInterestParams) {
+  return useQuery({
+    queryKey: smsAdminKeys.programInterest(params),
+    queryFn: () => getSmsProgramInterestReport(params),
     staleTime: 60 * 1000,
   })
 }

--- a/frontend/src/hooks/useSmsDwellTracker.ts
+++ b/frontend/src/hooks/useSmsDwellTracker.ts
@@ -40,10 +40,19 @@ async function ensureSessionToken(code: string): Promise<string> {
   return res.session_token
 }
 
-type DwellStatus = "starting" | "tracking" | "error"
+type DwellStatus = "idle" | "starting" | "tracking" | "error"
 
-export function useSmsDwellTracker(code: string, majorProgramId: number) {
-  const [status, setStatus] = useState<DwellStatus>("starting")
+/**
+ * @param enabled chỉ đo khi ngành ĐÃ resolve hợp lệ. Cold/deep-load có
+ * data=undefined → enabled=false → KHÔNG tạo session/program-view rác (tránh
+ * POST major_program_id=0 → 422 + phiên rác). Khi data về, effect chạy lại.
+ */
+export function useSmsDwellTracker(
+  code: string,
+  majorProgramId: number,
+  enabled: boolean,
+) {
+  const [status, setStatus] = useState<DwellStatus>("idle")
 
   // Refs: tránh re-render mỗi heartbeat + giữ giá trị mới nhất trong cleanup.
   const tokenRef = useRef<string | null>(null)
@@ -52,6 +61,10 @@ export function useSmsDwellTracker(code: string, majorProgramId: number) {
   const resumeAtRef = useRef<number | null>(null) // mốc bắt đầu khoảng hiển thị
 
   useEffect(() => {
+    // Chưa resolve ngành hợp lệ → no-op (không tạo session/view rác). Giữ
+    // status mặc định "idle" (không setState đồng bộ trong effect); enabled chỉ
+    // đi false→true (ngành resolve xong) nên không cần reset.
+    if (!enabled || majorProgramId < 1) return
     let cancelled = false
     let intervalId: ReturnType<typeof setInterval> | null = null
 
@@ -118,7 +131,10 @@ export function useSmsDwellTracker(code: string, majorProgramId: number) {
         })
         if (cancelled) return
         viewIdRef.current = view.program_view_id
-        resumeAtRef.current = Date.now()
+        // Chỉ bắt đầu đếm nếu tab ĐANG hiển thị; mở ở tab nền/hidden → chờ
+        // visibilitychange→visible mới set resumeAt (không tính thời gian ẩn).
+        resumeAtRef.current =
+          document.visibilityState === "visible" ? Date.now() : null
         setStatus("tracking")
         intervalId = setInterval(sendHeartbeat, HEARTBEAT_MS)
         document.addEventListener("visibilitychange", onVisibility)
@@ -140,7 +156,7 @@ export function useSmsDwellTracker(code: string, majorProgramId: number) {
       }
       sendBeacon()
     }
-  }, [code, majorProgramId])
+  }, [code, majorProgramId, enabled])
 
   return { status }
 }

--- a/frontend/src/hooks/useSmsDwellTracker.ts
+++ b/frontend/src/hooks/useSmsDwellTracker.ts
@@ -1,0 +1,146 @@
+// src/hooks/useSmsDwellTracker.ts
+"use client"
+
+/**
+ * Đo dwell trang ngành `/lp/{code}/nganh/{id}` (Phase 2 §16.2) — thin-client
+ * gửi tín hiệu thô, BE clamp/aggregate:
+ * 1. Đảm bảo 1 session/lượt-xem-landing (token bearer lưu sessionStorage theo
+ *    code → dùng chung mọi trang ngành trong cùng phiên; deep-link tự tạo).
+ * 2. Mở program-view khi vào trang ngành.
+ * 3. Heartbeat định kỳ + khi ẩn tab/rời trang, gửi dwell tích luỹ (chỉ tính
+ *    thời gian tab HIỂN THỊ — pause khi ẩn) → BE cộng dwell + tính interest.
+ *
+ * Bot không chạy JS → không heartbeat → tự loại (BE cũng lọc phiên bot).
+ */
+import { useEffect, useRef, useState } from "react"
+
+import {
+  postSmsHeartbeat,
+  postSmsProgramView,
+  postSmsSession,
+} from "@/lib/api/sms"
+
+const HEARTBEAT_MS = 15_000
+const SESSION_KEY = (code: string) => `sms_sess_${code}`
+
+/** Lấy/ tạo session token (cache sessionStorage theo code) — dùng chung phiên. */
+async function ensureSessionToken(code: string): Promise<string> {
+  try {
+    const cached = sessionStorage.getItem(SESSION_KEY(code))
+    if (cached) return cached
+  } catch {
+    // sessionStorage có thể bị chặn (private mode) → tạo phiên mới mỗi lần.
+  }
+  const res = await postSmsSession(code)
+  try {
+    sessionStorage.setItem(SESSION_KEY(code), res.session_token)
+  } catch {
+    // ignore
+  }
+  return res.session_token
+}
+
+type DwellStatus = "starting" | "tracking" | "error"
+
+export function useSmsDwellTracker(code: string, majorProgramId: number) {
+  const [status, setStatus] = useState<DwellStatus>("starting")
+
+  // Refs: tránh re-render mỗi heartbeat + giữ giá trị mới nhất trong cleanup.
+  const tokenRef = useRef<string | null>(null)
+  const viewIdRef = useRef<number | null>(null)
+  const accumulatedMsRef = useRef(0) // tổng thời gian tab HIỂN THỊ đã tích luỹ
+  const resumeAtRef = useRef<number | null>(null) // mốc bắt đầu khoảng hiển thị
+
+  useEffect(() => {
+    let cancelled = false
+    let intervalId: ReturnType<typeof setInterval> | null = null
+
+    const dwellSeconds = () => {
+      let ms = accumulatedMsRef.current
+      if (resumeAtRef.current != null) ms += Date.now() - resumeAtRef.current
+      return Math.max(0, Math.floor(ms / 1000))
+    }
+
+    const sendHeartbeat = () => {
+      const token = tokenRef.current
+      const viewId = viewIdRef.current
+      if (!token || viewId == null) return
+      // Best-effort — nuốt lỗi (đo lường không được chặn UX).
+      void postSmsHeartbeat(code, {
+        session_token: token,
+        program_view_id: viewId,
+        dwell_seconds: dwellSeconds(),
+      }).catch(() => undefined)
+    }
+
+    // Gửi beacon lúc rời trang (fetch có thể bị huỷ) — Blob JSON để BE parse.
+    const sendBeacon = () => {
+      const token = tokenRef.current
+      const viewId = viewIdRef.current
+      if (!token || viewId == null) return
+      try {
+        const url = `/api/public/sms/landing/${encodeURIComponent(
+          code,
+        )}/heartbeat`
+        const body = JSON.stringify({
+          session_token: token,
+          program_view_id: viewId,
+          dwell_seconds: dwellSeconds(),
+        })
+        const blob = new Blob([body], { type: "application/json" })
+        if (!navigator.sendBeacon(url, blob)) sendHeartbeat()
+      } catch {
+        sendHeartbeat()
+      }
+    }
+
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") {
+        // Chốt khoảng hiển thị hiện tại + gửi (rời tab tính là kết thúc xem).
+        if (resumeAtRef.current != null) {
+          accumulatedMsRef.current += Date.now() - resumeAtRef.current
+          resumeAtRef.current = null
+        }
+        sendBeacon()
+      } else if (document.visibilityState === "visible") {
+        resumeAtRef.current = Date.now()
+      }
+    }
+
+    ;(async () => {
+      try {
+        const token = await ensureSessionToken(code)
+        if (cancelled) return
+        tokenRef.current = token
+        const view = await postSmsProgramView(code, {
+          session_token: token,
+          major_program_id: majorProgramId,
+        })
+        if (cancelled) return
+        viewIdRef.current = view.program_view_id
+        resumeAtRef.current = Date.now()
+        setStatus("tracking")
+        intervalId = setInterval(sendHeartbeat, HEARTBEAT_MS)
+        document.addEventListener("visibilitychange", onVisibility)
+        window.addEventListener("pagehide", sendBeacon)
+      } catch {
+        if (!cancelled) setStatus("error")
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      if (intervalId) clearInterval(intervalId)
+      document.removeEventListener("visibilitychange", onVisibility)
+      window.removeEventListener("pagehide", sendBeacon)
+      // Chốt dwell lần cuối khi rời trang ngành (SPA navigate).
+      if (resumeAtRef.current != null) {
+        accumulatedMsRef.current += Date.now() - resumeAtRef.current
+        resumeAtRef.current = null
+      }
+      sendBeacon()
+    }
+  }, [code, majorProgramId])
+
+  return { status }
+}

--- a/frontend/src/lib/api/sms.ts
+++ b/frontend/src/lib/api/sms.ts
@@ -33,6 +33,11 @@ import {
   smsLandingResponseSchema,
   smsOptOutListSchema,
   smsOptOutSchema,
+  smsProgramInterestReportSchema,
+  smsContactInterestListSchema,
+  smsSessionStartResponseSchema,
+  smsProgramViewResponseSchema,
+  smsHeartbeatResponseSchema,
   smsPublicOptOutResponseSchema,
   type SmsCampaign,
   type SmsCampaignCreateInput,
@@ -63,6 +68,11 @@ import {
   type SmsManualOptOutSource,
   type SmsOptOut,
   type SmsOptOutList,
+  type SmsProgramInterestReport,
+  type SmsContactInterestList,
+  type SmsSessionStartResponse,
+  type SmsProgramViewResponse,
+  type SmsHeartbeatResponse,
   type SmsPublicOptOutResponse,
 } from "@/lib/zod/sms"
 
@@ -91,6 +101,54 @@ export async function postSmsOptOut(
     { code },
   )
   return smsPublicOptOutResponseSchema.parse(res.data)
+}
+
+// =====================================================================
+// Public — deep engagement tracking (Phase 2 §16.7): session/view/heartbeat.
+// Không auth; token bearer trả 1 lần từ /session, giữ ở client (sessionStorage).
+// =====================================================================
+
+/** Mở phiên xem landing → trả session_token raw (1 lần). @throws 404 code sai. */
+export async function postSmsSession(
+  code: string,
+): Promise<SmsSessionStartResponse> {
+  const res = await api.post<SmsSessionStartResponse>(
+    `/api/public/sms/landing/${encodeURIComponent(code)}/session`,
+    {},
+  )
+  return smsSessionStartResponseSchema.parse(res.data)
+}
+
+/** Ghi 1 lượt xem trang ngành → trả program_view_id (đính vào heartbeat). */
+export async function postSmsProgramView(
+  code: string,
+  payload: {
+    session_token: string
+    major_program_id: number
+    program_offering_id?: number
+  },
+): Promise<SmsProgramViewResponse> {
+  const res = await api.post<SmsProgramViewResponse>(
+    `/api/public/sms/landing/${encodeURIComponent(code)}/program-view`,
+    payload,
+  )
+  return smsProgramViewResponseSchema.parse(res.data)
+}
+
+/** Cộng dwell (giây, tích luỹ) cho trang ngành đang xem. */
+export async function postSmsHeartbeat(
+  code: string,
+  payload: {
+    session_token: string
+    program_view_id: number
+    dwell_seconds: number
+  },
+): Promise<SmsHeartbeatResponse> {
+  const res = await api.post<SmsHeartbeatResponse>(
+    `/api/public/sms/landing/${encodeURIComponent(code)}/heartbeat`,
+    payload,
+  )
+  return smsHeartbeatResponseSchema.parse(res.data)
 }
 
 // =====================================================================
@@ -124,6 +182,36 @@ export async function getSmsCampaignDashboard(
     `/api/sms/campaigns/${campaignId}/dashboard`,
   )
   return smsCampaignDashboardSchema.parse(res.data)
+}
+
+export interface SmsProgramInterestParams {
+  campaign_id?: number
+  group_id?: number
+  major_program_id?: number
+  /** ISO datetime (kèm offset) — khoảng viewed_at. */
+  date_from?: string
+  date_to?: string
+}
+
+/** Báo cáo "ngành nóng" theo campaign/nhóm/thời gian (§16.7, rank dwell desc). */
+export async function getSmsProgramInterestReport(
+  params: SmsProgramInterestParams,
+): Promise<SmsProgramInterestReport> {
+  const res = await api.get<SmsProgramInterestReport>(
+    `/api/sms/reports/program-interest`,
+    { params },
+  )
+  return smsProgramInterestReportSchema.parse(res.data)
+}
+
+/** Hồ sơ "quan tâm ngành" của 1 contact (rank dwell desc). */
+export async function getSmsContactInterests(
+  contactId: number,
+): Promise<SmsContactInterestList> {
+  const res = await api.get<SmsContactInterestList>(
+    `/api/sms/contacts/${contactId}/interests`,
+  )
+  return smsContactInterestListSchema.parse(res.data)
 }
 
 export interface SmsCampaignListParams {

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -5,6 +5,15 @@
 // Public landing /lp/{code} — KHÔNG lộ PII recipient.
 import { z } from "zod"
 
+/** 1 ngành trong danh mục landing 2 tầng (Phase 2 §16.1). */
+export const smsLandingProgramSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  code: z.string(),
+  degree_level: z.string(),
+})
+export type SmsLandingProgram = z.infer<typeof smsLandingProgramSchema>
+
 export const smsLandingResponseSchema = z.object({
   school_name: z.string(),
   headline: z.string().nullable().optional(),
@@ -13,6 +22,8 @@ export const smsLandingResponseSchema = z.object({
   cta_url: z.string().nullable().optional(),
   consent_notice: z.string(),
   already_opted_out: z.boolean(),
+  // Phase 2: danh mục ngành (rỗng nếu chưa có ngành active).
+  programs: z.array(smsLandingProgramSchema).default([]),
 })
 export type SmsLandingResponse = z.infer<typeof smsLandingResponseSchema>
 
@@ -22,6 +33,77 @@ export const smsPublicOptOutResponseSchema = z.object({
 })
 export type SmsPublicOptOutResponse = z.infer<
   typeof smsPublicOptOutResponseSchema
+>
+
+// =====================================================================
+// Phase 2 (§16) — deep engagement tracking (session / view / heartbeat)
+// Public: /api/public/sms/landing/{code}/{session,program-view,heartbeat}
+// =====================================================================
+export const smsSessionStartResponseSchema = z.object({
+  session_token: z.string(),
+  session_id: z.number().int(),
+})
+export type SmsSessionStartResponse = z.infer<
+  typeof smsSessionStartResponseSchema
+>
+
+export const smsProgramViewResponseSchema = z.object({
+  program_view_id: z.number().int(),
+  sequence_no: z.number().int(),
+})
+export type SmsProgramViewResponse = z.infer<
+  typeof smsProgramViewResponseSchema
+>
+
+export const smsHeartbeatResponseSchema = z.object({
+  ok: z.boolean(),
+  dwell_seconds: z.number().int(),
+  active_seconds: z.number().int(),
+})
+export type SmsHeartbeatResponse = z.infer<typeof smsHeartbeatResponseSchema>
+
+// Admin — report ngành nóng + hồ sơ sở thích 1 contact (§16.7).
+export const smsProgramInterestRowSchema = z.object({
+  major_program_id: z.number().int().nullable(),
+  program_name: z.string(),
+  distinct_contacts: z.number().int(),
+  view_count: z.number().int(),
+  total_dwell_seconds: z.number().int(),
+  avg_dwell_seconds: z.number(),
+})
+export type SmsProgramInterestRow = z.infer<
+  typeof smsProgramInterestRowSchema
+>
+
+export const smsProgramInterestReportSchema = z.object({
+  items: z.array(smsProgramInterestRowSchema).default([]),
+  distinct_contacts_total: z.number().int(),
+  view_count_total: z.number().int(),
+  total_dwell_seconds: z.number().int(),
+})
+export type SmsProgramInterestReport = z.infer<
+  typeof smsProgramInterestReportSchema
+>
+
+export const smsContactInterestRowSchema = z.object({
+  major_program_id: z.number().int(),
+  program_name: z.string(),
+  view_count: z.number().int(),
+  total_dwell_seconds: z.number().int(),
+  interest_score: z.number(),
+  first_interest_at: z.string().nullable().optional(),
+  last_interest_at: z.string().nullable().optional(),
+})
+export type SmsContactInterestRow = z.infer<
+  typeof smsContactInterestRowSchema
+>
+
+export const smsContactInterestListSchema = z.object({
+  contact_id: z.number().int(),
+  items: z.array(smsContactInterestRowSchema).default([]),
+})
+export type SmsContactInterestList = z.infer<
+  typeof smsContactInterestListSchema
 >
 
 // =====================================================================


### PR DESCRIPTION
## Tóm tắt
Frontend cho SMS **Phase 2 (§16)** — tiêu thụ BE P2-2 (#456 đã merge+deploy prod). Cho khách vào landing chọn ngành → đo **thời gian xem (dwell) từng ngành** → admin xem **ngành nóng**. Thin-client (FE CLAUDE.md): render đúng BE trả, không suy luận nghiệp vụ.

## Nội dung
**Landing 2 tầng:**
- `/lp/{code}` (`SmsLandingClient`): +danh mục ngành (card link tới trang ngành, render từ `programs` trong landing response), giữ opt-out.
- `/lp/{code}/nganh/{id}` (`SmsProgramClient` + page): render thông tin ngành từ landing response (KHÔNG gọi thêm endpoint) — nơi đo dwell chính.

**Dwell tracker (`useSmsDwellTracker`):**
- Đảm bảo 1 session/lượt-xem (token bearer cache `sessionStorage` theo code, dùng chung mọi trang ngành; deep-link tự tạo).
- Mở `program-view` khi vào trang ngành → heartbeat mỗi 15s + khi ẩn tab/rời trang (`pagehide`, `visibilitychange` → `sendBeacon`).
- **Chỉ tính thời gian tab HIỂN THỊ** (pause khi ẩn); BE clamp wall-clock + aggregate.

**Admin report:** tab "Quan tâm ngành" (`SmsProgramInterestPanel`) — ngành nóng rank tổng dwell (filter chiến dịch + khoảng ngày) + API `getSmsProgramInterestReport`/`getSmsContactInterests`.

**zod/api/hook:** schema mirror BE (landing `programs`, session/view/heartbeat, program-interest, contact-interests) + `useSmsProgramInterest` + `formatDwell`.

## /review đã vá (3 commit)
- **[P2]** `useSmsDwellTracker` thêm `enabled`: cold/deep-load `data=undefined` → KHÔNG tạo session + KHÔNG POST program-view `major_program_id=0` (trước → 422 + phiên rác). Bonus: dời tạo session khỏi StrictMode initial-mount → hết double-session dev.
- **[P3a]** chỉ đếm dwell khi `visibilityState==='visible'` lúc bắt đầu (mở tab nền không tính thời gian ẩn).
- **[P3b]** `<Button asChild><Link/></Button>` thay `<Link><Button/></Link>` (bỏ `<a><button>` lồng nhau — a11y/HTML hợp lệ).

## Kiểm chứng
- Type-check **sạch** · lint **0 error** · build compile OK (SIGKILL local = OOM container throwaway, không phải lỗi code).
- **Chrome smoke dev FULL PASS**: menu 20 ngành card-link đúng · trang ngành render · session/program-view/heartbeat 200 (+OPTIONS CORS) · **beacon lúc rời trang ghi dwell (30→67)** · session reuse qua ngành · interest aggregate (non-bot, score) · re-smoke sau fix: `sessions=1` + `bad_view_prog0=0` · cleanup 0 orphan.

## Ghi chú
- **FE-only, không migration** (BE P2-2 đã có trên prod). Deploy = build+restart frontend (chuẩn FE).
- ⚠️ **§16.9 gate pháp lý** (disclosure/consent riêng + DPIA) trước khi BẬT deep tracking với người thật (owner lo).
- CTA `<a><Button>` trong `SmsLandingClient` là code cũ (PR-5/6), giữ nguyên (ngoài scope).
- Còn **P2-3** (consult officer: tab lead + link tư vấn) — đợt sau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)