### PR TITLE
feat(assignment): trọng số phân công lead theo officer (member-weighted)

### DIFF
--- a/Backend_FastAPI/alembic/versions/memwt20260703001_add_assignment_weight_to_user.py
+++ b/Backend_FastAPI/alembic/versions/memwt20260703001_add_assignment_weight_to_user.py
@@ -1,0 +1,58 @@
+"""add_assignment_weight_to_user
+
+Revision ID: memwt20260703001
+Revises: smsp2consultcasbin20260702003
+Create Date: 2026-07-03 00:00:00.000000
+
+Member-weighted lead assignment: per-officer weight column on ``user``.
+
+    eff_util = workload / (capacity * assignment_weight)
+
+A higher weight makes an officer look "emptier", so the auto-assign balancer
+(``assignment_service.automatically_assign_lead`` BƯỚC 5, gated by
+``ENABLE_MEMBER_WEIGHTED_ASSIGNMENT``) hands them proportionally more leads.
+The safety gate (real utilization >= SAFETY_THRESHOLD) is never bent by weight.
+
+Existing rows get weight 1 via ``server_default='1'`` so deploying this
+migration changes NO behavior until an admin raises a weight AND the flag is
+flipped. Range 1–100 enforced by a CHECK constraint (DB backstop; the API
+also validates at the request layer).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "memwt20260703001"
+down_revision: Union[str, Sequence[str], None] = "smsp2consultcasbin20260702003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add ``assignment_weight`` (NOT NULL, default 1) + range CHECK to ``user``."""
+    op.add_column(
+        "user",
+        sa.Column(
+            "assignment_weight",
+            sa.Integer(),
+            nullable=False,
+            server_default="1",
+            comment="Officer lead-assignment weight (1-100). Higher = more leads.",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_user_assignment_weight_range",
+        "user",
+        "assignment_weight BETWEEN 1 AND 100",
+    )
+
+
+def downgrade() -> None:
+    """Drop the CHECK constraint then the column."""
+    op.drop_constraint(
+        "ck_user_assignment_weight_range", "user", type_="check"
+    )
+    op.drop_column("user", "assignment_weight")

--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -562,6 +562,13 @@ class Settings(BaseSettings):
     ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT: bool = Field(
         default=False, validation_alias="ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT"
     )  # Phase P2-2: Use fairness-weighted scoring instead of pure round-robin
+    ENABLE_MEMBER_WEIGHTED_ASSIGNMENT: bool = Field(
+        default=False, validation_alias="ENABLE_MEMBER_WEIGHTED_ASSIGNMENT"
+    )  # Member-weighted assignment: eff_util = workload/(capacity*assignment_weight).
+    # Officers with a higher assignment_weight are treated as "emptier" and receive
+    # proportionally more leads. INDEPENDENT of ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT
+    # (either, both, or neither may be on). Default False ⇒ no behavior change until
+    # flipped. The safety gate (real_util >= SAFETY_THRESHOLD) is never bent by weight.
 
     # -- Lead Lifecycle SLA: auto-close stale rejected consultations --
     # A lead in sts04 (CONSULT_REJECTED, is_final=false for re-engagement) that

--- a/Backend_FastAPI/app/models/user.py
+++ b/Backend_FastAPI/app/models/user.py
@@ -1,5 +1,15 @@
 # app/models/user.py
-from sqlalchemy import JSON, Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import TSVECTOR
 
@@ -8,6 +18,16 @@ from .base import Base
 
 class User(Base):
     __tablename__ = "user"
+
+    # DB backstop for the officer lead-assignment weight range (1–100).
+    # FastAPI/Pydantic validate at the request layer; this constraint is
+    # the last line of defense against an out-of-range write.
+    __table_args__ = (
+        CheckConstraint(
+            "assignment_weight BETWEEN 1 AND 100",
+            name="ck_user_assignment_weight_range",
+        ),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String(64), index=True, unique=True, nullable=False)
@@ -77,6 +97,18 @@ class User(Base):
     # Lead assignment fields
     skills = Column(JSON, nullable=True)
     max_capacity = Column(Integer, default=100)
+    # Member-weighted auto-assignment (opt-in via ENABLE_MEMBER_WEIGHTED_ASSIGNMENT).
+    # eff_util = workload / (capacity * assignment_weight): a higher weight makes an
+    # officer look "emptier" so they receive proportionally more leads. The safety
+    # gate (real_util >= SAFETY_THRESHOLD) is never bent by weight. Range 1–100,
+    # default 1 (weight 1 ⇒ eff_util == real_util ⇒ no behavior change).
+    assignment_weight = Column(
+        Integer,
+        nullable=False,
+        server_default="1",
+        default=1,
+        comment="Officer lead-assignment weight (1-100). Higher = more leads.",
+    )
     availability_status = Column(String(50), default="available")
     total_lead_score = Column(Integer, default=0, nullable=False)
     last_assigned_at = Column(DateTime(timezone=True), nullable=True)

--- a/Backend_FastAPI/app/routers/admin/users.py
+++ b/Backend_FastAPI/app/routers/admin/users.py
@@ -898,6 +898,9 @@ async def update_existing_user(
     avatar: Optional[UploadFile] = File(None),
     skills: Optional[str] = Form(None),  # Nhận JSON string từ form-data
     max_capacity: Optional[int] = Form(None),
+    # Officer lead-assignment weight. ge/le validate ở REQUEST layer ⇒ 0/101/
+    # non-int trả 422 chuẩn (khác pattern silent-drop của max_capacity >= 0 bên dưới).
+    assignment_weight: Optional[int] = Form(None, ge=1, le=100),
     unit_id: Optional[int] = Form(None),  # Organizational unit assignment
 ):
     """
@@ -938,6 +941,10 @@ async def update_existing_user(
         update_dict["status"] = status.strip()
     if max_capacity is not None and max_capacity >= 0:
         update_dict["max_capacity"] = max_capacity
+    # Range đã được FastAPI/Form validate (ge=1, le=100) — chỉ cần kiểm None để
+    # phân biệt "không gửi" (giữ nguyên) với "gửi giá trị" (cập nhật).
+    if assignment_weight is not None:
+        update_dict["assignment_weight"] = assignment_weight
 
     # Handle unit_id assignment - validate unit exists
     # ✅ PHASE 8: Use OrganizationRepository instead of db.get()

--- a/Backend_FastAPI/app/schemas/user.py
+++ b/Backend_FastAPI/app/schemas/user.py
@@ -153,6 +153,11 @@ class UserUpdate(BaseModel):
     role: Optional[str] = None
     status: Optional[str] = None
     max_capacity: Optional[int] = None
+    # Officer member-weighted assignment (1-100). Defense-in-depth: the router
+    # already validates via Form(ge=1, le=100), but pinning it here guards the
+    # UserUpdate(**update_dict) build so an out-of-range value can never reach
+    # setattr on the model.
+    assignment_weight: Optional[int] = Field(None, ge=1, le=100)
     skills: Optional[List[str]] = None
     unit_id: Optional[int] = None  # Organizational unit assignment
 
@@ -261,6 +266,10 @@ class UserAdminResponse(UserBase):
     skills: Optional[List[str]] = None
     availability_status: Optional[str] = None
     max_capacity: Optional[int] = None
+    # Admin-internal lead-routing weight — surfaced alongside max_capacity so the
+    # admin UI can display/edit it. Deliberately NOT on UserPickerSchema (officer/
+    # accountant picker) — same treatment as max_capacity.
+    assignment_weight: Optional[int] = None
     password_reset_required: Optional[bool] = False
     mfa_enabled: bool = False
 

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -43,25 +43,33 @@ def _non_final_status_filter():
     )
 
 
+def _safe_positive_int(value: int | None, default: int) -> int:
+    """Coerce to a usable positive int: None → ``default``, any value <= 0 → 1.
+    Single backbone for _safe_capacity / _safe_weight."""
+    if value is None:
+        return default
+    return value if value > 0 else 1
+
+
 def _safe_capacity(officer: models.User) -> int:
     """Officer capacity with a safe fallback (default 100, never <= 0).
     Shared by the referral threshold check and the assignment loop (BƯỚC 4)."""
-    capacity = officer.max_capacity if officer.max_capacity is not None else 100
-    return capacity if capacity > 0 else 1
+    return _safe_positive_int(officer.max_capacity, 100)
 
 
 def _safe_weight(officer: models.User) -> int:
     """Officer member-assignment weight with a safe fallback (default 1, never <= 0).
 
-    Mirrors ``_safe_capacity``. A higher weight makes the officer look emptier in
-    ``eff_util = workload / (capacity * weight)`` so they receive more leads. None
-    is coerced to 1 — an unflushed / mock ``User`` (tests) has ``assignment_weight``
-    still unset (the column ``default=1`` only fires at INSERT), so weight 1 keeps
-    ``eff_util == real_util`` and the balancer stays regression-safe."""
-    weight = getattr(officer, "assignment_weight", None)
-    if weight is None:
-        return 1
-    return weight if weight > 0 else 1
+    A higher weight lowers ``eff_util = workload / (capacity * weight)`` so the
+    officer is treated as emptier and receives more leads. Weight 1 makes
+    ``eff_util == real_util`` — but note that with ENABLE_MEMBER_WEIGHTED_ASSIGNMENT
+    ON this is NOT identical to legacy round-robin: member mode orders by eff_util
+    (workload-proportional), whereas legacy ignores workload magnitude in its
+    tie-break. Direct attribute access (not getattr) so an attribute-name typo
+    surfaces instead of silently returning 1. The None fallback only matters for an
+    unflushed/mock ``User`` in tests (the prod column is NOT NULL + server_default
+    '1' + CHECK 1..100)."""
+    return _safe_positive_int(officer.assignment_weight, 1)
 
 
 async def is_officer_at_threshold(
@@ -298,28 +306,29 @@ async def automatically_assign_lead(
                     capacity = _safe_capacity(officer)
 
                     if workload < capacity:
-                        utilization = workload / capacity
-                        # real_util = tải THẬT (workload/capacity), không bao giờ
-                        # nhân weight — cổng an toàn (BƯỚC 5 `overloaded`) luôn đọc
-                        # con số này. eff_util = tải hiệu dụng có nhân weight: weight
-                        # cao ⇒ eff_util thấp ⇒ officer "được coi là vơi hơn" ⇒ nhận
-                        # nhiều lead hơn (chỉ dùng khi member flag bật).
+                        # real_util = tải THẬT (workload/capacity), KHÔNG nhân weight —
+                        # cổng an toàn `overloaded` LUÔN đọc con số này. eff_util = tải
+                        # hiệu dụng có nhân weight: weight cao ⇒ eff_util thấp ⇒ officer
+                        # "được coi là vơi hơn" ⇒ nhận nhiều lead hơn (khi member ON).
+                        real_util = workload / capacity
                         weight = _safe_weight(officer)
                         eff_util = workload / (capacity * weight)
                         officer_loads.append(
                             {
                                 "officer": officer,
                                 "workload": workload,
-                                # Giữ "utilization" (== real_util) để không đổi các
-                                # nhánh legacy/fairness cũ đang đọc key này.
-                                "utilization": utilization,
-                                "real_util": utilization,
+                                "real_util": real_util,
                                 "eff_util": eff_util,
                                 "weight": weight,
-                                # Giá trị sort thực (BƯỚC 5 ghi đè theo matrix);
-                                # mặc định real_util cho nhánh legacy để snapshot
-                                # phản ánh đúng tải thật đã dùng.
-                                "score": utilization,
+                                # Cổng an toàn theo tải THẬT — đặt sẵn ở đây, khỏi cần
+                                # vòng lặp phụ ở BƯỚC 5 (weight không bao giờ phá trần).
+                                "overloaded": real_util >= SAFETY_THRESHOLD,
+                                # score = giá trị dùng để SẮP XẾP; mặc định real_util,
+                                # các nhánh weighted ở BƯỚC 5 ghi đè. Ở nhánh legacy/
+                                # fallback score GIỮ real_util nhưng KHÔNG quyết định thứ
+                                # tự (sort chỉ theo overloaded+last_assigned) — chỉ mang
+                                # tính thông tin cho snapshot.
+                                "score": real_util,
                                 # Xử lý last_assigned_at là None (coalesce)
                                 "last_assigned": officer.last_assigned_at
                                 or datetime.min.replace(tzinfo=timezone.utc),
@@ -381,10 +390,9 @@ async def automatically_assign_lead(
                 member_on = settings.ENABLE_MEMBER_WEIGHTED_ASSIGNMENT
                 fairness_on = settings.ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT
 
-                # SAFETY_THRESHOLD is a module-level constant (shared with the
-                # referral fast-path via is_officer_at_threshold). Cổng đọc tải THẬT.
-                for entry in officer_loads:
-                    entry["overloaded"] = entry["real_util"] >= SAFETY_THRESHOLD
+                # `overloaded` (cổng an toàn theo tải THẬT) đã đặt sẵn ở BƯỚC 4 —
+                # SAFETY_THRESHOLD là hằng module (chia sẻ với referral fast-path qua
+                # is_officer_at_threshold). weight KHÔNG BAO GIỜ phá cổng này.
 
                 # Lịch sử phân công của đơn vị — chỉ truy vấn khi fairness bật.
                 hist_counts: dict = {}
@@ -406,73 +414,64 @@ async def automatically_assign_lead(
                     except Exception as e:
                         log.warning(f"[Lead ID: {lead_id}] Fairness history query failed, falling back: {e}")
 
-                if fairness_on and member_on:
-                    # --- FAIRNESS + MEMBER: áp lực lệch so với TARGET weighted share ---
-                    # Target & actual PHẢI cùng pool = officer đang cạnh tranh ở quyết
-                    # định này (officer_loads = pool sau lọc capacity BƯỚC 4). KHÔNG
-                    # dùng total_hist toàn unit: history của officer offline/đầy tải sẽ
-                    # loãng mẫu số, khiến officer đã vượt share trong pool vẫn bị coi là
-                    # dưới target. Pool đồng đều weight ⇒ pressure = actual − 1/N.
-                    pool_ids = [e["officer"].id for e in officer_loads]
-                    eligible_hist_total = sum(hist_counts.get(oid, 0) for oid in pool_ids)
-                    total_weight = sum(e["weight"] for e in officer_loads)  # mỗi weight >= 1 ⇒ > 0
-                    has_history = eligible_hist_total >= 10  # ngưỡng cho nhánh fairness+member
-                    if has_history:
-                        for e in officer_loads:
-                            oid = e["officer"].id
-                            target_share = e["weight"] / total_weight if total_weight > 0 else 0
-                            actual_share = (
-                                hist_counts.get(oid, 0) / eligible_hist_total
-                                if eligible_hist_total > 0 else 0
-                            )
-                            pressure = actual_share - target_share  # <0 ⇒ đẩy lên, >0 ⇒ phạt
-                            e["score"] = 0.6 * e["eff_util"] + 0.4 * pressure
-                        assign_reason = "member_fairness_weighted"
-                        log.info(f"[Lead ID: {lead_id}] Member+fairness weighted (pool_hist={eligible_hist_total})")
-                    else:
-                        # Chưa đủ history trong pool ⇒ member-weighted (KHÔNG legacy):
-                        # nếu không weight vô tác dụng giai đoạn đầu rollout.
-                        for e in officer_loads:
-                            e["score"] = e["eff_util"]
-                        assign_reason = "member_weighted"
-                        log.info(f"[Lead ID: {lead_id}] Member+fairness ON but pool_hist={eligible_hist_total}<10 → member-weighted fallback")
-                    officer_loads.sort(key=lambda x: (x["overloaded"], x["score"], x["last_assigned"]))
+                # --- Quyết định CHẾ ĐỘ chấm điểm theo 2 flag độc lập + đủ history ---
+                #   member_fairness: fairness ON + member ON + đủ pool-history (>=10)
+                #   fairness:        fairness ON + member OFF + đủ unit-history (>=10) — Y HỆT P2-2 cũ
+                #   member:          member ON (gồm cả fallback fairness+member thiếu history)
+                #   legacy:          cả 2 OFF, HOẶC fairness ON + member OFF + thiếu history — Y HỆT hôm nay
+                # (member scoring viết ở MỘT nơi duy nhất bên dưới, tránh trùng lặp.)
+                if member_on and fairness_on:
+                    # Target & actual PHẢI cùng pool = officer_loads (sau lọc capacity).
+                    # KHÔNG dùng total_hist toàn unit: history officer offline/đầy tải sẽ
+                    # loãng mẫu số ⇒ officer đã vượt share trong pool vẫn bị coi là dưới
+                    # target. Pool đồng đều weight ⇒ pressure = actual − 1/N.
+                    eligible_hist_total = sum(hist_counts.get(e["officer"].id, 0) for e in officer_loads)
+                    scoring = "member_fairness" if eligible_hist_total >= 10 else "member"
                 elif fairness_on:
-                    # --- FAIRNESS ONLY (member OFF): giữ NGUYÊN VẸN hành vi P2-2 ---
-                    # raw_share = hist / total_hist TOÀN UNIT (như cũ, không đổi).
-                    total_hist = sum(hist_counts.values()) if hist_counts else 0
-                    has_history = total_hist >= 10  # minimum threshold (như cũ)
-                    if has_history:
-                        for entry in officer_loads:
-                            oid = entry["officer"].id
-                            share = hist_counts.get(oid, 0) / total_hist if total_hist > 0 else 0
-                            # 60% utilization THẬT + 40% historical share (như cũ)
-                            entry["score"] = 0.6 * entry["real_util"] + 0.4 * share
-                        officer_loads.sort(key=lambda x: (x["overloaded"], x["score"], x["last_assigned"]))
-                        assign_reason = "fairness_weighted"
-                        log.info(f"[Lead ID: {lead_id}] Using fairness-weighted scoring (history={total_hist})")
-                    else:
-                        # Insufficient history — fall back to legacy (như cũ). score giữ
-                        # mặc định real_util (BƯỚC 4) cho snapshot; sort KHÔNG dùng score.
-                        officer_loads.sort(key=lambda x: (x["overloaded"], x["last_assigned"]))
-                        assign_reason = "lowest_workload"
-                        log.info(f"[Lead ID: {lead_id}] Fairness ON but insufficient data ({total_hist}), using legacy")
+                    total_hist = sum(hist_counts.values())
+                    scoring = "fairness" if total_hist >= 10 else "legacy"
                 elif member_on:
-                    # --- MEMBER ONLY: hybrid threshold round robin theo eff_util ---
-                    # Cùng cấu trúc legacy nhưng tie-break đầu là eff_util (weight cao
-                    # ⇒ eff_util thấp ⇒ ưu tiên), rồi last_assigned (Round Robin).
+                    scoring = "member"
+                else:
+                    scoring = "legacy"
+
+                # --- Áp chế độ: đặt score + reason. Mỗi weight >= 1 và các ngưỡng
+                # history >= 10 đã đảm bảo mọi mẫu số dưới đây đều > 0 (không div-0). ---
+                if scoring == "member_fairness":
+                    total_weight = sum(e["weight"] for e in officer_loads)
+                    for e in officer_loads:
+                        target_share = e["weight"] / total_weight
+                        actual_share = hist_counts.get(e["officer"].id, 0) / eligible_hist_total
+                        # pressure = actual − target (<0 ⇒ dưới target ⇒ đẩy lên; >0 ⇒ phạt)
+                        e["score"] = 0.6 * e["eff_util"] + 0.4 * (actual_share - target_share)
+                    assign_reason = "member_fairness_weighted"
+                    log.info(f"[Lead ID: {lead_id}] Member+fairness weighted (pool_hist={eligible_hist_total})")
+                elif scoring == "fairness":
+                    for e in officer_loads:
+                        share = hist_counts.get(e["officer"].id, 0) / total_hist
+                        e["score"] = 0.6 * e["real_util"] + 0.4 * share  # Y HỆT P2-2 cũ
+                    assign_reason = "fairness_weighted"
+                    log.info(f"[Lead ID: {lead_id}] Using fairness-weighted scoring (history={total_hist})")
+                elif scoring == "member":
+                    # Tie-break đầu là eff_util (weight cao ⇒ eff_util thấp ⇒ ưu tiên),
+                    # rồi last_assigned. ⚠️ Weight ĐỒNG ĐỀU (đều =1) ⇒ eff_util == real_util
+                    # ⇒ order theo TẢI THẬT (workload-proportional), KHÔNG phải round-robin
+                    # thuần như legacy — đây là chủ đích của member mode, KHÁC legacy dù
+                    # chưa phân hoá weight (xem test_matrix_member_on_uniform_weight...).
                     for e in officer_loads:
                         e["score"] = e["eff_util"]
-                    officer_loads.sort(key=lambda x: (x["overloaded"], x["score"], x["last_assigned"]))
                     assign_reason = "member_weighted"
                     log.info(f"[Lead ID: {lead_id}] Using member-weighted scoring")
-                else:
-                    # --- LEGACY: HYBRID THRESHOLD ROUND ROBIN (cả 2 flag OFF) ---
-                    # 1. Nhóm chưa quá tải (real_util < 0.8) trước nhóm sắp quá tải (>= 0.8)
-                    # 2. Trong cùng nhóm, ưu tiên người được gán lâu nhất (Round Robin công bằng)
-                    # === Hành vi Y HỆT hôm nay (score giữ mặc định real_util cho snapshot).
-                    officer_loads.sort(key=lambda x: (x["overloaded"], x["last_assigned"]))
+                else:  # legacy — Y HỆT hôm nay
                     assign_reason = "lowest_workload"
+                    log.info(f"[Lead ID: {lead_id}] Using legacy round-robin")
+
+                # Legacy sắp xếp KHÔNG dùng score (round-robin thuần theo last_assigned);
+                # các chế độ weighted chèn score làm tie-break thứ 2 (sau cổng overloaded).
+                if scoring == "legacy":
+                    officer_loads.sort(key=lambda x: (x["overloaded"], x["last_assigned"]))
+                else:
+                    officer_loads.sort(key=lambda x: (x["overloaded"], x["score"], x["last_assigned"]))
 
                 chosen_officer_data = officer_loads[0]
                 chosen_one = chosen_officer_data["officer"]
@@ -480,7 +479,7 @@ async def automatically_assign_lead(
                 log.info(
                     f"[Lead ID: {lead_id}] Selected officer {chosen_one.id} ({chosen_one.username}). "
                     f"Current Workload: {chosen_workload}, Max Capacity: {chosen_one.max_capacity}, "
-                    f"Utilization: {chosen_officer_data['utilization']:.2f}, "
+                    f"Utilization: {chosen_officer_data['real_util']:.2f}, "
                     f"Last Assigned: {chosen_officer_data['last_assigned']}"
                 )
 
@@ -510,8 +509,11 @@ async def automatically_assign_lead(
                 # được BƯỚC 5 set theo decision matrix (lowest_workload /
                 # fairness_weighted / member_weighted / member_fairness_weighted).
                 # scores_snapshot enrich sang dict {real_util, eff_util, weight, score}
-                # — KHÔNG consumer nào đọc float phẳng (fairness_service chỉ đọc
-                # capacity_snapshot), score = giá trị đã sort thực tế.
+                # — KHÔNG consumer runtime nào đọc (fairness_service chỉ đọc
+                # capacity_snapshot); thuần audit. LƯU Ý: `score` là thành phần chấm
+                # điểm để SẮP XẾP ở các chế độ weighted; ở chế độ legacy/fallback nó
+                # GIỮ real_util nhưng KHÔNG quyết định thứ tự (sort chỉ theo
+                # overloaded + last_assigned) — đọc kèm `reason` để hiểu đúng.
                 await _log_assignment_decision(
                     db, lead_id=lead_id, assigned_officer_id=chosen_one.id,
                     eligible_officer_ids=officer_ids, unit_id=lead_unit_id,

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -508,25 +508,33 @@ async def automatically_assign_lead(
                 # A8/P2-2: Log decision — successful assignment. `assign_reason` đã
                 # được BƯỚC 5 set theo decision matrix (lowest_workload /
                 # fairness_weighted / member_weighted / member_fairness_weighted).
-                # scores_snapshot enrich sang dict {real_util, eff_util, weight, score}
-                # — KHÔNG consumer runtime nào đọc (fairness_service chỉ đọc
-                # capacity_snapshot); thuần audit. LƯU Ý: `score` là thành phần chấm
-                # điểm để SẮP XẾP ở các chế độ weighted; ở chế độ legacy/fallback nó
-                # GIỮ real_util nhưng KHÔNG quyết định thứ tự (sort chỉ theo
-                # overloaded + last_assigned) — đọc kèm `reason` để hiểu đúng.
+                # scores_snapshot (thuần audit — KHÔNG consumer runtime nào đọc;
+                # fairness_service chỉ đọc capacity_snapshot):
+                #  - Chế độ weighted → dict {real_util, eff_util, weight, score}
+                #    (`score` là thành phần SẮP XẾP; đọc kèm `reason`).
+                #  - Legacy/round-robin → gọn: chỉ real_util (eff_util==real_util,
+                #    weight==1, score==real_util nên 3 field kia thừa; sort chỉ theo
+                #    overloaded + last_assigned).
                 await _log_assignment_decision(
                     db, lead_id=lead_id, assigned_officer_id=chosen_one.id,
                     eligible_officer_ids=officer_ids, unit_id=lead_unit_id,
                     channel="auto", reason=assign_reason,
-                    scores_snapshot={
-                        str(ol["officer"].id): {
-                            "real_util": round(ol["real_util"], 4),
-                            "eff_util": round(ol["eff_util"], 4),
-                            "weight": ol["weight"],
-                            "score": round(ol["score"], 4),
+                    scores_snapshot=(
+                        {
+                            str(ol["officer"].id): round(ol["real_util"], 4)
+                            for ol in officer_loads
                         }
-                        for ol in officer_loads
-                    },
+                        if scoring == "legacy"
+                        else {
+                            str(ol["officer"].id): {
+                                "real_util": round(ol["real_util"], 4),
+                                "eff_util": round(ol["eff_util"], 4),
+                                "weight": ol["weight"],
+                                "score": round(ol["score"], 4),
+                            }
+                            for ol in officer_loads
+                        }
+                    ),
                     capacity_snapshot={
                         str(ol["officer"].id): {
                             "current": ol["workload"],

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -50,6 +50,20 @@ def _safe_capacity(officer: models.User) -> int:
     return capacity if capacity > 0 else 1
 
 
+def _safe_weight(officer: models.User) -> int:
+    """Officer member-assignment weight with a safe fallback (default 1, never <= 0).
+
+    Mirrors ``_safe_capacity``. A higher weight makes the officer look emptier in
+    ``eff_util = workload / (capacity * weight)`` so they receive more leads. None
+    is coerced to 1 — an unflushed / mock ``User`` (tests) has ``assignment_weight``
+    still unset (the column ``default=1`` only fires at INSERT), so weight 1 keeps
+    ``eff_util == real_util`` and the balancer stays regression-safe."""
+    weight = getattr(officer, "assignment_weight", None)
+    if weight is None:
+        return 1
+    return weight if weight > 0 else 1
+
+
 async def is_officer_at_threshold(
     db: AsyncSession,
     officer: models.User,
@@ -285,11 +299,27 @@ async def automatically_assign_lead(
 
                     if workload < capacity:
                         utilization = workload / capacity
+                        # real_util = tải THẬT (workload/capacity), không bao giờ
+                        # nhân weight — cổng an toàn (BƯỚC 5 `overloaded`) luôn đọc
+                        # con số này. eff_util = tải hiệu dụng có nhân weight: weight
+                        # cao ⇒ eff_util thấp ⇒ officer "được coi là vơi hơn" ⇒ nhận
+                        # nhiều lead hơn (chỉ dùng khi member flag bật).
+                        weight = _safe_weight(officer)
+                        eff_util = workload / (capacity * weight)
                         officer_loads.append(
                             {
                                 "officer": officer,
                                 "workload": workload,
+                                # Giữ "utilization" (== real_util) để không đổi các
+                                # nhánh legacy/fairness cũ đang đọc key này.
                                 "utilization": utilization,
+                                "real_util": utilization,
+                                "eff_util": eff_util,
+                                "weight": weight,
+                                # Giá trị sort thực (BƯỚC 5 ghi đè theo matrix);
+                                # mặc định real_util cho nhánh legacy để snapshot
+                                # phản ánh đúng tải thật đã dùng.
+                                "score": utilization,
                                 # Xử lý last_assigned_at là None (coalesce)
                                 "last_assigned": officer.last_assigned_at
                                 or datetime.min.replace(tzinfo=timezone.utc),
@@ -340,24 +370,25 @@ async def automatically_assign_lead(
                     return {"status": AssignmentResult.FAILED, "reason": AssignmentFailureReason.AT_CAPACITY, "lead_id": lead_id, "unit_id": lead_unit_id}, _post_commit_callbacks
 
                 # === BƯỚC 5: Sắp xếp và Chọn Officer ===
-                # P2-2: Feature flag switches between legacy and fairness-weighted scoring
+                # Hai flag ĐỘC LẬP chồng lên logic gốc (KHÔNG thay thế nhánh):
+                #   ENABLE_MEMBER_WEIGHTED_ASSIGNMENT   → order theo eff_util (nhân weight)
+                #   ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT → thêm thành phần fairness share
+                # order_util = eff_util nếu member ON, ngược lại real_util (=== hôm nay).
+                # overloaded = real_util >= SAFETY_THRESHOLD — LUÔN tải thật; weight
+                # KHÔNG BAO GIỜ phá cổng an toàn (không dồn quá tải thật).
                 from ..config import settings
 
+                member_on = settings.ENABLE_MEMBER_WEIGHTED_ASSIGNMENT
+                fairness_on = settings.ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT
+
                 # SAFETY_THRESHOLD is a module-level constant (shared with the
-                # referral fast-path via is_officer_at_threshold).
-                if settings.ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT:
-                    # --- FAIRNESS-WEIGHTED SCORING (P2-2) ---
-                    # Score = utilization_weight + fairness_weight + recency_weight
-                    # Lower score = higher priority
-                    #
-                    # 1. utilization_weight (0-1): current workload / capacity
-                    # 2. fairness_weight (0-1): historical assignment share
-                    #    (officers with higher share get penalized)
-                    # 3. recency_weight: normalized last_assigned time
-                    #    (longer since last assigned = higher priority)
-                    #
-                    # Fetch historical assignment counts for this unit
-                    hist_counts: dict = {}
+                # referral fast-path via is_officer_at_threshold). Cổng đọc tải THẬT.
+                for entry in officer_loads:
+                    entry["overloaded"] = entry["real_util"] >= SAFETY_THRESHOLD
+
+                # Lịch sử phân công của đơn vị — chỉ truy vấn khi fairness bật.
+                hist_counts: dict = {}
+                if fairness_on:
                     try:
                         from sqlalchemy import select as sel, func as fn
                         hist_q = await db.execute(
@@ -375,46 +406,73 @@ async def automatically_assign_lead(
                     except Exception as e:
                         log.warning(f"[Lead ID: {lead_id}] Fairness history query failed, falling back: {e}")
 
+                if fairness_on and member_on:
+                    # --- FAIRNESS + MEMBER: áp lực lệch so với TARGET weighted share ---
+                    # Target & actual PHẢI cùng pool = officer đang cạnh tranh ở quyết
+                    # định này (officer_loads = pool sau lọc capacity BƯỚC 4). KHÔNG
+                    # dùng total_hist toàn unit: history của officer offline/đầy tải sẽ
+                    # loãng mẫu số, khiến officer đã vượt share trong pool vẫn bị coi là
+                    # dưới target. Pool đồng đều weight ⇒ pressure = actual − 1/N.
+                    pool_ids = [e["officer"].id for e in officer_loads]
+                    eligible_hist_total = sum(hist_counts.get(oid, 0) for oid in pool_ids)
+                    total_weight = sum(e["weight"] for e in officer_loads)  # mỗi weight >= 1 ⇒ > 0
+                    has_history = eligible_hist_total >= 10  # ngưỡng cho nhánh fairness+member
+                    if has_history:
+                        for e in officer_loads:
+                            oid = e["officer"].id
+                            target_share = e["weight"] / total_weight if total_weight > 0 else 0
+                            actual_share = (
+                                hist_counts.get(oid, 0) / eligible_hist_total
+                                if eligible_hist_total > 0 else 0
+                            )
+                            pressure = actual_share - target_share  # <0 ⇒ đẩy lên, >0 ⇒ phạt
+                            e["score"] = 0.6 * e["eff_util"] + 0.4 * pressure
+                        assign_reason = "member_fairness_weighted"
+                        log.info(f"[Lead ID: {lead_id}] Member+fairness weighted (pool_hist={eligible_hist_total})")
+                    else:
+                        # Chưa đủ history trong pool ⇒ member-weighted (KHÔNG legacy):
+                        # nếu không weight vô tác dụng giai đoạn đầu rollout.
+                        for e in officer_loads:
+                            e["score"] = e["eff_util"]
+                        assign_reason = "member_weighted"
+                        log.info(f"[Lead ID: {lead_id}] Member+fairness ON but pool_hist={eligible_hist_total}<10 → member-weighted fallback")
+                    officer_loads.sort(key=lambda x: (x["overloaded"], x["score"], x["last_assigned"]))
+                elif fairness_on:
+                    # --- FAIRNESS ONLY (member OFF): giữ NGUYÊN VẸN hành vi P2-2 ---
+                    # raw_share = hist / total_hist TOÀN UNIT (như cũ, không đổi).
                     total_hist = sum(hist_counts.values()) if hist_counts else 0
-                    has_history = total_hist >= 10  # minimum threshold
-
+                    has_history = total_hist >= 10  # minimum threshold (như cũ)
                     if has_history:
                         for entry in officer_loads:
                             oid = entry["officer"].id
-                            # Utilization component (0-1)
-                            util_score = entry["utilization"]
-                            # Fairness component: historical share (0-1)
                             share = hist_counts.get(oid, 0) / total_hist if total_hist > 0 else 0
-                            # Combined score: 60% utilization + 40% historical share
-                            entry["fairness_score"] = 0.6 * util_score + 0.4 * share
-
-                        officer_loads.sort(
-                            key=lambda x: (
-                                x["utilization"] >= SAFETY_THRESHOLD,
-                                x.get("fairness_score", 0),
-                                x["last_assigned"],
-                            )
-                        )
+                            # 60% utilization THẬT + 40% historical share (như cũ)
+                            entry["score"] = 0.6 * entry["real_util"] + 0.4 * share
+                        officer_loads.sort(key=lambda x: (x["overloaded"], x["score"], x["last_assigned"]))
+                        assign_reason = "fairness_weighted"
                         log.info(f"[Lead ID: {lead_id}] Using fairness-weighted scoring (history={total_hist})")
                     else:
-                        # Insufficient history — fall back to legacy
-                        officer_loads.sort(
-                            key=lambda x: (
-                                x["utilization"] >= SAFETY_THRESHOLD,
-                                x["last_assigned"],
-                            )
-                        )
+                        # Insufficient history — fall back to legacy (như cũ). score giữ
+                        # mặc định real_util (BƯỚC 4) cho snapshot; sort KHÔNG dùng score.
+                        officer_loads.sort(key=lambda x: (x["overloaded"], x["last_assigned"]))
+                        assign_reason = "lowest_workload"
                         log.info(f"[Lead ID: {lead_id}] Fairness ON but insufficient data ({total_hist}), using legacy")
+                elif member_on:
+                    # --- MEMBER ONLY: hybrid threshold round robin theo eff_util ---
+                    # Cùng cấu trúc legacy nhưng tie-break đầu là eff_util (weight cao
+                    # ⇒ eff_util thấp ⇒ ưu tiên), rồi last_assigned (Round Robin).
+                    for e in officer_loads:
+                        e["score"] = e["eff_util"]
+                    officer_loads.sort(key=lambda x: (x["overloaded"], x["score"], x["last_assigned"]))
+                    assign_reason = "member_weighted"
+                    log.info(f"[Lead ID: {lead_id}] Using member-weighted scoring")
                 else:
-                    # --- LEGACY: HYBRID THRESHOLD ROUND ROBIN ---
-                    # 1. Nhóm chưa quá tải (utilization < 0.8) trước nhóm sắp quá tải (>= 0.8)
+                    # --- LEGACY: HYBRID THRESHOLD ROUND ROBIN (cả 2 flag OFF) ---
+                    # 1. Nhóm chưa quá tải (real_util < 0.8) trước nhóm sắp quá tải (>= 0.8)
                     # 2. Trong cùng nhóm, ưu tiên người được gán lâu nhất (Round Robin công bằng)
-                    officer_loads.sort(
-                        key=lambda x: (
-                            x["utilization"] >= SAFETY_THRESHOLD,
-                            x["last_assigned"],
-                        )
-                    )
+                    # === Hành vi Y HỆT hôm nay (score giữ mặc định real_util cho snapshot).
+                    officer_loads.sort(key=lambda x: (x["overloaded"], x["last_assigned"]))
+                    assign_reason = "lowest_workload"
 
                 chosen_officer_data = officer_loads[0]
                 chosen_one = chosen_officer_data["officer"]
@@ -448,18 +506,23 @@ async def automatically_assign_lead(
                 # Thêm tất cả các thay đổi vào session
                 db.add_all([lead, chosen_one, log_entry])
 
-                # A8/P2-2: Log decision — successful assignment
-                assign_reason = (
-                    "fairness_weighted" if (settings.ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT
-                                           and chosen_officer_data.get("fairness_score") is not None)
-                    else "lowest_workload"
-                )
+                # A8/P2-2: Log decision — successful assignment. `assign_reason` đã
+                # được BƯỚC 5 set theo decision matrix (lowest_workload /
+                # fairness_weighted / member_weighted / member_fairness_weighted).
+                # scores_snapshot enrich sang dict {real_util, eff_util, weight, score}
+                # — KHÔNG consumer nào đọc float phẳng (fairness_service chỉ đọc
+                # capacity_snapshot), score = giá trị đã sort thực tế.
                 await _log_assignment_decision(
                     db, lead_id=lead_id, assigned_officer_id=chosen_one.id,
                     eligible_officer_ids=officer_ids, unit_id=lead_unit_id,
                     channel="auto", reason=assign_reason,
                     scores_snapshot={
-                        str(ol["officer"].id): round(ol.get("fairness_score", ol["utilization"]), 4)
+                        str(ol["officer"].id): {
+                            "real_util": round(ol["real_util"], 4),
+                            "eff_util": round(ol["eff_util"], 4),
+                            "weight": ol["weight"],
+                            "score": round(ol["score"], 4),
+                        }
                         for ol in officer_loads
                     },
                     capacity_snapshot={

--- a/Backend_FastAPI/tests/api/test_admin_users.py
+++ b/Backend_FastAPI/tests/api/test_admin_users.py
@@ -412,6 +412,64 @@ async def test_admin_update_user_success(
 
 
 @pytest.mark.asyncio
+async def test_admin_update_user_assignment_weight_valid(
+    client: AsyncClient, admin_token_headers: dict, regular_user_in_db: dict
+):
+    """PUT /api/admin/users/{id} - assignment_weight hợp lệ (5) → 200, persist DB,
+    và XUẤT HIỆN trong UserAdminResponse (admin surface expose lead-routing weight)."""
+    log.info("--- Running: test_admin_update_user_assignment_weight_valid ---")
+    user_id = regular_user_in_db["id"]
+    update_url = AdminURLs.USER_DETAIL(user_id)
+    response = await client.put(
+        update_url, data={"assignment_weight": "5"}, headers=admin_token_headers
+    )
+
+    assert response.status_code == 200, f"Resp: {response.text}"
+    body = response.json()
+    # Contract: admin response phải lộ assignment_weight (mirror max_capacity).
+    assert "assignment_weight" in body, (
+        f"UserAdminResponse must expose assignment_weight. Keys: {list(body.keys())}"
+    )
+    assert body["assignment_weight"] == 5
+
+    async with AsyncSessionLocal() as session:
+        db_user = await session.get(User, user_id)
+        assert db_user is not None
+        assert db_user.assignment_weight == 5  # DB persisted as int
+    log.info("assignment_weight=5 persisted and surfaced in response.")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_value", ["0", "101", "-1", "abc"])
+async def test_admin_update_user_assignment_weight_invalid(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    regular_user_in_db: dict,
+    bad_value: str,
+):
+    """PUT assignment_weight ngoài [1,100] hoặc non-int → 422 (Form ge/le validate ở
+    REQUEST layer, khác pattern silent-drop của max_capacity). DB không đổi (giữ 1)."""
+    log.info(f"--- Running: test_admin_update_user_assignment_weight_invalid[{bad_value}] ---")
+    user_id = regular_user_in_db["id"]
+    update_url = AdminURLs.USER_DETAIL(user_id)
+    response = await client.put(
+        update_url, data={"assignment_weight": bad_value}, headers=admin_token_headers
+    )
+
+    assert response.status_code == 422, (
+        f"assignment_weight={bad_value!r} must be rejected 422; got "
+        f"{response.status_code}: {response.text[:200]}"
+    )
+
+    async with AsyncSessionLocal() as session:
+        db_user = await session.get(User, user_id)
+        assert db_user is not None
+        # server_default '1' — invalid request rejected before any write.
+        assert db_user.assignment_weight == 1
+    log.info(f"Invalid assignment_weight={bad_value!r} correctly blocked (422).")
+
+
+@pytest.mark.asyncio
 async def test_admin_update_user_duplicate_email(
     client: AsyncClient,
     admin_token_headers: dict,

--- a/Backend_FastAPI/tests/api/test_qa_e2e_findings_2026_05_16.py
+++ b/Backend_FastAPI/tests/api/test_qa_e2e_findings_2026_05_16.py
@@ -204,6 +204,7 @@ async def test_admin_users_endpoint_strips_pii_for_officer(
         "mfa_enabled",
         "password_reset_required",
         "max_capacity",
+        "assignment_weight",  # admin-internal lead-routing weight — not on picker
     }
     sample_user = body["users"][0]
     leaked_keys = forbidden_keys & set(sample_user.keys())
@@ -257,6 +258,7 @@ async def test_admin_users_endpoint_strips_pii_for_accountant(
         "mfa_enabled",
         "password_reset_required",
         "max_capacity",
+        "assignment_weight",  # admin-internal lead-routing weight — not on picker
     }
     sample_user = body["users"][0]
     leaked_keys = forbidden_keys & set(sample_user.keys())
@@ -300,6 +302,7 @@ async def test_admin_users_endpoint_returns_full_shape_for_admin(
         "phone_number",  # admin needs for contact
         "mfa_enabled",  # admin needs for security review
         "max_capacity",  # admin needs for lead-routing
+        "assignment_weight",  # admin needs for member-weighted lead-routing
     }
     missing = expected_admin_keys - set(sample_user.keys())
     assert not missing, (

--- a/Backend_FastAPI/tests/services/conftest.py
+++ b/Backend_FastAPI/tests/services/conftest.py
@@ -7,6 +7,7 @@ without going through the API layer.
 """
 import logging
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
@@ -604,3 +605,45 @@ async def deleted_lead_with_phone(
     await db.flush()
     await db.refresh(lead)
     return lead
+
+
+# =============================================================================
+# MOCK HARNESS FOR assignment_service UNIT TESTS
+# =============================================================================
+# Shared by test_assignment.py and test_lead_assignment_edge_cases.py so the
+# mock of automatically_assign_lead's session lives in ONE place — a change to
+# how the service uses the session is updated once. Pure mocks (no DB), distinct
+# from the real-DB fixtures above.
+
+
+class MockWorkloadRow:
+    """Row shape returned by the BƯỚC 3 workload GROUP BY query."""
+
+    def __init__(self, assigned_officer_id, workload):
+        self.assigned_officer_id = assigned_officer_id
+        self.workload = workload
+
+
+@pytest.fixture
+def mock_db_session():
+    """Mock AsyncSession wired for automatically_assign_lead. Each test stubs
+    ``session.execute`` per scenario (side_effect list of pre-canned results)."""
+    session = AsyncMock(spec=AsyncSession)
+    session.add = MagicMock()
+    session.add_all = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock(return_value=None)
+    session.execute = AsyncMock()
+    session.delete = AsyncMock()
+    session.get = AsyncMock()
+    session.scalar = AsyncMock()
+    session.rollback = AsyncMock()
+    session.flush = AsyncMock()
+
+    # async with db.begin_nested(): ... (savepoint) — does not suppress exceptions.
+    mock_nested = AsyncMock()
+    mock_nested.__aenter__ = AsyncMock(return_value=None)
+    mock_nested.__aexit__ = AsyncMock(return_value=None)
+    session.begin_nested = MagicMock(return_value=mock_nested)
+
+    return session

--- a/Backend_FastAPI/tests/services/test_assignment.py
+++ b/Backend_FastAPI/tests/services/test_assignment.py
@@ -16,17 +16,20 @@ independent flags on ``settings``:
     ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT  → add historical-share fairness term
 """
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models
 from app.config import settings
 from app.services import assignment_service
 from app.services.status_helper import AssignmentStatus
+
+# Shared mock harness: `mock_db_session` fixture is auto-discovered from conftest;
+# MockWorkloadRow is a plain class so it is imported explicitly.
+from tests.services.conftest import MockWorkloadRow
 
 try:
     from tests.fixtures.constants import NON_EXISTENT_ID
@@ -37,14 +40,6 @@ except ImportError:
 # =====================================================================
 # Mock helpers
 # =====================================================================
-class MockWorkloadRow:
-    """Row shape returned by the BƯỚC 3 workload GROUP BY query."""
-
-    def __init__(self, assigned_officer_id, workload):
-        self.assigned_officer_id = assigned_officer_id
-        self.workload = workload
-
-
 class MockHistRow:
     """Row shape returned by the BƯỚC 5 fairness history GROUP BY query."""
 
@@ -88,39 +83,6 @@ def _decision_log(mock_db):
 # =====================================================================
 # Fixtures
 # =====================================================================
-@pytest.fixture
-def mock_db_session():
-    """A mock AsyncSession wired for automatically_assign_lead."""
-    session = AsyncMock(spec=AsyncSession)
-    session.add = MagicMock()
-    session.add_all = MagicMock()
-    session.commit = AsyncMock()
-    session.refresh = AsyncMock(return_value=None)
-    session.execute = AsyncMock()
-    session.delete = AsyncMock()
-    session.get = AsyncMock()
-    session.scalar = AsyncMock()
-    session.rollback = AsyncMock()
-
-    # async with db.begin_nested(): ... (savepoint) — does not suppress exc.
-    mock_nested = AsyncMock()
-    mock_nested.__aenter__ = AsyncMock(return_value=None)
-    mock_nested.__aexit__ = AsyncMock(return_value=None)
-    session.begin_nested.return_value = mock_nested
-
-    async def _flush(objects=None):
-        return None
-
-    session.flush = AsyncMock(side_effect=_flush)
-
-    # Default empty result (overridden per-test via execute.side_effect).
-    empty = MagicMock()
-    empty.scalars.return_value.all.return_value = []
-    empty.scalar_one_or_none.return_value = None
-    session.execute.return_value = empty
-    return session
-
-
 @pytest_asyncio.fixture(autouse=True)
 async def _silence_logger(mocker):
     """Silence the module logger. The service resolves ``log = logger or
@@ -205,10 +167,12 @@ async def test_assign_success_roundrobin_oldest_wins(
     mock_db_session.execute.side_effect = [
         _lead_result(lead_new),
         _officers_result([officer_1, officer_2]),
-        _workload_result([
-            MockWorkloadRow(101, 5),  # officer_1 tải cao hơn...
-            MockWorkloadRow(102, 2),  # ...nhưng vừa được gán gần đây
-        ]),
+        _workload_result(
+            [
+                MockWorkloadRow(101, 5),  # officer_1 tải cao hơn...
+                MockWorkloadRow(102, 2),  # ...nhưng vừa được gán gần đây
+            ]
+        ),
     ]
 
     await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
@@ -246,10 +210,12 @@ async def test_assign_fail_all_officers_full_capacity(
     mock_db_session.execute.side_effect = [
         _lead_result(lead_new),
         _officers_result([officer_1, officer_2]),
-        _workload_result([
-            MockWorkloadRow(101, 10),
-            MockWorkloadRow(102, 10),
-        ]),
+        _workload_result(
+            [
+                MockWorkloadRow(101, 10),
+                MockWorkloadRow(102, 10),
+            ]
+        ),
     ]
 
     await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
@@ -325,13 +291,43 @@ async def test_matrix_both_off_is_legacy(
 
 
 @pytest.mark.asyncio
+async def test_matrix_member_on_uniform_weight_orders_by_workload(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """member ON nhưng weight ĐỒNG ĐỀU (đều =1): member mode order theo
+    eff_util == real_util ⇒ ưu tiên TẢI THẤP hơn — KHÁC legacy round-robin (chọn
+    theo last_assigned bất kể tải). Chốt tường minh finding /code-review: 'weight-1
+    KHÔNG regression-safe một khi flag ON'. Setup officer_1 tải 5 + last_assigned cũ
+    nhất (None) vs officer_2 tải 2 + mới hơn: member chọn officer_2 (tải thấp); legacy
+    sẽ chọn officer_1 (xem test_matrix_both_off_is_legacy dùng cùng cấu trúc)."""
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    officer_1.assignment_weight = 1
+    officer_2.assignment_weight = 1  # ĐỒNG ĐỀU
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([MockWorkloadRow(101, 5), MockWorkloadRow(102, 2)]),
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    # eff_util officer_2 (0.2) < officer_1 (0.5) ⇒ member chọn officer_2 (tải thấp),
+    # NGƯỢC với legacy (chọn officer_1 vì last_assigned cũ nhất bất kể tải).
+    assert lead_new.assigned_officer_id == officer_2.id
+    assert _decision_log(mock_db_session).reason == "member_weighted"
+
+
+@pytest.mark.asyncio
 async def test_matrix_member_on_weight_gets_more(
     monkeypatch, mock_db_session, lead_new, officer_1, officer_2
 ):
     """member ON, fairness OFF. Hai officer CÙNG workload dương bằng nhau (4/10 —
     không dùng 0 vì eff_util đều 0 thì weight vô nghĩa). officer_2 weight=2 ⇒
     eff_util = 4/(10*2)=0.2 < officer_1 eff_util 0.4 ⇒ officer_2 được chọn.
-    Cũng kiểm audit contract: scores_snapshot là dict {real_util,eff_util,weight,score}."""
+    Cũng kiểm audit contract: scores_snapshot là dict {real_util,eff_util,weight,score}.
+    """
     monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
     monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
     officer_1.assignment_weight = 1
@@ -368,8 +364,8 @@ async def test_matrix_member_on_safety_gate_not_bent(
     overloaded). Weight KHÔNG phá trần an toàn."""
     monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
     monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
-    officer_1.assignment_weight = 5   # eff_util = 9/(10*5) = 0.18 (thấp!)
-    officer_2.assignment_weight = 1   # eff_util = 4/(10*1) = 0.40
+    officer_1.assignment_weight = 5  # eff_util = 9/(10*5) = 0.18 (thấp!)
+    officer_2.assignment_weight = 1  # eff_util = 4/(10*1) = 0.40
 
     mock_db_session.execute.side_effect = [
         _lead_result(lead_new),
@@ -418,8 +414,8 @@ async def test_matrix_fairness_and_member_pressure(
     mới nhận 0.5 thực tế ⇒ pressure âm ⇒ được đẩy lên ⇒ được chọn."""
     monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", True)
     monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
-    officer_1.assignment_weight = 1   # target 1/4 = 0.25
-    officer_2.assignment_weight = 3   # target 3/4 = 0.75
+    officer_1.assignment_weight = 1  # target 1/4 = 0.25
+    officer_2.assignment_weight = 3  # target 3/4 = 0.75
 
     mock_db_session.execute.side_effect = [
         _lead_result(lead_new),
@@ -430,7 +426,8 @@ async def test_matrix_fairness_and_member_pressure(
 
     await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
 
-    # officer_1: 0.6*0.2 + 0.4*(0.5-0.25) = 0.22 ; officer_2: 0.6*0.0667 + 0.4*(0.5-0.75) = -0.06
+    # score officer_1 = 0.6*0.2 + 0.4*(0.5-0.25) = 0.22
+    # score officer_2 = 0.6*0.0667 + 0.4*(0.5-0.75) = -0.06  ⇒ officer_2 thắng
     assert lead_new.assigned_officer_id == officer_2.id
     assert _decision_log(mock_db_session).reason == "member_fairness_weighted"
 

--- a/Backend_FastAPI/tests/services/test_assignment.py
+++ b/Backend_FastAPI/tests/services/test_assignment.py
@@ -1,44 +1,99 @@
-# tests/services/test_assignment_service.py
+# tests/services/test_assignment.py
 # -*- coding: utf-8 -*-
-import asyncio
+"""Unit tests for assignment_service.automatically_assign_lead.
+
+Mock-based (no real DB): a MagicMock/AsyncMock ``AsyncSession`` feeds the
+service pre-canned query results and captures ``db.add`` / ``db.add_all``.
+
+Assertions target BEHAVIOUR — which officer wins (``lead.assigned_officer_id``),
+the ``lead.assignment_status`` set via ``StatusHelper``, and the
+``AssignmentDecisionLog`` (``reason`` + enriched ``scores_snapshot``) — rather
+than log message strings, so they stay stable across logging refactors.
+
+Member-weighted matrix (BƯỚC 5) is exercised by monkeypatching the two
+independent flags on ``settings``:
+    ENABLE_MEMBER_WEIGHTED_ASSIGNMENT    → order by eff_util (weight-adjusted)
+    ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT  → add historical-share fairness term
+"""
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import pytest_asyncio  # <-- Sử dụng pytest_asyncio
+import pytest_asyncio
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app import models, schemas
-from tests._lead_status_test_ids import (
-    ASSIGNED_LEAD_STATUS,
-    UNASSIGNED_LEAD_STATUS,
-)
-
-# Import các thành phần cần test
+from app import models
+from app.config import settings
 from app.services import assignment_service
-from app.utils.exceptions import (
-    ResourceNotFoundError,  # Mặc dù service không ném, nhưng để đó
-)
+from app.services.status_helper import AssignmentStatus
 
-# Import constants
 try:
-    from tests.fixtures.constants import (
-        NON_EXISTENT_ID,
-        TestLeadData,
-        TestOrgData,
-        TestUsers,
-    )
+    from tests.fixtures.constants import NON_EXISTENT_ID
 except ImportError:
     pytest.fail("Could not import constants from tests.fixtures.constants.")
 
 
-# === Fixture cho session mock (Giữ nguyên) ===
+# =====================================================================
+# Mock helpers
+# =====================================================================
+class MockWorkloadRow:
+    """Row shape returned by the BƯỚC 3 workload GROUP BY query."""
+
+    def __init__(self, assigned_officer_id, workload):
+        self.assigned_officer_id = assigned_officer_id
+        self.workload = workload
+
+
+class MockHistRow:
+    """Row shape returned by the BƯỚC 5 fairness history GROUP BY query."""
+
+    def __init__(self, assigned_officer_id, cnt):
+        self.assigned_officer_id = assigned_officer_id
+        self.cnt = cnt
+
+
+def _lead_result(lead):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = lead
+    return r
+
+
+def _officers_result(officers):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = officers
+    return r
+
+
+def _workload_result(rows):
+    # BƯỚC 3 iterates the result directly (`for row in workload_results`),
+    # so a plain list of rows is the correct shape.
+    return list(rows)
+
+
+def _hist_result(rows):
+    r = MagicMock()
+    r.all.return_value = list(rows)
+    return r
+
+
+def _decision_log(mock_db):
+    """Return the AssignmentDecisionLog instance passed to db.add (success path)."""
+    for c in mock_db.add.call_args_list:
+        if c.args and isinstance(c.args[0], models.AssignmentDecisionLog):
+            return c.args[0]
+    return None
+
+
+# =====================================================================
+# Fixtures
+# =====================================================================
 @pytest.fixture
 def mock_db_session():
-    """Tạo một mock AsyncSession."""
+    """A mock AsyncSession wired for automatically_assign_lead."""
     session = AsyncMock(spec=AsyncSession)
     session.add = MagicMock()
+    session.add_all = MagicMock()
     session.commit = AsyncMock()
     session.refresh = AsyncMock(return_value=None)
     session.execute = AsyncMock()
@@ -47,66 +102,31 @@ def mock_db_session():
     session.scalar = AsyncMock()
     session.rollback = AsyncMock()
 
-    # Mock cho async with db.begin_nested():
-    mock_nested_transaction = AsyncMock()
-    mock_nested_transaction.__aenter__ = AsyncMock(return_value=None)
-    mock_nested_transaction.__aexit__ = AsyncMock(return_value=None)
-    session.begin_nested.return_value = mock_nested_transaction
+    # async with db.begin_nested(): ... (savepoint) — does not suppress exc.
+    mock_nested = AsyncMock()
+    mock_nested.__aenter__ = AsyncMock(return_value=None)
+    mock_nested.__aexit__ = AsyncMock(return_value=None)
+    session.begin_nested.return_value = mock_nested
 
-    # Mock cho db.flush() để gán ID
-    async def mock_flush(objects=None):
-        if objects:
-            for obj in objects:
-                if (
-                    isinstance(obj, (models.Lead, models.AssignmentLog))
-                    and obj.id is None
-                ):
-                    obj.id = 1  # Gán ID giả
+    async def _flush(objects=None):
         return None
 
-    session.flush = AsyncMock(side_effect=mock_flush)
+    session.flush = AsyncMock(side_effect=_flush)
 
-    # Cấu hình mặc định (sẽ bị ghi đè trong tests)
-    mock_execute_result = MagicMock()
-    mock_scalars_result = MagicMock()
-    mock_scalars_result.all.return_value = []
-    mock_scalars_result.first.return_value = None
-    mock_scalars_result.scalar_one_or_none.return_value = None
-    mock_execute_result.scalars.return_value = mock_scalars_result
-    mock_execute_result.scalar_one_or_none.return_value = None
-    session.execute.return_value = mock_execute_result
-    session.scalar.return_value = None
-    session.get.return_value = None
+    # Default empty result (overridden per-test via execute.side_effect).
+    empty = MagicMock()
+    empty.scalars.return_value.all.return_value = []
+    empty.scalar_one_or_none.return_value = None
+    session.execute.return_value = empty
     return session
 
 
-# === Fixture cho Mock Logger ===
-@pytest_asyncio.fixture(autouse=True)  # <-- ĐỔI THÀNH pytest_asyncio.fixture
-async def mock_log(mocker):  # <-- ĐỔI THÀNH async def
-    """Mock logger trong service."""
-    log_path = "app.services.assignment_service.log"
-
-    # Tạo mock bên trong fixture (đã có event loop)
-    mock_log_obj = MagicMock()
-    mock_log_obj.info = AsyncMock(return_value=None)
-    mock_log_obj.error = AsyncMock(return_value=None)
-    mock_log_obj.warning = AsyncMock(return_value=None)
-    mock_log_obj.debug = AsyncMock(return_value=None)
-
-    # Patch vẫn dùng mocker (đồng bộ)
-    try:
-        mocker.patch(f"{log_path}.info", new=mock_log_obj.info)
-        mocker.patch(f"{log_path}.error", new=mock_log_obj.error)
-        mocker.patch(f"{log_path}.warning", new=mock_log_obj.warning)
-        mocker.patch(f"{log_path}.debug", new=mock_log_obj.debug)
-    except Exception as e:
-        # Cảnh báo này có thể vẫn xuất hiện nếu patch thất bại, nhưng mock nên hoạt động
-        print(f"WARNING: Structlog patching in test_assignment_service failed: {e}")
-
-    return mock_log_obj  # Trả về mock
-
-
-# === Dữ liệu mẫu cho Tests ===
+@pytest_asyncio.fixture(autouse=True)
+async def _silence_logger(mocker):
+    """Silence the module logger. The service resolves ``log = logger or
+    default_log`` and tests never pass a logger, so patching the module-level
+    ``default_log`` captures every log call without touching behaviour."""
+    mocker.patch.object(assignment_service, "default_log", new=MagicMock())
 
 
 @pytest.fixture
@@ -119,7 +139,7 @@ def lead_new():
         phone="123456",
         source="website",
         unit_id=1,
-        status="new",  # Trạng thái ban đầu
+        status="new",
         assigned_officer_id=None,
         assigned_at=None,
     )
@@ -127,7 +147,9 @@ def lead_new():
 
 @pytest.fixture
 def officer_1():
-    """Officer 1, unit 1, capacity 10, rảnh."""
+    """Officer 1, unit 1, capacity 10, chưa được gán bao giờ (last_assigned=None
+    ⇒ coalesce về datetime.min ⇒ 'cũ nhất' trong round-robin). Weight mặc định
+    (assignment_weight chưa set ⇒ _safe_weight = 1)."""
     return models.User(
         id=101,
         username="officer1",
@@ -136,13 +158,13 @@ def officer_1():
         availability_status="available",
         unit_id=1,
         max_capacity=10,
-        last_assigned_at=None,  # Chưa được gán bao giờ
+        last_assigned_at=None,
     )
 
 
 @pytest.fixture
 def officer_2():
-    """Officer 2, unit 1, capacity 10, vừa được gán."""
+    """Officer 2, unit 1, capacity 10, vừa được gán 1 giờ trước."""
     return models.User(
         id=102,
         username="officer2",
@@ -151,290 +173,288 @@ def officer_2():
         availability_status="available",
         unit_id=1,
         max_capacity=10,
-        last_assigned_at=datetime.now(timezone.utc) - timedelta(hours=1),  # Mới
+        last_assigned_at=datetime.now(timezone.utc) - timedelta(hours=1),
     )
 
 
 @pytest.fixture
 def officer_3_other_unit():
-    """Officer 3, unit 2, không liên quan."""
+    """Officer 3, unit 2, không liên quan (không lọt vào pool unit 1)."""
     return models.User(
         id=103,
         username="officer3",
         role="officer",
         status="active",
         availability_status="available",
-        unit_id=2,  # Unit khác
+        unit_id=2,
         max_capacity=10,
         last_assigned_at=None,
     )
 
 
-# === Bắt đầu Tests ===
+# =====================================================================
+# Core / legacy behaviour (repaired from the stale suite)
+# =====================================================================
 @pytest.mark.asyncio
-async def test_assign_success_picks_lower_workload(
-    mock_db_session, mock_log, lead_new, officer_1, officer_2
+async def test_assign_success_roundrobin_oldest_wins(
+    mock_db_session, lead_new, officer_1, officer_2
 ):
-    """
-    Test Kịch bản thành công:
-    - Lead 1 (unit 1)
-    - Officer 1 (unit 1, capacity 10, workload 2)
-    - Officer 2 (unit 1, capacity 10, workload 5)
-    - Service phải chọn Officer 1.
-    """
-
-    # 1. Setup Mocks
-    class MockWorkloadRow:
-        def __init__(self, assigned_officer_id, workload):
-            self.assigned_officer_id = assigned_officer_id
-            self.workload = workload
-
-    mock_lead_result = MagicMock()
-    mock_lead_result.scalar_one_or_none.return_value = lead_new
-
-    mock_officers_result = MagicMock()
-    mock_officers_result.scalars.return_value.all.return_value = [officer_1, officer_2]
-
-    mock_workload_result = [
-        MockWorkloadRow(assigned_officer_id=101, workload=2),
-        MockWorkloadRow(assigned_officer_id=102, workload=5),
-    ]
-
+    """Both flags OFF (default) ⇒ legacy hybrid threshold round-robin: cùng nhóm
+    dưới trần, ưu tiên người được gán LÂU NHẤT (officer_1 last_assigned=None)
+    bất kể workload. Đây là hành vi 'hôm nay'."""
     mock_db_session.execute.side_effect = [
-        mock_lead_result,
-        mock_officers_result,
-        mock_workload_result,
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([
+            MockWorkloadRow(101, 5),  # officer_1 tải cao hơn...
+            MockWorkloadRow(102, 2),  # ...nhưng vừa được gán gần đây
+        ]),
     ]
 
-    # 2. Action
     await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
 
-    # 3. Assert (Giữ nguyên assertions về model)
+    # Round-robin: officer_1 (last_assigned cũ nhất) thắng dù workload cao hơn.
     assert lead_new.assigned_officer_id == officer_1.id
-    assert lead_new.status == ASSIGNED_LEAD_STATUS
+    assert lead_new.assignment_status == AssignmentStatus.ASSIGNED
     assert lead_new.assigned_at is not None
     assert officer_1.last_assigned_at is not None
-    assert mock_db_session.add.call_count == 3
-    # ... (Giữ nguyên assertions về add) ...
 
-    # SỬA LỖI 2: Cập nhật assertion log (kwargs phải khớp)
-    mock_log.info.assert_any_await(
-        "Selected officer for assignment",
-        officer_id=officer_1.id,
-        current_workload=2,
-        max_capacity=officer_1.max_capacity,  # Thêm max_capacity
-        lead_id=lead_new.id,  # Thêm lead_id
-    )
-    mock_log.info.assert_any_await(
-        "Auto-assign task: Lead assigned successfully",
-        lead_id=lead_new.id,
-        officer_id=officer_1.id,
-    )
+    decision = _decision_log(mock_db_session)
+    assert decision is not None
+    assert decision.reason == "lowest_workload"
 
 
 @pytest.mark.asyncio
-async def test_assign_success_fairness_tiebreaker(
-    mock_db_session, mock_log, lead_new, officer_1, officer_2
-):
-    """
-    Test Kịch bản thành công (Fairness):
-    - Officer 1 (workload 2, last_assigned = 1 ngày trước)
-    - Officer 2 (workload 2, last_assigned = 1 giờ trước)
-    - Service phải chọn Officer 1.
-    """
-
-    officer_1.last_assigned_at = datetime.now(timezone.utc) - timedelta(days=1)
-
-    # 1. Setup Mocks
-    class MockWorkloadRow:
-        def __init__(self, assigned_officer_id, workload):
-            self.assigned_officer_id = assigned_officer_id
-            self.workload = workload
-
-    mock_lead_result = MagicMock()
-    mock_lead_result.scalar_one_or_none.return_value = lead_new
-
-    mock_officers_result = MagicMock()
-    mock_officers_result.scalars.return_value.all.return_value = [officer_1, officer_2]
-
-    mock_workload_result = [
-        MockWorkloadRow(assigned_officer_id=101, workload=2),
-        MockWorkloadRow(assigned_officer_id=102, workload=2),
-    ]
-
+async def test_assign_fail_no_officers_available(mock_db_session, lead_new):
+    """Không có officer nào ⇒ assignment_status = failed, không gán."""
     mock_db_session.execute.side_effect = [
-        mock_lead_result,
-        mock_officers_result,
-        mock_workload_result,
+        _lead_result(lead_new),
+        _officers_result([]),
     ]
 
-    # 2. Action
     await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
 
-    # 3. Assert (Giữ nguyên assertions về model)
-    assert lead_new.assigned_officer_id == officer_1.id
-    assert lead_new.status == ASSIGNED_LEAD_STATUS
-    # ... (Giữ nguyên assertions về add) ...
-
-    # SỬA LỖI 2: Cập nhật assertion log (kwargs phải khớp)
-    mock_log.info.assert_any_await(
-        "Selected officer for assignment",
-        officer_id=officer_1.id,
-        current_workload=2,
-        max_capacity=officer_1.max_capacity,  # Thêm max_capacity
-        lead_id=lead_new.id,  # Thêm lead_id
-    )
-
-
-@pytest.mark.asyncio
-async def test_assign_fail_no_officers_available(mock_db_session, mock_log, lead_new):
-    """Test Kịch bản lỗi: Không tìm thấy officer nào (danh sách rỗng)."""
-
-    # 1. Setup Mocks
-    mock_lead_result = MagicMock()
-    mock_lead_result.scalar_one_or_none.return_value = lead_new
-
-    mock_officers_result = MagicMock()
-    mock_officers_result.scalars.return_value.all.return_value = []  # Không có officer
-
-    mock_db_session.execute.side_effect = [mock_lead_result, mock_officers_result]
-
-    # 2. Action
-    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
-
-    # 3. Assert (Giữ nguyên assertions về model)
     assert lead_new.assigned_officer_id is None
-    assert lead_new.status == UNASSIGNED_LEAD_STATUS
-    assert mock_db_session.add.call_count == 1
-
-    # SỬA LỖI 2: Cập nhật assertion log (kwargs phải khớp)
-    mock_log.warning.assert_any_await(
-        "Auto-assign task: No available officers found",
-        lead_id=lead_new.id,
-        unit_id=lead_new.unit_id,  # Giữ nguyên
-    )
+    assert lead_new.assignment_status == AssignmentStatus.FAILED
 
 
 @pytest.mark.asyncio
 async def test_assign_fail_all_officers_full_capacity(
-    mock_db_session, mock_log, lead_new, officer_1, officer_2
+    mock_db_session, lead_new, officer_1, officer_2
 ):
-    """Test Kịch bản lỗi: Các officer đều đã đầy workload."""
-
-    # 1. Setup Mocks
-    class MockWorkloadRow:
-        def __init__(self, assigned_officer_id, workload):
-            self.assigned_officer_id = assigned_officer_id
-            self.workload = workload
-
-    mock_lead_result = MagicMock()
-    mock_lead_result.scalar_one_or_none.return_value = lead_new
-
-    mock_officers_result = MagicMock()
-    mock_officers_result.scalars.return_value.all.return_value = [officer_1, officer_2]
-
-    mock_workload_result = [
-        MockWorkloadRow(assigned_officer_id=101, workload=10),
-        MockWorkloadRow(assigned_officer_id=102, workload=10),
-    ]
-
+    """Tất cả officer đầy tải (workload >= capacity) ⇒ failed."""
     mock_db_session.execute.side_effect = [
-        mock_lead_result,
-        mock_officers_result,
-        mock_workload_result,
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([
+            MockWorkloadRow(101, 10),
+            MockWorkloadRow(102, 10),
+        ]),
     ]
 
-    # 2. Action
     await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
 
-    # 3. Assert (Giữ nguyên assertions về model)
     assert lead_new.assigned_officer_id is None
-    assert lead_new.status == UNASSIGNED_LEAD_STATUS
-    assert mock_db_session.add.call_count == 1
-
-    # SỬA LỖI 2: Cập nhật assertion log (kwargs phải khớp)
-    mock_log.warning.assert_any_await(
-        "Auto-assign task: All available officers are at full capacity",
-        lead_id=lead_new.id,
-        unit_id=lead_new.unit_id,  # Service log có unit_id
-    )
+    assert lead_new.assignment_status == AssignmentStatus.FAILED
 
 
 @pytest.mark.asyncio
-async def test_assign_skip_lead_not_found(mock_db_session, mock_log):
-    """Test Kịch bản bỏ qua: Lead ID không tồn tại."""
+async def test_assign_skip_lead_not_found(mock_db_session):
+    """Lead không tồn tại ⇒ bỏ qua, không add gì."""
+    mock_db_session.execute.side_effect = [_lead_result(None)]
 
-    # 1. Setup Mocks
-    mock_lead_result = MagicMock()
-    mock_lead_result.scalar_one_or_none.return_value = None  # Không tìm thấy lead
-    mock_db_session.execute.return_value = mock_lead_result
-
-    # 2. Action
     await assignment_service.automatically_assign_lead(NON_EXISTENT_ID, mock_db_session)
 
-    # 3. Assert
-    mock_db_session.execute.assert_awaited_once()
     assert mock_db_session.add.call_count == 0
-    # SỬA LỖI 2: Cập nhật assertion log
-    mock_log.warning.assert_any_await(
-        "Auto-assign task: Lead not found", lead_id=NON_EXISTENT_ID
-    )
+    assert mock_db_session.add_all.call_count == 0
 
 
 @pytest.mark.asyncio
-async def test_assign_skip_lead_already_assigned(mock_db_session, mock_log, lead_new):
-    """Test Kịch bản bỏ qua: Lead đã được gán (race condition)."""
-
-    # 1. Setup Mocks
+async def test_assign_skip_lead_already_assigned(mock_db_session, lead_new):
+    """Lead đã có officer (race) ⇒ bỏ qua, giữ nguyên officer cũ."""
     lead_new.assigned_officer_id = 999
-    mock_lead_result = MagicMock()
-    mock_lead_result.scalar_one_or_none.return_value = lead_new
-    mock_db_session.execute.return_value = mock_lead_result
+    mock_db_session.execute.side_effect = [_lead_result(lead_new)]
 
-    # 2. Action
     await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
 
-    # 3. Assert
-    mock_db_session.execute.assert_awaited_once()
+    assert lead_new.assigned_officer_id == 999
     assert mock_db_session.add.call_count == 0
-    # SỬA LỖI 2: Cập nhật assertion log
-    mock_log.info.assert_any_await(
-        "Auto-assign task: Lead already assigned", lead_id=lead_new.id
-    )
+    assert mock_db_session.add_all.call_count == 0
 
 
 @pytest.mark.asyncio
-async def test_assign_db_error_rollback(mock_db_session, mock_log, lead_new, officer_1):
-    """Test Kịch bản lỗi: DB Error xảy ra (ví dụ khi add)."""
-
-    # 1. Setup Mocks
-    mock_lead_result = MagicMock()
-    mock_lead_result.scalar_one_or_none.return_value = lead_new
-
-    mock_officers_result = MagicMock()
-    mock_officers_result.scalars.return_value.all.return_value = [officer_1]
-
-    mock_workload_result = []
-
+async def test_assign_db_error_propagates(mock_db_session, lead_new, officer_1):
+    """DB error khi ghi (db.add_all) ⇒ exception ném ra để Celery retry."""
     mock_db_session.execute.side_effect = [
-        mock_lead_result,
-        mock_officers_result,
-        mock_workload_result,
+        _lead_result(lead_new),
+        _officers_result([officer_1]),
+        _workload_result([MockWorkloadRow(101, 0)]),
     ]
-
     db_error = SQLAlchemyError("Simulated DB Error")
-    mock_db_session.add.side_effect = db_error
+    mock_db_session.add_all.side_effect = db_error
 
-    # 2. Action & Assert Exception
     with pytest.raises(SQLAlchemyError) as exc_info:
         await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
 
-    # 3. Assert
-    assert exc_info.value == db_error
-    # SỬA LỖI 2: Cập nhật assertion log (thêm exc_info=True)
-    mock_log.error.assert_any_await(
-        "Auto-assign task: Failed and rolled back",
-        lead_id=lead_new.id,
-        error=str(db_error),
-        exc_info=True,  # Service đang log với exc_info=True
-    )
+    assert exc_info.value is db_error
+
+
+# =====================================================================
+# Member-weighted decision matrix (BƯỚC 5)
+# =====================================================================
+@pytest.mark.asyncio
+async def test_matrix_both_off_is_legacy(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """fairness OFF + member OFF ⇒ legacy y hệt. Weight officer_2 dù cao vẫn KHÔNG
+    được xét (flag tắt) ⇒ round-robin theo last_assigned ⇒ officer_1."""
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", False)
+    officer_2.assignment_weight = 100  # bị bỏ qua vì member flag OFF
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([MockWorkloadRow(101, 2), MockWorkloadRow(102, 2)]),
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    assert lead_new.assigned_officer_id == officer_1.id
+    assert _decision_log(mock_db_session).reason == "lowest_workload"
+
+
+@pytest.mark.asyncio
+async def test_matrix_member_on_weight_gets_more(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """member ON, fairness OFF. Hai officer CÙNG workload dương bằng nhau (4/10 —
+    không dùng 0 vì eff_util đều 0 thì weight vô nghĩa). officer_2 weight=2 ⇒
+    eff_util = 4/(10*2)=0.2 < officer_1 eff_util 0.4 ⇒ officer_2 được chọn.
+    Cũng kiểm audit contract: scores_snapshot là dict {real_util,eff_util,weight,score}."""
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    officer_1.assignment_weight = 1
+    officer_2.assignment_weight = 2
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([MockWorkloadRow(101, 4), MockWorkloadRow(102, 4)]),
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    assert lead_new.assigned_officer_id == officer_2.id
+
+    decision = _decision_log(mock_db_session)
+    assert decision.reason == "member_weighted"
+    snap = decision.scores_snapshot
+    assert set(snap.keys()) == {"101", "102"}
+    for v in snap.values():
+        assert set(v.keys()) == {"real_util", "eff_util", "weight", "score"}
+    # real_util KHÔNG nhân weight (bằng nhau); eff_util có nhân weight.
+    assert snap["101"]["real_util"] == snap["102"]["real_util"] == 0.4
+    assert snap["102"]["eff_util"] < snap["101"]["eff_util"]
+    assert snap["102"]["weight"] == 2
+
+
+@pytest.mark.asyncio
+async def test_matrix_member_on_safety_gate_not_bent(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """member ON. officer_1 weight rất cao (eff_util thấp) NHƯNG tải THẬT >= 0.8
+    (9/10) ⇒ overloaded=True ⇒ bị đẩy xuống sau officer_2 (tải thật 0.4, không
+    overloaded). Weight KHÔNG phá trần an toàn."""
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    officer_1.assignment_weight = 5   # eff_util = 9/(10*5) = 0.18 (thấp!)
+    officer_2.assignment_weight = 1   # eff_util = 4/(10*1) = 0.40
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([MockWorkloadRow(101, 9), MockWorkloadRow(102, 4)]),
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    # officer_1 tải thật 0.9 ⇒ overloaded ⇒ officer_2 thắng dù eff_util cao hơn.
+    assert lead_new.assigned_officer_id == officer_2.id
+    assert _decision_log(mock_db_session).reason == "member_weighted"
+
+
+@pytest.mark.asyncio
+async def test_matrix_fairness_on_member_off_raw_share(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """fairness ON, member OFF, đủ history (>=10 toàn unit) ⇒ hành vi P2-2 cũ:
+    score = 0.6*real_util + 0.4*raw_share. officer_1 đã nhận 8/10 lịch sử ⇒ share
+    cao ⇒ bị phạt ⇒ officer_2 (share 2/10) được chọn. Weight KHÔNG được xét."""
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", True)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", False)
+    officer_2.assignment_weight = 100  # bị bỏ qua vì member OFF
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([MockWorkloadRow(101, 2), MockWorkloadRow(102, 2)]),
+        _hist_result([MockHistRow(101, 8), MockHistRow(102, 2)]),  # total=10
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    assert lead_new.assigned_officer_id == officer_2.id
+    assert _decision_log(mock_db_session).reason == "fairness_weighted"
+
+
+@pytest.mark.asyncio
+async def test_matrix_fairness_and_member_pressure(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """fairness ON + member ON, đủ pool history (>=10) ⇒ member_fairness_weighted:
+    score = 0.6*eff_util + 0.4*pressure, pressure = actual_share - target_share
+    (target = weight/Σweight trong pool). officer_2 weight=3 (target 0.75) nhưng
+    mới nhận 0.5 thực tế ⇒ pressure âm ⇒ được đẩy lên ⇒ được chọn."""
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", True)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    officer_1.assignment_weight = 1   # target 1/4 = 0.25
+    officer_2.assignment_weight = 3   # target 3/4 = 0.75
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([MockWorkloadRow(101, 2), MockWorkloadRow(102, 2)]),
+        _hist_result([MockHistRow(101, 6), MockHistRow(102, 6)]),  # pool=12
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    # officer_1: 0.6*0.2 + 0.4*(0.5-0.25) = 0.22 ; officer_2: 0.6*0.0667 + 0.4*(0.5-0.75) = -0.06
+    assert lead_new.assigned_officer_id == officer_2.id
+    assert _decision_log(mock_db_session).reason == "member_fairness_weighted"
+
+
+@pytest.mark.asyncio
+async def test_matrix_fairness_and_member_insufficient_history_falls_back(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """fairness ON + member ON nhưng pool history < 10 ⇒ fallback là MEMBER-WEIGHTED
+    (KHÔNG legacy): weight phải có tác dụng ngay đầu rollout. officer_2 weight=2 ⇒
+    eff_util thấp hơn ⇒ được chọn."""
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", True)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    officer_1.assignment_weight = 1
+    officer_2.assignment_weight = 2
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([MockWorkloadRow(101, 4), MockWorkloadRow(102, 4)]),
+        _hist_result([MockHistRow(101, 3), MockHistRow(102, 2)]),  # pool=5 < 10
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    assert lead_new.assigned_officer_id == officer_2.id
+    assert _decision_log(mock_db_session).reason == "member_weighted"

--- a/Backend_FastAPI/tests/services/test_lead_assignment_edge_cases.py
+++ b/Backend_FastAPI/tests/services/test_lead_assignment_edge_cases.py
@@ -32,6 +32,9 @@ from app.utils.exceptions import (
     PermissionDeniedError,
     BadRequest,
 )
+# Shared mock harness: `mock_db_session` fixture auto-discovered from conftest;
+# MockWorkloadRow imported explicitly (plain class).
+from tests.services.conftest import MockWorkloadRow
 
 # Import test constants
 try:
@@ -48,30 +51,6 @@ except ImportError:
 # =============================================================================
 # FIXTURES
 # =============================================================================
-
-@pytest.fixture
-def mock_db_session():
-    """Create a mock AsyncSession with all required methods."""
-    session = AsyncMock(spec=AsyncSession)
-    session.add = MagicMock()
-    session.add_all = MagicMock()
-    session.commit = AsyncMock()
-    session.refresh = AsyncMock(return_value=None)
-    session.execute = AsyncMock()
-    session.delete = AsyncMock()
-    session.get = AsyncMock()
-    session.scalar = AsyncMock()
-    session.rollback = AsyncMock()
-    session.flush = AsyncMock()
-
-    # Mock nested transaction
-    mock_nested = AsyncMock()
-    mock_nested.__aenter__ = AsyncMock(return_value=None)
-    mock_nested.__aexit__ = AsyncMock(return_value=None)
-    session.begin_nested = MagicMock(return_value=mock_nested)
-
-    return session
-
 
 @pytest.fixture
 def lead_unassigned():
@@ -221,11 +200,7 @@ def admin_user():
     )
 
 
-# Helper class for workload mock
-class MockWorkloadRow:
-    def __init__(self, assigned_officer_id: int, workload: int):
-        self.assigned_officer_id = assigned_officer_id
-        self.workload = workload
+# MockWorkloadRow now imported from tests.services.conftest (shared harness).
 
 
 # =============================================================================

--- a/frontend/src/app/(dashboard)/admin/users/[id]/_components/UserDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admin/users/[id]/_components/UserDetailClient.tsx
@@ -275,6 +275,12 @@ export function UserDetailClient({ userId, initialData }: UserDetailClientProps)
                       <p className="text-sm font-medium text-muted-foreground">Trạng thái sẵn sàng</p>
                       <p className="text-sm">{user.availability_status || "Không có"}</p>
                     </div>
+                    {user.role === "officer" && (
+                      <div>
+                        <p className="text-sm font-medium text-muted-foreground">Trọng số phân công lead</p>
+                        <p className="text-sm">{user.assignment_weight ?? 1}</p>
+                      </div>
+                    )}
                   </div>
                   {user.skills && user.skills.length > 0 && (
                     <div>

--- a/frontend/src/app/(dashboard)/admin/users/[id]/_components/UserDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admin/users/[id]/_components/UserDetailClient.tsx
@@ -275,10 +275,13 @@ export function UserDetailClient({ userId, initialData }: UserDetailClientProps)
                       <p className="text-sm font-medium text-muted-foreground">Trạng thái sẵn sàng</p>
                       <p className="text-sm">{user.availability_status || "Không có"}</p>
                     </div>
+                    {/* Thuộc tính riêng của officer (chỉ đọc); role-gate hiển thị là
+                        deviation có chủ đích với "no role checks" cho tab thông tin. */}
                     {user.role === "officer" && (
                       <div>
                         <p className="text-sm font-medium text-muted-foreground">Trọng số phân công lead</p>
-                        <p className="text-sm">{user.assignment_weight ?? 1}</p>
+                        {/* "—" khi thiếu (KHÔNG bịa giá trị nghiệp vụ "1") */}
+                        <p className="text-sm">{user.assignment_weight ?? "—"}</p>
                       </div>
                     )}
                   </div>

--- a/frontend/src/components/admin/UserDialog.tsx
+++ b/frontend/src/components/admin/UserDialog.tsx
@@ -91,6 +91,9 @@ const editUserSchema = z.object({
     .or(z.literal("")),
   role: z.string().min(1, "Vai trò là bắt buộc"),
   status: z.enum(["active", "pending", "banned"]),
+  // Trọng số phân công lead cho officer (1-100). coerce vì <input type="number">
+  // trả string; default(1) đảm bảo luôn có giá trị hợp lệ kể cả khi field ẩn.
+  assignment_weight: z.coerce.number().int().min(1, "Tối thiểu 1").max(100, "Tối đa 100").default(1),
   avatar: z.instanceof(File).optional(),
 });
 
@@ -105,6 +108,7 @@ type UserFormValues = {
   phone_number?: string;
   role: string;
   status: "active" | "pending" | "banned";
+  assignment_weight?: number;
   avatar?: File;
 };
 
@@ -146,6 +150,7 @@ export function UserDialog({ open, onOpenChange, user, mode }: UserDialogProps) 
           phone_number: user.phone_number || "",
           role: user.role, // architecture-allow serialization
           status: user.status,
+          assignment_weight: user.assignment_weight ?? 1,
         }
       : {
           username: "",
@@ -173,6 +178,7 @@ export function UserDialog({ open, onOpenChange, user, mode }: UserDialogProps) 
         phone_number: user.phone_number || "",
         role: user.role, // architecture-allow serialization
         status: user.status,
+        assignment_weight: user.assignment_weight ?? 1,
       });
       // Clear preview to show current user's avatar from server
       setAvatarPreview(null);
@@ -469,6 +475,37 @@ export function UserDialog({ open, onOpenChange, user, mode }: UserDialogProps) 
                 </FormItem>
               )}
             />
+
+            {/* Assignment Weight — chỉ khi edit + role đang chọn là officer.
+                Dùng form.watch("role") (KHÔNG user.role) để đổi role→officer là
+                nhập được weight ngay. Field vẫn trong form state khi ẩn (default 1). */}
+            {isEdit && form.watch("role") === "officer" && (
+              <FormField
+                control={form.control}
+                name="assignment_weight"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Trọng số phân công lead</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={1}
+                        max={100}
+                        disabled={isPending}
+                        {...field}
+                        value={field.value ?? 1}
+                        onChange={(e) => field.onChange(e.target.value)}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Officer trọng số cao nhận nhiều lead hơn theo tỉ lệ (1–100, mặc
+                      định 1). Không phá trần tải an toàn — chỉ ưu tiên khi còn chỗ.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
 
             {/* Status */}
             <FormField

--- a/frontend/src/components/admin/UserDialog.tsx
+++ b/frontend/src/components/admin/UserDialog.tsx
@@ -91,9 +91,18 @@ const editUserSchema = z.object({
     .or(z.literal("")),
   role: z.string().min(1, "Vai trò là bắt buộc"),
   status: z.enum(["active", "pending", "banned"]),
-  // Trọng số phân công lead cho officer (1-100). coerce vì <input type="number">
-  // trả string; default(1) đảm bảo luôn có giá trị hợp lệ kể cả khi field ẩn.
-  assignment_weight: z.coerce.number().int().min(1, "Tối thiểu 1").max(100, "Tối đa 100").default(1),
+  // Trọng số phân công lead cho officer (1-100). Mirror backend Optional[int]=None:
+  // ô trống (xoá / role≠officer) → undefined ⇒ KHÔNG gửi, BE giữ giá trị cũ — thay vì
+  // coerce "" về 0 (từng gây .min(1) fail âm thầm chặn Lưu khi field bị ẩn).
+  assignment_weight: z.preprocess(
+    (v) => (v === "" || v === null ? undefined : v),
+    z.coerce
+      .number()
+      .int("Trọng số phải là số nguyên")
+      .min(1, "Tối thiểu 1")
+      .max(100, "Tối đa 100")
+      .optional()
+  ),
   avatar: z.instanceof(File).optional(),
 });
 
@@ -255,7 +264,15 @@ export function UserDialog({ open, onOpenChange, user, mode }: UserDialogProps) 
         // onError is already handled in the hook (toast notification)
       });
     } else if (user) {
-      updateUserMutation.mutate(values as EditUserFormValues, {
+      // assignment_weight chỉ áp dụng cho officer — bỏ khỏi payload cho vai trò khác
+      // (mirror BE Optional[int]: không gửi ⇒ giữ nguyên), tránh ghi weight vô nghĩa
+      // lên non-officer mỗi lần lưu.
+      const editValues = values as EditUserFormValues;
+      const payload =
+        editValues.role === "officer"
+          ? editValues
+          : { ...editValues, assignment_weight: undefined };
+      updateUserMutation.mutate(payload, {
         onSuccess: onSuccessCallback,
         // onError is already handled in the hook (toast notification)
       });
@@ -477,8 +494,10 @@ export function UserDialog({ open, onOpenChange, user, mode }: UserDialogProps) 
             />
 
             {/* Assignment Weight — chỉ khi edit + role đang chọn là officer.
-                Dùng form.watch("role") (KHÔNG user.role) để đổi role→officer là
-                nhập được weight ngay. Field vẫn trong form state khi ẩn (default 1). */}
+                DEVIATION có chủ đích với quy tắc thin-client "no role checks":
+                đây là form GÁN vai trò, phải phản ứng theo role ĐANG CHỌN (chưa lưu),
+                nên dùng form.watch("role") — không có cờ BE nào phản ánh lựa chọn
+                chưa lưu. weight là thuộc tính riêng của officer. */}
             {isEdit && form.watch("role") === "officer" && (
               <FormField
                 control={form.control}
@@ -487,14 +506,16 @@ export function UserDialog({ open, onOpenChange, user, mode }: UserDialogProps) 
                   <FormItem>
                     <FormLabel>Trọng số phân công lead</FormLabel>
                     <FormControl>
+                      {/* onChange do {...field} cung cấp (RHF tự trích e.target.value —
+                          cùng pattern các field text khác). value ?? "" để ô trống hiện
+                          rỗng thay vì "0"; schema preprocess "" → undefined. */}
                       <Input
                         type="number"
                         min={1}
                         max={100}
                         disabled={isPending}
                         {...field}
-                        value={field.value ?? 1}
-                        onChange={(e) => field.onChange(e.target.value)}
+                        value={field.value ?? ""}
                       />
                     </FormControl>
                     <FormDescription>

--- a/frontend/src/components/admin/UserDialog.tsx
+++ b/frontend/src/components/admin/UserDialog.tsx
@@ -149,6 +149,10 @@ export function UserDialog({ open, onOpenChange, user, mode }: UserDialogProps) 
       .sort(); // Sort alphabetically
   }, [rolesData]);
 
+  // Officer weight mặc định — dùng chung cho defaultValues + reset() để 2 chỗ
+  // init form không lệch nhau nếu sau này đổi default.
+  const editWeightDefault = user?.assignment_weight ?? 1;
+
   // Form setup - use unified types to avoid union type issues with react-hook-form
   const form = useForm<UserFormValues>({
     resolver: zodResolver(isCreate ? createUserSchema : editUserSchema) as Resolver<UserFormValues>,
@@ -159,7 +163,7 @@ export function UserDialog({ open, onOpenChange, user, mode }: UserDialogProps) 
           phone_number: user.phone_number || "",
           role: user.role, // architecture-allow serialization
           status: user.status,
-          assignment_weight: user.assignment_weight ?? 1,
+          assignment_weight: editWeightDefault,
         }
       : {
           username: "",
@@ -187,7 +191,7 @@ export function UserDialog({ open, onOpenChange, user, mode }: UserDialogProps) 
         phone_number: user.phone_number || "",
         role: user.role, // architecture-allow serialization
         status: user.status,
-        assignment_weight: user.assignment_weight ?? 1,
+        assignment_weight: editWeightDefault,
       });
       // Clear preview to show current user's avatar from server
       setAvatarPreview(null);

--- a/frontend/src/hooks/useAdminUsers.ts
+++ b/frontend/src/hooks/useAdminUsers.ts
@@ -142,6 +142,8 @@ export function useAdminUpdateUser(userId: number) {
       if (data.skills) formData.append("skills", JSON.stringify(data.skills));
       if (data.max_capacity !== undefined)
         formData.append("max_capacity", data.max_capacity.toString());
+      if (data.assignment_weight !== undefined)
+        formData.append("assignment_weight", data.assignment_weight.toString());
       if (data.unit_id !== undefined)
         formData.append("unit_id", (data.unit_id ?? 0).toString());
 

--- a/frontend/src/types/api.types.ts
+++ b/frontend/src/types/api.types.ts
@@ -15,6 +15,7 @@ export interface User {
   skills?: string[] | null; // User skills
   availability_status?: string | null; // Availability status
   max_capacity?: number | null; // Max capacity
+  assignment_weight?: number | null; // Officer lead-assignment weight (1-100). Higher = more leads.
   password_reset_required?: boolean; // Security: Set true after "Secure Account" action
   mfa_enabled?: boolean; // MFA: Whether TOTP MFA is enabled
 }
@@ -157,6 +158,7 @@ export interface AdminUserUpdate {
   avatar?: File;
   skills?: string[];
   max_capacity?: number;
+  assignment_weight?: number; // Officer lead-assignment weight (1-100)
   unit_id?: number | null; // Organizational unit assignment
 }
 


### PR DESCRIPTION
## Tóm tắt

Thêm **trọng số phân công lead theo từng officer** (`assignment_weight`) cho bộ cân bằng auto-assign: officer weight cao nhận nhiều lead hơn **theo tỉ lệ**, **không phá trần tải an toàn**, và **không đổi hành vi hiện tại** cho tới khi bật flag.

**Cơ chế:** `eff_util = workload / (capacity × weight)` — weight cao ⇒ officer "được coi là vơi hơn" ⇒ nhận nhiều lead hơn. Cổng an toàn `overloaded = real_util ≥ 0.8` **LUÔN** tính trên tải THẬT (không nhân weight) — weight ưu tiên nhưng không dồn quá tải.

## Phạm vi

**Backend**
- `User.assignment_weight` (Integer 1–100, default 1) + `CHECK (1..100)`. Migration `memwt20260703001` — `server_default '1'` ⇒ hàng cũ = 1 (**no behavior change**).
- Flag `ENABLE_MEMBER_WEIGHTED_ASSIGNMENT` (default **False**), **độc lập** với `ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT`.
- `assignment_service` BƯỚC 5 = decision matrix 6 nhánh (legacy / fairness / member / member+fairness). **member OFF ⇒ bảo toàn nguyên vẹn** legacy + fairness (byte-for-byte).
- `PUT /api/admin/users/{id}`: `Form(ge=1, le=100)` → 422 chuẩn. `UserAdminResponse` lộ weight; **`UserPickerSchema` (officer/accountant picker) KHÔNG lộ** (PII-safe, mirror `max_capacity`).

**Frontend**
- UserDialog: field "Trọng số phân công lead" hiện khi role đang chọn = officer (`form.watch`). Zod mirror BE `Optional[int]=None`.
- Trang chi tiết user: hiển thị read-only cho officer.

## Review & Verify

- ✅ `/code-review max`: **BE algorithm / matrix / cổng an toàn SẠCH** (5 finder + verifier độc lập). 13 finding (đều FE + cleanup) đã vá ở commit follow-up `84cb7a43`.
- ✅ 42 backend mock test (đủ 6-nhánh matrix + safety-gate + uniform-weight) · API test (weight valid → persist, 0/101/-1/abc → 422, PII regression officer/accountant/admin).
- ✅ FE type-check + **1789 vitest** + lint **0 error**.
- ✅ Migration verify trên dev DB (25 user cũ = 1, CHECK chặn 101).
- ✅ Chrome smoke: field render / role-gate ẩn-hiện / persist DB / fix silent-Save — PASS.
- ✅ Thí nghiệm phân **12 lead thật** (service thật, transaction rollback): legacy **6:6** vs member weight 1:3 → **3:9** (đúng tỉ lệ); scores_snapshot xác nhận `eff_util = real_util/weight`.

## Rollout (flag-gated, an toàn)

1. Deploy code + migration → **không đổi hành vi** (flag OFF ⇒ round-robin như hiện tại, weight=1).
2. Admin đặt weight officer qua UI.
3. Bật `ENABLE_MEMBER_WEIGHTED_ASSIGNMENT=true` + restart backend.
4. Theo dõi `AssignmentDecisionLog.scores_snapshot` / `reason` xác nhận tỉ lệ.

Không migration Casbin mới.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
