### PR TITLE
feat(finance): officer xem + chia sẻ QR chuyển khoản học phí (tab Học phí hồ sơ)

### DIFF
--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -611,6 +611,9 @@ async def get_profile_finance_summary(
                 paid_amount=f.paid_amount,
                 remaining_amount=f.remaining_amount,
                 status=f.status,
+                has_payable_invoice=any(
+                    _invoice_is_payable(inv) for inv in (f.invoices or [])
+                ),
             )
             for f in summary["fees"]
         ],
@@ -726,6 +729,9 @@ async def get_profile_collection(
                 paid_amount=f.paid_amount,
                 remaining_amount=f.remaining_amount,
                 status=f.status,
+                has_payable_invoice=any(
+                    _invoice_is_payable(inv) for inv in (f.invoices or [])
+                ),
                 # Role-aware (route gate): drawer shows each fee action only when
                 # the matching route would accept it. Same single-source helpers as
                 # the detail FeeResponse. CAVEAT: can_cancel mirrors only the
@@ -957,6 +963,17 @@ async def recalculate_fee(
 def _inv_status_value(inv):
     """Normalize an invoice status to its string value (Enum or str)."""
     return inv.status.value if hasattr(inv.status, "value") else inv.status
+
+
+def _invoice_is_payable(inv) -> bool:
+    """Hóa đơn còn THU ĐƯỢC: đã phát hành (issued/partial/overdue) và còn dư nợ
+    (inv.remaining_amount = amount + penalty - paid > 0, GỒM penalty). Khớp
+    ``isInvoicePayable`` phía FE — nguồn cho FeeSummaryResponse.has_payable_invoice
+    (draft/cancelled/paid đều loại: draft chưa phát hành, paid/cancelled dư nợ=0)."""
+    return (
+        _inv_status_value(inv) in ("issued", "partial", "overdue")
+        and inv.remaining_amount > 0
+    )
 
 
 def _count_pending_overdue(invoices, today):

--- a/Backend_FastAPI/app/routers/invoices.py
+++ b/Backend_FastAPI/app/routers/invoices.py
@@ -46,6 +46,7 @@ from app.repositories.fee_repository import InvoiceRepository
 from app.utils.id_helpers import format_profile_code
 from app.utils.text_helpers import to_bank_transfer_note
 from app.utils.vietqr import build_vietqr_payload, render_qr_png
+from app.utils.bank_names import bank_name_from_bin
 from app.utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
@@ -314,7 +315,12 @@ async def get_invoices_by_fee(
             installment_no=inv.installment_no,
             amount=inv.amount,
             paid_amount=inv.paid_amount,
-            remaining_amount=inv.amount - inv.paid_amount,
+            # Dùng property remaining_amount (= amount + penalty − paid, GỒM
+            # penalty) — KHÔNG phải amount−paid. Khớp cờ has_payable_invoice
+            # (_invoice_is_payable cũng dùng property): ca penalty-only (principal
+            # đã trả, còn dư nợ phạt) vẫn ra remaining > 0 nên FeeQRTransferDialog
+            # không lọc nhầm → tránh "nút hiện nhưng dialog rỗng".
+            remaining_amount=inv.remaining_amount,
             due_date=inv.due_date,
             status=inv.status,
         )
@@ -399,6 +405,7 @@ async def get_invoice_vietqr(
                 bank_bin=bank_bin,
                 account_number=account_number,
                 account_name=account_name,
+                bank_name=bank_name_from_bin(bank_bin),
             ),
             amount=amount,
             content=content,

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -1162,6 +1162,9 @@ class VietQRBankAccount(BaseModel):
     bank_bin: str
     account_number: str
     account_name: str
+    # Tên ngân hàng đầy đủ (BE resolve từ bank_bin) — nguồn duy nhất; FE chỉ
+    # render, không tự map BIN→tên.
+    bank_name: str
 
 
 class VietQRResponse(BaseModel):

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -411,6 +411,13 @@ class FeeSummaryResponse(BaseModel):
     paid_amount: Decimal
     remaining_amount: Decimal
     status: FeeStatusEnum
+    # Invoice-level: có ≥1 hóa đơn của khoản phí này còn THU ĐƯỢC
+    # (issued/partial/overdue AND invoice.remaining_amount > 0; remaining GỒM
+    # penalty). Nguồn DUY NHẤT để FE quyết hiện nút "Mã QR chuyển khoản" — thay
+    # cho suy luận fee.status/fee.remaining ở FE, vốn (a) bỏ sót ca penalty-only
+    # (fee remaining=0 nhưng hóa đơn còn phạt) và (b) lệch khi hóa đơn đợt kế còn
+    # draft (fee partial nhưng không có hóa đơn payable). Default False.
+    has_payable_invoice: bool = False
     # Role-aware capability flags (same rules as FeeResponse: each mirrors its
     # route gate so the thin client never shows a button the route would 403).
     #   can_waive       — not terminal AND remaining > 0 AND role in [admin, manager]

--- a/Backend_FastAPI/app/utils/bank_names.py
+++ b/Backend_FastAPI/app/utils/bank_names.py
@@ -1,0 +1,44 @@
+"""BIN (Napas) → tên ngân hàng đầy đủ, để hiển thị kèm mã VietQR.
+
+Nguồn DUY NHẤT cho tên ngân hàng (thin-client): FE chỉ render giá trị BE trả,
+không tự map BIN→tên. Trường thường dùng 1 ngân hàng cố định nên chỉ cần phủ
+các ngân hàng phổ biến; BIN lạ rơi về nhãn "Ngân hàng (BIN xxxxxx)".
+"""
+
+BANK_NAMES = {
+    "970436": "Ngân hàng TMCP Ngoại thương Việt Nam (Vietcombank)",
+    "970418": "Ngân hàng TMCP Đầu tư và Phát triển Việt Nam (BIDV)",
+    "970405": "Ngân hàng Nông nghiệp và PTNT Việt Nam (Agribank)",
+    "970415": "Ngân hàng TMCP Công thương Việt Nam (VietinBank)",
+    "970422": "Ngân hàng TMCP Quân đội (MB)",
+    "970407": "Ngân hàng TMCP Kỹ thương Việt Nam (Techcombank)",
+    "970416": "Ngân hàng TMCP Á Châu (ACB)",
+    "970432": "Ngân hàng TMCP Việt Nam Thịnh Vượng (VPBank)",
+    "970423": "Ngân hàng TMCP Tiên Phong (TPBank)",
+    "970403": "Ngân hàng TMCP Sài Gòn Thương Tín (Sacombank)",
+    "970443": "Ngân hàng TMCP Sài Gòn - Hà Nội (SHB)",
+    "970431": "Ngân hàng TMCP Xuất Nhập khẩu Việt Nam (Eximbank)",
+    "970426": "Ngân hàng TMCP Hàng Hải Việt Nam (MSB)",
+    "970441": "Ngân hàng TMCP Quốc tế Việt Nam (VIB)",
+    "970448": "Ngân hàng TMCP Phương Đông (OCB)",
+    "970437": "Ngân hàng TMCP Phát triển TP.HCM (HDBank)",
+    "970429": "Ngân hàng TMCP Sài Gòn (SCB)",
+    "970409": "Ngân hàng TMCP Bắc Á (BacABank)",
+    "970425": "Ngân hàng TMCP An Bình (ABBANK)",
+    "970412": "Ngân hàng TMCP Đại Chúng Việt Nam (PVcomBank)",
+    "970440": "Ngân hàng TMCP Đông Nam Á (SeABank)",
+    "970419": "Ngân hàng TMCP Quốc Dân (NCB)",
+    "970433": "Ngân hàng TMCP Việt Nam Thương Tín (VietBank)",
+    "970438": "Ngân hàng TMCP Bảo Việt (BaoVietBank)",
+    "970406": "Ngân hàng TMCP Đông Á (DongABank)",
+    "970424": "Ngân hàng Shinhan Việt Nam (Shinhan Bank)",
+    "970430": "Ngân hàng TMCP Xăng dầu Petrolimex (PGBank)",
+    "970452": "Ngân hàng TMCP Kiên Long (KienLongBank)",
+    "970457": "Ngân hàng Woori Việt Nam (Woori Bank)",
+    "970454": "Ngân hàng TMCP Bản Việt (BVBank)",
+}
+
+
+def bank_name_from_bin(bin_code: str) -> str:
+    """Tên ngân hàng đầy đủ theo BIN; BIN lạ → nhãn fallback."""
+    return BANK_NAMES.get(bin_code, f"Ngân hàng (BIN {bin_code})")

--- a/Backend_FastAPI/tests/unit/test_bank_names.py
+++ b/Backend_FastAPI/tests/unit/test_bank_names.py
@@ -1,0 +1,19 @@
+"""Unit tests cho bank_name_from_bin — nguồn tên ngân hàng kèm VietQR."""
+
+from app.utils.bank_names import bank_name_from_bin
+
+
+def test_known_bin_returns_full_name():
+    assert bank_name_from_bin("970436") == (
+        "Ngân hàng TMCP Ngoại thương Việt Nam (Vietcombank)"
+    )
+    assert "BIDV" in bank_name_from_bin("970418")
+    assert "Techcombank" in bank_name_from_bin("970407")
+
+
+def test_unknown_bin_falls_back_to_labelled_bin():
+    assert bank_name_from_bin("999999") == "Ngân hàng (BIN 999999)"
+
+
+def test_empty_bin_falls_back_without_crash():
+    assert bank_name_from_bin("") == "Ngân hàng (BIN )"

--- a/Backend_FastAPI/tests/unit/test_invoice_payable.py
+++ b/Backend_FastAPI/tests/unit/test_invoice_payable.py
@@ -1,0 +1,53 @@
+"""Unit tests cho `_invoice_is_payable` — predicate nguồn của
+FeeSummaryResponse.has_payable_invoice (nút "Mã QR chuyển khoản" ở tab Học phí).
+
+Chạy thuần trên ORM instance (không DB): `Invoice.remaining_amount` là property
+`amount + penalty_amount - paid_amount`.
+"""
+
+from decimal import Decimal
+
+from app.models.finance import Invoice
+from app.routers.fees import _invoice_is_payable
+
+
+def _inv(status: str, amount: str, paid: str, penalty: str = "0") -> Invoice:
+    return Invoice(
+        status=status,
+        amount=Decimal(amount),
+        paid_amount=Decimal(paid),
+        penalty_amount=Decimal(penalty),
+    )
+
+
+def test_issued_with_balance_is_payable():
+    assert _invoice_is_payable(_inv("issued", "1000000", "0")) is True
+
+
+def test_partial_and_overdue_are_payable():
+    assert _invoice_is_payable(_inv("partial", "1000000", "400000")) is True
+    assert _invoice_is_payable(_inv("overdue", "1000000", "0")) is True
+
+
+def test_penalty_only_balance_is_payable():
+    """P2: principal thu đủ nhưng còn dư nợ PHẠT → vẫn thu được (QR cho phần
+    phạt). fee-level remaining = 0 sẽ bỏ sót ca này; invoice-level remaining
+    (gồm penalty) = 500k > 0 nên predicate đúng."""
+    inv = _inv("issued", "1000000", "1000000", penalty="500000")
+    assert inv.remaining_amount == Decimal("500000")
+    assert _invoice_is_payable(inv) is True
+
+
+def test_draft_is_not_payable():
+    # Chưa phát hành → không QR (BE cũng chặn /vietqr trên draft).
+    assert _invoice_is_payable(_inv("draft", "1000000", "0")) is False
+
+
+def test_paid_is_not_payable():
+    # Dư nợ (gồm penalty) = 0.
+    assert _invoice_is_payable(_inv("paid", "1000000", "1000000")) is False
+
+
+def test_cancelled_is_not_payable():
+    # Status ngoài tập payable, dù còn số dư danh nghĩa.
+    assert _invoice_is_payable(_inv("cancelled", "1000000", "0")) is False

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@/test/utils/test-utils"
+
+import { FeeQRTransferDialog } from "./FeeQRTransferDialog"
+
+const useInvoicesByFee = vi.fn()
+const useInvoiceVietQR = vi.fn()
+
+vi.mock("@/hooks/finance/useInvoices", () => ({
+  useInvoicesByFee: (...args: unknown[]) => useInvoicesByFee(...args),
+  useInvoiceVietQR: (...args: unknown[]) => useInvoiceVietQR(...args),
+}))
+
+const fakeVietQR = {
+  qr_payload: "00020101...",
+  qr_image_base64: "iVBORw0KGgoAAAANSUhEUg==",
+  bank_account: {
+    bank_bin: "970436",
+    account_number: "123456789",
+    account_name: "TRUONG ABC",
+  },
+  amount: "10000000",
+  content: "HS-000178 thanh toan hoc phi",
+}
+
+function makeInvoice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 701,
+    fee_id: 501,
+    invoice_number: "INV-2026-0001",
+    installment_no: 1,
+    amount: "10000000",
+    due_date: "2026-08-01",
+    status: "issued",
+    paid_amount: "0",
+    remaining_amount: "10000000",
+    penalty_amount: "0",
+    total_due: "10000000",
+    is_overdue: false,
+    issued_at: "2026-07-01T00:00:00Z",
+    paid_at: null,
+    cancelled_at: null,
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-01T00:00:00Z",
+    can_issue: false,
+    can_cancel: false,
+    can_record_payment: false,
+    can_apply_penalty: false,
+    ...overrides,
+  }
+}
+
+describe("FeeQRTransferDialog", () => {
+  beforeEach(() => {
+    useInvoicesByFee.mockReset()
+    useInvoiceVietQR.mockReset()
+    useInvoiceVietQR.mockReturnValue({
+      data: fakeVietQR,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+  })
+
+  it("shows the VietQR image for a single payable invoice and selects it", async () => {
+    useInvoicesByFee.mockReturnValue({
+      data: [makeInvoice()],
+      isLoading: false,
+      error: null,
+    })
+
+    render(
+      <FeeQRTransferDialog feeId={501} feeLabel="Học phí — HK1" open onOpenChange={vi.fn()} />
+    )
+
+    expect(await screen.findByAltText("VietQR")).toBeInTheDocument()
+    // Single installment → no picker.
+    expect(screen.queryByText(/chọn đợt thanh toán/i)).not.toBeInTheDocument()
+    // Auto-selected the payable invoice id for the QR query.
+    await waitFor(() =>
+      expect(useInvoiceVietQR).toHaveBeenCalledWith(701, expect.objectContaining({ enabled: true }))
+    )
+  })
+
+  it("filters out draft / paid / cancelled invoices (no payable → empty notice)", () => {
+    useInvoicesByFee.mockReturnValue({
+      data: [
+        makeInvoice({ id: 1, status: "draft" }),
+        makeInvoice({ id: 2, status: "paid", remaining_amount: "0" }),
+        makeInvoice({ id: 3, status: "cancelled" }),
+        // issued but fully settled → not payable.
+        makeInvoice({ id: 4, status: "issued", remaining_amount: "0" }),
+      ],
+      isLoading: false,
+      error: null,
+    })
+
+    render(
+      <FeeQRTransferDialog feeId={501} feeLabel="Học phí — HK1" open onOpenChange={vi.fn()} />
+    )
+
+    expect(screen.getByText(/chưa có hóa đơn cần thanh toán/i)).toBeInTheDocument()
+    expect(screen.queryByAltText("VietQR")).not.toBeInTheDocument()
+  })
+
+  it("renders an installment picker when there are multiple payable invoices", () => {
+    useInvoicesByFee.mockReturnValue({
+      data: [
+        makeInvoice({ id: 701, installment_no: 1, status: "partial", remaining_amount: "4000000" }),
+        makeInvoice({ id: 702, installment_no: 2, status: "overdue", remaining_amount: "6000000" }),
+      ],
+      isLoading: false,
+      error: null,
+    })
+
+    render(
+      <FeeQRTransferDialog feeId={501} feeLabel="Học phí — HK1" open onOpenChange={vi.fn()} />
+    )
+
+    expect(screen.getByText(/chọn đợt thanh toán/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, waitFor } from "@/test/utils/test-utils"
+import { fireEvent, render, screen, waitFor } from "@/test/utils/test-utils"
 
 import { FeeQRTransferDialog } from "./FeeQRTransferDialog"
 
@@ -87,6 +87,38 @@ describe("FeeQRTransferDialog", () => {
     expect(screen.queryByText(/chọn đợt thanh toán/i)).not.toBeInTheDocument()
     // The QR block is queried for the single payable invoice (id 701).
     await waitFor(() => expect(useInvoiceVietQR).toHaveBeenCalledWith(701))
+    // Officer can share the QR to the student.
+    expect(
+      screen.getByRole("button", { name: /chia sẻ mã qr/i })
+    ).toBeInTheDocument()
+  })
+
+  it("falls back to downloading the QR image when Web Share is unavailable", async () => {
+    useInvoicesByFee.mockReturnValue({
+      data: [makeInvoice()],
+      isLoading: false,
+      error: null,
+    })
+    // jsdom has no Web Share (navigator.canShare), so ShareQRButton hits the
+    // download fallback: it must create (and revoke) a blob URL for the PNG.
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:mock")
+    const revokeObjectURL = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {})
+
+    render(
+      <FeeQRTransferDialog feeId={501} feeLabel="Học phí — HK1" open onOpenChange={vi.fn()} />
+    )
+
+    fireEvent.click(await screen.findByRole("button", { name: /chia sẻ mã qr/i }))
+
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(1))
+    expect(revokeObjectURL).toHaveBeenCalled()
+
+    createObjectURL.mockRestore()
+    revokeObjectURL.mockRestore()
   })
 
   it("filters out draft / paid / cancelled invoices (no payable → empty notice)", () => {

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
@@ -17,11 +17,17 @@ vi.mock("@/hooks/finance/useInvoices", () => ({
   useInvoiceVietQR,
 }))
 
-// Thẻ QR vẽ bằng canvas (không chạy trong jsdom) → mock trả blob giả để test
-// luồng chia sẻ / tải ảnh mà không phụ thuộc canvas thật.
-vi.mock("@/lib/finance/qr-card", () => ({
-  renderVietQRCard: vi.fn(async () => new Blob(["png"], { type: "image/png" })),
+// Thẻ QR vẽ bằng canvas (không chạy jsdom); downloadBlob + sonner cũng mock để
+// test luồng chia sẻ/tải mà không đụng canvas / URL / toast thật. Dùng vi.hoisted
+// và RE-ESTABLISH trong beforeEach (vitest.config mockReset:true wipe impl mỗi test).
+const { renderVietQRCard, downloadBlob, toast } = vi.hoisted(() => ({
+  renderVietQRCard: vi.fn(),
+  downloadBlob: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
 }))
+vi.mock("@/lib/finance/qr-card", () => ({ renderVietQRCard }))
+vi.mock("@/lib/utils/download-blob", () => ({ downloadBlob }))
+vi.mock("sonner", () => ({ toast }))
 
 const fakeVietQR = {
   qr_payload: "00020101...",
@@ -30,6 +36,7 @@ const fakeVietQR = {
     bank_bin: "970436",
     account_number: "123456789",
     account_name: "TRUONG ABC",
+    bank_name: "Ngân hàng TMCP Ngoại thương Việt Nam (Vietcombank)",
   },
   amount: "10000000",
   content: "HS-000178 thanh toan hoc phi",
@@ -66,6 +73,10 @@ describe("FeeQRTransferDialog", () => {
   beforeEach(() => {
     useInvoicesByFee.mockReset()
     useInvoiceVietQR.mockReset()
+    renderVietQRCard.mockReset()
+    downloadBlob.mockReset()
+    toast.success.mockReset()
+    toast.error.mockReset()
     // Defaults so a test that only cares about one hook doesn't crash on the
     // other's destructure (both return the loaded/empty shape unless overridden).
     useInvoicesByFee.mockReturnValue({ data: [], isLoading: false, error: null })
@@ -75,6 +86,8 @@ describe("FeeQRTransferDialog", () => {
       error: null,
       refetch: vi.fn(),
     })
+    // Re-establish (mockReset wiped the hoisted impl): render a valid blob.
+    renderVietQRCard.mockResolvedValue(new Blob(["png"], { type: "image/png" }))
   })
 
   it("shows the VietQR image for a single payable invoice and selects it", async () => {
@@ -99,20 +112,12 @@ describe("FeeQRTransferDialog", () => {
     ).toBeInTheDocument()
   })
 
-  it("falls back to downloading the QR image when Web Share is unavailable", async () => {
+  it("downloads the QR card with the right filename when Web Share is unavailable", async () => {
     useInvoicesByFee.mockReturnValue({
       data: [makeInvoice()],
       isLoading: false,
       error: null,
     })
-    // jsdom has no Web Share (navigator.canShare), so ShareQRButton hits the
-    // download fallback: it must create (and revoke) a blob URL for the PNG.
-    const createObjectURL = vi
-      .spyOn(URL, "createObjectURL")
-      .mockReturnValue("blob:mock")
-    const revokeObjectURL = vi
-      .spyOn(URL, "revokeObjectURL")
-      .mockImplementation(() => {})
 
     render(
       <FeeQRTransferDialog feeId={501} feeLabel="Học phí — HK1" open onOpenChange={vi.fn()} />
@@ -120,11 +125,63 @@ describe("FeeQRTransferDialog", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /chia sẻ mã qr/i }))
 
-    await waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(1))
-    expect(revokeObjectURL).toHaveBeenCalled()
+    // jsdom has no navigator.canShare → fallback tải file qua helper chung, tên
+    // theo số TK.
+    await waitFor(() =>
+      expect(downloadBlob).toHaveBeenCalledWith(expect.any(Blob), "vietqr-123456789.png")
+    )
+    expect(toast.success).toHaveBeenCalled()
+  })
 
-    createObjectURL.mockRestore()
-    revokeObjectURL.mockRestore()
+  it("shows an error toast and does NOT download when card rendering fails", async () => {
+    useInvoicesByFee.mockReturnValue({
+      data: [makeInvoice()],
+      isLoading: false,
+      error: null,
+    })
+    renderVietQRCard.mockRejectedValueOnce(new Error("canvas fail"))
+
+    render(
+      <FeeQRTransferDialog feeId={501} feeLabel="Học phí — HK1" open onOpenChange={vi.fn()} />
+    )
+
+    fireEvent.click(await screen.findByRole("button", { name: /chia sẻ mã qr/i }))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(downloadBlob).not.toHaveBeenCalled()
+  })
+
+  it("uses Web Share when available; user-cancel is silent (no download, no error)", async () => {
+    useInvoicesByFee.mockReturnValue({
+      data: [makeInvoice()],
+      isLoading: false,
+      error: null,
+    })
+    const share = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("cancelled"), { name: "AbortError" }))
+    const canShare = vi.fn().mockReturnValue(true)
+    const origNavigator = globalThis.navigator
+    Object.defineProperty(globalThis, "navigator", {
+      value: Object.assign(Object.create(origNavigator), { canShare, share }),
+      configurable: true,
+    })
+    try {
+      render(
+        <FeeQRTransferDialog feeId={501} feeLabel="Học phí — HK1" open onOpenChange={vi.fn()} />
+      )
+      fireEvent.click(await screen.findByRole("button", { name: /chia sẻ mã qr/i }))
+
+      await waitFor(() => expect(share).toHaveBeenCalled())
+      // User huỷ share sheet (AbortError) → KHÔNG rơi xuống tải + KHÔNG toast lỗi.
+      expect(downloadBlob).not.toHaveBeenCalled()
+      expect(toast.error).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(globalThis, "navigator", {
+        value: origNavigator,
+        configurable: true,
+      })
+    }
   })
 
   it("filters out draft / paid / cancelled invoices (no payable → empty notice)", () => {

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
@@ -3,14 +3,18 @@ import { render, screen, waitFor } from "@/test/utils/test-utils"
 
 import { FeeQRTransferDialog } from "./FeeQRTransferDialog"
 
-const useInvoicesByFee = vi.fn()
-const useInvoiceVietQR = vi.fn()
+// vi.hoisted khởi tạo 2 mock fn TRƯỚC khi vi.mock factory (bị hoist lên trên các
+// static import) chạy → khử mọi rủi ro TDZ, không phụ thuộc thứ tự khai báo.
+const { useInvoicesByFee, useInvoiceVietQR } = vi.hoisted(() => ({
+  useInvoicesByFee: vi.fn(),
+  useInvoiceVietQR: vi.fn(),
+}))
 
 // FeeQRTransferDialog resolve hóa đơn qua useInvoicesByFee; khối hiển thị QR
 // (InvoiceVietQR) gọi useInvoiceVietQR(invoiceId). Mock chung 1 module.
 vi.mock("@/hooks/finance/useInvoices", () => ({
-  useInvoicesByFee: (...args: unknown[]) => useInvoicesByFee(...args),
-  useInvoiceVietQR: (...args: unknown[]) => useInvoiceVietQR(...args),
+  useInvoicesByFee,
+  useInvoiceVietQR,
 }))
 
 const fakeVietQR = {

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
@@ -17,6 +17,12 @@ vi.mock("@/hooks/finance/useInvoices", () => ({
   useInvoiceVietQR,
 }))
 
+// Thẻ QR vẽ bằng canvas (không chạy trong jsdom) → mock trả blob giả để test
+// luồng chia sẻ / tải ảnh mà không phụ thuộc canvas thật.
+vi.mock("@/lib/finance/qr-card", () => ({
+  renderVietQRCard: vi.fn(async () => new Blob(["png"], { type: "image/png" })),
+}))
+
 const fakeVietQR = {
   qr_payload: "00020101...",
   qr_image_base64: "iVBORw0KGgoAAAANSUhEUg==",

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.test.tsx
@@ -6,6 +6,8 @@ import { FeeQRTransferDialog } from "./FeeQRTransferDialog"
 const useInvoicesByFee = vi.fn()
 const useInvoiceVietQR = vi.fn()
 
+// FeeQRTransferDialog resolve hóa đơn qua useInvoicesByFee; khối hiển thị QR
+// (InvoiceVietQR) gọi useInvoiceVietQR(invoiceId). Mock chung 1 module.
 vi.mock("@/hooks/finance/useInvoices", () => ({
   useInvoicesByFee: (...args: unknown[]) => useInvoicesByFee(...args),
   useInvoiceVietQR: (...args: unknown[]) => useInvoiceVietQR(...args),
@@ -54,6 +56,9 @@ describe("FeeQRTransferDialog", () => {
   beforeEach(() => {
     useInvoicesByFee.mockReset()
     useInvoiceVietQR.mockReset()
+    // Defaults so a test that only cares about one hook doesn't crash on the
+    // other's destructure (both return the loaded/empty shape unless overridden).
+    useInvoicesByFee.mockReturnValue({ data: [], isLoading: false, error: null })
     useInvoiceVietQR.mockReturnValue({
       data: fakeVietQR,
       isLoading: false,
@@ -76,10 +81,8 @@ describe("FeeQRTransferDialog", () => {
     expect(await screen.findByAltText("VietQR")).toBeInTheDocument()
     // Single installment → no picker.
     expect(screen.queryByText(/chọn đợt thanh toán/i)).not.toBeInTheDocument()
-    // Auto-selected the payable invoice id for the QR query.
-    await waitFor(() =>
-      expect(useInvoiceVietQR).toHaveBeenCalledWith(701, expect.objectContaining({ enabled: true }))
-    )
+    // The QR block is queried for the single payable invoice (id 701).
+    await waitFor(() => expect(useInvoiceVietQR).toHaveBeenCalledWith(701))
   })
 
   it("filters out draft / paid / cancelled invoices (no payable → empty notice)", () => {
@@ -101,9 +104,11 @@ describe("FeeQRTransferDialog", () => {
 
     expect(screen.getByText(/chưa có hóa đơn cần thanh toán/i)).toBeInTheDocument()
     expect(screen.queryByAltText("VietQR")).not.toBeInTheDocument()
+    // No payable → QR block never renders → its query is never fired.
+    expect(useInvoiceVietQR).not.toHaveBeenCalledWith(expect.any(Number))
   })
 
-  it("renders an installment picker when there are multiple payable invoices", () => {
+  it("renders the installment picker and defaults to the first payable installment", async () => {
     useInvoicesByFee.mockReturnValue({
       data: [
         makeInvoice({ id: 701, installment_no: 1, status: "partial", remaining_amount: "4000000" }),
@@ -117,6 +122,43 @@ describe("FeeQRTransferDialog", () => {
       <FeeQRTransferDialog feeId={501} feeLabel="Học phí — HK1" open onOpenChange={vi.fn()} />
     )
 
+    // Picker present. Radix Select options render in a portal (unreliable in
+    // JSDOM), so per project convention we assert the trigger + the default
+    // selection instead of opening the dropdown and clicking an option.
     expect(screen.getByText(/chọn đợt thanh toán/i)).toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    // Defaults to the FIRST payable installment (701) for the QR, not 702.
+    await waitFor(() => expect(useInvoiceVietQR).toHaveBeenCalledWith(701))
+    expect(useInvoiceVietQR).not.toHaveBeenCalledWith(702)
+  })
+
+  it("shows a distinct error notice (not the empty state) when the by-fee request fails", () => {
+    useInvoicesByFee.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("boom"),
+    })
+
+    render(
+      <FeeQRTransferDialog feeId={501} feeLabel="Học phí — HK1" open onOpenChange={vi.fn()} />
+    )
+
+    expect(screen.getByText(/không thể tải hóa đơn/i)).toBeInTheDocument()
+    // Must NOT collapse into the "settled/not issued" empty message.
+    expect(screen.queryByText(/chưa có hóa đơn cần thanh toán/i)).not.toBeInTheDocument()
+    expect(screen.queryByAltText("VietQR")).not.toBeInTheDocument()
+  })
+
+  it("shows the loading skeleton while invoices are being fetched", () => {
+    useInvoicesByFee.mockReturnValue({ data: undefined, isLoading: true, error: null })
+
+    render(
+      <FeeQRTransferDialog feeId={501} feeLabel="Học phí — HK1" open onOpenChange={vi.fn()} />
+    )
+
+    // Neither terminal state renders during load.
+    expect(screen.queryByText(/chưa có hóa đơn cần thanh toán/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/không thể tải hóa đơn/i)).not.toBeInTheDocument()
+    expect(screen.queryByAltText("VietQR")).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.tsx
@@ -8,7 +8,7 @@
  * (nav + proxy chặn), nhưng vẫn cần đưa mã QR cho phụ huynh chuyển khoản học
  * phí. Backend đã cấp officer quyền đọc `GET /api/invoices/by-fee/{fee_id}` và
  * `GET /api/invoices/{id}/vietqr`, nên dialog này thuần FE: từ `feeId` resolve
- * hóa đơn còn phải trả rồi tái dùng `VietQRDisplay`.
+ * hóa đơn còn phải trả rồi tái dùng `InvoiceVietQR`.
  *
  * QR chỉ là thông tin chuyển khoản read-only (KHÔNG phải thao tác ghi nhận
  * thanh toán) nên không gate theo role — mọi ai xem được tab đều dùng được.
@@ -31,21 +31,10 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
-import { VietQRDisplay } from "@/components/finance"
-import { useInvoicesByFee, useInvoiceVietQR } from "@/hooks/finance/useInvoices"
+import { InvoiceVietQR } from "@/components/finance"
+import { useInvoicesByFee } from "@/hooks/finance/useInvoices"
 import { formatVND } from "@/lib/zod/finance"
-import type { Invoice } from "@/types/finance.types"
-
-// Mirror backend PAYABLE_INVOICE_STATUSES — chỉ hóa đơn đã phát hành và còn nợ
-// mới sinh được VietQR (BE cũng chặn draft/cancelled/paid ở endpoint /vietqr).
-const PAYABLE_STATUSES: ReadonlyArray<Invoice["status"]> = ["issued", "partial", "overdue"]
-
-function isPayable(invoice: Invoice): boolean {
-  return (
-    PAYABLE_STATUSES.includes(invoice.status) &&
-    parseFloat(invoice.remaining_amount) > 0
-  )
-}
+import { isInvoicePayable } from "@/types/finance.types"
 
 interface FeeQRTransferDialogProps {
   feeId: number
@@ -68,29 +57,19 @@ export function FeeQRTransferDialog({
   } = useInvoicesByFee(feeId, { enabled: open })
 
   const payable = React.useMemo(
-    () => (invoices ?? []).filter(isPayable),
+    () => (invoices ?? []).filter(isInvoicePayable),
     [invoices],
   )
 
-  // Đợt đang chọn. Mặc định đợt payable đầu tiên; reset khi đóng dialog hoặc khi
-  // tập hóa đơn đổi (mở lại cho khoản phí khác).
-  const [selectedId, setSelectedId] = React.useState<number | null>(null)
-  React.useEffect(() => {
-    if (!open) {
-      setSelectedId(null)
-      return
-    }
-    if (selectedId === null || !payable.some((inv) => inv.id === selectedId)) {
-      setSelectedId(payable[0]?.id ?? null)
-    }
-  }, [open, payable, selectedId])
-
-  const {
-    data: vietqr,
-    isLoading: vietqrLoading,
-    error: vietqrError,
-    refetch: refetchVietQR,
-  } = useInvoiceVietQR(selectedId ?? 0, { enabled: open && !!selectedId })
+  // Đợt người dùng chọn thủ công (null = chưa chọn). Giá trị hiệu lực suy ra
+  // THẲNG khi render (đợt đã chọn nếu còn hợp lệ, ngược lại đợt payable đầu) —
+  // không auto-select bằng useEffect nên tránh 1-frame trống / uncontrolled-flip
+  // và không có state-write-in-effect. State tự mất khi dialog unmount lúc đóng.
+  const [manualSelectedId, setManualSelectedId] = React.useState<number | null>(null)
+  const selectedId =
+    manualSelectedId !== null && payable.some((inv) => inv.id === manualSelectedId)
+      ? manualSelectedId
+      : (payable[0]?.id ?? null)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -110,18 +89,20 @@ export function FeeQRTransferDialog({
           </div>
         ) : invoicesError ? (
           <EmptyNotice text="Không thể tải hóa đơn của khoản phí này. Vui lòng thử lại." />
-        ) : payable.length === 0 ? (
+        ) : selectedId === null ? (
           <EmptyNotice text="Chưa có hóa đơn cần thanh toán. Hóa đơn có thể chưa được phát hành hoặc khoản phí đã thu đủ." />
         ) : (
           <div className="space-y-3">
             {payable.length > 1 && (
               <div className="space-y-1.5">
-                <span className="text-sm text-muted-foreground">Chọn đợt thanh toán</span>
+                <span id="fee-qr-installment-label" className="text-sm text-muted-foreground">
+                  Chọn đợt thanh toán
+                </span>
                 <Select
-                  value={selectedId ? String(selectedId) : undefined}
-                  onValueChange={(v) => setSelectedId(Number(v))}
+                  value={String(selectedId)}
+                  onValueChange={(v) => setManualSelectedId(Number(v))}
                 >
-                  <SelectTrigger>
+                  <SelectTrigger aria-labelledby="fee-qr-installment-label">
                     <SelectValue placeholder="Chọn đợt..." />
                   </SelectTrigger>
                   <SelectContent>
@@ -134,12 +115,7 @@ export function FeeQRTransferDialog({
                 </Select>
               </div>
             )}
-            <VietQRDisplay
-              data={vietqr}
-              isLoading={vietqrLoading}
-              error={vietqrError}
-              onRetry={() => refetchVietQR()}
-            />
+            <InvoiceVietQR invoiceId={selectedId} />
           </div>
         )}
       </DialogContent>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FeeQRTransferDialog.tsx
@@ -1,0 +1,159 @@
+"use client"
+
+/**
+ * FeeQRTransferDialog — hiển thị mã QR chuyển khoản (VietQR) cho một khoản phí,
+ * ngay trong tab "Học phí" của hồ sơ.
+ *
+ * Vì sao ở đây: officer (tư vấn viên) không được vào module Finance
+ * (nav + proxy chặn), nhưng vẫn cần đưa mã QR cho phụ huynh chuyển khoản học
+ * phí. Backend đã cấp officer quyền đọc `GET /api/invoices/by-fee/{fee_id}` và
+ * `GET /api/invoices/{id}/vietqr`, nên dialog này thuần FE: từ `feeId` resolve
+ * hóa đơn còn phải trả rồi tái dùng `VietQRDisplay`.
+ *
+ * QR chỉ là thông tin chuyển khoản read-only (KHÔNG phải thao tác ghi nhận
+ * thanh toán) nên không gate theo role — mọi ai xem được tab đều dùng được.
+ */
+
+import * as React from "react"
+import { AlertTriangle } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import { VietQRDisplay } from "@/components/finance"
+import { useInvoicesByFee, useInvoiceVietQR } from "@/hooks/finance/useInvoices"
+import { formatVND } from "@/lib/zod/finance"
+import type { Invoice } from "@/types/finance.types"
+
+// Mirror backend PAYABLE_INVOICE_STATUSES — chỉ hóa đơn đã phát hành và còn nợ
+// mới sinh được VietQR (BE cũng chặn draft/cancelled/paid ở endpoint /vietqr).
+const PAYABLE_STATUSES: ReadonlyArray<Invoice["status"]> = ["issued", "partial", "overdue"]
+
+function isPayable(invoice: Invoice): boolean {
+  return (
+    PAYABLE_STATUSES.includes(invoice.status) &&
+    parseFloat(invoice.remaining_amount) > 0
+  )
+}
+
+interface FeeQRTransferDialogProps {
+  feeId: number
+  /** Nhãn khoản phí (ví dụ "Học phí — HK1") hiển thị trong mô tả dialog. */
+  feeLabel: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function FeeQRTransferDialog({
+  feeId,
+  feeLabel,
+  open,
+  onOpenChange,
+}: FeeQRTransferDialogProps) {
+  const {
+    data: invoices,
+    isLoading: invoicesLoading,
+    error: invoicesError,
+  } = useInvoicesByFee(feeId, { enabled: open })
+
+  const payable = React.useMemo(
+    () => (invoices ?? []).filter(isPayable),
+    [invoices],
+  )
+
+  // Đợt đang chọn. Mặc định đợt payable đầu tiên; reset khi đóng dialog hoặc khi
+  // tập hóa đơn đổi (mở lại cho khoản phí khác).
+  const [selectedId, setSelectedId] = React.useState<number | null>(null)
+  React.useEffect(() => {
+    if (!open) {
+      setSelectedId(null)
+      return
+    }
+    if (selectedId === null || !payable.some((inv) => inv.id === selectedId)) {
+      setSelectedId(payable[0]?.id ?? null)
+    }
+  }, [open, payable, selectedId])
+
+  const {
+    data: vietqr,
+    isLoading: vietqrLoading,
+    error: vietqrError,
+    refetch: refetchVietQR,
+  } = useInvoiceVietQR(selectedId ?? 0, { enabled: open && !!selectedId })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Mã QR chuyển khoản</DialogTitle>
+          <DialogDescription>
+            {feeLabel} — quét mã hoặc sao chép thông tin để phụ huynh chuyển khoản học phí.
+          </DialogDescription>
+        </DialogHeader>
+
+        {invoicesLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="mx-auto h-44 w-44 rounded-md" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+        ) : invoicesError ? (
+          <EmptyNotice text="Không thể tải hóa đơn của khoản phí này. Vui lòng thử lại." />
+        ) : payable.length === 0 ? (
+          <EmptyNotice text="Chưa có hóa đơn cần thanh toán. Hóa đơn có thể chưa được phát hành hoặc khoản phí đã thu đủ." />
+        ) : (
+          <div className="space-y-3">
+            {payable.length > 1 && (
+              <div className="space-y-1.5">
+                <span className="text-sm text-muted-foreground">Chọn đợt thanh toán</span>
+                <Select
+                  value={selectedId ? String(selectedId) : undefined}
+                  onValueChange={(v) => setSelectedId(Number(v))}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Chọn đợt..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {payable.map((inv) => (
+                      <SelectItem key={inv.id} value={String(inv.id)}>
+                        Đợt {inv.installment_no} — còn {formatVND(inv.remaining_amount)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <VietQRDisplay
+              data={vietqr}
+              isLoading={vietqrLoading}
+              error={vietqrError}
+              onRetry={() => refetchVietQR()}
+            />
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function EmptyNotice({ text }: { text: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+      <p>{text}</p>
+    </div>
+  )
+}
+
+export default FeeQRTransferDialog

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.test.tsx
@@ -60,6 +60,7 @@ const summary = {
       paid_amount: "0",
       remaining_amount: "10000000",
       status: "calculated",
+      has_payable_invoice: false,
     },
   ],
   pending_invoices: 1,
@@ -107,6 +108,50 @@ describe("TuitionTab finance module links", () => {
       "/finance/fees?profile_id=178"
     )
     expect(document.querySelector('a[href="/finance/fees/501"]')).toBeInTheDocument()
+  })
+
+  it("shows the QR button when the fee has a payable invoice (BE flag)", () => {
+    useAuthStore.setState({
+      user: { id: 1, role: "officer", username: "officer" } as any,
+      isAuthenticated: true,
+    })
+    useProfileFinanceSummary.mockReturnValue({
+      data: {
+        ...summary,
+        fees: [{ ...summary.fees[0], status: "partial", has_payable_invoice: true }],
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    render(<TuitionTab profile={profile as any} />)
+
+    expect(
+      screen.getByRole("button", { name: /mã qr chuyển khoản/i })
+    ).toBeInTheDocument()
+  })
+
+  it("hides the QR button when has_payable_invoice is false, even if status looks payable", () => {
+    // status 'partial' would have shown the button under the old status-derive
+    // logic; the BE flag is now the single source (penalty-only / draft-next cases).
+    useAuthStore.setState({
+      user: { id: 1, role: "officer", username: "officer" } as any,
+      isAuthenticated: true,
+    })
+    useProfileFinanceSummary.mockReturnValue({
+      data: {
+        ...summary,
+        fees: [{ ...summary.fees[0], status: "partial", has_payable_invoice: false }],
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    render(<TuitionTab profile={profile as any} />)
+
+    expect(
+      screen.queryByRole("button", { name: /mã qr chuyển khoản/i })
+    ).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.tsx
@@ -21,6 +21,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { ApplicationFeeCollectionPanel } from "./ApplicationFeeCollectionPanel"
+import { FeeQRTransferDialog } from "./FeeQRTransferDialog"
 import { CalculateFeeDialog } from "@/components/admissions/CalculateFeeDialog"
 import {
   CreditCard,
@@ -31,6 +32,7 @@ import {
   Clock,
   Calculator,
   FileText,
+  QrCode,
 } from "lucide-react"
 import { useProfileFinanceSummary } from "@/hooks/finance/useFees"
 import {
@@ -53,6 +55,9 @@ export function TuitionTab({ profile }: TuitionTabProps) {
   // PR #7 — inline calculation. Button visibility is driven entirely by
   // backend `available_actions`; no role-checking in the FE.
   const [calcDialogOpen, setCalcDialogOpen] = useState(false)
+  // Mã QR chuyển khoản cho một khoản phí (officer đưa cho phụ huynh). QR là
+  // thông tin read-only → không gate theo role; dialog tự resolve hóa đơn.
+  const [qrDialogFee, setQrDialogFee] = useState<{ id: number; label: string } | null>(null)
   // PR-3D-A Sub-1: hasAction() helper checks `available_actions_v2` typed
   // (preferred) then legacy `available_actions` list (Wave B+90 soft cutoff).
   const canCalculateFee = hasAction(profile, "calculate_fee")
@@ -284,11 +289,21 @@ export function TuitionTab({ profile }: TuitionTabProps) {
         <CardContent>
           <div className="space-y-3">
             {summary.fees.map((fee) => {
+              const feeLabel =
+                (FEE_TYPE_LABELS[fee.fee_type] ?? fee.fee_type) +
+                (fee.semester_no ? ` — HK${fee.semester_no}` : "")
+              // QR chỉ có nghĩa khi khoản phí đã có hóa đơn phát hành và còn nợ
+              // (invoiced/partial/overdue). Dialog tự resolve đúng hóa đơn payable.
+              const showQr =
+                (fee.status === "invoiced" ||
+                  fee.status === "partial" ||
+                  fee.status === "overdue") &&
+                parseFloat(fee.remaining_amount) > 0
               // Officers can't open the finance detail page (proxy gate),
               // so render a non-link card for them. Manager / accountant /
               // admin keep the navigation affordance.
               const rowClass =
-                "flex items-center justify-between p-3 border rounded-lg" +
+                "flex items-center justify-between p-3" +
                 (canAccessFinanceModule ? " hover:bg-muted/50 transition-colors" : "")
               const rowBody = (
                 <>
@@ -297,10 +312,7 @@ export function TuitionTab({ profile }: TuitionTabProps) {
                       <FileText className="h-4 w-4 text-primary" aria-hidden="true" />
                     </div>
                     <div>
-                      <p className="font-medium">
-                        {FEE_TYPE_LABELS[fee.fee_type] ?? fee.fee_type}
-                        {fee.semester_no ? ` — HK${fee.semester_no}` : ""}
-                      </p>
+                      <p className="font-medium">{feeLabel}</p>
                       <p className="text-xs text-muted-foreground">
                         Năm học: {fee.academic_year}
                         {fee.semester_no ? ` | HK${fee.semester_no}` : ""}
@@ -318,13 +330,29 @@ export function TuitionTab({ profile }: TuitionTabProps) {
                   </div>
                 </>
               )
-              return canAccessFinanceModule ? (
-                <Link key={fee.id} href={`/finance/fees/${fee.id}`} className={rowClass}>
-                  {rowBody}
-                </Link>
-              ) : (
-                <div key={fee.id} className={rowClass}>
-                  {rowBody}
+              // Nút QR nằm NGOÀI Link (không lồng button trong anchor). Wrapper
+              // giữ border/bo góc cho cả phần thông tin lẫn hàng thao tác.
+              return (
+                <div key={fee.id} className="overflow-hidden rounded-lg border">
+                  {canAccessFinanceModule ? (
+                    <Link href={`/finance/fees/${fee.id}`} className={rowClass}>
+                      {rowBody}
+                    </Link>
+                  ) : (
+                    <div className={rowClass}>{rowBody}</div>
+                  )}
+                  {showQr && (
+                    <div className="flex justify-end border-t bg-muted/20 px-3 py-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setQrDialogFee({ id: fee.id, label: feeLabel })}
+                      >
+                        <QrCode className="h-4 w-4 mr-2" aria-hidden="true" />
+                        Mã QR chuyển khoản
+                      </Button>
+                    </div>
+                  )}
                 </div>
               )
             })}
@@ -377,6 +405,15 @@ export function TuitionTab({ profile }: TuitionTabProps) {
           open={calcDialogOpen}
           onOpenChange={setCalcDialogOpen}
           profileId={profile.id}
+        />
+      )}
+
+      {qrDialogFee && (
+        <FeeQRTransferDialog
+          feeId={qrDialogFee.id}
+          feeLabel={qrDialogFee.label}
+          open={!!qrDialogFee}
+          onOpenChange={(o) => !o && setQrDialogFee(null)}
         />
       )}
     </div>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.tsx
@@ -292,13 +292,9 @@ export function TuitionTab({ profile }: TuitionTabProps) {
               const feeLabel =
                 (FEE_TYPE_LABELS[fee.fee_type] ?? fee.fee_type) +
                 (fee.semester_no ? ` — HK${fee.semester_no}` : "")
-              // QR chỉ có nghĩa khi khoản phí đã có hóa đơn phát hành và còn nợ
-              // (invoiced/partial/overdue). Dialog tự resolve đúng hóa đơn payable.
-              const showQr =
-                (fee.status === "invoiced" ||
-                  fee.status === "partial" ||
-                  fee.status === "overdue") &&
-                parseFloat(fee.remaining_amount) > 0
+              // Cờ BE-owned invoice-level (gồm penalty) — nguồn duy nhất; KHÔNG
+              // suy luận payability từ fee.status/remaining ở FE (thin-client).
+              const showQr = fee.has_payable_invoice
               // Officers can't open the finance detail page (proxy gate),
               // so render a non-link card for them. Manager / accountant /
               // admin keep the navigation affordance.

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
@@ -76,7 +76,7 @@ import {
 
 import { useProfileCollection } from "@/hooks/finance/useFees"
 import { calculateOverdueDays } from "@/hooks/finance/useInvoiceViewModel"
-import { FEE_TYPE_LABELS } from "@/types/finance.types"
+import { FEE_TYPE_LABELS, PAYABLE_INVOICE_STATUSES } from "@/types/finance.types"
 import type {
   ProfileCollection,
   InvoiceListItem,
@@ -96,7 +96,7 @@ import type { WorkspaceDialog } from "./WorkspaceActionDialogs"
 // enum issued→overdue once past due, so an only-overdue invoice must still count
 // toward "Hạn gần nhất"; otherwise the header shows "Quá hạn" with no due date
 // (the BE-owned `is_overdue` already lit hasOverdue). Mirrors PAYABLE_INVOICE_STATUSES.
-const OPEN_INVOICE_STATUSES = new Set(["issued", "partial", "overdue"])
+const OPEN_INVOICE_STATUSES = new Set(PAYABLE_INVOICE_STATUSES)
 
 /** Earliest due date among OPEN (issued/partial/overdue) invoices — drawer "Hạn". */
 function nextDue(invoices: InvoiceListItem[]): InvoiceListItem | null {

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/WorkspaceActionDialogs.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/WorkspaceActionDialogs.tsx
@@ -36,8 +36,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { toast } from "sonner"
 
 import { useVerifyPayment, useRejectPayment } from "@/hooks/finance/usePayments"
-import { useInvoiceVietQR } from "@/hooks/finance/useInvoices"
-import { AmountDisplay, VietQRDisplay } from "@/components/finance"
+import { AmountDisplay, InvoiceVietQR } from "@/components/finance"
 
 import { PaymentRecordDialog } from "../[invoiceId]/_components/PaymentRecordDialog"
 import { InvoiceIssueDialog } from "../[invoiceId]/_components/InvoiceIssueDialog"
@@ -335,8 +334,6 @@ function InvoiceQRDialog({
   invoiceNumber: string
   onClose: () => void
 }) {
-  const { data, isLoading, error, refetch } = useInvoiceVietQR(invoiceId)
-
   return (
     <Dialog open onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="sm:max-w-sm">
@@ -346,12 +343,7 @@ function InvoiceQRDialog({
             Quét mã hoặc sao chép thông tin để chuyển khoản học phí.
           </DialogDescription>
         </DialogHeader>
-        <VietQRDisplay
-          data={data}
-          isLoading={isLoading}
-          error={error}
-          onRetry={() => refetch()}
-        />
+        <InvoiceVietQR invoiceId={invoiceId} />
       </DialogContent>
     </Dialog>
   )

--- a/frontend/src/components/finance/InvoiceVietQR.tsx
+++ b/frontend/src/components/finance/InvoiceVietQR.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+/**
+ * InvoiceVietQR — tải payload VietQR của MỘT hóa đơn rồi hiển thị (ảnh QR + số
+ * tài khoản + nội dung) kèm trạng thái loading / error / retry.
+ *
+ * Tách riêng để mọi nơi cần "hiện QR chuyển khoản cho một invoiceId" dùng chung
+ * một khối — dialog QR ở workspace Finance (InvoiceQRDialog) lẫn dialog QR theo
+ * khoản phí ở tab Học phí của hồ sơ (FeeQRTransferDialog) — thay vì tự dựng lại
+ * cặp useInvoiceVietQR + VietQRDisplay.
+ */
+
+import { useInvoiceVietQR } from "@/hooks/finance/useInvoices"
+import { VietQRDisplay } from "./VietQRDisplay"
+
+interface InvoiceVietQRProps {
+  invoiceId: number
+}
+
+export function InvoiceVietQR({ invoiceId }: InvoiceVietQRProps) {
+  const { data, isLoading, error, refetch } = useInvoiceVietQR(invoiceId)
+  return (
+    <VietQRDisplay
+      data={data}
+      isLoading={isLoading}
+      error={error}
+      onRetry={() => refetch()}
+    />
+  )
+}
+
+export default InvoiceVietQR

--- a/frontend/src/components/finance/InvoiceVietQR.tsx
+++ b/frontend/src/components/finance/InvoiceVietQR.tsx
@@ -16,6 +16,7 @@ import { Share2 } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { useInvoiceVietQR } from "@/hooks/finance/useInvoices"
+import { renderVietQRCard } from "@/lib/finance/qr-card"
 import { formatVND } from "@/lib/zod/finance"
 import type { VietQRResponse } from "@/types/finance.types"
 import { VietQRDisplay } from "./VietQRDisplay"
@@ -39,14 +40,6 @@ export function InvoiceVietQR({ invoiceId }: InvoiceVietQRProps) {
   )
 }
 
-/** Base64 (PNG do BE render) → Blob để chia sẻ / tải về. */
-function base64ToBlob(base64: string, type: string): Blob {
-  const binary = atob(base64)
-  const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
-  return new Blob([bytes], { type })
-}
-
 /** Caption kèm ảnh QR để học viên có đủ thông tin ngay cả khi không quét được. */
 function buildCaption(data: VietQRResponse): string {
   return [
@@ -63,7 +56,9 @@ function ShareQRButton({ data }: { data: VietQRResponse }) {
   const handleShare = React.useCallback(async () => {
     setBusy(true)
     try {
-      const blob = base64ToBlob(data.qr_image_base64, "image/png")
+      // Thẻ QR đầy đủ (QR + số tiền/nội dung/tên TK/số TK/ngân hàng) để học
+      // viên tin tưởng khi quét — thay vì ảnh QR "trần".
+      const blob = await renderVietQRCard(data)
       const file = new File(
         [blob],
         `vietqr-${data.bank_account.account_number}.png`,

--- a/frontend/src/components/finance/InvoiceVietQR.tsx
+++ b/frontend/src/components/finance/InvoiceVietQR.tsx
@@ -12,11 +12,12 @@
  */
 
 import * as React from "react"
-import { Share2 } from "lucide-react"
+import { Loader2, Share2 } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { useInvoiceVietQR } from "@/hooks/finance/useInvoices"
 import { renderVietQRCard } from "@/lib/finance/qr-card"
+import { downloadBlob } from "@/lib/utils/download-blob"
 import { formatVND } from "@/lib/zod/finance"
 import type { VietQRResponse } from "@/types/finance.types"
 import { VietQRDisplay } from "./VietQRDisplay"
@@ -46,6 +47,7 @@ function buildCaption(data: VietQRResponse): string {
     "Chuyển khoản học phí",
     `Số tiền: ${formatVND(data.amount)}`,
     `STK: ${data.bank_account.account_number} — ${data.bank_account.account_name}`,
+    `Ngân hàng: ${data.bank_account.bank_name}`,
     `Nội dung: ${data.content}`,
   ].join("\n")
 }
@@ -59,45 +61,43 @@ function ShareQRButton({ data }: { data: VietQRResponse }) {
       // Thẻ QR đầy đủ (QR + số tiền/nội dung/tên TK/số TK/ngân hàng) để học
       // viên tin tưởng khi quét — thay vì ảnh QR "trần".
       const blob = await renderVietQRCard(data)
-      const file = new File(
-        [blob],
-        `vietqr-${data.bank_account.account_number}.png`,
-        { type: "image/png" },
-      )
-      const caption = buildCaption(data)
+      const fileName = `vietqr-${data.bank_account.account_number}.png`
 
-      // Web Share Level 2 (chia sẻ file): mobile/tablet mở share sheet để gửi
-      // thẳng qua Zalo / Messenger / email…
+      // Web Share Level 2 (chia sẻ file) — mobile/tablet mở share sheet gửi
+      // thẳng qua Zalo / Messenger / email. File dựng trong nhánh này để môi
+      // trường thiếu File constructor không làm chết luôn nhánh tải PNG.
+      const file =
+        typeof File !== "undefined"
+          ? new File([blob], fileName, { type: "image/png" })
+          : null
       const canShareFile =
+        file != null &&
         typeof navigator !== "undefined" &&
         typeof navigator.canShare === "function" &&
+        typeof navigator.share === "function" &&
         navigator.canShare({ files: [file] })
 
       if (canShareFile) {
-        await navigator.share({
-          files: [file],
-          title: "Mã QR chuyển khoản học phí",
-          text: caption,
-        })
-        return
+        try {
+          await navigator.share({
+            files: [file],
+            title: "Mã QR chuyển khoản học phí",
+            text: buildCaption(data),
+          })
+          return
+        } catch (shareErr) {
+          // Người dùng bấm huỷ share sheet → dừng im lặng.
+          if ((shareErr as Error)?.name === "AbortError") return
+          // Chia sẻ lỗi lý do khác (mất user-activation / permission) → không
+          // để officer kẹt: rơi xuống nhánh tải PNG bên dưới.
+        }
       }
 
-      // Fallback (đa số desktop không hỗ trợ chia sẻ file): tải ảnh PNG về máy
-      // để officer gửi cho học viên qua Zalo / email.
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement("a")
-      a.href = url
-      a.download = file.name
-      document.body.appendChild(a)
-      a.click()
-      a.remove()
-      URL.revokeObjectURL(url)
+      // Fallback (desktop / share fail): tải ảnh về máy để gửi qua Zalo / email.
+      downloadBlob(blob, fileName)
       toast.success("Đã tải ảnh mã QR — gửi cho học viên qua Zalo/email")
-    } catch (err) {
-      // Người dùng bấm huỷ trên share sheet → im lặng, không báo lỗi.
-      if ((err as Error)?.name !== "AbortError") {
-        toast.error("Không thể chia sẻ mã QR. Vui lòng thử lại.")
-      }
+    } catch {
+      toast.error("Không thể tạo/chia sẻ mã QR. Vui lòng thử lại.")
     } finally {
       setBusy(false)
     }
@@ -109,9 +109,14 @@ function ShareQRButton({ data }: { data: VietQRResponse }) {
       className="w-full"
       onClick={handleShare}
       disabled={busy}
+      aria-busy={busy}
     >
-      <Share2 className="mr-2 h-4 w-4" aria-hidden="true" />
-      Chia sẻ mã QR cho học viên
+      {busy ? (
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+      ) : (
+        <Share2 className="mr-2 h-4 w-4" aria-hidden="true" />
+      )}
+      {busy ? "Đang tạo mã QR…" : "Chia sẻ mã QR"}
     </Button>
   )
 }

--- a/frontend/src/components/finance/InvoiceVietQR.tsx
+++ b/frontend/src/components/finance/InvoiceVietQR.tsx
@@ -2,7 +2,8 @@
 
 /**
  * InvoiceVietQR — tải payload VietQR của MỘT hóa đơn rồi hiển thị (ảnh QR + số
- * tài khoản + nội dung) kèm trạng thái loading / error / retry.
+ * tài khoản + nội dung) kèm trạng thái loading / error / retry, và nút CHIA SẺ
+ * để officer gửi mã QR cho học viên / phụ huynh.
  *
  * Tách riêng để mọi nơi cần "hiện QR chuyển khoản cho một invoiceId" dùng chung
  * một khối — dialog QR ở workspace Finance (InvoiceQRDialog) lẫn dialog QR theo
@@ -10,7 +11,13 @@
  * cặp useInvoiceVietQR + VietQRDisplay.
  */
 
+import * as React from "react"
+import { Share2 } from "lucide-react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
 import { useInvoiceVietQR } from "@/hooks/finance/useInvoices"
+import { formatVND } from "@/lib/zod/finance"
+import type { VietQRResponse } from "@/types/finance.types"
 import { VietQRDisplay } from "./VietQRDisplay"
 
 interface InvoiceVietQRProps {
@@ -20,12 +27,97 @@ interface InvoiceVietQRProps {
 export function InvoiceVietQR({ invoiceId }: InvoiceVietQRProps) {
   const { data, isLoading, error, refetch } = useInvoiceVietQR(invoiceId)
   return (
-    <VietQRDisplay
-      data={data}
-      isLoading={isLoading}
-      error={error}
-      onRetry={() => refetch()}
-    />
+    <div className="space-y-3">
+      <VietQRDisplay
+        data={data}
+        isLoading={isLoading}
+        error={error}
+        onRetry={() => refetch()}
+      />
+      {data && <ShareQRButton data={data} />}
+    </div>
+  )
+}
+
+/** Base64 (PNG do BE render) → Blob để chia sẻ / tải về. */
+function base64ToBlob(base64: string, type: string): Blob {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return new Blob([bytes], { type })
+}
+
+/** Caption kèm ảnh QR để học viên có đủ thông tin ngay cả khi không quét được. */
+function buildCaption(data: VietQRResponse): string {
+  return [
+    "Chuyển khoản học phí",
+    `Số tiền: ${formatVND(data.amount)}`,
+    `STK: ${data.bank_account.account_number} — ${data.bank_account.account_name}`,
+    `Nội dung: ${data.content}`,
+  ].join("\n")
+}
+
+function ShareQRButton({ data }: { data: VietQRResponse }) {
+  const [busy, setBusy] = React.useState(false)
+
+  const handleShare = React.useCallback(async () => {
+    setBusy(true)
+    try {
+      const blob = base64ToBlob(data.qr_image_base64, "image/png")
+      const file = new File(
+        [blob],
+        `vietqr-${data.bank_account.account_number}.png`,
+        { type: "image/png" },
+      )
+      const caption = buildCaption(data)
+
+      // Web Share Level 2 (chia sẻ file): mobile/tablet mở share sheet để gửi
+      // thẳng qua Zalo / Messenger / email…
+      const canShareFile =
+        typeof navigator !== "undefined" &&
+        typeof navigator.canShare === "function" &&
+        navigator.canShare({ files: [file] })
+
+      if (canShareFile) {
+        await navigator.share({
+          files: [file],
+          title: "Mã QR chuyển khoản học phí",
+          text: caption,
+        })
+        return
+      }
+
+      // Fallback (đa số desktop không hỗ trợ chia sẻ file): tải ảnh PNG về máy
+      // để officer gửi cho học viên qua Zalo / email.
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = file.name
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(url)
+      toast.success("Đã tải ảnh mã QR — gửi cho học viên qua Zalo/email")
+    } catch (err) {
+      // Người dùng bấm huỷ trên share sheet → im lặng, không báo lỗi.
+      if ((err as Error)?.name !== "AbortError") {
+        toast.error("Không thể chia sẻ mã QR. Vui lòng thử lại.")
+      }
+    } finally {
+      setBusy(false)
+    }
+  }, [data])
+
+  return (
+    <Button
+      variant="outline"
+      className="w-full"
+      onClick={handleShare}
+      disabled={busy}
+    >
+      <Share2 className="mr-2 h-4 w-4" aria-hidden="true" />
+      Chia sẻ mã QR cho học viên
+    </Button>
   )
 }
 

--- a/frontend/src/components/finance/index.ts
+++ b/frontend/src/components/finance/index.ts
@@ -44,6 +44,7 @@ export {
 // Cross-reference components
 export { FeeStatusLink, type FeeStatusLinkProps } from "./FeeStatusLink"
 export { VietQRDisplay } from "./VietQRDisplay"
+export { InvoiceVietQR } from "./InvoiceVietQR"
 
 // Invoice components
 export { InvoiceTable, type InvoiceTableProps } from "./InvoiceTable"

--- a/frontend/src/lib/finance/qr-card.ts
+++ b/frontend/src/lib/finance/qr-card.ts
@@ -1,0 +1,173 @@
+/**
+ * Render một "thẻ VietQR" đầy đủ thông tin (canvas → PNG) để officer chia sẻ
+ * cho học viên / phụ huynh.
+ *
+ * Vì sao TỰ vẽ ở FE thay vì tải ảnh từ vietqr.io: giữ đúng triết lý tự-sinh-QR
+ * cục bộ (miễn phí, không phụ thuộc dịch vụ ngoài) và KHÔNG gửi số TK / số tiền
+ * / nội dung CK (chứa tên học viên = PII) ra bên thứ ba. Mã QR "trần" do backend
+ * render (`VietQRResponse.qr_image_base64`) chỉ có ô QR — thiếu số tiền / tên
+ * chủ TK / ngân hàng nên học viên ít tin tưởng khi quét. Thẻ này bổ sung các
+ * thông tin đó quanh mã QR.
+ */
+
+import { formatVND } from "@/lib/zod/finance"
+import type { VietQRResponse } from "@/types/finance.types"
+
+// BIN (Napas) → tên ngân hàng đầy đủ. Trường thường dùng 1 ngân hàng cố định
+// nên chỉ cần phủ các ngân hàng phổ biến; BIN lạ rơi về nhãn "BIN xxxxxx".
+const BANK_NAMES: Record<string, string> = {
+  "970436": "Ngân hàng TMCP Ngoại thương Việt Nam (Vietcombank)",
+  "970418": "Ngân hàng TMCP Đầu tư và Phát triển Việt Nam (BIDV)",
+  "970405": "Ngân hàng Nông nghiệp và PTNT Việt Nam (Agribank)",
+  "970415": "Ngân hàng TMCP Công thương Việt Nam (VietinBank)",
+  "970422": "Ngân hàng TMCP Quân đội (MB)",
+  "970407": "Ngân hàng TMCP Kỹ thương Việt Nam (Techcombank)",
+  "970416": "Ngân hàng TMCP Á Châu (ACB)",
+  "970432": "Ngân hàng TMCP Việt Nam Thịnh Vượng (VPBank)",
+  "970423": "Ngân hàng TMCP Tiên Phong (TPBank)",
+  "970403": "Ngân hàng TMCP Sài Gòn Thương Tín (Sacombank)",
+  "970443": "Ngân hàng TMCP Sài Gòn - Hà Nội (SHB)",
+  "970431": "Ngân hàng TMCP Xuất Nhập khẩu Việt Nam (Eximbank)",
+  "970426": "Ngân hàng TMCP Hàng Hải Việt Nam (MSB)",
+  "970441": "Ngân hàng TMCP Quốc tế Việt Nam (VIB)",
+  "970448": "Ngân hàng TMCP Phương Đông (OCB)",
+  "970437": "Ngân hàng TMCP Phát triển TP.HCM (HDBank)",
+  "970429": "Ngân hàng TMCP Sài Gòn (SCB)",
+  "970409": "Ngân hàng TMCP Bắc Á (BacABank)",
+  "970425": "Ngân hàng TMCP An Bình (ABBANK)",
+  "970412": "Ngân hàng TMCP Đại Chúng Việt Nam (PVcomBank)",
+  "970440": "Ngân hàng TMCP Đông Nam Á (SeABank)",
+  "970419": "Ngân hàng TMCP Quốc Dân (NCB)",
+  "970433": "Ngân hàng TMCP Việt Nam Thương Tín (VietBank)",
+  "970438": "Ngân hàng TMCP Bảo Việt (BaoVietBank)",
+  "970406": "Ngân hàng TMCP Đông Á (DongABank)",
+  "970424": "Ngân hàng Shinhan Việt Nam (Shinhan Bank)",
+  "970430": "Ngân hàng TMCP Xăng dầu Petrolimex (PGBank)",
+  "970452": "Ngân hàng TMCP Kiên Long (KienLongBank)",
+  "970457": "Ngân hàng Woori Việt Nam (Woori Bank)",
+  "970454": "Ngân hàng TMCP Bản Việt (BVBank)",
+}
+
+export function bankNameFromBin(bin: string): string {
+  return BANK_NAMES[bin] ?? `Ngân hàng (BIN ${bin})`
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error("Không tải được ảnh QR"))
+    img.src = src
+  })
+}
+
+/** Ngắt dòng text theo bề rộng tối đa (canvas) với font cho trước. */
+function wrapText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+  font: string,
+): string[] {
+  ctx.font = font
+  const words = text.split(" ")
+  const lines: string[] = []
+  let current = ""
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word
+    if (ctx.measureText(candidate).width > maxWidth && current) {
+      lines.push(current)
+      current = word
+    } else {
+      current = candidate
+    }
+  }
+  if (current) lines.push(current)
+  return lines
+}
+
+/**
+ * Vẽ thẻ VietQR (mã QR + thông tin chuyển khoản) và trả về PNG blob.
+ * Ném lỗi nếu môi trường không có canvas 2D (caller fallback / báo lỗi).
+ */
+export async function renderVietQRCard(data: VietQRResponse): Promise<Blob> {
+  const qrImg = await loadImage(`data:image/png;base64,${data.qr_image_base64}`)
+
+  const W = 680
+  const PAD = 44
+  const QR = 400
+  const LINE_H = 34
+
+  const canvas = document.createElement("canvas")
+  canvas.width = W
+  const ctx = canvas.getContext("2d")
+  if (!ctx) throw new Error("Trình duyệt không hỗ trợ canvas 2D")
+
+  const infoFont = "22px sans-serif"
+  const infoFontStrong = "bold 22px sans-serif"
+  const maxTextW = W - PAD * 2
+
+  const rows: Array<{ text: string; strong?: boolean }> = [
+    { text: `Số tiền: ${formatVND(data.amount)}`, strong: true },
+    { text: `Nội dung CK: ${data.content}` },
+    { text: `Tên chủ TK: ${data.bank_account.account_name}` },
+    { text: `Số TK: ${data.bank_account.account_number}`, strong: true },
+    { text: bankNameFromBin(data.bank_account.bank_bin) },
+  ]
+
+  // Đo trước để tính chiều cao chính xác (nội dung CK có thể dài, xuống dòng).
+  const wrapped = rows.map((r) => ({
+    ...r,
+    lines: wrapText(ctx, r.text, maxTextW, r.strong ? infoFontStrong : infoFont),
+  }))
+  const infoLines = wrapped.reduce((n, r) => n + r.lines.length, 0)
+
+  const titleH = 92
+  const qrTop = titleH
+  const hintH = 46
+  const infoTop = qrTop + QR + hintH
+  const H = infoTop + infoLines * LINE_H + PAD
+  canvas.height = H // ⚠️ reset toàn bộ state context → set lại style khi vẽ
+
+  // Nền + viền.
+  ctx.fillStyle = "#ffffff"
+  ctx.fillRect(0, 0, W, H)
+  ctx.strokeStyle = "#1d4ed8"
+  ctx.lineWidth = 6
+  ctx.strokeRect(10, 10, W - 20, H - 20)
+
+  // Tiêu đề.
+  ctx.textAlign = "center"
+  ctx.fillStyle = "#0f172a"
+  ctx.font = "bold 34px sans-serif"
+  ctx.fillText("CHUYỂN KHOẢN HỌC PHÍ", W / 2, 60)
+
+  // Mã QR.
+  ctx.drawImage(qrImg, (W - QR) / 2, qrTop, QR, QR)
+
+  // Gợi ý quét.
+  ctx.fillStyle = "#64748b"
+  ctx.font = "18px sans-serif"
+  ctx.fillText(
+    "Quét mã bằng ứng dụng ngân hàng để chuyển khoản",
+    W / 2,
+    qrTop + QR + 30,
+  )
+
+  // Thông tin (căn giữa như thẻ VietQR chuẩn).
+  let y = infoTop + 26
+  for (const r of wrapped) {
+    ctx.font = r.strong ? infoFontStrong : infoFont
+    ctx.fillStyle = r.strong ? "#0f172a" : "#334155"
+    for (const line of r.lines) {
+      ctx.fillText(line, W / 2, y)
+      y += LINE_H
+    }
+  }
+
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error("Không tạo được ảnh PNG"))),
+      "image/png",
+    )
+  })
+}

--- a/frontend/src/lib/finance/qr-card.ts
+++ b/frontend/src/lib/finance/qr-card.ts
@@ -7,50 +7,12 @@
  * / nội dung CK (chứa tên học viên = PII) ra bên thứ ba. Mã QR "trần" do backend
  * render (`VietQRResponse.qr_image_base64`) chỉ có ô QR — thiếu số tiền / tên
  * chủ TK / ngân hàng nên học viên ít tin tưởng khi quét. Thẻ này bổ sung các
- * thông tin đó quanh mã QR.
+ * thông tin đó quanh mã QR. Tên ngân hàng lấy từ `bank_account.bank_name` do BE
+ * trả (nguồn duy nhất) — FE không tự map BIN→tên.
  */
 
 import { formatVND } from "@/lib/zod/finance"
 import type { VietQRResponse } from "@/types/finance.types"
-
-// BIN (Napas) → tên ngân hàng đầy đủ. Trường thường dùng 1 ngân hàng cố định
-// nên chỉ cần phủ các ngân hàng phổ biến; BIN lạ rơi về nhãn "BIN xxxxxx".
-const BANK_NAMES: Record<string, string> = {
-  "970436": "Ngân hàng TMCP Ngoại thương Việt Nam (Vietcombank)",
-  "970418": "Ngân hàng TMCP Đầu tư và Phát triển Việt Nam (BIDV)",
-  "970405": "Ngân hàng Nông nghiệp và PTNT Việt Nam (Agribank)",
-  "970415": "Ngân hàng TMCP Công thương Việt Nam (VietinBank)",
-  "970422": "Ngân hàng TMCP Quân đội (MB)",
-  "970407": "Ngân hàng TMCP Kỹ thương Việt Nam (Techcombank)",
-  "970416": "Ngân hàng TMCP Á Châu (ACB)",
-  "970432": "Ngân hàng TMCP Việt Nam Thịnh Vượng (VPBank)",
-  "970423": "Ngân hàng TMCP Tiên Phong (TPBank)",
-  "970403": "Ngân hàng TMCP Sài Gòn Thương Tín (Sacombank)",
-  "970443": "Ngân hàng TMCP Sài Gòn - Hà Nội (SHB)",
-  "970431": "Ngân hàng TMCP Xuất Nhập khẩu Việt Nam (Eximbank)",
-  "970426": "Ngân hàng TMCP Hàng Hải Việt Nam (MSB)",
-  "970441": "Ngân hàng TMCP Quốc tế Việt Nam (VIB)",
-  "970448": "Ngân hàng TMCP Phương Đông (OCB)",
-  "970437": "Ngân hàng TMCP Phát triển TP.HCM (HDBank)",
-  "970429": "Ngân hàng TMCP Sài Gòn (SCB)",
-  "970409": "Ngân hàng TMCP Bắc Á (BacABank)",
-  "970425": "Ngân hàng TMCP An Bình (ABBANK)",
-  "970412": "Ngân hàng TMCP Đại Chúng Việt Nam (PVcomBank)",
-  "970440": "Ngân hàng TMCP Đông Nam Á (SeABank)",
-  "970419": "Ngân hàng TMCP Quốc Dân (NCB)",
-  "970433": "Ngân hàng TMCP Việt Nam Thương Tín (VietBank)",
-  "970438": "Ngân hàng TMCP Bảo Việt (BaoVietBank)",
-  "970406": "Ngân hàng TMCP Đông Á (DongABank)",
-  "970424": "Ngân hàng Shinhan Việt Nam (Shinhan Bank)",
-  "970430": "Ngân hàng TMCP Xăng dầu Petrolimex (PGBank)",
-  "970452": "Ngân hàng TMCP Kiên Long (KienLongBank)",
-  "970457": "Ngân hàng Woori Việt Nam (Woori Bank)",
-  "970454": "Ngân hàng TMCP Bản Việt (BVBank)",
-}
-
-export function bankNameFromBin(bin: string): string {
-  return BANK_NAMES[bin] ?? `Ngân hàng (BIN ${bin})`
-}
 
 function loadImage(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
@@ -111,7 +73,7 @@ export async function renderVietQRCard(data: VietQRResponse): Promise<Blob> {
     { text: `Nội dung CK: ${data.content}` },
     { text: `Tên chủ TK: ${data.bank_account.account_name}` },
     { text: `Số TK: ${data.bank_account.account_number}`, strong: true },
-    { text: bankNameFromBin(data.bank_account.bank_bin) },
+    { text: data.bank_account.bank_name },
   ]
 
   // Đo trước để tính chiều cao chính xác (nội dung CK có thể dài, xuống dòng).

--- a/frontend/src/lib/zod/finance.ts
+++ b/frontend/src/lib/zod/finance.ts
@@ -408,6 +408,7 @@ export const vietQRResponseSchema = z.object({
     bank_bin: z.string(),
     account_number: z.string(),
     account_name: z.string(),
+    bank_name: z.string(),
   }),
   amount: z.string(),
   content: z.string(),

--- a/frontend/src/lib/zod/finance.ts
+++ b/frontend/src/lib/zod/finance.ts
@@ -213,6 +213,8 @@ export const feeSummarySchema = z.object({
   paid_amount: z.string(),
   remaining_amount: z.string(),
   status: feeStatusSchema,
+  // BE-owned: khoản phí có hóa đơn còn thu được (invoice-level, gồm penalty).
+  has_payable_invoice: z.boolean(),
 })
 
 export type FeeSummary = z.infer<typeof feeSummarySchema>

--- a/frontend/src/test/mocks/handlers/finance.ts
+++ b/frontend/src/test/mocks/handlers/finance.ts
@@ -142,6 +142,7 @@ export const financeHandlers = [
           paid_amount: fee.paid_amount,
           remaining_amount: fee.remaining_amount,
           status: fee.status,
+          has_payable_invoice: ["issued", "partial", "overdue"].includes(fee.status),
         }],
         pending_invoices: 1,
         overdue_invoices: fee.status === "overdue" ? 1 : 0,

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -821,6 +821,28 @@ export const INVOICE_STATUS_VARIANTS: Record<InvoiceStatus, "default" | "seconda
   overdue: "destructive",
 }
 
+/**
+ * Trạng thái hóa đơn "còn thu được" (đã phát hành, chưa tất toán/hủy) — mirror
+ * backend PAYABLE_INVOICE_STATUSES. Chỉ các trạng thái này mới ghi nhận thanh
+ * toán / sinh được VietQR. Nguồn DUY NHẤT cho mọi nơi FE lọc hóa đơn payable
+ * (thay vì mỗi chỗ khai báo lại một literal set).
+ */
+export const PAYABLE_INVOICE_STATUSES: readonly InvoiceStatus[] = [
+  "issued",
+  "partial",
+  "overdue",
+]
+
+/** Hóa đơn còn phải thu: đã phát hành (issued/partial/overdue) VÀ còn dư nợ > 0. */
+export function isInvoicePayable(
+  invoice: Pick<Invoice, "status" | "remaining_amount">,
+): boolean {
+  return (
+    PAYABLE_INVOICE_STATUSES.includes(invoice.status) &&
+    parseFloat(invoice.remaining_amount) > 0
+  )
+}
+
 export const PAYMENT_STATUS_LABELS: Record<PaymentStatus, string> = {
   pending: "Chờ xác minh",
   verified: "Đã xác minh",

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -135,6 +135,11 @@ export interface FeeSummary {
   paid_amount: string
   remaining_amount: string
   status: FeeStatus
+  // Backend-owned: có ≥1 hóa đơn của khoản phí này còn THU ĐƯỢC (invoice-level,
+  // remaining GỒM penalty). Nguồn DUY NHẤT để quyết hiện nút "Mã QR chuyển khoản"
+  // — KHÔNG suy luận từ fee.status/remaining ở FE (bỏ sót penalty-only + lệch
+  // hóa đơn đợt draft). Mọi builder FeeSummaryResponse serialize (default false).
+  has_payable_invoice: boolean
   // Role-aware capability flags (backend-owned, each mirrors its route gate).
   // Optional: only the collection drawer populates them; other FeeSummary
   // sources leave them falsy → no action button (safe default).

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -417,6 +417,7 @@ export interface VietQRBankAccount {
   bank_bin: string
   account_number: string
   account_name: string
+  bank_name: string
 }
 
 export interface VietQRResponse {


### PR DESCRIPTION
## Mục tiêu
Officer (tư vấn viên) không được vào module Finance nhưng cần đưa mã QR cho phụ huynh chuyển khoản học phí. PR này cho officer thấy nút **"Mã QR chuyển khoản"** ngay tại tab **Học phí** của hồ sơ, và **chia sẻ tấm thẻ QR đầy đủ thông tin** cho học viên — không phá separation of duties, không đụng Casbin.

## Backend
- `FeeSummaryResponse.has_payable_invoice` (invoice-level, `_invoice_is_payable`: status issued/partial/overdue AND `remaining_amount > 0`, remaining **gồm penalty**) — nguồn duy nhất để FE quyết hiện nút, thay cho suy luận `fee.status` (bỏ sót penalty-only + lệch hóa đơn đợt draft).
- `by-fee` trả `remaining_amount` **gồm penalty** (dùng `inv.remaining_amount` property) — khớp cờ trên, hết ca nút-hiện-dialog-rỗng.
- `VietQRBankAccount.bank_name` (BE resolve BIN→tên, `app/utils/bank_names.py`) — 1 nguồn, FE chỉ render.

## Frontend
- `FeeQRTransferDialog`: từ `fee_id` resolve hóa đơn payable → `InvoiceVietQR`; nhiều đợt thì có picker chọn đợt (derived selection, không flash).
- `InvoiceVietQR` dùng chung (tab Học phí + workspace Finance): hiển thị QR + nút **chia sẻ**.
- Thẻ QR chia sẻ (`lib/finance/qr-card.ts`, canvas): mã QR + số tiền / nội dung CK / tên chủ TK / số TK / **tên ngân hàng**. **Tự vẽ ở FE** — miễn phí, không phụ thuộc vietqr.io, không gửi PII ra ngoài. Web Share (mobile) / fallback tải PNG (desktop).
- `TuitionTab.showQr = fee.has_payable_invoice` (thin-client, bỏ derive).

## Deploy
**Code-only + RESTART backend** — KHÔNG migration, KHÔNG Casbin.

## Kiểm thử
- 2 vòng `/code-review max` + follow-up (P1/P2) — đã vá trọn (share-fail fallback, downloadBlob reuse, bank_name BE, penalty-inclusive by-fee, a11y…).
- BE unit (bank_names + invoice_payable) + FE **819 test** (finance + admissions) pass; type-check/lint sạch.
- Chrome smoke dev FULL PASS: nút theo cờ, dialog resolve, picker + đổi đợt requery, thẻ chia sẻ đầy đủ thông tin (tên ngân hàng từ BE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)