### PR TITLE
feat(sms): PR-7 P2-3/P2-4b — consult officer (link tư vấn + quan tâm ngành) + SSR hardening

### DIFF
--- a/Backend_FastAPI/alembic/versions/smsp2consult20260702002_sms_consult_link.py
+++ b/Backend_FastAPI/alembic/versions/smsp2consult20260702002_sms_consult_link.py
@@ -1,0 +1,125 @@
+"""sms phase2 P2-3 consult officer — sms_consult_link + session.consult_link_id
+
+Viết TAY (không autogenerate — nhiễm drift dev DB). Tạo bảng
+``sms_consult_link`` (link tư vấn officer↔lead) + thêm cột
+``consult_link_id`` vào ``sms_landing_session`` (nguồn consult). Xem §16.4.
+
+Revision ID: smsp2consult20260702002
+Revises: smsp2eng20260702001
+Create Date: 2026-07-02
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "smsp2consult20260702002"
+down_revision: Union[str, Sequence[str], None] = "smsp2eng20260702001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. sms_consult_link
+    op.create_table(
+        "sms_consult_link",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("lead_id", sa.Integer(), nullable=False),
+        sa.Column("contact_id", sa.Integer(), nullable=False),
+        sa.Column("created_by_id", sa.Integer(), nullable=True),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "landing_type", sa.String(length=20),
+            server_default="qlts_hosted", nullable=False,
+        ),
+        sa.Column("landing_url", sa.String(length=1024), nullable=True),
+        sa.Column(
+            "raw_click_count", sa.Integer(),
+            server_default="0", nullable=False,
+        ),
+        sa.Column(
+            "human_click_count", sa.Integer(),
+            server_default="0", nullable=False,
+        ),
+        sa.Column(
+            "first_human_clicked_at", sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column(
+            "last_human_clicked_at", sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True),
+            server_default=sa.text("now()"), nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["lead_id"], ["lead.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["contact_id"], ["sms_contact.id"], ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_id"], ["user.id"], ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_sms_consult_link_contact_id"),
+        "sms_consult_link", ["contact_id"], unique=False,
+    )
+    op.create_index(
+        op.f("ix_sms_consult_link_created_by_id"),
+        "sms_consult_link", ["created_by_id"], unique=False,
+    )
+    op.create_index(
+        "ix_sms_consult_link_lead_id",
+        "sms_consult_link", ["lead_id"], unique=False,
+    )
+    # Partial UNIQUE token_hash — resolve /r/{code} (nhánh consult).
+    op.create_index(
+        "uq_sms_consult_link_token_hash",
+        "sms_consult_link", ["token_hash"], unique=True,
+        postgresql_where=sa.text("token_hash IS NOT NULL"),
+    )
+
+    # 2. sms_landing_session.consult_link_id (nguồn consult)
+    op.add_column(
+        "sms_landing_session",
+        sa.Column("consult_link_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_sms_landing_session_consult_link_id",
+        "sms_landing_session", "sms_consult_link",
+        ["consult_link_id"], ["id"], ondelete="SET NULL",
+    )
+    op.create_index(
+        op.f("ix_sms_landing_session_consult_link_id"),
+        "sms_landing_session", ["consult_link_id"], unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_sms_landing_session_consult_link_id"),
+        table_name="sms_landing_session",
+    )
+    op.drop_constraint(
+        "fk_sms_landing_session_consult_link_id",
+        "sms_landing_session", type_="foreignkey",
+    )
+    op.drop_column("sms_landing_session", "consult_link_id")
+
+    op.drop_index(
+        "uq_sms_consult_link_token_hash", table_name="sms_consult_link",
+    )
+    op.drop_index(
+        "ix_sms_consult_link_lead_id", table_name="sms_consult_link",
+    )
+    op.drop_index(
+        op.f("ix_sms_consult_link_created_by_id"),
+        table_name="sms_consult_link",
+    )
+    op.drop_index(
+        op.f("ix_sms_consult_link_contact_id"),
+        table_name="sms_consult_link",
+    )
+    op.drop_table("sms_consult_link")

--- a/Backend_FastAPI/alembic/versions/smsp2consultcasbin20260702003_officer_consult_grants.py
+++ b/Backend_FastAPI/alembic/versions/smsp2consultcasbin20260702003_officer_consult_grants.py
@@ -1,0 +1,76 @@
+"""SMS P2-3 consult officer Casbin grants (role:officer 2 route).
+
+Seeds POST /api/sms/leads/{id}/consult-link + GET /api/sms/leads/{id}/interests
+cho role:officer (manager kế thừa qua g, role:manager, role:officer; accountant
+kế thừa nhưng get_lead_for_user chặn 404; admin dùng wildcard /*.*). Không có
+migration này → entrypoint không sync template grant → CasbinAuth 403 officer.
+Idempotent (mẫu feepicker_casbin_20260621).
+
+Revision ID: smsp2consultcasbin20260702003
+Revises: smsp2consult20260702002
+Create Date: 2026-07-02
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "smsp2consultcasbin20260702003"
+down_revision: Union[str, None] = "smsp2consult20260702002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# (v0=sub, v1=obj, v2=act, v3=eft) — eft MUST be present (NULL v3 crashes load).
+# {id} = keyMatch4 named wildcard (giữ literal trong casbin_rule).
+_POLICIES = [
+    ("role:officer", "/api/sms/leads/{id}/consult-link", "POST", "allow"),
+    ("role:officer", "/api/sms/leads/{id}/interests", "GET", "allow"),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for v0, v1, v2, v3 in _POLICIES:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO casbin_rule
+                    (ptype, v0, v1, v2, v3, template_id, applied_at)
+                SELECT 'p',
+                       CAST(:v0 AS VARCHAR),
+                       CAST(:v1 AS VARCHAR),
+                       CAST(:v2 AS VARCHAR),
+                       CAST(:v3 AS VARCHAR),
+                       '_smsp2consultcasbin20260702003',
+                       NOW()
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM casbin_rule
+                    WHERE ptype='p'
+                      AND v0=CAST(:v0 AS VARCHAR)
+                      AND v1=CAST(:v1 AS VARCHAR)
+                      AND v2=CAST(:v2 AS VARCHAR)
+                      AND v3=CAST(:v3 AS VARCHAR)
+                )
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for v0, v1, v2, v3 in _POLICIES:
+        conn.execute(
+            sa.text(
+                """
+                DELETE FROM casbin_rule
+                WHERE ptype='p'
+                  AND v0=CAST(:v0 AS VARCHAR)
+                  AND v1=CAST(:v1 AS VARCHAR)
+                  AND v2=CAST(:v2 AS VARCHAR)
+                  AND v3=CAST(:v3 AS VARCHAR)
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -131,6 +131,10 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/leads/my/reassign-quota", "action": "GET"},  # Reassign quota
         {"subject": "{role}", "object": "/api/leads/import/template", "action": "GET"},  # Import template
         {"subject": "{role}", "object": "/api/leads/import", "action": "POST"},  # Import leads
+        # SMS consult officer (P2-3 §16.7) — tạo link tư vấn + xem interest ngành của lead.
+        # IDOR scope qua get_lead_for_user (officer chỉ lead được giao); manager kế thừa.
+        {"subject": "{role}", "object": "/api/sms/leads/{id}/consult-link", "action": "POST"},  # Tạo consult link
+        {"subject": "{role}", "object": "/api/sms/leads/{id}/interests", "action": "GET"},  # Interest ngành của lead
         # Admin users (read-only) — needed for officer filter bar and lead assignment dialog
         {"subject": "{role}", "object": "/api/admin/users", "action": "GET"},
         # Collaborators — GET for referrer dropdown, POST to propose new CTV (pending), GET detail

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -91,6 +91,7 @@ from .routers import (
     sms_reports,  # ✅ SMS MARKETING: reports/dashboard (routes PR-5)
     sms_public,  # ✅ SMS MARKETING: public landing + opt-out (routes PR-5)
     sms_shortlink,  # ✅ SMS MARKETING: /r/{code} resolver (routes PR-5)
+    sms_consult,  # ✅ SMS MARKETING: consult officer (routes P2-3)
     users,
     zalo_webhooks,  # ✅ PHASE C1: Zalo webhook receiver
     zalo_bot_link,  # ✅ v5 Step 19: staff Zalo Bot link API
@@ -923,6 +924,7 @@ fastapi_app.include_router(sms_export.router)
 fastapi_app.include_router(sms_reports.router)
 fastapi_app.include_router(sms_public.router)
 fastapi_app.include_router(sms_shortlink.router)
+fastapi_app.include_router(sms_consult.router)
 fastapi_app.include_router(security.router, prefix="/api")  # ✅ LOGIN SECURITY: Phase 5
 fastapi_app.include_router(monitoring.router, prefix="/api")
 # ✅ FINANCE MODULE: Phase 4 - API Layer

--- a/Backend_FastAPI/app/models/__init__.py
+++ b/Backend_FastAPI/app/models/__init__.py
@@ -169,6 +169,7 @@ from .sms import (
     SmsLandingSession,
     SmsProgramView,
     SmsContactProgramInterest,
+    SmsConsultLink,
 )
 
 # Import tất cả các model để chúng được đăng ký với Base
@@ -310,4 +311,5 @@ __all__ = [
     "SmsLandingSession",
     "SmsProgramView",
     "SmsContactProgramInterest",
+    "SmsConsultLink",
 ]

--- a/Backend_FastAPI/app/models/sms/__init__.py
+++ b/Backend_FastAPI/app/models/sms/__init__.py
@@ -17,6 +17,7 @@ from .marketing_consent_event import SmsMarketingConsentEvent
 from .landing_session import SmsLandingSession
 from .program_view import SmsProgramView
 from .contact_program_interest import SmsContactProgramInterest
+from .consult_link import SmsConsultLink  # P2-3 consult officer
 
 __all__ = [
     "SmsContactGroup",
@@ -35,4 +36,5 @@ __all__ = [
     "SmsLandingSession",
     "SmsProgramView",
     "SmsContactProgramInterest",
+    "SmsConsultLink",
 ]

--- a/Backend_FastAPI/app/models/sms/consult_link.py
+++ b/Backend_FastAPI/app/models/sms/consult_link.py
@@ -1,0 +1,96 @@
+# app/models/sms/consult_link.py
+"""
+SMS consult link (Phase 2 §16.4) — link tư vấn 1-1 officer gửi lead (NGOÀI
+campaign). Officer tạo → sinh short code (bearer) → gửi tay/Zalo cho lead →
+lead vào landing 2 tầng → dwell đo về CÙNG `contact_id` (khóa thống nhất với
+campaign). Chỉ lưu `token_hash` (HMAC), KHÔNG raw code.
+
+MVP (P2-Q1 chốt): link luôn trỏ danh mục ĐẦY ĐỦ (`landing_type=qlts_hosted`),
+officer KHÔNG chọn ngành riêng. Consult 1-1 KHÔNG tự cấp consent marketing —
+contact tạo từ lead giữ `marketing_consent_status='unknown'` (§16.5).
+Xem `Documents/SMS_MARKETING_MODULE_DESIGN.md` §16.4.
+"""
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    DateTime, ForeignKey, Index, Integer, String, text,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+
+
+class SmsConsultLink(Base):
+    """Link tư vấn officer↔lead — resolve `/r/{code}` như recipient (nhánh 2)."""
+
+    __tablename__ = "sms_consult_link"
+
+    __table_args__ = (
+        # token_hash phải UNIQUE (resolve /r/{code}); partial để an toàn nếu
+        # tương lai có hàng token NULL (hiện luôn set). hex 64 [0-9a-f].
+        Index(
+            "uq_sms_consult_link_token_hash",
+            "token_hash",
+            unique=True,
+            postgresql_where=text("token_hash IS NOT NULL"),
+        ),
+        Index("ix_sms_consult_link_lead_id", "lead_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    lead_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("lead.id", ondelete="CASCADE"),
+        nullable=False,
+        comment="lead officer tạo link tư vấn cho",
+    )
+    contact_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("sms_contact.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+        comment="contact match/tạo từ phone lead — khóa thống nhất interest",
+    )
+    created_by_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True, index=True,
+        comment="officer tạo link (SET NULL nếu user xoá — giữ lịch sử)",
+    )
+    token_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False,
+        comment="HMAC-SHA256(code, SMS_TOKEN_HASH_SECRET); resolve /r/{code}",
+    )
+    landing_type: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="qlts_hosted",
+        comment="MVP luôn qlts_hosted (danh mục đầy đủ)",
+    )
+    landing_url: Mapped[Optional[str]] = mapped_column(
+        String(1024), nullable=True,
+        comment="external (DEFER) — MVP NULL, resolve → /lp/{code} nội bộ",
+    )
+
+    # --- Click denormalize (bot tách khỏi human) — đối xứng recipient ---
+    raw_click_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+    )
+    human_click_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+    )
+    first_human_clicked_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    last_human_clicked_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    expires_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+        comment="NULL = không hết hạn (link tư vấn cá nhân)",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<SmsConsultLink {self.id} lead={self.lead_id} "
+            f"contact={self.contact_id} by={self.created_by_id}>"
+        )

--- a/Backend_FastAPI/app/models/sms/landing_session.py
+++ b/Backend_FastAPI/app/models/sms/landing_session.py
@@ -40,11 +40,16 @@ class SmsLandingSession(Base):
         Integer,
         ForeignKey("sms_campaign_recipient.id", ondelete="SET NULL"),
         nullable=True, index=True,
-        comment="nguồn campaign (NULL nếu consult — Phase 2 sau)",
+        comment="nguồn campaign (NULL nếu consult)",
     )
     campaign_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("sms_campaign.id", ondelete="SET NULL"),
         nullable=True, index=True,
+    )
+    consult_link_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("sms_consult_link.id", ondelete="SET NULL"),
+        nullable=True, index=True,
+        comment="nguồn consult officer (NULL nếu campaign) — P2-3",
     )
     session_token_hash: Mapped[str] = mapped_column(
         String(64), nullable=False, unique=True,

--- a/Backend_FastAPI/app/repositories/sms_engagement_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_engagement_repository.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.major_program import MajorProgram
 from app.models.sms import (
     SmsCampaignRecipient,
+    SmsConsultLink,
     SmsContactProgramInterest,
     SmsLandingSession,
     SmsProgramView,
@@ -32,6 +33,15 @@ class SmsEngagementRepository:
 
     def __init__(self, db: AsyncSession):
         self.db = db
+
+    # ---------------------------------------------------------------
+    # Consult link (P2-3 officer)
+    # ---------------------------------------------------------------
+    async def create_consult_link(self, fields: dict) -> SmsConsultLink:
+        row = SmsConsultLink(**fields)
+        self.db.add(row)
+        await self.db.flush()
+        return row
 
     # ---------------------------------------------------------------
     # Danh mục ngành (landing 2 tầng — tái dùng major_program active)

--- a/Backend_FastAPI/app/repositories/sms_tracking_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_tracking_repository.py
@@ -20,6 +20,7 @@ from app.models.sms import (
     SmsCampaignExportBatch,
     SmsCampaignRecipient,
     SmsClickEvent,
+    SmsConsultLink,
     SmsOptOut,
 )
 
@@ -50,6 +51,53 @@ class SmsTrackingRepository:
         )
         row = res.first()
         return (row[0], row[1]) if row else None
+
+    # ---------------------------------------------------------------
+    # Consult link resolve + click (P2-3 — nhánh 2 của /r/{code})
+    # ---------------------------------------------------------------
+    async def lookup_consult_by_token_hash(
+        self, token_hash: str
+    ) -> Optional[SmsConsultLink]:
+        """SmsConsultLink nếu token_hash khớp; None nếu không. Dùng khi
+        recipient lookup KHÔNG thấy (resolve mở rộng §16.7)."""
+        res = await self.db.execute(
+            select(SmsConsultLink)
+            .where(SmsConsultLink.token_hash == token_hash)
+            .limit(1)
+        )
+        return res.scalars().first()
+
+    async def record_consult_click(
+        self,
+        *,
+        consult_link_id: int,
+        ip_hash: Optional[str],
+        user_agent: Optional[str],
+        is_bot: bool,
+        bot_reason: Optional[str],
+        now: datetime,
+    ) -> None:
+        """Ghi click cho consult link — đối xứng record_click recipient. Không
+        có sms_click_event cho consult (event gắn recipient_id) → chỉ counter
+        denorm atomic trên consult_link."""
+        inc_human = 0 if is_bot else 1
+        values = {
+            "raw_click_count": SmsConsultLink.raw_click_count + 1,
+            "human_click_count": (
+                SmsConsultLink.human_click_count + inc_human
+            ),
+        }
+        if not is_bot:
+            values["last_human_clicked_at"] = now
+            values["first_human_clicked_at"] = case(
+                (SmsConsultLink.first_human_clicked_at.is_(None), now),
+                else_=SmsConsultLink.first_human_clicked_at,
+            )
+        await self.db.execute(
+            update(SmsConsultLink)
+            .where(SmsConsultLink.id == consult_link_id)
+            .values(**values)
+        )
 
     # ---------------------------------------------------------------
     # Click event + denorm counter (atomic — chống lost update khi click //)
@@ -102,6 +150,16 @@ class SmsTrackingRepository:
     # ---------------------------------------------------------------
     # Opt-out
     # ---------------------------------------------------------------
+    async def get_contact_phone(self, contact_id: int) -> Optional[str]:
+        """phone_normalized của 1 contact (consult resolve — recipient dùng
+        snapshot; consult phải tra contact). None nếu contact đã xoá."""
+        from app.models.sms import SmsContact
+        return await self.db.scalar(
+            select(SmsContact.phone_normalized).where(
+                SmsContact.id == contact_id
+            )
+        )
+
     async def is_phone_opted_out(self, phone_normalized: str) -> bool:
         res = await self.db.scalar(
             select(SmsOptOut.id)

--- a/Backend_FastAPI/app/repositories/sms_tracking_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_tracking_repository.py
@@ -21,6 +21,7 @@ from app.models.sms import (
     SmsCampaignRecipient,
     SmsClickEvent,
     SmsConsultLink,
+    SmsContact,
     SmsOptOut,
 )
 
@@ -153,7 +154,6 @@ class SmsTrackingRepository:
     async def get_contact_phone(self, contact_id: int) -> Optional[str]:
         """phone_normalized của 1 contact (consult resolve — recipient dùng
         snapshot; consult phải tra contact). None nếu contact đã xoá."""
-        from app.models.sms import SmsContact
         return await self.db.scalar(
             select(SmsContact.phone_normalized).where(
                 SmsContact.id == contact_id

--- a/Backend_FastAPI/app/repositories/sms_tracking_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_tracking_repository.py
@@ -58,15 +58,19 @@ class SmsTrackingRepository:
     # ---------------------------------------------------------------
     async def lookup_consult_by_token_hash(
         self, token_hash: str
-    ) -> Optional[SmsConsultLink]:
-        """SmsConsultLink nếu token_hash khớp; None nếu không. Dùng khi
-        recipient lookup KHÔNG thấy (resolve mở rộng §16.7)."""
+    ) -> Optional[Tuple[SmsConsultLink, Optional[str]]]:
+        """(consult_link, phone_normalized) nếu token_hash khớp; None nếu không.
+        LEFT JOIN contact để lấy phone luôn (khỏi query get_contact_phone thêm ở
+        landing/opt-out); phone=None nếu contact đã xoá (link vẫn resolve cho /r/).
+        Dùng khi recipient lookup KHÔNG thấy (resolve mở rộng §16.7)."""
         res = await self.db.execute(
-            select(SmsConsultLink)
+            select(SmsConsultLink, SmsContact.phone_normalized)
+            .outerjoin(SmsContact, SmsContact.id == SmsConsultLink.contact_id)
             .where(SmsConsultLink.token_hash == token_hash)
             .limit(1)
         )
-        return res.scalars().first()
+        row = res.first()
+        return (row[0], row[1]) if row else None
 
     async def record_consult_click(
         self,
@@ -151,15 +155,6 @@ class SmsTrackingRepository:
     # ---------------------------------------------------------------
     # Opt-out
     # ---------------------------------------------------------------
-    async def get_contact_phone(self, contact_id: int) -> Optional[str]:
-        """phone_normalized của 1 contact (consult resolve — recipient dùng
-        snapshot; consult phải tra contact). None nếu contact đã xoá."""
-        return await self.db.scalar(
-            select(SmsContact.phone_normalized).where(
-                SmsContact.id == contact_id
-            )
-        )
-
     async def is_phone_opted_out(self, phone_normalized: str) -> bool:
         res = await self.db.scalar(
             select(SmsOptOut.id)

--- a/Backend_FastAPI/app/routers/sms_consult.py
+++ b/Backend_FastAPI/app/routers/sms_consult.py
@@ -1,0 +1,46 @@
+# app/routers/sms_consult.py
+"""
+SMS Marketing — consult officer (P2-3 §16.7). Officer tạo link tư vấn 1-1 cho
+lead trong phạm vi mình + xem hồ sơ 'quan tâm ngành' của lead. Router "dumb":
+commit (mutation) rồi trả. KHÔNG sửa main.py logic (chỉ đăng ký router).
+
+Gate 2 tầng: `CasbinAuth` (RBAC path-level — officer có policy) + `get_lead_for_user`
+(IDOR resource-level — officer chỉ lead được giao; ngoài phạm vi → 404).
+"""
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database, models
+from app.core.deps import CasbinAuth, get_lead_for_user
+from app.schemas import sms as sms_schemas
+from app.services.sms_consult_service import SmsConsultService
+
+router = APIRouter(prefix="/api/sms", tags=["SMS Consult"])
+
+
+@router.post(
+    "/leads/{lead_id}/consult-link",
+    response_model=sms_schemas.SmsConsultLinkResponse,
+)
+async def create_consult_link(
+    lead: models.Lead = Depends(get_lead_for_user),
+    current_user: models.User = CasbinAuth,
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Sinh consult link cho lead → trả raw `code`/`url` 1 LẦN (copy gửi Zalo)."""
+    result = await SmsConsultService(db).create_consult_link(lead, current_user)
+    await db.commit()
+    return result
+
+
+@router.get(
+    "/leads/{lead_id}/interests",
+    response_model=sms_schemas.SmsLeadInterestResponse,
+)
+async def get_lead_interests(
+    lead: models.Lead = Depends(get_lead_for_user),
+    current_user: models.User = CasbinAuth,
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Hồ sơ 'quan tâm ngành' của lead (qua contact match phone) — read-only."""
+    return await SmsConsultService(db).lead_interests(lead)

--- a/Backend_FastAPI/app/schemas/sms.py
+++ b/Backend_FastAPI/app/schemas/sms.py
@@ -661,6 +661,26 @@ class SmsContactInterestList(BaseModel):
     items: List[SmsContactInterestRow] = Field(default_factory=list)
 
 
+# --- P2-3 consult officer (§16.7) ---
+class SmsConsultLinkResponse(BaseModel):
+    """Trả sau `POST /leads/{id}/consult-link` — `code`/`url` raw TRẢ 1 LẦN để
+    officer copy gửi Zalo/tay. Server chỉ lưu token_hash."""
+
+    code: str
+    url: str
+    consult_link_id: int
+    contact_id: int
+
+
+class SmsLeadInterestResponse(BaseModel):
+    """Hồ sơ 'quan tâm ngành' của 1 LEAD (match qua phone → contact). Rỗng nếu
+    lead chưa có contact / chưa có tương tác landing."""
+
+    lead_id: int
+    contact_id: Optional[int] = None
+    items: List[SmsContactInterestRow] = Field(default_factory=list)
+
+
 class SmsPublicOptOutRequest(BaseModel):
     """Body opt-out công khai từ landing — chỉ mang bearer code (§19.3)."""
 

--- a/Backend_FastAPI/app/services/sms_campaign_service.py
+++ b/Backend_FastAPI/app/services/sms_campaign_service.py
@@ -12,6 +12,8 @@ SMS_MARKETING_MODULE_DESIGN.md §3/§6/§7/§8.
 import re
 import unicodedata
 from datetime import datetime, timezone
+
+from app.utils.tz import ensure_aware
 from typing import List, Optional, Tuple
 
 from sqlalchemy.exc import IntegrityError
@@ -60,8 +62,7 @@ def _slugify(name: str) -> str:
     return s[:50] or "campaign"
 
 
-def _aware(dt: datetime) -> datetime:
-    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+_aware = ensure_aware  # alias tới helper tz chung (bỏ bản sao logic)
 
 
 class SmsCampaignService:

--- a/Backend_FastAPI/app/services/sms_consult_service.py
+++ b/Backend_FastAPI/app/services/sms_consult_service.py
@@ -1,0 +1,129 @@
+# app/services/sms_consult_service.py
+"""
+Business logic P2-3 consult officer (§16.5/§16.7): officer tạo link tư vấn 1-1
+cho 1 lead trong phạm vi IDOR của mình → match/tạo contact theo phone lead
+(khóa thống nhất) → sinh consult link (short code raw TRẢ 1 LẦN). Và xem hồ sơ
+'quan tâm ngành' của lead (qua contact match).
+
+Consult 1-1 KHÔNG tự cấp consent marketing: contact tạo giữ
+`marketing_consent_status='unknown'` (§16.5) → KHÔNG đủ điều kiện build campaign.
+
+KHÔNG import fastapi; raise domain exception; service flush (router commit).
+"""
+from typing import Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.repositories.sms_contact_repository import SmsContactRepository
+from app.repositories.sms_engagement_repository import SmsEngagementRepository
+from app.schemas import sms as sms_schemas
+from app.utils.exceptions import ValidationError
+from app.utils.phone_helpers import (
+    is_vietnam_mobile,
+    normalize_and_validate_vietnam_phone,
+    to_zalo_phone,
+)
+from app.utils.sms_token import (
+    build_link,
+    compute_token_hash,
+    ensure_token_secrets_configured,
+    generate_short_code,
+)
+
+
+class SmsConsultService:
+    """Officer consult link + lead interests (Phase 2 §16)."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.contact_repo = SmsContactRepository(db)
+        self.engagement_repo = SmsEngagementRepository(db)
+
+    @staticmethod
+    def _normalize_lead_phone(phone: Optional[str]) -> str:
+        """(normalized) cho số di động lead — raise ValidationError nếu không
+        phải di động VN hợp lệ (không tạo consult link cho số rác)."""
+        normalized, valid = normalize_and_validate_vietnam_phone(phone)
+        if not valid or not normalized or not is_vietnam_mobile(normalized):
+            raise ValidationError(
+                detail="Lead chưa có số di động hợp lệ để tạo link tư vấn."
+            )
+        return normalized
+
+    async def create_consult_link(
+        self, lead: models.Lead, current_user: models.User
+    ) -> sms_schemas.SmsConsultLinkResponse:
+        # Prod bắt buộc secret hash mạnh + base URL hợp lệ (link công khai).
+        ensure_token_secrets_configured()
+        normalized = self._normalize_lead_phone(lead.phone)
+
+        # Match contact theo phone (khóa thống nhất); chưa có → tạo (consent
+        # unknown — consult không tự cấp consent marketing §16.5).
+        contact = await self.contact_repo.get_contact_by_phone(normalized)
+        if contact is None:
+            try:
+                async with self.db.begin_nested():
+                    contact = await self.contact_repo.create_contact(
+                        {
+                            "full_name": (lead.full_name or "Lead")[:255],
+                            "phone_normalized": normalized,
+                            "phone_international": to_zalo_phone(normalized),
+                            "source_label": "lead_consult",
+                            "created_by_id": getattr(current_user, "id", None),
+                        }
+                    )
+            except IntegrityError:
+                # Race: 2 request tạo cùng phone → lấy contact đã có.
+                contact = await self.contact_repo.get_contact_by_phone(
+                    normalized
+                )
+                if contact is None:
+                    raise
+
+        code = generate_short_code()
+        consult = await self.engagement_repo.create_consult_link(
+            {
+                "lead_id": lead.id,
+                "contact_id": contact.id,
+                "created_by_id": getattr(current_user, "id", None),
+                "token_hash": compute_token_hash(code),
+                "landing_type": "qlts_hosted",
+            }
+        )
+        return sms_schemas.SmsConsultLinkResponse(
+            code=code,
+            url=build_link(code),
+            consult_link_id=consult.id,
+            contact_id=contact.id,
+        )
+
+    async def lead_interests(
+        self, lead: models.Lead
+    ) -> sms_schemas.SmsLeadInterestResponse:
+        """Interest của lead qua contact match phone. Rỗng nếu chưa có
+        contact/tương tác. KHÔNG raise nếu phone lead không hợp lệ → trả rỗng."""
+        normalized, valid = normalize_and_validate_vietnam_phone(lead.phone)
+        if not valid or not normalized:
+            return sms_schemas.SmsLeadInterestResponse(lead_id=lead.id)
+        contact = await self.contact_repo.get_contact_by_phone(normalized)
+        if contact is None:
+            return sms_schemas.SmsLeadInterestResponse(lead_id=lead.id)
+        rows = await self.engagement_repo.contact_interests(contact.id)
+        return sms_schemas.SmsLeadInterestResponse(
+            lead_id=lead.id,
+            contact_id=contact.id,
+            items=[
+                sms_schemas.SmsContactInterestRow(
+                    major_program_id=r.major_program_id,
+                    program_name=name or "(ngành đã xoá)",
+                    view_count=r.view_count,
+                    total_dwell_seconds=r.total_dwell_seconds,
+                    interest_score=r.interest_score,
+                    first_interest_at=r.first_interest_at,
+                    last_interest_at=r.last_interest_at,
+                )
+                for r, name in rows
+            ],
+        )

--- a/Backend_FastAPI/app/services/sms_consult_service.py
+++ b/Backend_FastAPI/app/services/sms_consult_service.py
@@ -82,16 +82,26 @@ class SmsConsultService:
                 if contact is None:
                     raise
 
-        code = generate_short_code()
-        consult = await self.engagement_repo.create_consult_link(
-            {
-                "lead_id": lead.id,
-                "contact_id": contact.id,
-                "created_by_id": getattr(current_user, "id", None),
-                "token_hash": compute_token_hash(code),
-                "landing_type": "qlts_hosted",
-            }
-        )
+        # Retry sinh code nếu token_hash trùng (collision base62×9 ~2^54 cực
+        # hiếm; đối xứng retry của campaign build) → tránh IntegrityError→500.
+        consult = None
+        for attempt in range(5):
+            code = generate_short_code()
+            try:
+                async with self.db.begin_nested():
+                    consult = await self.engagement_repo.create_consult_link(
+                        {
+                            "lead_id": lead.id,
+                            "contact_id": contact.id,
+                            "created_by_id": getattr(current_user, "id", None),
+                            "token_hash": compute_token_hash(code),
+                            "landing_type": "qlts_hosted",
+                        }
+                    )
+                break
+            except IntegrityError:
+                if attempt == 4:
+                    raise
         return sms_schemas.SmsConsultLinkResponse(
             code=code,
             url=build_link(code),

--- a/Backend_FastAPI/app/services/sms_consult_service.py
+++ b/Backend_FastAPI/app/services/sms_consult_service.py
@@ -19,7 +19,7 @@ from app import models
 from app.repositories.sms_contact_repository import SmsContactRepository
 from app.repositories.sms_engagement_repository import SmsEngagementRepository
 from app.schemas import sms as sms_schemas
-from app.utils.exceptions import ValidationError
+from app.utils.exceptions import ConflictError, ValidationError
 from app.utils.phone_helpers import (
     is_vietnam_mobile,
     normalize_and_validate_vietnam_phone,
@@ -32,6 +32,10 @@ from app.utils.sms_token import (
     generate_short_code,
 )
 
+# Số lần sinh lại short code khi trúng UNIQUE token_hash (collision base62×9
+# ~2^54 cực hiếm). Đối xứng _TOKEN_RETRY của sms_campaign_service.
+_TOKEN_RETRY = 5
+
 
 class SmsConsultService:
     """Officer consult link + lead interests (Phase 2 §16)."""
@@ -42,25 +46,26 @@ class SmsConsultService:
         self.engagement_repo = SmsEngagementRepository(db)
 
     @staticmethod
-    def _normalize_lead_phone(phone: Optional[str]) -> str:
-        """(normalized) cho số di động lead — raise ValidationError nếu không
-        phải di động VN hợp lệ (không tạo consult link cho số rác)."""
+    def _normalize_lead_phone(phone: Optional[str]) -> tuple[str, str]:
+        """(normalized, international) cho số di động lead — raise ValidationError
+        nếu không phải di động VN hợp lệ (không tạo consult link cho số rác)."""
         normalized, valid = normalize_and_validate_vietnam_phone(phone)
         if not valid or not normalized or not is_vietnam_mobile(normalized):
             raise ValidationError(
                 detail="Lead chưa có số di động hợp lệ để tạo link tư vấn."
             )
-        return normalized
+        return normalized, to_zalo_phone(normalized)
 
     async def create_consult_link(
         self, lead: models.Lead, current_user: models.User
     ) -> sms_schemas.SmsConsultLinkResponse:
         # Prod bắt buộc secret hash mạnh + base URL hợp lệ (link công khai).
         ensure_token_secrets_configured()
-        normalized = self._normalize_lead_phone(lead.phone)
+        normalized, international = self._normalize_lead_phone(lead.phone)
 
         # Match contact theo phone (khóa thống nhất); chưa có → tạo (consent
-        # unknown — consult không tự cấp consent marketing §16.5).
+        # unknown — consult không tự cấp consent marketing §16.5). phone_raw giữ
+        # số gốc lead để đồng nhất với contact tạo qua endpoint thường.
         contact = await self.contact_repo.get_contact_by_phone(normalized)
         if contact is None:
             try:
@@ -68,8 +73,9 @@ class SmsConsultService:
                     contact = await self.contact_repo.create_contact(
                         {
                             "full_name": (lead.full_name or "Lead")[:255],
+                            "phone_raw": (lead.phone or "").strip()[:32] or None,
                             "phone_normalized": normalized,
-                            "phone_international": to_zalo_phone(normalized),
+                            "phone_international": international,
                             "source_label": "lead_consult",
                             "created_by_id": getattr(current_user, "id", None),
                         }
@@ -82,10 +88,10 @@ class SmsConsultService:
                 if contact is None:
                     raise
 
-        # Retry sinh code nếu token_hash trùng (collision base62×9 ~2^54 cực
-        # hiếm; đối xứng retry của campaign build) → tránh IntegrityError→500.
-        consult = None
-        for attempt in range(5):
+        # Sinh short code, retry CHỈ khi trúng UNIQUE token_hash (collision
+        # base62×9 ~2^54 cực hiếm); lỗi Integrity khác → re-raise ngay. Đối xứng
+        # sms_campaign_service (for…else + hằng + check tên constraint).
+        for _attempt in range(_TOKEN_RETRY):
             code = generate_short_code()
             try:
                 async with self.db.begin_nested():
@@ -99,9 +105,13 @@ class SmsConsultService:
                         }
                     )
                 break
-            except IntegrityError:
-                if attempt == 4:
+            except IntegrityError as exc:
+                if "uq_sms_consult_link_token_hash" not in str(exc.orig):
                     raise
+        else:
+            raise ConflictError(
+                detail="Không sinh được mã tư vấn (trùng token), vui lòng thử lại."
+            )
         return sms_schemas.SmsConsultLinkResponse(
             code=code,
             url=build_link(code),

--- a/Backend_FastAPI/app/services/sms_consult_service.py
+++ b/Backend_FastAPI/app/services/sms_consult_service.py
@@ -21,9 +21,8 @@ from app.repositories.sms_engagement_repository import SmsEngagementRepository
 from app.schemas import sms as sms_schemas
 from app.utils.exceptions import ConflictError, ValidationError
 from app.utils.phone_helpers import (
-    is_vietnam_mobile,
     normalize_and_validate_vietnam_phone,
-    to_zalo_phone,
+    normalize_vn_mobile,
 )
 from app.utils.sms_token import (
     build_link,
@@ -49,12 +48,12 @@ class SmsConsultService:
     def _normalize_lead_phone(phone: Optional[str]) -> tuple[str, str]:
         """(normalized, international) cho số di động lead — raise ValidationError
         nếu không phải di động VN hợp lệ (không tạo consult link cho số rác)."""
-        normalized, valid = normalize_and_validate_vietnam_phone(phone)
-        if not valid or not normalized or not is_vietnam_mobile(normalized):
+        result = normalize_vn_mobile(phone)
+        if result is None:
             raise ValidationError(
                 detail="Lead chưa có số di động hợp lệ để tạo link tư vấn."
             )
-        return normalized, to_zalo_phone(normalized)
+        return result
 
     async def create_consult_link(
         self, lead: models.Lead, current_user: models.User

--- a/Backend_FastAPI/app/services/sms_contact_service.py
+++ b/Backend_FastAPI/app/services/sms_contact_service.py
@@ -38,6 +38,7 @@ from app.utils.exceptions import (
 from app.utils.phone_helpers import (
     is_vietnam_mobile,
     normalize_vietnam_phone,
+    normalize_vn_mobile,
     to_zalo_phone,
 )
 
@@ -179,13 +180,12 @@ class SmsContactService:
     def _normalize_mobile(self, phone_raw: str) -> Tuple[str, str]:
         """Normalize + ép mobile-only. Trả (normalized, international).
         Raise ValidationError nếu không phải di động VN hợp lệ."""
-        normalized = normalize_vietnam_phone(phone_raw)
-        if not normalized or not is_vietnam_mobile(normalized):
+        result = normalize_vn_mobile(phone_raw)
+        if result is None:
             raise ValidationError(
                 detail="Số điện thoại không hợp lệ (chỉ nhận di động VN)"
             )
-        international = to_zalo_phone(normalized)
-        return normalized, international
+        return result
 
     async def create_contact(
         self, data: sms_schemas.SmsContactCreate, user

--- a/Backend_FastAPI/app/services/sms_engagement_service.py
+++ b/Backend_FastAPI/app/services/sms_engagement_service.py
@@ -101,18 +101,11 @@ class SmsEngagementService:
             {
                 "contact_id": resolved.contact_id,
                 "source_type": resolved.kind,  # "campaign" | "consult"
-                "recipient_id": (
-                    resolved.recipient.id
-                    if resolved.kind == "campaign" else None
-                ),
-                "campaign_id": (
-                    resolved.campaign.id
-                    if resolved.kind == "campaign" else None
-                ),
-                "consult_link_id": (
-                    resolved.consult.id
-                    if resolved.kind == "consult" else None
-                ),
+                # ResolvedCode để None sẵn nhánh không khớp → truthiness object là
+                # đủ (không cần so chuỗi kind).
+                "recipient_id": resolved.recipient.id if resolved.recipient else None,
+                "campaign_id": resolved.campaign.id if resolved.campaign else None,
+                "consult_link_id": resolved.consult.id if resolved.consult else None,
                 "session_token_hash": compute_session_token_hash(raw_token),
                 "started_at": now,
                 "last_heartbeat_at": now,

--- a/Backend_FastAPI/app/services/sms_engagement_service.py
+++ b/Backend_FastAPI/app/services/sms_engagement_service.py
@@ -13,6 +13,8 @@ interest + report. Xem SMS_MARKETING_MODULE_DESIGN.md §16.
 """
 import logging
 from datetime import datetime, timezone
+
+from app.utils.tz import ensure_aware
 from typing import Mapping, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,7 +23,7 @@ from app.config import settings
 from app.repositories.sms_engagement_repository import SmsEngagementRepository
 from app.repositories.sms_tracking_repository import SmsTrackingRepository
 from app.schemas import sms as sms_schemas
-from app.services.sms_resolve import resolve_code
+from app.services.sms_resolve import GENERIC_404, resolve_code
 from app.utils.exceptions import ResourceNotFoundError
 from app.utils.sms_bot import detect_bot
 from app.utils.sms_interest import compute_interest_score
@@ -34,15 +36,13 @@ from app.utils.sms_token import (
 
 log = logging.getLogger(__name__)
 
-_GENERIC_404 = "Liên kết không hợp lệ hoặc đã hết hạn"
 # Dung sai clamp dwell: cho phép dwell client báo vượt thời gian thực đã trôi
 # tối đa ngần này (bù lệch đồng hồ + độ trễ heartbeat cuối). Chống client gửi
 # dwell_seconds khổng lồ (thổi phồng interest).
 _HEARTBEAT_GRACE_SECONDS = 30
 
 
-def _aware(dt: datetime) -> datetime:
-    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+_aware = ensure_aware  # alias tới helper tz chung (bỏ bản sao logic)
 
 
 class SmsEngagementService:
@@ -65,12 +65,12 @@ class SmsEngagementService:
         chặn theo expiry ở đây. `code` path chỉ validate format (routing)."""
         token = (session_token or "").strip()
         if not token:
-            raise ResourceNotFoundError(detail=_GENERIC_404)
+            raise ResourceNotFoundError(detail=GENERIC_404)
         session = await self.repo.get_session_by_token_hash(
             compute_session_token_hash(token)
         )
         if session is None:
-            raise ResourceNotFoundError(detail=_GENERIC_404)
+            raise ResourceNotFoundError(detail=GENERIC_404)
         return session
 
     # ---------------------------------------------------------------
@@ -91,7 +91,7 @@ class SmsEngagementService:
         # contact_id = khóa thống nhất gắn interest; NULL (recipient mất contact
         # do xoá) → không quy được sở thích → 404 (ca hiếm; consult luôn có).
         if resolved.contact_id is None:
-            raise ResourceNotFoundError(detail=_GENERIC_404)
+            raise ResourceNotFoundError(detail=GENERIC_404)
         now = datetime.now(timezone.utc)
         is_bot, _reason = detect_bot(
             user_agent=user_agent, headers=headers, now=now
@@ -125,12 +125,12 @@ class SmsEngagementService:
         self, code: str, payload: sms_schemas.SmsProgramViewRequest
     ) -> sms_schemas.SmsProgramViewResponse:
         if not is_valid_code(code):
-            raise ResourceNotFoundError(detail=_GENERIC_404)
+            raise ResourceNotFoundError(detail=GENERIC_404)
         session = await self._resolve_session(payload.session_token)
         program = await self.repo.get_active_program(payload.major_program_id)
         if program is None:
             # Ngành không tồn tại/không active → không đo (404 generic).
-            raise ResourceNotFoundError(detail=_GENERIC_404)
+            raise ResourceNotFoundError(detail=GENERIC_404)
         seq = await self.repo.next_sequence_no(session.id)
         view = await self.repo.create_program_view(
             {
@@ -155,13 +155,13 @@ class SmsEngagementService:
         self, code: str, payload: sms_schemas.SmsHeartbeatRequest
     ) -> sms_schemas.SmsHeartbeatResponse:
         if not is_valid_code(code):
-            raise ResourceNotFoundError(detail=_GENERIC_404)
+            raise ResourceNotFoundError(detail=GENERIC_404)
         session = await self._resolve_session(payload.session_token)
         view = await self.repo.get_program_view(
             payload.program_view_id, session.id
         )
         if view is None:
-            raise ResourceNotFoundError(detail=_GENERIC_404)
+            raise ResourceNotFoundError(detail=GENERIC_404)
         now = datetime.now(timezone.utc)
         # Clamp: dwell ≤ thời gian thực đã trôi kể từ khi mở view + grace, và
         # đơn điệu tăng (heartbeat trễ/trùng không làm tụt). Chống thổi phồng.

--- a/Backend_FastAPI/app/services/sms_engagement_service.py
+++ b/Backend_FastAPI/app/services/sms_engagement_service.py
@@ -21,13 +21,13 @@ from app.config import settings
 from app.repositories.sms_engagement_repository import SmsEngagementRepository
 from app.repositories.sms_tracking_repository import SmsTrackingRepository
 from app.schemas import sms as sms_schemas
+from app.services.sms_resolve import resolve_code
 from app.utils.exceptions import ResourceNotFoundError
 from app.utils.sms_bot import detect_bot
 from app.utils.sms_interest import compute_interest_score
 from app.utils.sms_token import (
     compute_ip_hash,
     compute_session_token_hash,
-    compute_token_hash,
     generate_session_token,
     is_valid_code,
 )
@@ -52,24 +52,6 @@ class SmsEngagementService:
         self.db = db
         self.repo = SmsEngagementRepository(db)
         self.tracking_repo = SmsTrackingRepository(db)
-
-    # ---------------------------------------------------------------
-    # Resolve code → recipient + campaign (mirror landing/tracking)
-    # ---------------------------------------------------------------
-    async def _resolve_recipient(self, code: str):
-        if not is_valid_code(code):
-            raise ResourceNotFoundError(detail=_GENERIC_404)
-        found = await self.tracking_repo.lookup_by_token_hash(
-            compute_token_hash(code)
-        )
-        if found is None:
-            raise ResourceNotFoundError(detail=_GENERIC_404)
-        recipient, campaign = found
-        if campaign.link_expires_at and _aware(
-            campaign.link_expires_at
-        ) <= datetime.now(timezone.utc):
-            raise ResourceNotFoundError(detail=_GENERIC_404)
-        return recipient, campaign
 
     async def _resolve_session(self, session_token: str):
         """Session theo token hash (bearer). None → 404 generic.
@@ -102,10 +84,13 @@ class SmsEngagementService:
         user_agent: Optional[str],
         headers: Optional[Mapping[str, str]] = None,
     ) -> sms_schemas.SmsSessionStartResponse:
-        recipient, campaign = await self._resolve_recipient(code)
-        # contact_id = khóa thống nhất gắn interest; NULL (contact đã xoá) →
-        # không quy được sở thích → 404 generic (measurement bỏ qua ca hiếm này).
-        if recipient.contact_id is None:
+        # Resolve mở rộng: recipient (campaign) HOẶC consult link (§16.7).
+        resolved = await resolve_code(
+            self.tracking_repo, code, enforce_expiry=True
+        )
+        # contact_id = khóa thống nhất gắn interest; NULL (recipient mất contact
+        # do xoá) → không quy được sở thích → 404 (ca hiếm; consult luôn có).
+        if resolved.contact_id is None:
             raise ResourceNotFoundError(detail=_GENERIC_404)
         now = datetime.now(timezone.utc)
         is_bot, _reason = detect_bot(
@@ -114,10 +99,20 @@ class SmsEngagementService:
         raw_token = generate_session_token()
         session = await self.repo.create_session(
             {
-                "contact_id": recipient.contact_id,
-                "source_type": "campaign",
-                "recipient_id": recipient.id,
-                "campaign_id": campaign.id,
+                "contact_id": resolved.contact_id,
+                "source_type": resolved.kind,  # "campaign" | "consult"
+                "recipient_id": (
+                    resolved.recipient.id
+                    if resolved.kind == "campaign" else None
+                ),
+                "campaign_id": (
+                    resolved.campaign.id
+                    if resolved.kind == "campaign" else None
+                ),
+                "consult_link_id": (
+                    resolved.consult.id
+                    if resolved.kind == "consult" else None
+                ),
                 "session_token_hash": compute_session_token_hash(raw_token),
                 "started_at": now,
                 "last_heartbeat_at": now,

--- a/Backend_FastAPI/app/services/sms_export_service.py
+++ b/Backend_FastAPI/app/services/sms_export_service.py
@@ -14,6 +14,8 @@ import asyncio
 import logging
 import os
 from datetime import datetime, timedelta, timezone
+
+from app.utils.tz import ensure_aware
 from typing import Callable, List, Optional, Tuple
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -47,8 +49,7 @@ _EXPORTABLE_CAMPAIGN_STATUS = {"ready", "exported", "handed_off"}
 _REGENERATE_BATCH_STATUS = {"pending", "failed", "purged", "invalidated"}
 
 
-def _aware(dt: datetime) -> datetime:
-    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+_aware = ensure_aware  # alias tới helper tz chung (bỏ bản sao logic)
 
 
 def _carrier_label(carrier_bucket: str) -> str:

--- a/Backend_FastAPI/app/services/sms_landing_service.py
+++ b/Backend_FastAPI/app/services/sms_landing_service.py
@@ -17,8 +17,8 @@ from app.config import settings
 from app.repositories.sms_engagement_repository import SmsEngagementRepository
 from app.repositories.sms_tracking_repository import SmsTrackingRepository
 from app.schemas import sms as sms_schemas
+from app.services.sms_resolve import ResolvedCode, resolve_code
 from app.utils.exceptions import ResourceNotFoundError
-from app.utils.sms_token import compute_token_hash, is_valid_code
 from app.utils.sms_url import host_in_allowlist
 
 log = logging.getLogger(__name__)
@@ -26,54 +26,52 @@ log = logging.getLogger(__name__)
 _GENERIC_404 = "Liên kết không hợp lệ hoặc đã hết hạn"
 
 
-def _aware(dt: datetime) -> datetime:
-    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
-
-
 class SmsLandingService:
-    """Landing read-only + opt-out công khai."""
+    """Landing read-only + opt-out công khai (campaign HOẶC consult)."""
 
     def __init__(self, db: AsyncSession):
         self.db = db
         self.repo = SmsTrackingRepository(db)
         self.engagement_repo = SmsEngagementRepository(db)
 
-    async def _resolve(self, code: str, *, enforce_expiry: bool = True):
-        if not is_valid_code(code):
+    async def _phone_for(self, resolved: ResolvedCode) -> str:
+        """phone_normalized của nguồn: recipient dùng snapshot; consult tra
+        contact. Raise 404 nếu consult contact đã xoá (không opt-out được)."""
+        if resolved.kind == "campaign":
+            return resolved.recipient.phone_normalized_snapshot
+        phone = await self.repo.get_contact_phone(resolved.contact_id)
+        if not phone:
             raise ResourceNotFoundError(detail=_GENERIC_404)
-        found = await self.repo.lookup_by_token_hash(compute_token_hash(code))
-        if found is None:
-            raise ResourceNotFoundError(detail=_GENERIC_404)
-        recipient, campaign = found
-        # Opt-out KHÔNG gate hết hạn (enforce_expiry=False): nghĩa vụ cho phép
-        # từ chối nhận tin phải LUÔN thực hiện được kể cả khi link đã hết hạn
-        # (NĐ91). Landing GET vẫn gate (hiện trang hết-hạn thân thiện).
-        if enforce_expiry and campaign.link_expires_at and _aware(
-            campaign.link_expires_at
-        ) <= datetime.now(timezone.utc):
-            raise ResourceNotFoundError(detail=_GENERIC_404)
-        return recipient, campaign
+        return phone
 
     async def get_landing(self, code: str) -> sms_schemas.SmsLandingResponse:
-        recipient, campaign = await self._resolve(code)
-        already = await self.repo.is_phone_opted_out(
-            recipient.phone_normalized_snapshot
-        )
-        # CTA external → re-check allowlist lúc render; ngoài → ẩn CTA + log.
-        cta_label = campaign.landing_cta_label
-        cta_url = campaign.landing_cta_url
-        if cta_url and not host_in_allowlist(cta_url):
-            log.warning(
-                "SMS landing: CTA url ngoài allowlist campaign_id=%s", campaign.id
-            )
-            cta_label = cta_url = None
+        resolved = await resolve_code(self.repo, code, enforce_expiry=True)
+        phone = await self._phone_for(resolved)
+        already = await self.repo.is_phone_opted_out(phone)
+
+        headline = body = cta_label = cta_url = None
+        if resolved.kind == "campaign":
+            campaign = resolved.campaign
+            headline = campaign.landing_headline
+            body = campaign.landing_body
+            # CTA external → re-check allowlist lúc render; ngoài → ẩn CTA + log.
+            cta_label = campaign.landing_cta_label
+            cta_url = campaign.landing_cta_url
+            if cta_url and not host_in_allowlist(cta_url):
+                log.warning(
+                    "SMS landing: CTA url ngoài allowlist campaign_id=%s",
+                    campaign.id,
+                )
+                cta_label = cta_url = None
+        # consult: MVP không headline/body/CTA campaign — chỉ danh mục ngành.
+
         # Phase 2 (§16.1): danh mục ngành cho landing 2 tầng (read-only, no
         # session — session chỉ tạo qua POST để tránh crawler tạo phiên rác).
         programs = await self.engagement_repo.list_active_programs()
         return sms_schemas.SmsLandingResponse(
             school_name=settings.SMS_LANDING_SCHOOL_NAME,
-            headline=campaign.landing_headline,
-            body=campaign.landing_body,
+            headline=headline,
+            body=body,
             cta_label=cta_label,
             cta_url=cta_url,
             consent_notice=settings.SMS_LANDING_CONSENT_NOTICE,
@@ -90,8 +88,9 @@ class SmsLandingService:
     async def public_opt_out(
         self, code: str
     ) -> sms_schemas.SmsPublicOptOutResponse:
-        recipient, campaign = await self._resolve(code, enforce_expiry=False)
-        phone = recipient.phone_normalized_snapshot
+        # Opt-out KHÔNG gate hết hạn (NĐ91 — luôn cho từ chối nhận tin).
+        resolved = await resolve_code(self.repo, code, enforce_expiry=False)
+        phone = await self._phone_for(resolved)
         if await self.repo.get_opt_out(phone) is not None:
             return sms_schemas.SmsPublicOptOutResponse(
                 success=True, already_opted_out=True
@@ -104,8 +103,11 @@ class SmsLandingService:
                     {
                         "phone_normalized": phone,
                         "source": "landing_optout",
-                        "campaign_id": campaign.id,
-                        "contact_id": recipient.contact_id,
+                        "campaign_id": (
+                            resolved.campaign.id
+                            if resolved.kind == "campaign" else None
+                        ),
+                        "contact_id": resolved.contact_id,
                         "observed_at": datetime.now(timezone.utc),
                     }
                 )

--- a/Backend_FastAPI/app/services/sms_landing_service.py
+++ b/Backend_FastAPI/app/services/sms_landing_service.py
@@ -17,13 +17,11 @@ from app.config import settings
 from app.repositories.sms_engagement_repository import SmsEngagementRepository
 from app.repositories.sms_tracking_repository import SmsTrackingRepository
 from app.schemas import sms as sms_schemas
-from app.services.sms_resolve import ResolvedCode, resolve_code
+from app.services.sms_resolve import GENERIC_404, ResolvedCode, resolve_code
 from app.utils.exceptions import ResourceNotFoundError
 from app.utils.sms_url import host_in_allowlist
 
 log = logging.getLogger(__name__)
-
-_GENERIC_404 = "Liên kết không hợp lệ hoặc đã hết hạn"
 
 
 class SmsLandingService:
@@ -35,13 +33,12 @@ class SmsLandingService:
         self.engagement_repo = SmsEngagementRepository(db)
 
     async def _phone_for(self, resolved: ResolvedCode) -> str:
-        """phone_normalized của nguồn: recipient dùng snapshot; consult tra
-        contact. Raise 404 nếu consult contact đã xoá (không opt-out được)."""
-        if resolved.kind == "campaign":
-            return resolved.recipient.phone_normalized_snapshot
-        phone = await self.repo.get_contact_phone(resolved.contact_id)
+        """phone_normalized của nguồn (recipient snapshot / consult JOIN contact,
+        resolve_code đã nạp sẵn). Raise 404 nếu consult contact đã xoá (không
+        opt-out/landing được)."""
+        phone = resolved.phone_normalized
         if not phone:
-            raise ResourceNotFoundError(detail=_GENERIC_404)
+            raise ResourceNotFoundError(detail=GENERIC_404)
         return phone
 
     async def get_landing(self, code: str) -> sms_schemas.SmsLandingResponse:
@@ -104,8 +101,7 @@ class SmsLandingService:
                         "phone_normalized": phone,
                         "source": "landing_optout",
                         "campaign_id": (
-                            resolved.campaign.id
-                            if resolved.kind == "campaign" else None
+                            resolved.campaign.id if resolved.campaign else None
                         ),
                         "contact_id": resolved.contact_id,
                         "observed_at": datetime.now(timezone.utc),

--- a/Backend_FastAPI/app/services/sms_resolve.py
+++ b/Backend_FastAPI/app/services/sms_resolve.py
@@ -1,0 +1,79 @@
+# app/services/sms_resolve.py
+"""
+Resolver dùng chung cho bearer code `/r/{code}`, landing `/lp/{code}` và session
+Phase 2 (§16.7 resolve mở rộng): tra `sms_campaign_recipient.token_hash` TRƯỚC,
+không thấy → `sms_consult_link.token_hash`. Trả 1 kết quả chuẩn hoá để tracking/
+landing/engagement service xử lý đồng nhất (contact_id thống nhất giữa 2 nguồn).
+
+KHÔNG import fastapi; raise ResourceNotFoundError (404 generic). Không log raw
+code.
+"""
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.models.sms import SmsCampaign, SmsCampaignRecipient, SmsConsultLink
+from app.repositories.sms_tracking_repository import SmsTrackingRepository
+from app.utils.exceptions import ResourceNotFoundError
+from app.utils.sms_token import compute_token_hash, is_valid_code
+
+_GENERIC_404 = "Liên kết không hợp lệ hoặc đã hết hạn"
+
+
+def _aware(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+@dataclass
+class ResolvedCode:
+    """Nguồn 1 bearer code — campaign recipient HOẶC consult link."""
+
+    kind: str  # "campaign" | "consult"
+    contact_id: Optional[int]
+    expires_at: Optional[datetime]
+    recipient: Optional[SmsCampaignRecipient] = None
+    campaign: Optional[SmsCampaign] = None
+    consult: Optional[SmsConsultLink] = None
+
+    @property
+    def is_expired(self) -> bool:
+        return bool(
+            self.expires_at
+            and _aware(self.expires_at) <= datetime.now(timezone.utc)
+        )
+
+
+async def resolve_code(
+    repo: SmsTrackingRepository, code: str, *, enforce_expiry: bool = True
+) -> ResolvedCode:
+    """Validate code → tra recipient TRƯỚC, không thấy → consult. Raise
+    ResourceNotFoundError (404 generic) nếu sai/không thấy; nếu hết hạn và
+    enforce_expiry → 404 (opt-out gọi với enforce_expiry=False, §NĐ91)."""
+    if not is_valid_code(code):
+        raise ResourceNotFoundError(detail=_GENERIC_404)
+    token_hash = compute_token_hash(code)
+
+    found = await repo.lookup_by_token_hash(token_hash)
+    if found is not None:
+        recipient, campaign = found
+        resolved = ResolvedCode(
+            kind="campaign",
+            contact_id=recipient.contact_id,
+            expires_at=campaign.link_expires_at,
+            recipient=recipient,
+            campaign=campaign,
+        )
+    else:
+        consult = await repo.lookup_consult_by_token_hash(token_hash)
+        if consult is None:
+            raise ResourceNotFoundError(detail=_GENERIC_404)
+        resolved = ResolvedCode(
+            kind="consult",
+            contact_id=consult.contact_id,
+            expires_at=consult.expires_at,
+            consult=consult,
+        )
+
+    if enforce_expiry and resolved.is_expired:
+        raise ResourceNotFoundError(detail=_GENERIC_404)
+    return resolved

--- a/Backend_FastAPI/app/services/sms_resolve.py
+++ b/Backend_FastAPI/app/services/sms_resolve.py
@@ -10,6 +10,8 @@ code.
 """
 from dataclasses import dataclass
 from datetime import datetime, timezone
+
+from app.utils.tz import ensure_aware
 from typing import Optional
 
 from app.models.sms import SmsCampaign, SmsCampaignRecipient, SmsConsultLink
@@ -17,11 +19,10 @@ from app.repositories.sms_tracking_repository import SmsTrackingRepository
 from app.utils.exceptions import ResourceNotFoundError
 from app.utils.sms_token import compute_token_hash, is_valid_code
 
-_GENERIC_404 = "Liên kết không hợp lệ hoặc đã hết hạn"
+GENERIC_404 = "Liên kết không hợp lệ hoặc đã hết hạn"
 
 
-def _aware(dt: datetime) -> datetime:
-    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+_aware = ensure_aware  # alias tới helper tz chung (bỏ bản sao logic)
 
 
 @dataclass
@@ -31,6 +32,9 @@ class ResolvedCode:
     kind: str  # "campaign" | "consult"
     contact_id: Optional[int]
     expires_at: Optional[datetime]
+    # phone_normalized của nguồn (recipient snapshot / consult JOIN contact) —
+    # tránh query get_contact_phone thêm ở opt-out/landing.
+    phone_normalized: Optional[str] = None
     recipient: Optional[SmsCampaignRecipient] = None
     campaign: Optional[SmsCampaign] = None
     consult: Optional[SmsConsultLink] = None
@@ -50,7 +54,7 @@ async def resolve_code(
     ResourceNotFoundError (404 generic) nếu sai/không thấy; nếu hết hạn và
     enforce_expiry → 404 (opt-out gọi với enforce_expiry=False, §NĐ91)."""
     if not is_valid_code(code):
-        raise ResourceNotFoundError(detail=_GENERIC_404)
+        raise ResourceNotFoundError(detail=GENERIC_404)
     token_hash = compute_token_hash(code)
 
     found = await repo.lookup_by_token_hash(token_hash)
@@ -60,20 +64,23 @@ async def resolve_code(
             kind="campaign",
             contact_id=recipient.contact_id,
             expires_at=campaign.link_expires_at,
+            phone_normalized=recipient.phone_normalized_snapshot,
             recipient=recipient,
             campaign=campaign,
         )
     else:
-        consult = await repo.lookup_consult_by_token_hash(token_hash)
-        if consult is None:
-            raise ResourceNotFoundError(detail=_GENERIC_404)
+        found_consult = await repo.lookup_consult_by_token_hash(token_hash)
+        if found_consult is None:
+            raise ResourceNotFoundError(detail=GENERIC_404)
+        consult, phone_normalized = found_consult
         resolved = ResolvedCode(
             kind="consult",
             contact_id=consult.contact_id,
             expires_at=consult.expires_at,
+            phone_normalized=phone_normalized,
             consult=consult,
         )
 
     if enforce_expiry and resolved.is_expired:
-        raise ResourceNotFoundError(detail=_GENERIC_404)
+        raise ResourceNotFoundError(detail=GENERIC_404)
     return resolved

--- a/Backend_FastAPI/app/services/sms_tracking_service.py
+++ b/Backend_FastAPI/app/services/sms_tracking_service.py
@@ -15,15 +15,13 @@ from typing import Mapping, Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.sms_tracking_repository import SmsTrackingRepository
-from app.services.sms_resolve import resolve_code
+from app.services.sms_resolve import GENERIC_404, resolve_code
 from app.utils.exceptions import ResourceNotFoundError
 from app.utils.sms_bot import detect_bot
 from app.utils.sms_token import compute_ip_hash
 from app.utils.sms_url import host_in_allowlist
 
 log = logging.getLogger(__name__)
-
-_GENERIC_404 = "Liên kết không hợp lệ hoặc đã hết hạn"
 
 
 class SmsTrackingService:
@@ -57,7 +55,7 @@ class SmsTrackingService:
                         "SMS /r: external landing_url ngoài allowlist "
                         "campaign_id=%s", campaign.id,
                     )
-                    raise ResourceNotFoundError(detail=_GENERIC_404)
+                    raise ResourceNotFoundError(detail=GENERIC_404)
             else:
                 target = f"/lp/{code}"
             is_bot, reason = detect_bot(

--- a/Backend_FastAPI/app/services/sms_tracking_service.py
+++ b/Backend_FastAPI/app/services/sms_tracking_service.py
@@ -15,18 +15,15 @@ from typing import Mapping, Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.sms_tracking_repository import SmsTrackingRepository
+from app.services.sms_resolve import resolve_code
 from app.utils.exceptions import ResourceNotFoundError
 from app.utils.sms_bot import detect_bot
-from app.utils.sms_token import compute_ip_hash, compute_token_hash, is_valid_code
+from app.utils.sms_token import compute_ip_hash
 from app.utils.sms_url import host_in_allowlist
 
 log = logging.getLogger(__name__)
 
 _GENERIC_404 = "Liên kết không hợp lệ hoặc đã hết hạn"
-
-
-def _aware(dt: datetime) -> datetime:
-    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
 
 
 class SmsTrackingService:
@@ -45,44 +42,51 @@ class SmsTrackingService:
         headers: Optional[Mapping[str, str]] = None,
     ) -> str:
         """Trả URL đích cho 302. Raise ResourceNotFoundError (404 generic) nếu
-        code sai/không thấy/hết hạn/external ngoài allowlist."""
-        if not is_valid_code(code):
-            raise ResourceNotFoundError(detail=_GENERIC_404)
-        found = await self.repo.lookup_by_token_hash(compute_token_hash(code))
-        if found is None:
-            raise ResourceNotFoundError(detail=_GENERIC_404)
-        recipient, campaign = found
+        code sai/không thấy/hết hạn/external ngoài allowlist. Resolve mở rộng:
+        recipient TRƯỚC, không thấy → consult link (§16.7)."""
+        resolved = await resolve_code(self.repo, code, enforce_expiry=True)
         now = datetime.now(timezone.utc)
-        if campaign.link_expires_at and _aware(campaign.link_expires_at) <= now:
-            raise ResourceNotFoundError(detail=_GENERIC_404)
 
-        # Đích redirect (re-check allowlist external — §6.2 lớp 2).
-        if campaign.landing_type == "external":
-            target = (campaign.landing_url or "").strip()
-            if not target or not host_in_allowlist(target):
-                log.warning(
-                    "SMS /r: external landing_url ngoài allowlist campaign_id=%s",
-                    campaign.id,
-                )
-                raise ResourceNotFoundError(detail=_GENERIC_404)
+        if resolved.kind == "campaign":
+            campaign = resolved.campaign
+            # Đích redirect (re-check allowlist external — §6.2 lớp 2).
+            if campaign.landing_type == "external":
+                target = (campaign.landing_url or "").strip()
+                if not target or not host_in_allowlist(target):
+                    log.warning(
+                        "SMS /r: external landing_url ngoài allowlist "
+                        "campaign_id=%s", campaign.id,
+                    )
+                    raise ResourceNotFoundError(detail=_GENERIC_404)
+            else:
+                target = f"/lp/{code}"
+            is_bot, reason = detect_bot(
+                user_agent=user_agent,
+                headers=headers,
+                handed_off_at=resolved.recipient.handed_off_at,
+                now=now,
+            )
+            await self.repo.record_click(
+                recipient_id=resolved.recipient.id,
+                ip_hash=compute_ip_hash(ip),
+                user_agent=user_agent,
+                is_bot=is_bot,
+                bot_reason=reason,
+                now=now,
+            )
         else:
-            # qlts_hosted → landing nội bộ (relative, cùng host public).
+            # Consult link — MVP luôn qlts_hosted danh mục nội bộ.
             target = f"/lp/{code}"
-
-        # Ghi click (bot eval + ip_hash) — counter atomic ở repo.
-        is_bot, reason = detect_bot(
-            user_agent=user_agent,
-            headers=headers,
-            handed_off_at=recipient.handed_off_at,
-            now=now,
-        )
-        await self.repo.record_click(
-            recipient_id=recipient.id,
-            ip_hash=compute_ip_hash(ip),
-            user_agent=user_agent,
-            is_bot=is_bot,
-            bot_reason=reason,
-            now=now,
-        )
+            is_bot, reason = detect_bot(
+                user_agent=user_agent, headers=headers, now=now,
+            )
+            await self.repo.record_consult_click(
+                consult_link_id=resolved.consult.id,
+                ip_hash=compute_ip_hash(ip),
+                user_agent=user_agent,
+                is_bot=is_bot,
+                bot_reason=reason,
+                now=now,
+            )
         await self.db.flush()
         return target

--- a/Backend_FastAPI/app/utils/phone_helpers.py
+++ b/Backend_FastAPI/app/utils/phone_helpers.py
@@ -193,3 +193,17 @@ def is_vietnam_mobile(phone_normalized: Optional[str]) -> bool:
     if not phone_normalized:
         return False
     return bool(VIETNAM_MOBILE_REGEX.match(phone_normalized))
+
+
+def normalize_vn_mobile(phone: Optional[str]) -> Optional[tuple[str, str]]:
+    """(normalized, international=84xxx) nếu là DI ĐỘNG VN hợp lệ; None nếu không.
+
+    Gộp normalize + ép mobile-only + dựng dạng quốc tế — dùng chung cho tạo
+    contact (``SmsContactService``) và consult-link (khoá thống nhất theo phone).
+    KHÔNG raise (giữ util thuần); caller tự raise domain exception với thông điệp
+    phù hợp ngữ cảnh.
+    """
+    normalized = normalize_vietnam_phone(phone)
+    if not normalized or not is_vietnam_mobile(normalized):
+        return None
+    return normalized, to_zalo_phone(normalized)

--- a/Backend_FastAPI/app/utils/sms_bot.py
+++ b/Backend_FastAPI/app/utils/sms_bot.py
@@ -13,6 +13,8 @@ phía người (chỉ flag khi có dấu hiệu rõ) — CTR thà thiếu hơn t
   fetch tức thì khi tin vừa gửi) — đo `now - recipient.handed_off_at`.
 """
 from datetime import datetime, timedelta, timezone
+
+from app.utils.tz import ensure_aware
 from typing import Mapping, Optional, Tuple
 
 # Token UA hay gặp ở crawler/link-preview/HTTP client (so khớp lower-case).
@@ -27,8 +29,7 @@ _SCANNER_UA_TOKENS = (
 _INSTANT_SECONDS = 8  # click ≤8s sau handoff → nghi preview server
 
 
-def _aware(dt: datetime) -> datetime:
-    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+_aware = ensure_aware  # alias tới helper tz chung (bỏ bản sao logic)
 
 
 def detect_bot(

--- a/Backend_FastAPI/app/utils/sms_interest.py
+++ b/Backend_FastAPI/app/utils/sms_interest.py
@@ -15,12 +15,13 @@ Nguồn: Dynamic Yield affinity + Dotdigital weighting curve. KHÔNG ML.
 Xem `Documents/SMS_MARKETING_MODULE_DESIGN.md` §18.F.
 """
 import math
-from datetime import datetime, timezone
+from datetime import datetime
+
+from app.utils.tz import ensure_aware
 from typing import Iterable, Tuple
 
 
-def _aware(dt: datetime) -> datetime:
-    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+_aware = ensure_aware  # alias tới helper tz chung (bỏ bản sao logic)
 
 
 def dwell_factor(dwell_seconds: int, cap: int) -> float:

--- a/Backend_FastAPI/app/utils/tz.py
+++ b/Backend_FastAPI/app/utils/tz.py
@@ -1,0 +1,13 @@
+# app/utils/tz.py
+"""Chuẩn hoá timezone dùng chung — gộp các bản sao `_aware` rải khắp SMS.
+
+Khác `datetime_helpers.py` (quy ước naive = giờ-app VN, dùng cho HIỂN THỊ):
+`ensure_aware` coi naive là **UTC** — hợp với các cột SMS lưu `datetime.now(
+timezone.utc)` rồi so với `datetime.now(timezone.utc)` khi tính hết hạn/dwell.
+"""
+from datetime import datetime, timezone
+
+
+def ensure_aware(dt: datetime) -> datetime:
+    """Trả datetime tz-aware; naive được coi là UTC (không đổi wall-clock)."""
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)

--- a/Backend_FastAPI/tests/integration/test_sms_consult.py
+++ b/Backend_FastAPI/tests/integration/test_sms_consult.py
@@ -148,12 +148,19 @@ async def test_consult_full_flow(
     )
     assert hb.status_code == 200
 
-    # 5) lead interests (qua contact match phone) — thấy ngành 1
+    # 5) lead interests (qua contact match phone) — thấy ngành 1 + GIÁ TRỊ đúng
     li = await client.get(f"{API}/leads/{lead_id}/interests", headers=h)
     assert li.status_code == 200, li.text
     lij = li.json()
     assert lij["lead_id"] == lead_id and lij["contact_id"] == contact_id
-    assert len(lij["items"]) == 1 and lij["items"][0]["major_program_id"] == 1
+    assert len(lij["items"]) == 1
+    it0 = lij["items"][0]
+    assert it0["major_program_id"] == 1
+    # Assert TÍN HIỆU cốt lõi (không chỉ tồn tại row): dwell=20 (heartbeat, <grace
+    # nên không clamp), view_count=1, score dương → bắt regression đo về 0.
+    assert it0["view_count"] == 1
+    assert it0["total_dwell_seconds"] == 20
+    assert it0["interest_score"] > 0.0
 
 
 async def test_consult_reuses_existing_contact(
@@ -213,6 +220,45 @@ async def test_consult_officer_idor(
 
     idor = await client.post(f"{API}/leads/{other}/consult-link", headers=oh)
     assert idor.status_code == 404  # ngoài phạm vi officer → 404 (không lộ)
+
+
+async def test_consult_click_bot_not_counted_human(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """/r/ consult click bằng UA bot → raw tăng nhưng human KHÔNG (đối xứng
+    recipient; record_consult_click tách bot)."""
+    h = admin_token_headers
+    lead_id = await _mk_lead("0987755666")
+    body = (
+        await client.post(f"{API}/leads/{lead_id}/consult-link", headers=h)
+    ).json()
+    res = await client.get(
+        f"/r/{body['code']}",
+        headers={"User-Agent": "facebookexternalhit/1.1"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    async with AsyncSessionLocal() as s:
+        cc = (
+            await s.execute(
+                text(
+                    "SELECT raw_click_count, human_click_count, "
+                    "first_human_clicked_at FROM sms_consult_link WHERE id=:i"
+                ),
+                {"i": body["consult_link_id"]},
+            )
+        ).first()
+    assert cc[0] == 1 and cc[1] == 0 and cc[2] is None  # raw tăng, human KHÔNG
+
+
+async def test_consult_link_rejects_non_mobile_phone(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """Lead số cố định (không di động) → 400 (không tạo consult link/contact rác)."""
+    h = admin_token_headers
+    lead_id = await _mk_lead("0243825123")  # số bàn Hà Nội (không di động)
+    r = await client.post(f"{API}/leads/{lead_id}/consult-link", headers=h)
+    assert r.status_code == 400, r.text
 
 
 async def test_consult_requires_auth(client: AsyncClient):

--- a/Backend_FastAPI/tests/integration/test_sms_consult.py
+++ b/Backend_FastAPI/tests/integration/test_sms_consult.py
@@ -261,6 +261,52 @@ async def test_consult_link_rejects_non_mobile_phone(
     assert r.status_code == 400, r.text
 
 
+async def test_consult_optout_via_consult_code(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """Opt-out công khai qua consult code (§NĐ91): resolve nhánh consult →
+    suppress SĐT lead (source landing_optout, campaign_id NULL) + idempotent."""
+    h = admin_token_headers
+    phone = "0987755777"
+    lead_id = await _mk_lead(phone)
+    code = (
+        await client.post(f"{API}/leads/{lead_id}/consult-link", headers=h)
+    ).json()["code"]
+
+    # 1) opt-out lần đầu qua consult code → success, chưa từng opt-out
+    r1 = await client.post(f"{PUB}/opt-out", json={"code": code})
+    assert r1.status_code == 200, r1.text
+    assert r1.json()["success"] is True
+    assert r1.json()["already_opted_out"] is False
+
+    # DB: sms_opt_out ghi đúng phone lead, source landing_optout, campaign NULL
+    async with AsyncSessionLocal() as s:
+        row = (
+            await s.execute(
+                text(
+                    "SELECT source, campaign_id FROM sms_opt_out "
+                    "WHERE phone_normalized=:p"
+                ),
+                {"p": phone},
+            )
+        ).first()
+    assert row is not None, "opt-out qua consult code KHÔNG suppress SĐT (NĐ91)"
+    assert row[0] == "landing_optout" and row[1] is None
+
+    # 2) opt-out lại (idempotent) → already_opted_out=True, KHÔNG tạo bản trùng
+    r2 = await client.post(f"{PUB}/opt-out", json={"code": code})
+    assert r2.status_code == 200
+    assert r2.json()["already_opted_out"] is True
+    async with AsyncSessionLocal() as s:
+        cnt = (
+            await s.execute(
+                text("SELECT count(*) FROM sms_opt_out WHERE phone_normalized=:p"),
+                {"p": phone},
+            )
+        ).scalar()
+    assert cnt == 1
+
+
 async def test_consult_requires_auth(client: AsyncClient):
     assert (
         await client.post(f"{API}/leads/1/consult-link")

--- a/Backend_FastAPI/tests/integration/test_sms_consult.py
+++ b/Backend_FastAPI/tests/integration/test_sms_consult.py
@@ -1,0 +1,224 @@
+# tests/integration/test_sms_consult.py
+"""
+Integration test PR-7 P2-3 (SMS consult officer §16.5/§16.7).
+
+Phủ: tạo consult link cho lead (match/tạo contact từ phone) → resolve /r/{code}
+(nhánh consult) 302 + click → landing consult (programs, no campaign headline) →
+session source_type='consult' → program-view+heartbeat → interest → lead
+interests (qua contact match). IDOR officer (lead người khác → 404). Auth.
+
+Chạy one-off container (CLAUDE.md — fixture chain officer/lead).
+"""
+from datetime import datetime, timezone
+
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app import models
+from app.database import AsyncSessionLocal
+from tests._lead_status_test_ids import INITIAL_LEAD_STATUS_ID
+from tests.fixtures.constants import TestOrgData
+
+API = "/api/sms"
+PUB = "/api/public/sms"
+_UA_HUMAN = (
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) "
+    "AppleWebKit/605.1.15 Version/16.0 Mobile Safari/604.1"
+)
+
+
+async def _mk_lead(phone: str, officer_id=None) -> int:
+    """Tạo 1 lead trực tiếp (assigned officer nếu có). Trả lead_id."""
+    async with AsyncSessionLocal() as s:
+        lead = models.Lead(
+            full_name="QA Consult Lead",
+            phone=phone,
+            source="test",
+            unit_id=TestOrgData.UNIT_1["id"],
+            status=INITIAL_LEAD_STATUS_ID,
+            consultation_status_id=INITIAL_LEAD_STATUS_ID,
+            pipeline_stage_id="STAGE_A",
+            assigned_officer_id=officer_id,
+            assigned_at=datetime.now(timezone.utc) if officer_id else None,
+        )
+        s.add(lead)
+        await s.flush()
+        lid = lead.id
+        await s.commit()
+    return lid
+
+
+# ---------------------------------------------------------------------
+# Flow đầy đủ: consult link → /r → landing → session → interest → lead interests
+# ---------------------------------------------------------------------
+async def test_consult_full_flow(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    h = admin_token_headers
+    lead_id = await _mk_lead("0987755111")
+
+    # 1) admin tạo consult link
+    r = await client.post(f"{API}/leads/{lead_id}/consult-link", headers=h)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    code = body["code"]
+    assert body["url"].endswith(f"/r/{code}")
+    contact_id = body["contact_id"]
+    assert body["consult_link_id"] > 0
+
+    # DB: consult link + contact tạo (consent unknown, source lead_consult)
+    async with AsyncSessionLocal() as s:
+        cl = (
+            await s.execute(
+                text(
+                    "SELECT lead_id, contact_id, landing_type FROM "
+                    "sms_consult_link WHERE id=:i"
+                ),
+                {"i": body["consult_link_id"]},
+            )
+        ).first()
+        ct = (
+            await s.execute(
+                text(
+                    "SELECT source_label, marketing_consent_status FROM "
+                    "sms_contact WHERE id=:c"
+                ),
+                {"c": contact_id},
+            )
+        ).first()
+    assert cl[0] == lead_id and cl[1] == contact_id and cl[2] == "qlts_hosted"
+    assert ct[0] == "lead_consult" and ct[1] == "unknown"
+
+    # 2) /r/{code} → 302 /lp + consult click ghi (nhánh consult của resolve)
+    res = await client.get(
+        f"/r/{code}", headers={"User-Agent": _UA_HUMAN}, follow_redirects=False
+    )
+    assert res.status_code == 302
+    assert res.headers["location"] == f"/lp/{code}"
+    async with AsyncSessionLocal() as s:
+        cc = (
+            await s.execute(
+                text(
+                    "SELECT raw_click_count, human_click_count FROM "
+                    "sms_consult_link WHERE id=:i"
+                ),
+                {"i": body["consult_link_id"]},
+            )
+        ).first()
+    assert cc[0] == 1 and cc[1] == 1
+
+    # 3) landing consult: programs có, headline null (no campaign)
+    lr = await client.get(f"{PUB}/landing/{code}")
+    assert lr.status_code == 200, lr.text
+    lb = lr.json()
+    assert lb["headline"] is None
+    assert isinstance(lb["programs"], list) and len(lb["programs"]) >= 1
+
+    # 4) session (source consult) → program-view → heartbeat
+    token = (
+        await client.post(
+            f"{PUB}/landing/{code}/session",
+            headers={"User-Agent": _UA_HUMAN},
+        )
+    ).json()["session_token"]
+    async with AsyncSessionLocal() as s:
+        srow = (
+            await s.execute(
+                text(
+                    "SELECT source_type, consult_link_id, contact_id FROM "
+                    "sms_landing_session WHERE contact_id=:c"
+                ),
+                {"c": contact_id},
+            )
+        ).first()
+    assert srow[0] == "consult" and srow[1] == body["consult_link_id"]
+    assert srow[2] == contact_id
+
+    vid = (
+        await client.post(
+            f"{PUB}/landing/{code}/program-view",
+            json={"session_token": token, "major_program_id": 1},
+            headers={"User-Agent": _UA_HUMAN},
+        )
+    ).json()["program_view_id"]
+    hb = await client.post(
+        f"{PUB}/landing/{code}/heartbeat",
+        json={"session_token": token, "program_view_id": vid, "dwell_seconds": 20},
+        headers={"User-Agent": _UA_HUMAN},
+    )
+    assert hb.status_code == 200
+
+    # 5) lead interests (qua contact match phone) — thấy ngành 1
+    li = await client.get(f"{API}/leads/{lead_id}/interests", headers=h)
+    assert li.status_code == 200, li.text
+    lij = li.json()
+    assert lij["lead_id"] == lead_id and lij["contact_id"] == contact_id
+    assert len(lij["items"]) == 1 and lij["items"][0]["major_program_id"] == 1
+
+
+async def test_consult_reuses_existing_contact(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """Contact đã tồn tại theo phone → consult link DÙNG LẠI (không tạo trùng)."""
+    h = admin_token_headers
+    # tạo contact trước qua API
+    rc = await client.post(
+        f"{API}/contacts",
+        json={"full_name": "Existing", "phone": "0987755222"},
+        headers=h,
+    )
+    assert rc.status_code == 201, rc.text
+    existing_cid = rc.json()["id"]
+    lead_id = await _mk_lead("0987755222")
+    r = await client.post(f"{API}/leads/{lead_id}/consult-link", headers=h)
+    assert r.status_code == 200
+    assert r.json()["contact_id"] == existing_cid  # dùng lại, không tạo mới
+
+
+async def test_lead_interests_empty_no_contact(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    h = admin_token_headers
+    lead_id = await _mk_lead("0987755333")
+    li = await client.get(f"{API}/leads/{lead_id}/interests", headers=h)
+    assert li.status_code == 200
+    assert li.json()["contact_id"] is None and li.json()["items"] == []
+
+
+async def test_consult_missing_lead_404(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    h = admin_token_headers
+    assert (
+        await client.post(f"{API}/leads/999999/consult-link", headers=h)
+    ).status_code == 404
+    assert (
+        await client.get(f"{API}/leads/999999/interests", headers=h)
+    ).status_code == 404
+
+
+async def test_consult_officer_idor(
+    client: AsyncClient,
+    officer_token_headers: dict,
+    officer_user_in_db: dict,
+    seed_lead_dependencies,
+):
+    """Officer: lead CỦA MÌNH → 200; lead officer KHÁC (assigned=None) → 404."""
+    oh = officer_token_headers
+    own = await _mk_lead("0987755444", officer_id=officer_user_in_db["id"])
+    other = await _mk_lead("0987755555", officer_id=None)  # không giao officer
+
+    ok = await client.post(f"{API}/leads/{own}/consult-link", headers=oh)
+    assert ok.status_code == 200, ok.text  # Casbin officer policy + IDOR pass
+
+    idor = await client.post(f"{API}/leads/{other}/consult-link", headers=oh)
+    assert idor.status_code == 404  # ngoài phạm vi officer → 404 (không lộ)
+
+
+async def test_consult_requires_auth(client: AsyncClient):
+    assert (
+        await client.post(f"{API}/leads/1/consult-link")
+    ).status_code == 401
+    assert (
+        await client.get(f"{API}/leads/1/interests")
+    ).status_code == 401

--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
@@ -67,6 +67,7 @@ import { ActionBanner } from "@/components/leads/ActionBanner";
 import { LeadScoringCollapsible } from "@/components/leads/LeadScoringCollapsible";
 import { AdmissionReadinessChecklist } from "@/components/leads/AdmissionReadinessChecklist";
 import { LeadInfoTabs } from "./LeadInfoTabs";
+import { LeadConsultSection } from "@/components/leads/LeadConsultSection";
 import { WorkflowBreadcrumb } from "@/components/common";
 import { cn, sanitizeColorCode } from "@/lib/utils";
 import { getLeadScoreLabel, getLeadScoreTextColor } from "@/constants";
@@ -455,6 +456,9 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
                 currentProfile && router.push(`/admissions/${currentProfile.id}`)
               }
             />
+
+            {/* P2-4b: Tư vấn SMS — link tư vấn + quan tâm ngành (officer/mgr/admin) */}
+            <LeadConsultSection leadId={leadId} />
           </div>
 
           {/* ===== RIGHT PANEL (8 cols): Quick Actions ===== */}

--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
@@ -457,8 +457,10 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
               }
             />
 
-            {/* P2-4b: Tư vấn SMS — link tư vấn + quan tâm ngành (officer/mgr/admin) */}
-            <LeadConsultSection leadId={leadId} />
+            {/* P2-4b: Tư vấn SMS — link tư vấn + quan tâm ngành (officer/mgr/admin).
+                key={leadId} → đổi lead thì remount, reset sạch mọi state (link vừa
+                tạo, copied, expanded) mà không cần useEffect reset thủ công. */}
+            <LeadConsultSection key={leadId} leadId={leadId} />
           </div>
 
           {/* ===== RIGHT PANEL (8 cols): Quick Actions ===== */}

--- a/frontend/src/app/(dashboard)/leads/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/page.tsx
@@ -11,7 +11,7 @@
  */
 
 import { Suspense } from 'react';
-import { notFound } from 'next/navigation';
+import { notFound, unstable_rethrow } from 'next/navigation';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent } from '@/components/ui/card';
 import { serverApi } from '@/lib/api/server';
@@ -58,6 +58,11 @@ async function LeadDetailPageContent({ leadId }: { leadId: number }) {
   try {
     initialData = await serverApi.leads.getLead(leadId);
   } catch (err) {
+    // Rethrow framework control-flow FIRST: serverFetch calls redirect('/login')
+    // on a 401 (throws NEXT_REDIRECT) and cookies() throws the dynamic-render
+    // bailout — neither is a fetch error. Swallowing them renders a broken/empty
+    // page instead of redirecting to login (or bailing to a dynamic render).
+    unstable_rethrow(err);
     // ✅ T9 FIX: Only notFound() for actual 404s; other errors (500, network) go to error boundary
     // serverFetch throws: "API Error (STATUS): message" — match the exact prefix pattern
     const message = err instanceof Error ? err.message : "";
@@ -70,8 +75,8 @@ async function LeadDetailPageContent({ leadId }: { leadId: number }) {
 
   // ✅ Parallel fetch: timeline and insights (non-critical, catch gracefully)
   const [initialTimeline, initialInsights] = await Promise.all([
-    serverApi.leads.getLeadTimeline(leadId).catch(() => undefined),
-    serverApi.leads.getLeadInsights(leadId).catch(() => undefined),
+    serverApi.leads.getLeadTimeline(leadId).catch((e) => { unstable_rethrow(e); return undefined; }),
+    serverApi.leads.getLeadInsights(leadId).catch((e) => { unstable_rethrow(e); return undefined; }),
   ]);
 
   return (

--- a/frontend/src/components/leads/LeadConsultSection.tsx
+++ b/frontend/src/components/leads/LeadConsultSection.tsx
@@ -1,7 +1,7 @@
 // src/components/leads/LeadConsultSection.tsx
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import {
   AlertCircle,
@@ -19,7 +19,8 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { formatDwell } from "@/components/sms/admin/labels"
+import { formatDwell } from "@/lib/format"
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
 import {
   useCreateConsultLink,
   useLeadSmsInterests,
@@ -29,14 +30,13 @@ import {
  * P2-4b — "Tư vấn SMS: Quan tâm ngành" ở trang chi tiết lead. Collapsible
  * (§16.5 tab, lazy): chỉ fetch interest khi mở → không thêm request cho mọi
  * lead không dùng SMS. Thin-client: BE gác quyền (CasbinAuth + IDOR); FE render.
- * - Nút "Tạo link tư vấn" → BE sinh consult link (match/tạo contact từ phone) →
- *   hiển thị code/url để copy gửi Zalo (mã CHỈ hiện 1 lần — không lấy lại được).
- * - Danh sách ngành lead quan tâm (rank tổng dwell desc, qua contact match).
+ * - Nút "Tạo link tư vấn" CHỈ hiện khi query interest thành công (cùng gate
+ *   Casbin+IDOR → dùng kết quả API làm cờ quyền, không đoán theo role).
+ * - Mã/url CHỈ hiện 1 lần (BE lưu token_hash) → copy ngay.
  */
 export function LeadConsultSection({ leadId }: { leadId: number }) {
   const [expanded, setExpanded] = useState(false)
-  const [copied, setCopied] = useState(false)
-  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { copied, copy, reset: resetCopied } = useCopyToClipboard()
 
   const { data, isLoading, isError, refetch, isFetching } =
     useLeadSmsInterests(leadId, expanded)
@@ -44,27 +44,17 @@ export function LeadConsultSection({ leadId }: { leadId: number }) {
   const link = createLink.data
 
   // Đổi lead → reset link vừa tạo (tránh hiện link lead cũ trên lead mới) +
-  // trạng thái copied. createLink.data là mutation-state không tự re-key.
+  // copied. createLink.data là mutation-state không tự re-key theo leadId.
   useEffect(() => {
     createLink.reset()
-    setCopied(false)
-    if (copyTimer.current) clearTimeout(copyTimer.current)
+    resetCopied()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [leadId])
 
-  // Dọn timer copied khi unmount.
-  useEffect(() => () => {
-    if (copyTimer.current) clearTimeout(copyTimer.current)
-  }, [])
-
   const onCopy = async () => {
     if (!link) return
-    try {
-      await navigator.clipboard.writeText(link.url)
-      setCopied(true)
-      if (copyTimer.current) clearTimeout(copyTimer.current)
-      copyTimer.current = setTimeout(() => setCopied(false), 2000)
-    } catch {
+    const ok = await copy(link.url)
+    if (!ok) {
       toast.error("Không tự sao chép được — vui lòng copy tay từ ô hiển thị.")
     }
   }
@@ -92,56 +82,6 @@ export function LeadConsultSection({ leadId }: { leadId: number }) {
 
       {expanded && (
         <CardContent className="space-y-4">
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => createLink.mutate(leadId)}
-            disabled={createLink.isPending}
-            className="w-full"
-          >
-            {createLink.isPending ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <Link2 className="mr-2 h-4 w-4" />
-            )}
-            {link ? "Tạo link khác" : "Tạo link tư vấn"}
-          </Button>
-
-          {/* Link vừa tạo — copy NGAY (mã chỉ hiện 1 lần) */}
-          {link && (
-            <div
-              role="status"
-              className="bg-muted/50 space-y-2 rounded border p-3"
-            >
-              <p className="text-muted-foreground text-xs">
-                Sao chép NGAY và gửi cho khách qua Zalo/tin nhắn — mã chỉ hiển
-                thị một lần, rời trang sẽ không lấy lại được (tạo link mới nếu
-                cần). Link không hết hạn.
-              </p>
-              <div className="flex items-center gap-2">
-                <code
-                  title={link.url}
-                  className="bg-background min-w-0 flex-1 truncate rounded px-2 py-1 text-xs"
-                >
-                  {link.url}
-                </code>
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  onClick={onCopy}
-                  aria-label={copied ? "Đã sao chép link" : "Sao chép link"}
-                >
-                  {copied ? (
-                    <Check className="h-4 w-4 text-green-600" />
-                  ) : (
-                    <Copy className="h-4 w-4" />
-                  )}
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {/* Danh sách ngành quan tâm — error KHÁC empty */}
           {isLoading ? (
             <div className="space-y-2">
               {Array.from({ length: 2 }).map((_, i) => (
@@ -149,6 +89,8 @@ export function LeadConsultSection({ leadId }: { leadId: number }) {
               ))}
             </div>
           ) : isError ? (
+            // Query lỗi (403 không quyền / network) → error KHÁC empty; ẩn nút
+            // tạo (cùng gate → không tạo được) + cho thử lại.
             <div className="text-muted-foreground flex flex-col items-center gap-2 py-4 text-center text-sm">
               <AlertCircle className="text-destructive h-5 w-5" />
               <span>Không tải được dữ liệu quan tâm ngành.</span>
@@ -161,31 +103,85 @@ export function LeadConsultSection({ leadId }: { leadId: number }) {
                 Thử lại
               </Button>
             </div>
-          ) : !data || data.items.length === 0 ? (
-            <p className="text-muted-foreground text-sm">
-              Khách chưa xem ngành nào. Tạo link tư vấn và gửi cho khách để bắt
-              đầu đo mức quan tâm.
-            </p>
           ) : (
-            <ul className="max-h-64 space-y-2 overflow-y-auto">
-              {data.items.map((it) => (
-                <li
-                  key={it.major_program_id}
-                  className="flex items-center gap-3 rounded border p-2"
+            <>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => createLink.mutate(leadId)}
+                disabled={createLink.isPending}
+                className="w-full"
+              >
+                {createLink.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Link2 className="mr-2 h-4 w-4" />
+                )}
+                {link ? "Tạo link khác" : "Tạo link tư vấn"}
+              </Button>
+
+              {/* Link vừa tạo — copy NGAY (mã chỉ hiện 1 lần) */}
+              {link && (
+                <div
+                  role="status"
+                  className="bg-muted/50 space-y-2 rounded border p-3"
                 >
-                  <GraduationCap className="text-primary h-4 w-4 shrink-0" />
-                  <span
-                    title={it.program_name}
-                    className="min-w-0 flex-1 truncate text-sm font-medium"
-                  >
-                    {it.program_name}
-                  </span>
-                  <Badge variant="secondary" className="shrink-0">
-                    {formatDwell(it.total_dwell_seconds)}
-                  </Badge>
-                </li>
-              ))}
-            </ul>
+                  <p className="text-muted-foreground text-xs">
+                    Sao chép NGAY và gửi cho khách qua Zalo/tin nhắn — mã chỉ
+                    hiển thị một lần, rời trang sẽ không lấy lại được (tạo link
+                    mới nếu cần). Link không hết hạn.
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <code
+                      title={link.url}
+                      className="bg-background min-w-0 flex-1 truncate rounded px-2 py-1 text-xs"
+                    >
+                      {link.url}
+                    </code>
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      onClick={onCopy}
+                      aria-label={copied ? "Đã sao chép link" : "Sao chép link"}
+                    >
+                      {copied ? (
+                        <Check className="h-4 w-4 text-green-600" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {/* Danh sách ngành quan tâm */}
+              {!data || data.items.length === 0 ? (
+                <p className="text-muted-foreground text-sm">
+                  Khách chưa xem ngành nào. Tạo link tư vấn và gửi cho khách để
+                  bắt đầu đo mức quan tâm.
+                </p>
+              ) : (
+                <ul className="max-h-64 space-y-2 overflow-y-auto">
+                  {data.items.map((it) => (
+                    <li
+                      key={it.major_program_id}
+                      className="flex items-center gap-3 rounded border p-2"
+                    >
+                      <GraduationCap className="text-primary h-4 w-4 shrink-0" />
+                      <span
+                        title={it.program_name}
+                        className="min-w-0 flex-1 truncate text-sm font-medium"
+                      >
+                        {it.program_name}
+                      </span>
+                      <Badge variant="secondary" className="shrink-0">
+                        {formatDwell(it.total_dwell_seconds)}
+                      </Badge>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
           )}
         </CardContent>
       )}

--- a/frontend/src/components/leads/LeadConsultSection.tsx
+++ b/frontend/src/components/leads/LeadConsultSection.tsx
@@ -1,0 +1,133 @@
+// src/components/leads/LeadConsultSection.tsx
+"use client"
+
+import { useState } from "react"
+import {
+  Check,
+  Copy,
+  GraduationCap,
+  Link2,
+  Loader2,
+  MessageSquareShare,
+} from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { formatDwell } from "@/components/sms/admin/labels"
+import {
+  useCreateConsultLink,
+  useLeadSmsInterests,
+} from "@/hooks/useSmsConsult"
+
+/**
+ * P2-4b — "Tư vấn SMS: Quan tâm ngành" ở trang chi tiết lead. Thin-client:
+ * - Nút "Tạo link tư vấn" → BE sinh consult link (match/tạo contact từ phone
+ *   lead) → hiển thị code/url để officer copy gửi Zalo/tay.
+ * - Danh sách ngành lead quan tâm (rank tổng dwell desc, qua contact match).
+ * BE gác quyền (CasbinAuth + IDOR); FE chỉ render.
+ */
+export function LeadConsultSection({ leadId }: { leadId: number }) {
+  const { data, isLoading, isError } = useLeadSmsInterests(leadId)
+  const createLink = useCreateConsultLink()
+  const [copied, setCopied] = useState(false)
+
+  const link = createLink.data
+  const onCopy = async () => {
+    if (!link) return
+    try {
+      await navigator.clipboard.writeText(link.url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // clipboard bị chặn → officer copy tay từ ô hiển thị.
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <MessageSquareShare className="h-4 w-4" /> Tư vấn SMS — Quan tâm ngành
+        </CardTitle>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => createLink.mutate(leadId)}
+          disabled={createLink.isPending}
+        >
+          {createLink.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Link2 className="mr-2 h-4 w-4" />
+          )}
+          Tạo link tư vấn
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Link vừa tạo — copy gửi khách */}
+        {link && (
+          <div className="bg-muted/50 space-y-2 rounded border p-3">
+            <p className="text-muted-foreground text-xs">
+              Gửi link này cho khách qua Zalo/tin nhắn. Không hết hạn; lượt xem
+              ngành của khách sẽ hiện bên dưới.
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="min-w-0 flex-1 truncate rounded bg-background px-2 py-1 text-xs">
+                {link.url}
+              </code>
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={onCopy}
+                aria-label="Sao chép link"
+              >
+                {copied ? (
+                  <Check className="h-4 w-4 text-green-600" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Danh sách ngành quan tâm */}
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <Skeleton key={i} className="h-9 w-full" />
+            ))}
+          </div>
+        ) : isError ? (
+          <p className="text-muted-foreground text-sm">
+            Chưa có dữ liệu quan tâm ngành cho lead này.
+          </p>
+        ) : !data || data.items.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            Khách chưa xem ngành nào. Tạo link tư vấn và gửi cho khách để bắt
+            đầu đo mức quan tâm.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {data.items.map((it) => (
+              <li
+                key={it.major_program_id}
+                className="flex items-center gap-3 rounded border p-2"
+              >
+                <GraduationCap className="text-primary h-4 w-4 shrink-0" />
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                  {it.program_name}
+                </span>
+                <Badge variant="secondary" className="shrink-0">
+                  {formatDwell(it.total_dwell_seconds)}
+                </Badge>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/leads/LeadConsultSection.tsx
+++ b/frontend/src/components/leads/LeadConsultSection.tsx
@@ -18,6 +18,11 @@ import {
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatDwell } from "@/lib/format"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
@@ -56,130 +61,127 @@ export function LeadConsultSection({ leadId }: { leadId: number }) {
 
   return (
     <Card>
-      <CardHeader className="px-4 py-3">
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          aria-expanded={expanded}
-          className="flex w-full items-center gap-2 text-left"
-        >
-          {expanded ? (
-            <ChevronDown className="text-muted-foreground h-4 w-4 shrink-0" />
-          ) : (
-            <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
-          )}
-          <MessageSquareShare className="h-4 w-4 shrink-0" />
-          <CardTitle className="flex-1 text-sm font-medium">
-            Tư vấn SMS — Quan tâm ngành
-          </CardTitle>
-        </button>
-      </CardHeader>
+      <Collapsible open={expanded} onOpenChange={setExpanded}>
+        <CardHeader className="px-4 py-3">
+          <CollapsibleTrigger className="flex w-full items-center gap-2 text-left">
+            {expanded ? (
+              <ChevronDown className="text-muted-foreground h-4 w-4 shrink-0" />
+            ) : (
+              <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+            )}
+            <MessageSquareShare className="h-4 w-4 shrink-0" />
+            <CardTitle className="flex-1 text-sm font-medium">
+              Tư vấn SMS — Quan tâm ngành
+            </CardTitle>
+          </CollapsibleTrigger>
+        </CardHeader>
 
-      {expanded && (
-        <CardContent className="space-y-4">
-          {isLoading ? (
-            <div className="space-y-2">
-              {Array.from({ length: 2 }).map((_, i) => (
-                <Skeleton key={i} className="h-9 w-full" />
-              ))}
-            </div>
-          ) : isError ? (
-            // Query lỗi (403 không quyền / network) → error KHÁC empty; ẩn nút
-            // tạo (cùng gate → không tạo được) + cho thử lại.
-            <div className="text-muted-foreground flex flex-col items-center gap-2 py-4 text-center text-sm">
-              <AlertCircle className="text-destructive h-5 w-5" />
-              <span>Không tải được dữ liệu quan tâm ngành.</span>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => refetch()}
-                disabled={isFetching}
-              >
-                Thử lại
-              </Button>
-            </div>
-          ) : (
-            <>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => createLink.mutate(leadId)}
-                disabled={createLink.isPending}
-                className="w-full"
-              >
-                {createLink.isPending ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                  <Link2 className="mr-2 h-4 w-4" />
-                )}
-                {link ? "Tạo link khác" : "Tạo link tư vấn"}
-              </Button>
-
-              {/* Link vừa tạo — copy NGAY (mã chỉ hiện 1 lần) */}
-              {link && (
-                <div
-                  role="status"
-                  className="bg-muted/50 space-y-2 rounded border p-3"
+        <CollapsibleContent>
+          <CardContent className="space-y-4">
+            {isLoading ? (
+              <div className="space-y-2">
+                {Array.from({ length: 2 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-full" />
+                ))}
+              </div>
+            ) : isError ? (
+              // Query lỗi (403 không quyền / network) → error KHÁC empty; ẩn nút
+              // tạo (cùng gate → không tạo được) + cho thử lại.
+              <div className="text-muted-foreground flex flex-col items-center gap-2 py-4 text-center text-sm">
+                <AlertCircle className="text-destructive h-5 w-5" />
+                <span>Không tải được dữ liệu quan tâm ngành.</span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => refetch()}
+                  disabled={isFetching}
                 >
-                  <p className="text-muted-foreground text-xs">
-                    Sao chép NGAY và gửi cho khách qua Zalo/tin nhắn — mã chỉ
-                    hiển thị một lần, rời trang sẽ không lấy lại được (tạo link
-                    mới nếu cần). Link không hết hạn.
-                  </p>
-                  <div className="flex items-center gap-2">
-                    <code
-                      title={link.url}
-                      className="bg-background min-w-0 flex-1 truncate rounded px-2 py-1 text-xs"
-                    >
-                      {link.url}
-                    </code>
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={onCopy}
-                      aria-label={copied ? "Đã sao chép link" : "Sao chép link"}
-                    >
-                      {copied ? (
-                        <Check className="h-4 w-4 text-green-600" />
-                      ) : (
-                        <Copy className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </div>
-                </div>
-              )}
+                  Thử lại
+                </Button>
+              </div>
+            ) : (
+              <>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => createLink.mutate(leadId)}
+                  disabled={createLink.isPending}
+                  className="w-full"
+                >
+                  {createLink.isPending ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Link2 className="mr-2 h-4 w-4" />
+                  )}
+                  {link ? "Tạo link khác" : "Tạo link tư vấn"}
+                </Button>
 
-              {/* Danh sách ngành quan tâm */}
-              {!data || data.items.length === 0 ? (
-                <p className="text-muted-foreground text-sm">
-                  Khách chưa xem ngành nào. Tạo link tư vấn và gửi cho khách để
-                  bắt đầu đo mức quan tâm.
-                </p>
-              ) : (
-                <ul className="max-h-64 space-y-2 overflow-y-auto">
-                  {data.items.map((it) => (
-                    <li
-                      key={it.major_program_id}
-                      className="flex items-center gap-3 rounded border p-2"
-                    >
-                      <GraduationCap className="text-primary h-4 w-4 shrink-0" />
-                      <span
-                        title={it.program_name}
-                        className="min-w-0 flex-1 truncate text-sm font-medium"
+                {/* Link vừa tạo — copy NGAY (mã chỉ hiện 1 lần) */}
+                {link && (
+                  <div
+                    role="status"
+                    className="bg-muted/50 space-y-2 rounded border p-3"
+                  >
+                    <p className="text-muted-foreground text-xs">
+                      Sao chép NGAY và gửi cho khách qua Zalo/tin nhắn — mã chỉ
+                      hiển thị một lần, rời trang sẽ không lấy lại được (tạo link
+                      mới nếu cần). Link không hết hạn.
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <code
+                        title={link.url}
+                        className="bg-background min-w-0 flex-1 truncate rounded px-2 py-1 text-xs"
                       >
-                        {it.program_name}
-                      </span>
-                      <Badge variant="secondary" className="shrink-0">
-                        {formatDwell(it.total_dwell_seconds)}
-                      </Badge>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </>
-          )}
-        </CardContent>
-      )}
+                        {link.url}
+                      </code>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={onCopy}
+                        aria-label={copied ? "Đã sao chép link" : "Sao chép link"}
+                      >
+                        {copied ? (
+                          <Check className="h-4 w-4 text-green-600" />
+                        ) : (
+                          <Copy className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Danh sách ngành quan tâm */}
+                {!data || data.items.length === 0 ? (
+                  <p className="text-muted-foreground text-sm">
+                    Khách chưa xem ngành nào. Tạo link tư vấn và gửi cho khách để
+                    bắt đầu đo mức quan tâm.
+                  </p>
+                ) : (
+                  <ul className="max-h-64 space-y-2 overflow-y-auto">
+                    {data.items.map((it) => (
+                      <li
+                        key={it.major_program_id}
+                        className="flex items-center gap-3 rounded border p-2"
+                      >
+                        <GraduationCap className="text-primary h-4 w-4 shrink-0" />
+                        <span
+                          title={it.program_name}
+                          className="min-w-0 flex-1 truncate text-sm font-medium"
+                        >
+                          {it.program_name}
+                        </span>
+                        <Badge variant="secondary" className="shrink-0">
+                          {formatDwell(it.total_dwell_seconds)}
+                        </Badge>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </>
+            )}
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
     </Card>
   )
 }

--- a/frontend/src/components/leads/LeadConsultSection.tsx
+++ b/frontend/src/components/leads/LeadConsultSection.tsx
@@ -1,7 +1,7 @@
 // src/components/leads/LeadConsultSection.tsx
 "use client"
 
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import {
   AlertCircle,
@@ -36,20 +36,15 @@ import {
  */
 export function LeadConsultSection({ leadId }: { leadId: number }) {
   const [expanded, setExpanded] = useState(false)
-  const { copied, copy, reset: resetCopied } = useCopyToClipboard()
+  const { copied, copy } = useCopyToClipboard()
 
   const { data, isLoading, isError, refetch, isFetching } =
     useLeadSmsInterests(leadId, expanded)
   const createLink = useCreateConsultLink()
   const link = createLink.data
 
-  // Đổi lead → reset link vừa tạo (tránh hiện link lead cũ trên lead mới) +
-  // copied. createLink.data là mutation-state không tự re-key theo leadId.
-  useEffect(() => {
-    createLink.reset()
-    resetCopied()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [leadId])
+  // Reset link/copied/expanded khi đổi lead do <LeadConsultSection key={leadId}>
+  // remount ở LeadDetailClient — không cần useEffect reset thủ công.
 
   const onCopy = async () => {
     if (!link) return

--- a/frontend/src/components/leads/LeadConsultSection.tsx
+++ b/frontend/src/components/leads/LeadConsultSection.tsx
@@ -1,9 +1,13 @@
 // src/components/leads/LeadConsultSection.tsx
 "use client"
 
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
+import { toast } from "sonner"
 import {
+  AlertCircle,
   Check,
+  ChevronDown,
+  ChevronRight,
   Copy,
   GraduationCap,
   Link2,
@@ -22,112 +26,169 @@ import {
 } from "@/hooks/useSmsConsult"
 
 /**
- * P2-4b — "Tư vấn SMS: Quan tâm ngành" ở trang chi tiết lead. Thin-client:
- * - Nút "Tạo link tư vấn" → BE sinh consult link (match/tạo contact từ phone
- *   lead) → hiển thị code/url để officer copy gửi Zalo/tay.
+ * P2-4b — "Tư vấn SMS: Quan tâm ngành" ở trang chi tiết lead. Collapsible
+ * (§16.5 tab, lazy): chỉ fetch interest khi mở → không thêm request cho mọi
+ * lead không dùng SMS. Thin-client: BE gác quyền (CasbinAuth + IDOR); FE render.
+ * - Nút "Tạo link tư vấn" → BE sinh consult link (match/tạo contact từ phone) →
+ *   hiển thị code/url để copy gửi Zalo (mã CHỈ hiện 1 lần — không lấy lại được).
  * - Danh sách ngành lead quan tâm (rank tổng dwell desc, qua contact match).
- * BE gác quyền (CasbinAuth + IDOR); FE chỉ render.
  */
 export function LeadConsultSection({ leadId }: { leadId: number }) {
-  const { data, isLoading, isError } = useLeadSmsInterests(leadId)
-  const createLink = useCreateConsultLink()
+  const [expanded, setExpanded] = useState(false)
   const [copied, setCopied] = useState(false)
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  const { data, isLoading, isError, refetch, isFetching } =
+    useLeadSmsInterests(leadId, expanded)
+  const createLink = useCreateConsultLink()
   const link = createLink.data
+
+  // Đổi lead → reset link vừa tạo (tránh hiện link lead cũ trên lead mới) +
+  // trạng thái copied. createLink.data là mutation-state không tự re-key.
+  useEffect(() => {
+    createLink.reset()
+    setCopied(false)
+    if (copyTimer.current) clearTimeout(copyTimer.current)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [leadId])
+
+  // Dọn timer copied khi unmount.
+  useEffect(() => () => {
+    if (copyTimer.current) clearTimeout(copyTimer.current)
+  }, [])
+
   const onCopy = async () => {
     if (!link) return
     try {
       await navigator.clipboard.writeText(link.url)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      if (copyTimer.current) clearTimeout(copyTimer.current)
+      copyTimer.current = setTimeout(() => setCopied(false), 2000)
     } catch {
-      // clipboard bị chặn → officer copy tay từ ô hiển thị.
+      toast.error("Không tự sao chép được — vui lòng copy tay từ ô hiển thị.")
     }
   }
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
-        <CardTitle className="flex items-center gap-2 text-sm font-medium">
-          <MessageSquareShare className="h-4 w-4" /> Tư vấn SMS — Quan tâm ngành
-        </CardTitle>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => createLink.mutate(leadId)}
-          disabled={createLink.isPending}
+      <CardHeader className="px-4 py-3">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          className="flex w-full items-center gap-2 text-left"
         >
-          {createLink.isPending ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          {expanded ? (
+            <ChevronDown className="text-muted-foreground h-4 w-4 shrink-0" />
           ) : (
-            <Link2 className="mr-2 h-4 w-4" />
+            <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
           )}
-          Tạo link tư vấn
-        </Button>
+          <MessageSquareShare className="h-4 w-4 shrink-0" />
+          <CardTitle className="flex-1 text-sm font-medium">
+            Tư vấn SMS — Quan tâm ngành
+          </CardTitle>
+        </button>
       </CardHeader>
-      <CardContent className="space-y-4">
-        {/* Link vừa tạo — copy gửi khách */}
-        {link && (
-          <div className="bg-muted/50 space-y-2 rounded border p-3">
-            <p className="text-muted-foreground text-xs">
-              Gửi link này cho khách qua Zalo/tin nhắn. Không hết hạn; lượt xem
-              ngành của khách sẽ hiện bên dưới.
-            </p>
-            <div className="flex items-center gap-2">
-              <code className="min-w-0 flex-1 truncate rounded bg-background px-2 py-1 text-xs">
-                {link.url}
-              </code>
+
+      {expanded && (
+        <CardContent className="space-y-4">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => createLink.mutate(leadId)}
+            disabled={createLink.isPending}
+            className="w-full"
+          >
+            {createLink.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Link2 className="mr-2 h-4 w-4" />
+            )}
+            {link ? "Tạo link khác" : "Tạo link tư vấn"}
+          </Button>
+
+          {/* Link vừa tạo — copy NGAY (mã chỉ hiện 1 lần) */}
+          {link && (
+            <div
+              role="status"
+              className="bg-muted/50 space-y-2 rounded border p-3"
+            >
+              <p className="text-muted-foreground text-xs">
+                Sao chép NGAY và gửi cho khách qua Zalo/tin nhắn — mã chỉ hiển
+                thị một lần, rời trang sẽ không lấy lại được (tạo link mới nếu
+                cần). Link không hết hạn.
+              </p>
+              <div className="flex items-center gap-2">
+                <code
+                  title={link.url}
+                  className="bg-background min-w-0 flex-1 truncate rounded px-2 py-1 text-xs"
+                >
+                  {link.url}
+                </code>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={onCopy}
+                  aria-label={copied ? "Đã sao chép link" : "Sao chép link"}
+                >
+                  {copied ? (
+                    <Check className="h-4 w-4 text-green-600" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Danh sách ngành quan tâm — error KHÁC empty */}
+          {isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 2 }).map((_, i) => (
+                <Skeleton key={i} className="h-9 w-full" />
+              ))}
+            </div>
+          ) : isError ? (
+            <div className="text-muted-foreground flex flex-col items-center gap-2 py-4 text-center text-sm">
+              <AlertCircle className="text-destructive h-5 w-5" />
+              <span>Không tải được dữ liệu quan tâm ngành.</span>
               <Button
                 size="sm"
-                variant="secondary"
-                onClick={onCopy}
-                aria-label="Sao chép link"
+                variant="outline"
+                onClick={() => refetch()}
+                disabled={isFetching}
               >
-                {copied ? (
-                  <Check className="h-4 w-4 text-green-600" />
-                ) : (
-                  <Copy className="h-4 w-4" />
-                )}
+                Thử lại
               </Button>
             </div>
-          </div>
-        )}
-
-        {/* Danh sách ngành quan tâm */}
-        {isLoading ? (
-          <div className="space-y-2">
-            {Array.from({ length: 2 }).map((_, i) => (
-              <Skeleton key={i} className="h-9 w-full" />
-            ))}
-          </div>
-        ) : isError ? (
-          <p className="text-muted-foreground text-sm">
-            Chưa có dữ liệu quan tâm ngành cho lead này.
-          </p>
-        ) : !data || data.items.length === 0 ? (
-          <p className="text-muted-foreground text-sm">
-            Khách chưa xem ngành nào. Tạo link tư vấn và gửi cho khách để bắt
-            đầu đo mức quan tâm.
-          </p>
-        ) : (
-          <ul className="space-y-2">
-            {data.items.map((it) => (
-              <li
-                key={it.major_program_id}
-                className="flex items-center gap-3 rounded border p-2"
-              >
-                <GraduationCap className="text-primary h-4 w-4 shrink-0" />
-                <span className="min-w-0 flex-1 truncate text-sm font-medium">
-                  {it.program_name}
-                </span>
-                <Badge variant="secondary" className="shrink-0">
-                  {formatDwell(it.total_dwell_seconds)}
-                </Badge>
-              </li>
-            ))}
-          </ul>
-        )}
-      </CardContent>
+          ) : !data || data.items.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              Khách chưa xem ngành nào. Tạo link tư vấn và gửi cho khách để bắt
+              đầu đo mức quan tâm.
+            </p>
+          ) : (
+            <ul className="max-h-64 space-y-2 overflow-y-auto">
+              {data.items.map((it) => (
+                <li
+                  key={it.major_program_id}
+                  className="flex items-center gap-3 rounded border p-2"
+                >
+                  <GraduationCap className="text-primary h-4 w-4 shrink-0" />
+                  <span
+                    title={it.program_name}
+                    className="min-w-0 flex-1 truncate text-sm font-medium"
+                  >
+                    {it.program_name}
+                  </span>
+                  <Badge variant="secondary" className="shrink-0">
+                    {formatDwell(it.total_dwell_seconds)}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      )}
     </Card>
   )
 }

--- a/frontend/src/components/sms/admin/labels.ts
+++ b/frontend/src/components/sms/admin/labels.ts
@@ -95,24 +95,9 @@ export const CARRIER_FILTER_OPTIONS: {
   label: CARRIER_LABELS[value],
 }))
 
-/** Định dạng số nguyên kiểu Việt (1.234.567). */
-export function formatInt(n: number): string {
-  return n.toLocaleString("vi-VN")
-}
-
-/** Định dạng phần trăm CTR (BE trả sẵn dạng %; tối đa 1 chữ số thập phân). */
-export function formatPercent(n: number): string {
-  return `${n.toLocaleString("vi-VN", { maximumFractionDigits: 1 })}%`
-}
-
-/** Định dạng dwell (giây) → "M phút S giây" / "S giây" (Phase 2 report). */
-export function formatDwell(seconds: number): string {
-  const s = Math.max(0, Math.round(seconds))
-  if (s < 60) return `${s} giây`
-  const m = Math.floor(s / 60)
-  const rem = s % 60
-  return rem === 0 ? `${m} phút` : `${m} phút ${rem} giây`
-}
+// Formatter số/thời lượng thuần đã chuyển sang @/lib/format (dùng chung, hết
+// coupling leads→sms/admin); re-export để callers cũ ở admin không phải đổi.
+export { formatDwell, formatInt, formatPercent } from "@/lib/format"
 
 /**
  * Định dạng ISO datetime → "dd/MM/yyyy HH:mm" (giờ trình duyệt). An toàn,

--- a/frontend/src/hooks/useCopyToClipboard.ts
+++ b/frontend/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,45 @@
+// src/hooks/useCopyToClipboard.ts
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+/**
+ * Copy-to-clipboard với trạng thái `copied` tự tắt sau `resetMs` — gom pattern
+ * lặp ở nhiều nút copy (consult link, magic link, số điện thoại…). Tự
+ * clearTimeout khi copy lại/unmount (chống set-state sau unmount). `copy` trả
+ * boolean thành/bại để caller báo lỗi (clipboard bị chặn / context HTTP).
+ */
+export function useCopyToClipboard(resetMs = 2000) {
+  const [copied, setCopied] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current)
+    },
+    [],
+  )
+
+  const copy = useCallback(
+    async (text: string): Promise<boolean> => {
+      try {
+        await navigator.clipboard.writeText(text)
+        setCopied(true)
+        if (timer.current) clearTimeout(timer.current)
+        timer.current = setTimeout(() => setCopied(false), resetMs)
+        return true
+      } catch {
+        return false
+      }
+    },
+    [resetMs],
+  )
+
+  /** Reset thủ công (vd khi đổi nội dung nguồn). */
+  const reset = useCallback(() => {
+    if (timer.current) clearTimeout(timer.current)
+    setCopied(false)
+  }, [])
+
+  return { copied, copy, reset }
+}

--- a/frontend/src/hooks/useSmsConsult.ts
+++ b/frontend/src/hooks/useSmsConsult.ts
@@ -4,7 +4,7 @@
  * Endpoint gate `CasbinAuth` + `get_lead_for_user` IDOR ở BE (officer chỉ lead
  * được giao). FE thin-client: hiển thị, để BE gác quyền (403/404 → ẩn/lỗi).
  */
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import { AxiosError } from "axios"
 import { toast } from "sonner"
 
@@ -36,19 +36,17 @@ export function useLeadSmsInterests(leadId: number, enabled = true) {
 
 /** Tạo link tư vấn — trả code/url (component hiển thị + copy). */
 export function useCreateConsultLink() {
-  const queryClient = useQueryClient()
   return useMutation<
     SmsConsultLinkResponse,
     AxiosError<ApiErrorResponse>,
     number
   >({
     mutationFn: (leadId: number) => createSmsConsultLink(leadId),
-    onSuccess: (_data, leadId) => {
+    onSuccess: () => {
       toast.success("Đã tạo link tư vấn. Sao chép để gửi cho khách.")
-      // Interest có thể phát sinh sau khi khách bấm link — làm mới khi quay lại.
-      queryClient.invalidateQueries({
-        queryKey: smsConsultKeys.leadInterests(leadId),
-      })
+      // KHÔNG invalidate interest: interest chỉ phát sinh SAU khi khách bấm link
+      // (sự kiện tương lai) → refetch ngay không thể có dữ liệu mới; staleTime +
+      // refetch-on-mount lo khi officer quay lại lead.
     },
     onError: (err) => {
       toast.error(parseApiError(err, "Không thể tạo link tư vấn."))

--- a/frontend/src/hooks/useSmsConsult.ts
+++ b/frontend/src/hooks/useSmsConsult.ts
@@ -1,0 +1,57 @@
+// src/hooks/useSmsConsult.ts
+/**
+ * React Query hooks P2-4b — consult officer (tiêu thụ BE P2-3).
+ * Endpoint gate `CasbinAuth` + `get_lead_for_user` IDOR ở BE (officer chỉ lead
+ * được giao). FE thin-client: hiển thị, để BE gác quyền (403/404 → ẩn/lỗi).
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { AxiosError } from "axios"
+import { toast } from "sonner"
+
+import {
+  createSmsConsultLink,
+  getSmsLeadInterests,
+} from "@/lib/api/sms"
+import { parseApiError } from "@/lib/utils/api-errors"
+import type { ApiErrorResponse } from "@/types/api.types"
+import type { SmsConsultLinkResponse } from "@/lib/zod/sms"
+
+export const smsConsultKeys = {
+  all: ["sms-consult"] as const,
+  leadInterests: (leadId: number) =>
+    [...smsConsultKeys.all, "lead-interests", leadId] as const,
+}
+
+/** Interest ngành của 1 lead. `enabled` để chỉ query khi mở section. */
+export function useLeadSmsInterests(leadId: number, enabled = true) {
+  return useQuery({
+    queryKey: smsConsultKeys.leadInterests(leadId),
+    queryFn: () => getSmsLeadInterests(leadId),
+    enabled: enabled && leadId > 0,
+    staleTime: 60 * 1000,
+    // 403/404 (không quyền / ngoài IDOR) không retry.
+    retry: false,
+  })
+}
+
+/** Tạo link tư vấn — trả code/url (component hiển thị + copy). */
+export function useCreateConsultLink() {
+  const queryClient = useQueryClient()
+  return useMutation<
+    SmsConsultLinkResponse,
+    AxiosError<ApiErrorResponse>,
+    number
+  >({
+    mutationFn: (leadId: number) => createSmsConsultLink(leadId),
+    onSuccess: (_data, leadId) => {
+      toast.success("Đã tạo link tư vấn. Sao chép để gửi cho khách.")
+      // Interest có thể phát sinh sau khi khách bấm link — làm mới khi quay lại.
+      queryClient.invalidateQueries({
+        queryKey: smsConsultKeys.leadInterests(leadId),
+      })
+    },
+    onError: (err) => {
+      toast.error(parseApiError(err, "Không thể tạo link tư vấn."))
+    },
+  })
+}

--- a/frontend/src/lib/api/server.ts
+++ b/frontend/src/lib/api/server.ts
@@ -29,7 +29,7 @@
  */
 
 import { cookies, headers as nextHeaders } from 'next/headers';
-import { redirect } from 'next/navigation';
+import { redirect, unstable_rethrow } from 'next/navigation';
 import type {
   Lead,
   LeadDetail,
@@ -136,9 +136,17 @@ async function serverFetch<T>(
     try {
       const cookieStore = await cookies();
       cookieHeader = cookieStore.toString();
-    } catch {
-      // Ignore if cookies() fails (e.g., inside "use cache" without explicit header)
-      // The request will likely fail with 401 later, which is expected behavior
+    } catch (err) {
+      // A thrown cookies() under cacheComponents is Next's dynamic-render BAILOUT
+      // signal, not a real error — rethrow it so the segment renders dynamically
+      // and the auth cookie IS forwarded. Swallowing it sends the request WITHOUT
+      // auth → 401, which callers then turn into a 404/broken render (the class of
+      // bug that made every SSR detail page — leads/[id], admissions/[id],
+      // admin/users/[id] — 404 on direct load). unstable_rethrow only re-throws
+      // framework control-flow (bailout/redirect/notFound); genuine cookies()
+      // failures (e.g. inside "use cache" without an explicit header) fall through
+      // and the request fails with 401 downstream as before.
+      unstable_rethrow(err);
     }
   }
 
@@ -169,7 +177,10 @@ async function serverFetch<T>(
       // sets X-Real-IP, so a fallback would only ever fire off-nginx anyway.
       const realIp = inbound.get('x-real-ip');
       if (realIp) headers['X-Real-IP'] = realIp;
-    } catch {
+    } catch (err) {
+      // Rethrow Next's dynamic-render bailout (see the cookies() catch above);
+      // only a genuine headers()-unavailable case should be swallowed.
+      unstable_rethrow(err);
       // headers() unavailable (e.g. inside a "use cache" scope, ISR, or
       // generateMetadata) — leave X-Real-IP unset; the backend then keys on this
       // container's IP. ⚠️ INVARIANT: any get_client_ip-keyed (ENFORCED) endpoint

--- a/frontend/src/lib/api/sms.ts
+++ b/frontend/src/lib/api/sms.ts
@@ -35,6 +35,8 @@ import {
   smsOptOutSchema,
   smsProgramInterestReportSchema,
   smsContactInterestListSchema,
+  smsConsultLinkResponseSchema,
+  smsLeadInterestResponseSchema,
   smsSessionStartResponseSchema,
   smsProgramViewResponseSchema,
   smsHeartbeatResponseSchema,
@@ -70,6 +72,8 @@ import {
   type SmsOptOutList,
   type SmsProgramInterestReport,
   type SmsContactInterestList,
+  type SmsConsultLinkResponse,
+  type SmsLeadInterestResponse,
   type SmsSessionStartResponse,
   type SmsProgramViewResponse,
   type SmsHeartbeatResponse,
@@ -212,6 +216,31 @@ export async function getSmsContactInterests(
     `/api/sms/contacts/${contactId}/interests`,
   )
   return smsContactInterestListSchema.parse(res.data)
+}
+
+// =====================================================================
+// P2-3/P2-4b — consult officer (officer/manager/admin; IDOR scope BE)
+// =====================================================================
+
+/** Interest ngành của 1 LEAD (qua contact match phone). Rỗng nếu chưa có. */
+export async function getSmsLeadInterests(
+  leadId: number,
+): Promise<SmsLeadInterestResponse> {
+  const res = await api.get<SmsLeadInterestResponse>(
+    `/api/sms/leads/${leadId}/interests`,
+  )
+  return smsLeadInterestResponseSchema.parse(res.data)
+}
+
+/** Tạo link tư vấn cho lead → trả code/url raw 1 LẦN (copy gửi Zalo/tay). */
+export async function createSmsConsultLink(
+  leadId: number,
+): Promise<SmsConsultLinkResponse> {
+  const res = await api.post<SmsConsultLinkResponse>(
+    `/api/sms/leads/${leadId}/consult-link`,
+    {},
+  )
+  return smsConsultLinkResponseSchema.parse(res.data)
 }
 
 export interface SmsCampaignListParams {

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,23 @@
+// src/lib/format.ts
+// Formatter số/thời lượng thuần (không phụ thuộc domain) — dùng chung mọi
+// module (admin SMS report, lead detail…). Trước đây ở components/sms/admin/
+// labels.ts gây coupling leads→sms/admin; tách ra đây (labels re-export lại).
+
+/** Định dạng số nguyên kiểu Việt (1.234.567). */
+export function formatInt(n: number): string {
+  return n.toLocaleString("vi-VN")
+}
+
+/** Định dạng phần trăm (giá trị đã ở dạng %; tối đa 1 chữ số thập phân). */
+export function formatPercent(n: number): string {
+  return `${n.toLocaleString("vi-VN", { maximumFractionDigits: 1 })}%`
+}
+
+/** Định dạng thời lượng (giây) → "M phút S giây" / "S giây". */
+export function formatDwell(seconds: number): string {
+  const s = Math.max(0, Math.round(seconds))
+  if (s < 60) return `${s} giây`
+  const m = Math.floor(s / 60)
+  const rem = s % 60
+  return rem === 0 ? `${m} phút` : `${m} phút ${rem} giây`
+}

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -106,6 +106,26 @@ export type SmsContactInterestList = z.infer<
   typeof smsContactInterestListSchema
 >
 
+// --- P2-3/P2-4b consult officer (§16.7) ---
+export const smsConsultLinkResponseSchema = z.object({
+  code: z.string(),
+  url: z.string(),
+  consult_link_id: z.number().int(),
+  contact_id: z.number().int(),
+})
+export type SmsConsultLinkResponse = z.infer<
+  typeof smsConsultLinkResponseSchema
+>
+
+export const smsLeadInterestResponseSchema = z.object({
+  lead_id: z.number().int(),
+  contact_id: z.number().int().nullable().optional(),
+  items: z.array(smsContactInterestRowSchema).default([]),
+})
+export type SmsLeadInterestResponse = z.infer<
+  typeof smsLeadInterestResponseSchema
+>
+
 // =====================================================================
 // Admin — enum literal (mirror CHECK constraint / Literal ở Backend)
 // =====================================================================

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -120,7 +120,9 @@ export type SmsConsultLinkResponse = z.infer<
 export const smsLeadInterestResponseSchema = z.object({
   lead_id: z.number().int(),
   contact_id: z.number().int().nullable(),
-  items: z.array(smsContactInterestRowSchema).default([]),
+  // BE (Pydantic default_factory=list, không exclude_none) LUÔN phát items dạng
+  // mảng → mirror strict, không cần .default([]).
+  items: z.array(smsContactInterestRowSchema),
 })
 export type SmsLeadInterestResponse = z.infer<
   typeof smsLeadInterestResponseSchema

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -119,7 +119,7 @@ export type SmsConsultLinkResponse = z.infer<
 
 export const smsLeadInterestResponseSchema = z.object({
   lead_id: z.number().int(),
-  contact_id: z.number().int().nullable().optional(),
+  contact_id: z.number().int().nullable(),
   items: z.array(smsContactInterestRowSchema).default([]),
 })
 export type SmsLeadInterestResponse = z.infer<


### PR DESCRIPTION
## Tóm tắt
SMS Phase 2 **consult officer** (§16.5/§16.7): officer tạo **link tư vấn 1-1** cho lead trong phạm vi IDOR của mình + xem hồ sơ **"quan tâm ngành"** của lead. Gồm BE (P2-3) + FE card ở trang chi tiết lead (P2-4b), một **fix hạ tầng SSR** (bundle, xem dưới), và **13/14 finding /code-review đã vá**.

## Nội dung chính
**BE (P2-3):**
- Model `sms_consult_link` (lead↔contact↔officer, `token_hash` HMAC partial-unique) + `consult_link_id` vào `sms_landing_session`.
- Resolver dùng chung `sms_resolve.resolve_code` (recipient TRƯỚC → consult) wire vào `/r/` + landing + opt-out + session.
- 2 endpoint officer: `POST /api/sms/leads/{id}/consult-link` (match/tạo contact từ phone lead, `source_label=lead_consult`, **consent `unknown` §16.5**) + `GET .../interests`. Gate 2 tầng `CasbinAuth` + `get_lead_for_user` (IDOR→404).
- Casbin +2 policy `role:officer` (manager kế thừa; accountant chặn ở IDOR).

**FE (P2-4b):** card collapsible `LeadConsultSection` ở lead detail — fetch interest khi mở (lazy, thin-client), nút "Tạo link tư vấn" → hiện URL 1 lần + copy; list ngành rank theo dwell.

**Fix hạ tầng SSR (bundle — commit `26731b1e`):** `serverFetch` (`lib/api/server.ts`) nuốt tín hiệu dynamic-bailout của `cookies()` dưới `cacheComponents` → trang detail SSR (`/leads/[id]`, `/admissions/[id]`, `/admin/users/[id]`) **404 khi mở trực tiếp Ở DEV**. Fix gốc = `unstable_rethrow` ở 2 catch của `serverFetch` + catch getLead của lead page (bỏ `connection()` bandaid). ⚠️ **Chỉ ảnh hưởng DEV** (đã verify prod render 200 bình thường); trên prod fix là no-op + vá nhẹ ca 401-blacklist redirect.

## /code-review max — 13/14 finding đã vá
Correctness (A–E) sạch. Đã vá: #1/#2 SSR · #3 test opt-out (NĐ91) · #4 phone_raw parity · #5 retry `for…else` · #6 helper `normalize_vn_mobile` chung · #7 dedup `ensure_aware`+`GENERIC_404` · #8 `key={leadId}` remount · #9 bỏ invalidate thừa · #10 bỏ ternary kind · #11 zod strict · #12 LEFT JOIN contact bỏ query `get_contact_phone` · #14 Radix Collapsible.
**Defer có chủ đích #13** (gộp 2-probe resolver → 1 query): giữ 2-probe — `resolve_code` là lõi mọi luồng công khai, gộp UNION đổi clarity+rủi ro lấy 1 round-trip trên nhánh consult ít lưu lượng.

## Verify
- ✅ BE **135 test SMS pass** (consult/engagement/tracking/campaign/export/contacts/schema — one-off container) + flake8 mã-mới sạch.
- ✅ FE type-check + lint 0 error.
- ✅ Chrome smoke dev: card render/expand/tạo-link end-to-end · 3 route SSR render 200 · prod smoke xác nhận 404 = dev-only. Data test dọn sạch.

## ⚠️ Deploy KHÔNG code-only
- **2 migration**: `smsp2consult20260702002` (bảng `sms_consult_link` + cột `consult_link_id`) + `smsp2consultcasbin20260702003` (seed Casbin officer).
- **Restart backend** (nạp Casbin) + **rebuild FE**.
- Audit `prod..main` trước deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)