### PR TITLE
fix(deploy): reload nginx sau khi re-render config (Step 8b)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -3,11 +3,13 @@ name: Backend Test (PR Gate)
 # Touched 2026-05-14 alongside PR #288 (.gitignore cleanup) AND PR #289
 # (Documents/scripts inventory batch) only to trigger this gate —
 # branch protection ruleset 16381130 requires ``pytest`` on every PR,
-# but root-level / Documents/ / scripts/ only PRs do not match any
-# path filter below and would otherwise sit at "expected, not run"
-# forever. Future Documents/scripts/root PRs: bundle a no-op workflow
-# touch like this OR expand the path filter below explicitly (trade-off:
-# gate runs on every doc change, ~17 phút CI per).
+# but root-level / Documents/ only PRs do not match any path filter
+# below and would otherwise sit at "expected, not run" forever.
+# ``scripts/**`` WAS ADDED to the path filter (2026-07-02, PR #459) so
+# deploy/ops-script PRs trigger the gate (surfaced when a deploy.sh-only
+# fix stuck at "expected, not run"). Future Documents/root-only PRs:
+# bundle a no-op workflow touch like this OR expand the path filter
+# below explicitly (trade-off: gate runs on every such change).
 #
 # Sprint S2 hardening (memory `auto-merge-requires-full-ci-not-just-green`):
 # Closes the systemic gap surfaced by PR #283 orphan-merge. The existing
@@ -92,6 +94,7 @@ on:
       - 'Backend_FastAPI/**'
       - 'frontend/**'
       - '.github/workflows/**'
+      - 'scripts/**'
 
 concurrency:
   group: be-pr-${{ github.ref }}

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -28,6 +28,7 @@ on:
       - 'frontend/**'
       - 'Backend_FastAPI/**'
       - '.github/workflows/**'
+      - 'scripts/**'
 
 concurrency:
   group: fe-pr-${{ github.ref }}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -300,6 +300,30 @@ while [ $timeout -gt 0 ]; do
 done
 
 # =============================================================================
+# Step 8b: Reload nginx to APPLY the re-rendered config
+# =============================================================================
+# ``up -d nginx`` above does NOT recreate/reload an already-running nginx when
+# only the bind-mounted config file (rendered by the ``envsubst`` step above)
+# changed — the container keeps serving whatever config it loaded at its last
+# (re)start. Without this explicit reload, nginx changes (new ``location``
+# blocks, security headers) SILENTLY never take effect. Observed 2026-07-02:
+# nginx ran 6 weeks on a stale config → the SMS ``/r/`` short-link fell through
+# to the frontend (307 → /login) because its ``location /r/`` was never loaded.
+# Validate first (bad config → keep last-good, don't reload) then gracefully
+# reload (SIGHUP, zero-downtime). Non-fatal so a fresh-start deploy (nginx just
+# loaded the config) is unaffected.
+log "Step 8b: Reloading nginx (apply re-rendered config)..."
+if docker compose -f docker-compose.yml --profile production --env-file .env.production exec -T nginx nginx -t >/dev/null 2>&1; then
+    if docker compose -f docker-compose.yml --profile production --env-file .env.production exec -T nginx nginx -s reload; then
+        log "  nginx reloaded — config applied"
+    else
+        log "  WARNING: nginx reload failed — check 'docker compose logs nginx'"
+    fi
+else
+    log "  WARNING: nginx config test FAILED — NOT reloading (keeps last-good config). Fix nginx/conf.d/default.conf"
+fi
+
+# =============================================================================
 # Done
 # =============================================================================
 log "========================================="


### PR DESCRIPTION
## Vấn đề
`deploy.sh` re-render nginx template (envsubst) nhưng bước `up -d nginx` **KHÔNG** recreate/reload một nginx đang chạy khi chỉ file config (bind-mount) đổi → thay đổi nginx **silently không hiệu lực**.

## Bằng chứng (prod 2026-07-02)
nginx container chạy từ **23/05**, config file mtime hôm nay → workers chạy config CŨ ~6 tuần:
- **SMS `/r/{code}`** short-link rơi vào frontend catch-all → `307 /login` (location `/r/` chưa load) → click SMS gãy.
- **`location /uploads/`** (đã gỡ ở fix bảo mật #365, deploy 02/06) VẪN phục vụ hồ sơ tuyển sinh **PII (CCCD/học bạ) KHÔNG auth** suốt 02/06→02/07 vì nginx chưa reload.

Reload thủ công hôm nay đã đóng cả hai. Fix này ngăn tái diễn.

## Thay đổi
Thêm **Step 8b** vào `scripts/deploy.sh`: `nginx -t` (validate) → `nginx -s reload` (graceful, zero-downtime). Non-fatal (fresh-start deploy đã load config nên vô hại; config lỗi → giữ last-good, không reload).

## Kiểm chứng
`bash -n scripts/deploy.sh` OK. Reload thủ công trên prod đã verify: `/r/{valid}`→302+click, `/uploads/*`→307/login (đóng PII), health/lp/storefront/login không vỡ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)