### PR TITLE
feat(admission): đại tu UX trang chi tiết hồ sơ — Dải trạng thái + required-data + CTA routing

### DIFF
--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -18,7 +18,16 @@ from decimal import Decimal
 from typing import Annotated, Any, Dict, List, Literal, Optional
 import html
 
-from pydantic import BaseModel, EmailStr, Field, StringConstraints, field_validator, model_validator, ConfigDict
+from pydantic import (
+    BaseModel,
+    EmailStr,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+    ConfigDict,
+    computed_field,
+)
 
 from app.schemas.admission_profile_choice import AdmissionProfileChoiceResponse
 
@@ -1448,6 +1457,30 @@ class AdmissionProfileResponse(BaseModel):
             # để Pydantic xử lý tự nhiên.
             pass
         return data
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def primary_choice_display(self) -> Optional[str]:
+        """Resolved display name of the primary nguyện vọng — the SINGLE BE source
+        so the FE header doesn't heuristically pick between ``choices[0]`` and the
+        legacy ``program_name``.
+
+        - Choice-engine profile: the lowest-``display_order`` choice's program name
+          (falls back to its path name when the program label is blank).
+        - Legacy single-NV profile (``uses_choice_engine=False``): ``program_name``.
+        - Choice-engine profile with an EMPTY ``choices`` genuinely has no nguyện
+          vọng yet → ``None`` (so the FE shows "Chưa chọn nguyện vọng" rather than a
+          stale lead/offering value). Returns ``None`` when nothing is available.
+        """
+        if self.choices:
+            first = min(self.choices, key=lambda c: c.display_order)
+            name = (first.display_program_name or "").strip()
+            if name:
+                return name
+            return (first.display_path_name or "").strip() or None
+        if not self.uses_choice_engine and self.program_name:
+            return self.program_name.strip() or None
+        return None
 
     model_config = ConfigDict(
         from_attributes=True,

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1301,10 +1301,11 @@ class AdmissionProfileResponse(BaseModel):
 
     # Draft còn thiếu dữ liệu bắt buộc (quá trình học tập / thông tin gia đình)
     # vốn chặn submit nhưng không nằm trong validation_errors → FE dùng cờ này để
-    # disable nút Nộp + hiện lý do rõ ràng. False khi allow_unverified_submission.
+    # disable nút Nộp + hiện lý do rõ ràng. Bypass-independent: cờ phản ánh submit
+    # gate VÔ ĐIỀU KIỆN (allow_unverified_submission chỉ nới kiểm tra tài liệu).
     submit_blocked_by_data: Optional[bool] = Field(
         default=False,
-        description="Draft blocked from submit by missing required data (family/academic); False if allow_unverified_submission bypass."
+        description="Draft blocked from submit by missing required data (family/academic). Bypass-independent: mirrors the unconditional submit gate; allow_unverified_submission only relaxes document verification, never these two groups."
     )
 
     # Executive summary for dashboard overview

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1296,7 +1296,15 @@ class AdmissionProfileResponse(BaseModel):
     # Grouped validation errors (categorized display)
     grouped_validation_errors: Optional[Dict[str, Any]] = Field(
         default=None,
-        description="Validation errors grouped by category: {personal_info: {category, errors, count}, documents: {...}, scores: {...}}"
+        description="Validation errors grouped by category: {personal_info: {category, errors, count}, documents: {...}, scores: {...}, required_data: {...}}"
+    )
+
+    # Draft còn thiếu dữ liệu bắt buộc (quá trình học tập / thông tin gia đình)
+    # vốn chặn submit nhưng không nằm trong validation_errors → FE dùng cờ này để
+    # disable nút Nộp + hiện lý do rõ ràng. False khi allow_unverified_submission.
+    submit_blocked_by_data: Optional[bool] = Field(
+        default=False,
+        description="Draft blocked from submit by missing required data (family/academic); False if allow_unverified_submission bypass."
     )
 
     # Executive summary for dashboard overview

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2010,6 +2010,25 @@ def _build_executive_summary_items(
     return critical_blockers, warnings
 
 
+def _missing_submit_required_data(profile: models.AdmissionProfile) -> List[str]:
+    """Data groups that ``submit_and_evaluate`` rejects UNCONDITIONALLY
+    (``family_info`` / ``academic_history``) yet which never appear in
+    ``validation_errors``. Single source of truth shared by the real submit gate
+    AND the FE-facing ``submit_blocked_by_data`` flag + ``required_data`` bucket,
+    so the draft-view button gate cannot diverge from the actual gate — adding a
+    third mandatory group here updates both at once.
+
+    Bypass-independent: ``allow_unverified_submission`` only relaxes DOCUMENT
+    verification, never these two data groups.
+    """
+    missing: List[str] = []
+    if not profile.academic_history:
+        missing.append("Chưa nhập quá trình học tập")
+    if not profile.family_info:
+        missing.append("Chưa nhập thông tin gia đình")
+    return missing
+
+
 def _compute_frontend_fields(
     profile: models.AdmissionProfile,
     current_user: models.User,
@@ -2547,35 +2566,26 @@ def _compute_frontend_fields(
     has_academic = profile.academic_history and len(profile.academic_history) > 0
 
     # --- Required-data visibility (family + academic history) -------------------
-    # These two groups HARD-block submit (submit_and_evaluate: "Chưa nhập thông
-    # tin gia đình" / "Chưa nhập quá trình học tập") but were historically absent
-    # from validation_errors/grouped_validation_errors → the draft view showed no
-    # error while submit rejected them (draft↔submit mismatch → user bỏ trống →
-    # kẹt). Surface them as a dedicated grouped bucket + a submit-gate flag so the
-    # FE can warn up-front and disable the submit button with a clear reason.
+    # These two groups HARD-block submit (submit_and_evaluate rejects them
+    # UNCONDITIONALLY) but are absent from validation_errors → the draft view
+    # showed no error while submit rejected them (draft↔submit mismatch → user bỏ
+    # trống → kẹt). Surface via the SAME predicate the real submit gate uses
+    # (``_missing_submit_required_data``) so the button gate cannot diverge from
+    # the actual gate. Scoped to draft: submit is the only transition these groups
+    # gate (resubmit/approve don't re-check them), so bucket + flag both stay empty
+    # on non-draft statuses — a submitted profile with legacy-empty data must NOT
+    # surface "Thông tin bắt buộc".
     # NOTE: deliberately NOT added to validation_errors/eligibility_status (that
     # would flip step-8 lock, bypass_warning, and approve gating — out of scope).
-    _missing_required_data: List[str] = []
-    if not has_academic:
-        _missing_required_data.append("Chưa nhập quá trình học tập")
-    if not has_family:
-        _missing_required_data.append("Chưa nhập thông tin gia đình")
+    _missing_required_data = (
+        _missing_submit_required_data(profile) if status == "draft" else []
+    )
     profile.grouped_validation_errors["required_data"] = {
         "category": "Thông tin bắt buộc",
         "errors": _missing_required_data,
         "count": len(_missing_required_data),
     }
-    # Mirror the ACTUAL submit gate: submit_and_evaluate rejects missing
-    # family_info / academic_history UNCONDITIONALLY. allow_unverified_submission
-    # only relaxes DOCUMENT verification (strict vs lax uploaded-doc handling) —
-    # it NEVER makes these two data groups optional. So the flag must NOT honour
-    # that bypass; otherwise a doc-lax draft missing family/academic would show an
-    # enabled submit (or nợ-giấy-tờ) button and then bounce back from the backend,
-    # reintroducing the exact draft↔submit mismatch this surfacing fix removes.
-    profile.submit_blocked_by_data = bool(
-        status == "draft"
-        and _missing_required_data
-    )
+    profile.submit_blocked_by_data = bool(_missing_required_data)
     
     # P0 hotfix multi-NV — Step 5 (Scores) "has any" must read per-choice
     # ProfileChoiceScore for multi-NV (profile.subject_scores is always empty
@@ -6235,13 +6245,11 @@ async def submit_and_evaluate(
                 f"(Mã SV: {existing_student.student_code})"
             )
 
-    # Validation 4: Check Family Info (Fix Finding 1.7)
-    if not profile.family_info:
-        errors.append("Chưa nhập thông tin gia đình (Family Info is empty)")
-
-    # Validation 5: Check Academic History (Fix Finding 1.7)
-    if not profile.academic_history:
-        errors.append("Chưa nhập quá trình học tập (Academic History is empty)")
+    # Validation 4+5: Family Info + Academic History (Fix Finding 1.7). Shared
+    # with the draft-view ``submit_blocked_by_data`` flag + ``required_data``
+    # bucket via one predicate (``_missing_submit_required_data``) so the button
+    # gate and this real submit gate cannot drift apart.
+    errors.extend(_missing_submit_required_data(profile))
 
     # Q9 #07 Phase E.4 reviewer v4 — KV freeze + assert chuyển từ "post if-errors
     # transition prep" lên đây để errors collect cho cả KV failure. Nếu raise

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1454,7 +1454,11 @@ def _compute_completion_percent(
 
     cccd_error = not profile.citizen_id
     personal_required = ["full_name", "phone", "citizen_id"]
-    personal_optional = ["email", "dob", "gender", "nationality", "ethnicity"]
+    # place_of_birth: keep step-1 status in sync with _validate_personal_info so
+    # completion_percent doesn't count step 1 as done while it's a submit blocker.
+    personal_optional = [
+        "email", "dob", "gender", "nationality", "ethnicity", "place_of_birth",
+    ]
     personal_required_filled = all(getattr(profile, f, None) for f in personal_required)
     personal_optional_filled = all(getattr(profile, f, None) for f in personal_optional)
     permanent_address_complete = all(
@@ -2551,7 +2555,12 @@ def _compute_frontend_fields(
     # =========================================================================
     # Required personal fields for step 1 check
     personal_required = ["full_name", "phone", "citizen_id"]
-    personal_optional = ["email", "dob", "gender", "nationality", "ethnicity"]
+    # place_of_birth is validated in _validate_personal_info (a blocker); keep it
+    # in step-1 status so a missing value shows amber, not a false "success" that
+    # dead-ends the header work-items CTA (count > 0 but no navigable step).
+    personal_optional = [
+        "email", "dob", "gender", "nationality", "ethnicity", "place_of_birth",
+    ]
     personal_required_filled = all(getattr(profile, f, None) for f in personal_required)
     personal_optional_filled = all(getattr(profile, f, None) for f in personal_optional)
     permanent_address_complete = all(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2429,6 +2429,16 @@ def _compute_frontend_fields(
     # in the submit-with-debt dialog (B3).
     profile.missing_doc_codes = list(missing_doc_codes)
 
+    # Family/academic are UNCONDITIONAL submit blockers (submit_and_evaluate
+    # rejects them regardless of docs) but are NOT in validation_errors, so they
+    # never reach _other_errors. Compute the same draft-scoped predicate the
+    # submit_blocked_by_data flag + required_data bucket use (below) and fold it
+    # into the doc-debt flag, so the response can't advertise a submit-with-debt
+    # that the API would still reject on missing family/academic.
+    _missing_required_data = (
+        _missing_submit_required_data(profile) if status == "draft" else []
+    )
+
     # L1 owner-consistency: gate the submit-with-debt button on the SAME actor
     # set as ``permissions["submit"]`` (is_owner or is_manager or is_admin) to
     # prevent drift — submit-with-debt is just submit + a doc-debt snapshot, so
@@ -2438,11 +2448,12 @@ def _compute_frontend_fields(
     # The server-side submit gate in submit_and_evaluate is role+IDOR based and
     # unchanged — this only aligns the FE flag. The button shows only when the
     # draft is eligible apart from missing docs (other_errors empty + ≥1 missing
-    # doc) and is not a multi-NV profile lacking choices.
+    # doc), has its required data, and is not a multi-NV profile lacking choices.
     profile.can_submit_with_document_debt = bool(
         status == "draft"
         and (is_owner or is_manager or is_admin)
         and not _other_errors
+        and not _missing_required_data
         and missing_doc_codes
         and not _multi_nv_no_choice
     )
@@ -2586,9 +2597,8 @@ def _compute_frontend_fields(
     # surface "Thông tin bắt buộc".
     # NOTE: deliberately NOT added to validation_errors/eligibility_status (that
     # would flip step-8 lock, bypass_warning, and approve gating — out of scope).
-    _missing_required_data = (
-        _missing_submit_required_data(profile) if status == "draft" else []
-    )
+    # ``_missing_required_data`` is computed once above (shared with the doc-debt
+    # gate) so the two flags cannot diverge.
     profile.grouped_validation_errors["required_data"] = {
         "category": "Thông tin bắt buộc",
         "errors": _missing_required_data,

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2432,12 +2432,29 @@ def _compute_frontend_fields(
     # Family/academic are UNCONDITIONAL submit blockers (submit_and_evaluate
     # rejects them regardless of docs) but are NOT in validation_errors, so they
     # never reach _other_errors. Compute the same draft-scoped predicate the
-    # submit_blocked_by_data flag + required_data bucket use (below) and fold it
-    # into the doc-debt flag, so the response can't advertise a submit-with-debt
-    # that the API would still reject on missing family/academic.
+    # submit_blocked_by_data flag + required_data bucket use (below).
     _missing_required_data = (
         _missing_submit_required_data(profile) if status == "draft" else []
     )
+
+    # Single named set of the SYNC-observable non-document submit blockers, so the
+    # doc-debt gate can't advertise a submit-with-debt the API would reject on a
+    # non-doc error. Folds `_other_errors` (validation errors minus missing-docs)
+    # + `_missing_required_data` (family/academic — absent from validation_errors)
+    # into ONE term future gates can reuse without re-remembering both.
+    #
+    # OPTIMISTIC on two axes by design — two submit gates are NOT observable in
+    # this sync, db-less compute:
+    #   * current-era ward (`_is_current_era_ward`, submit_and_evaluate:~6344) —
+    #     an async administrative_nodes lookup.
+    #   * KV resolution (`_kv_unresolved_error_message`) — the priority snapshot is
+    #     FROZEN AT SUBMIT and is null for an un-previewed draft, so sync-gating on
+    #     it would false-negative every valid-but-un-previewed draft.
+    # For those two the flag is a hint: the API stays authoritative and the FE
+    # surfaces any residual bounce. Do NOT add them here (see the test
+    # `test_document_debt_flag_gated_on_required_data`, which asserts on a FULLY
+    # submittable profile so it doesn't cement the optimistic edge as truth).
+    _non_doc_submit_blockers = bool(_other_errors) or bool(_missing_required_data)
 
     # L1 owner-consistency: gate the submit-with-debt button on the SAME actor
     # set as ``permissions["submit"]`` (is_owner or is_manager or is_admin) to
@@ -2447,13 +2464,12 @@ def _compute_frontend_fields(
     # one not assigned to the lead, which submit itself rejects via is_owner.)
     # The server-side submit gate in submit_and_evaluate is role+IDOR based and
     # unchanged — this only aligns the FE flag. The button shows only when the
-    # draft is eligible apart from missing docs (other_errors empty + ≥1 missing
-    # doc), has its required data, and is not a multi-NV profile lacking choices.
+    # draft is eligible apart from missing docs (no non-doc blockers + ≥1 missing
+    # doc) and is not a multi-NV profile lacking choices.
     profile.can_submit_with_document_debt = bool(
         status == "draft"
         and (is_owner or is_manager or is_admin)
-        and not _other_errors
-        and not _missing_required_data
+        and not _non_doc_submit_blockers
         and missing_doc_codes
         and not _multi_nv_no_choice
     )

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2545,6 +2545,37 @@ def _compute_frontend_fields(
     
     # Academic
     has_academic = profile.academic_history and len(profile.academic_history) > 0
+
+    # --- Required-data visibility (family + academic history) -------------------
+    # These two groups HARD-block submit (submit_and_evaluate: "Chưa nhập thông
+    # tin gia đình" / "Chưa nhập quá trình học tập") but were historically absent
+    # from validation_errors/grouped_validation_errors → the draft view showed no
+    # error while submit rejected them (draft↔submit mismatch → user bỏ trống →
+    # kẹt). Surface them as a dedicated grouped bucket + a submit-gate flag so the
+    # FE can warn up-front and disable the submit button with a clear reason.
+    # NOTE: deliberately NOT added to validation_errors/eligibility_status (that
+    # would flip step-8 lock, bypass_warning, and approve gating — out of scope).
+    _missing_required_data: List[str] = []
+    if not has_academic:
+        _missing_required_data.append("Chưa nhập quá trình học tập")
+    if not has_family:
+        _missing_required_data.append("Chưa nhập thông tin gia đình")
+    profile.grouped_validation_errors["required_data"] = {
+        "category": "Thông tin bắt buộc",
+        "errors": _missing_required_data,
+        "count": len(_missing_required_data),
+    }
+    # Mirror the ACTUAL submit gate: submit_and_evaluate rejects missing
+    # family_info / academic_history UNCONDITIONALLY. allow_unverified_submission
+    # only relaxes DOCUMENT verification (strict vs lax uploaded-doc handling) —
+    # it NEVER makes these two data groups optional. So the flag must NOT honour
+    # that bypass; otherwise a doc-lax draft missing family/academic would show an
+    # enabled submit (or nợ-giấy-tờ) button and then bounce back from the backend,
+    # reintroducing the exact draft↔submit mismatch this surfacing fix removes.
+    profile.submit_blocked_by_data = bool(
+        status == "draft"
+        and _missing_required_data
+    )
     
     # P0 hotfix multi-NV — Step 5 (Scores) "has any" must read per-choice
     # ProfileChoiceScore for multi-NV (profile.subject_scores is always empty

--- a/Backend_FastAPI/tests/api/test_admission_submit_requires_verified_docs.py
+++ b/Backend_FastAPI/tests/api/test_admission_submit_requires_verified_docs.py
@@ -68,39 +68,28 @@ async def strict_path_config(seed_lead_dependencies: dict):
         AdmissionRoundBuilder,
         ensure_submittable_ward,
         seed_submittable_offering_config,
+        _next_id,
     )
 
     uid = seed_lead_dependencies["unit_id"]
-    ts = f"{int(datetime.now().timestamp())}"
     await ensure_submittable_ward()
     async with AsyncSessionLocal() as s:
         async with s.begin():
+            # The recipe returns every chain id we need (academic_info/offering/
+            # criteria/method/offering_type), so no config→…→criteria re-walk.
             seed = await seed_submittable_offering_config(
                 s, unit_id=uid, academic_year=2026
             )
-            # Resolve the chain ids the strict path + doc group need; capture
-            # inside the transaction to avoid post-commit lazy access.
-            config = await s.get(
-                models.OfferingAdmissionConfig,
-                seed["offering_admission_config_id"],
-            )
-            academic_info = await s.get(
-                models.OfferingAcademicInfo, config.academic_info_id
-            )
-            offering = await s.get(models.ProgramOffering, academic_info.offering_id)
-            criteria = await s.get(models.AdmissionCriteria, config.criteria_id)
-            offering_id = offering.id
-            offering_type_id = offering.offering_type_id
-            method_id = criteria.method_id
+            method_id = seed["method_id"]
             round_id = await AdmissionRoundBuilder.get_or_create_default_round(
                 s, academic_year=2026
             )
 
             ap = models.AdmissionPath(
-                academic_info_id=academic_info.id,
+                academic_info_id=seed["academic_info_id"],
                 admission_method_id=method_id,
                 admission_round_id=round_id,
-                criteria_id=criteria.id,
+                criteria_id=seed["criteria_id"],
                 status="active", display_name="PR6 Strict", display_order=0,
                 visibility="public",
                 allow_unverified_submission=False,  # strict mode explicit
@@ -109,16 +98,20 @@ async def strict_path_config(seed_lead_dependencies: dict):
             await s.flush()
             path_id = ap.id
 
+            # Collision-free suffix (monotonic _next_id, not seconds-resolution
+            # datetime) — code columns are UNIQUE, and two same-second fixture
+            # instantiations would otherwise clash.
+            sid = _next_id()
             dt = models.ConfigDocumentType(
-                code=f"tcc_{ts}", name=f"TCC_{ts}", display_order=1
+                code=f"tcc_{sid}", name=f"TCC_{sid}", display_order=1
             )
             s.add(dt)
             await s.flush()
             doc_code = dt.code
             dg = models.DocumentGroup(
-                offering_type_id=offering_type_id,
+                offering_type_id=seed["offering_type_id"],
                 admission_method_id=method_id,
-                code=f"dg_{ts}", name=f"DG_{ts}", is_active=True,
+                code=f"dg_{sid}", name=f"DG_{sid}", is_active=True,
             )
             s.add(dg)
             await s.flush()
@@ -131,7 +124,7 @@ async def strict_path_config(seed_lead_dependencies: dict):
             await s.flush()
     return {
         "unit_id": uid,
-        "offering_id": offering_id,
+        "offering_id": seed["offering_id"],
         "method_id": method_id,
         "path_id": path_id,
         "doc_code": doc_code,
@@ -191,7 +184,7 @@ async def _fill_personal(client, oh, pid, *, school_id):
     family_info."""
     ts_cccd = f"{int(datetime.now().timestamp()) % 10**12:012d}"
     v = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()["version"]
-    await client.put(f"{ADMISSIONS}/{pid}", json={
+    r = await client.put(f"{ADMISSIONS}/{pid}", json={
         "version": v,
         "citizen_id": ts_cccd,
         "gender": "male",
@@ -213,6 +206,7 @@ async def _fill_personal(client, oh, pid, *, school_id):
         }],
         "admission_scores": {"gpa": 8.0, "subject_scores": {}},
     }, headers=oh)
+    assert r.status_code == 200, f"_fill_personal PUT failed: {r.status_code} {r.text}"
 
 
 @pytest.mark.asyncio
@@ -354,25 +348,29 @@ async def test_document_debt_flag_gated_on_required_data(
     strict_path_config: dict,
 ):
     """``can_submit_with_document_debt`` must NOT be advertised while family/
-    academic data is still missing.
+    academic data is still missing, and MUST be honoured once it is.
 
-    Those two groups hard-block submit-with-debt regardless of docs (the debt API
-    rejects them), so the flag, the (disabled) submit button and the API must all
-    agree — otherwise the response offers a debt submission that bounces.
+    Phase 2 fills the profile so it is GENUINELY submittable-with-debt (submittable
+    address incl. current-era commune_code + KV-resolvable academic_history via
+    ``school_id`` + cultural level), so the flag=True is faithful (not an optimistic
+    edge). Phase 3 then POSTs the advertised debt submission and asserts it is
+    ACCEPTED — closing the flag↔API loop the flag exists to guarantee.
     """
     prof = await _create_draft(
         client, admin_token_headers, officer_user_in_db, strict_path_config
     )
     pid = prof["id"]
+    school_id = strict_path_config["school_id"]
     oh = await _login(
         client, officer_user_in_db["username"], officer_user_in_db["password"]
     )
 
-    # Personal + address + scores complete, mandatory doc left MISSING (so the
-    # doc-debt path would otherwise be offered) — but family/academic omitted.
+    # Phase 1 — everything a submit-with-debt needs EXCEPT family/academic and the
+    # doc: personal + full submittable address + cultural level + scores. The
+    # mandatory doc is left MISSING so the doc-debt path would otherwise be offered.
     ts_cccd = f"{int(datetime.now().timestamp()) % 10**12:012d}"
     v = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()["version"]
-    await client.put(f"{ADMISSIONS}/{pid}", json={
+    r = await client.put(f"{ADMISSIONS}/{pid}", json={
         "version": v,
         "citizen_id": ts_cccd,
         "gender": "male",
@@ -380,30 +378,50 @@ async def test_document_debt_flag_gated_on_required_data(
         "nationality": "Viet Nam",
         "ethnicity": "Kinh",
         "place_of_birth": "Test",
-        "permanent_province": "Tỉnh Test KV",
-        "permanent_ward": "Phường Test KV",
+        "cultural_education_level": "graduated_thpt",
+        "vocational_qualification": "none",
+        **SUBMITTABLE_PERMANENT_ADDRESS,
         "admission_scores": {"gpa": 8.0, "subject_scores": {}},
     }, headers=oh)
+    assert r.status_code == 200, f"phase-1 PUT failed: {r.status_code} {r.text}"
 
     blocked = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
     assert blocked["submit_blocked_by_data"] is True, blocked
     assert blocked["can_submit_with_document_debt"] is False, blocked
 
-    # Supplying the required data unblocks BOTH — proving the doc-debt path was
-    # otherwise reachable and the missing family/academic was the only suppressor.
+    # Phase 2 — supply family + a KV-resolvable academic_history. The profile is
+    # now fully submittable-with-debt, so BOTH flags flip.
     v = blocked["version"]
-    await client.put(f"{ADMISSIONS}/{pid}", json={
+    r = await client.put(f"{ADMISSIONS}/{pid}", json={
         "version": v,
         "family_info": [{
             "relationship": "Cha", "full_name": "P",
             "phone": "0901111111", "is_primary_guardian": True,
         }],
         "academic_history": [{
-            "school_name": "THPT", "year_from": 2019,
-            "year_to": 2022, "gpa": 8.0, "graduation_type": "THPT",
+            "school_name": "THPT Submittable", "year_from": 2020,
+            "year_to": 2024, "gpa": 8.0, "graduation_type": "THPT",
+            "level": "THPT", "grade_to": 12, "school_id": school_id,
         }],
     }, headers=oh)
+    assert r.status_code == 200, f"phase-2 PUT failed: {r.status_code} {r.text}"
 
     ok = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
     assert ok["submit_blocked_by_data"] is False, ok
     assert ok["can_submit_with_document_debt"] is True, ok
+
+    # Phase 3 — honour the flag end-to-end: the advertised debt submission is
+    # ACCEPTED (status → submitted), not bounced back to draft. This is what makes
+    # the phase-2 flag=True faithful rather than over-advertised.
+    v = ok["version"]
+    submit = await client.post(
+        f"{ADMISSIONS}/{pid}/submit",
+        json={
+            "version": v,
+            "acknowledge_missing_docs": True,
+            "document_debt_reason": "Nợ giấy tờ — nộp trước, bổ sung sau (test)",
+        },
+        headers=oh,
+    )
+    assert submit.status_code == 200, submit.text
+    assert submit.json()["status"] == "submitted", submit.json()

--- a/Backend_FastAPI/tests/api/test_admission_submit_requires_verified_docs.py
+++ b/Backend_FastAPI/tests/api/test_admission_submit_requires_verified_docs.py
@@ -37,6 +37,7 @@ from httpx import AsyncClient
 
 from app import models
 from app.database import AsyncSessionLocal
+from tests.fixtures.builders import SUBMITTABLE_PERMANENT_ADDRESS
 from tests.fixtures.constants import AuthURLs, LeadsURLs
 
 
@@ -51,78 +52,91 @@ async def _login(client: AsyncClient, username: str, password: str) -> dict:
 
 @pytest_asyncio.fixture
 async def strict_path_config(seed_lead_dependencies: dict):
-    """Seed an admission path with allow_unverified_submission=False.
+    """Seed a STRICT admission path (allow_unverified_submission=False) on top of
+    the full #337 submittable offering chain.
 
-    Mirrors the inline fixture from prior PRs; duplicated so the test
-    file stays self-contained until a third consumer warrants a
-    promoted conftest fixture.
+    The prior inline seed lacked the legacy target-level config
+    (``OfferingAdmissionConfig`` + ``MajorProgram.degree_level_id``) and the KV
+    school, so ``submit_and_evaluate`` fail-closed with ``CONFIG_GAP_TARGET_LEVEL``
+    before ever reaching the doc-verification rule under test. Build on
+    ``seed_submittable_offering_config`` (the proven #337 recipe) and add ONLY the
+    strict path + a mandatory doc so the doc rule is the sole remaining gate.
+    Pair with the submittable ``_fill_personal`` (KV-resolvable academic_history
+    via ``school_id`` + submittable ward).
     """
+    from tests.fixtures.builders import (
+        AdmissionRoundBuilder,
+        ensure_submittable_ward,
+        seed_submittable_offering_config,
+    )
+
     uid = seed_lead_dependencies["unit_id"]
-    mpid = seed_lead_dependencies["major_program_id"]
     ts = f"{int(datetime.now().timestamp())}"
+    await ensure_submittable_ward()
     async with AsyncSessionLocal() as s:
         async with s.begin():
-            ot = models.ConfigOfferingType(code=f"tq_{ts}", name=f"TQ_{ts}", display_order=1)
-            s.add(ot); await s.flush()
-            dt = models.ConfigDocumentType(code=f"tcc_{ts}", name=f"TCC_{ts}", display_order=1)
-            s.add(dt); await s.flush()
-            po = models.ProgramOffering(
-                offering_type=f"TQ_{ts}", program_id=mpid, offering_type_id=ot.id,
-                is_active=True, duration_semesters=6,
+            seed = await seed_submittable_offering_config(
+                s, unit_id=uid, academic_year=2026
             )
-            s.add(po); await s.flush()
-            ai = models.OfferingAcademicInfo(
-                offering_id=po.id, academic_year=2026,
-                tuition_fee_per_year=5000000, annual_admission_quota=100, is_published=True,
+            # Resolve the chain ids the strict path + doc group need; capture
+            # inside the transaction to avoid post-commit lazy access.
+            config = await s.get(
+                models.OfferingAdmissionConfig,
+                seed["offering_admission_config_id"],
             )
-            s.add(ai); await s.flush()
-            am = models.AdmissionMethod(
-                code=f"hb_{ts}", name=f"HB_{ts}",
-                requires_gpa=True, requires_subject_scores=False, is_active=True,
+            academic_info = await s.get(
+                models.OfferingAcademicInfo, config.academic_info_id
             )
-            s.add(am); await s.flush()
-            ac = models.AdmissionCriteria(
-                method_id=am.id, code=f"TC_{ts}", name=f"TC_{ts}",
-                min_gpa=0.0, scoring_method="average", subject_selection_mode="fixed",
-                policy_version="2026.1", is_active=True,
+            offering = await s.get(models.ProgramOffering, academic_info.offering_id)
+            criteria = await s.get(models.AdmissionCriteria, config.criteria_id)
+            offering_id = offering.id
+            offering_type_id = offering.offering_type_id
+            method_id = criteria.method_id
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                s, academic_year=2026
             )
-            s.add(ac); await s.flush()
-            from tests.fixtures.builders import AdmissionRoundBuilder
-            round_id = await AdmissionRoundBuilder.get_or_create_default_round(s, academic_year=2026)
+
             ap = models.AdmissionPath(
-                academic_info_id=ai.id, admission_method_id=am.id,
-                admission_round_id=round_id, criteria_id=ac.id,
+                academic_info_id=academic_info.id,
+                admission_method_id=method_id,
+                admission_round_id=round_id,
+                criteria_id=criteria.id,
                 status="active", display_name="PR6 Strict", display_order=0,
                 visibility="public",
                 allow_unverified_submission=False,  # strict mode explicit
             )
-            s.add(ap); await s.flush()
+            s.add(ap)
+            await s.flush()
+            path_id = ap.id
+
+            dt = models.ConfigDocumentType(
+                code=f"tcc_{ts}", name=f"TCC_{ts}", display_order=1
+            )
+            s.add(dt)
+            await s.flush()
+            doc_code = dt.code
             dg = models.DocumentGroup(
-                offering_type_id=ot.id,
-                admission_method_id=am.id,
-                code=f"dg_{ts}",
-                name=f"DG_{ts}",
-                is_active=True,
+                offering_type_id=offering_type_id,
+                admission_method_id=method_id,
+                code=f"dg_{ts}", name=f"DG_{ts}", is_active=True,
             )
-            s.add(dg); await s.flush()
+            s.add(dg)
+            await s.flush()
             dgi = models.DocumentGroupItem(
-                group_id=dg.id,
-                document_type_id=dt.id,
-                is_mandatory=True,
-                requires_upload=True,
-                submission_format="photo",
-                display_order=1,
+                group_id=dg.id, document_type_id=dt.id,
+                is_mandatory=True, requires_upload=True,
+                submission_format="photo", display_order=1,
             )
-            s.add(dgi); await s.flush()
+            s.add(dgi)
+            await s.flush()
     return {
         "unit_id": uid,
-        "offering_id": po.id,
-        "method_id": am.id,
-        "path_id": ap.id,
-        "doc_code": dt.code,
-        # Round contract hardening (plan v4): expose seeded round for the
-        # now-required admission_round_id on create-profile.
+        "offering_id": offering_id,
+        "method_id": method_id,
+        "path_id": path_id,
+        "doc_code": doc_code,
         "round_id": round_id,
+        "school_id": seed["school_id"],
     }
 
 
@@ -170,8 +184,11 @@ async def _officer_upload(client, oh, pid, doc_code):
     )
 
 
-async def _fill_personal(client, oh, pid):
-    """Fill required personal fields so submit doesn't fail on those instead of docs."""
+async def _fill_personal(client, oh, pid, *, school_id):
+    """Clear every NON-doc submit gate so submit outcome hinges purely on the doc
+    rule: personal fields + submittable address + graduated_thpt cultural level +
+    a KV-resolvable THPT academic_history (``school_id`` → seeded VnSchool) +
+    family_info."""
     ts_cccd = f"{int(datetime.now().timestamp()) % 10**12:012d}"
     v = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()["version"]
     await client.put(f"{ADMISSIONS}/{pid}", json={
@@ -182,8 +199,18 @@ async def _fill_personal(client, oh, pid):
         "nationality": "Viet Nam",
         "ethnicity": "Kinh",
         "place_of_birth": "Test",
-        "family_info": [{"relationship": "Cha", "full_name": "P", "phone": "0901111111", "is_primary_guardian": True}],
-        "academic_history": [{"school_name": "THPT", "year_from": 2019, "year_to": 2022, "gpa": 8.0, "graduation_type": "THPT"}],
+        "cultural_education_level": "graduated_thpt",
+        "vocational_qualification": "none",
+        **SUBMITTABLE_PERMANENT_ADDRESS,
+        "family_info": [{
+            "relationship": "Cha", "full_name": "P",
+            "phone": "0901111111", "is_primary_guardian": True,
+        }],
+        "academic_history": [{
+            "school_name": "THPT Submittable", "year_from": 2020,
+            "year_to": 2024, "gpa": 8.0, "graduation_type": "THPT",
+            "level": "THPT", "grade_to": 12, "school_id": school_id,
+        }],
         "admission_scores": {"gpa": 8.0, "subject_scores": {}},
     }, headers=oh)
 
@@ -200,7 +227,7 @@ async def test_strict_path_blocks_submit_with_uploaded_only(
     pid = prof["id"]
 
     oh = await _login(client, officer_user_in_db["username"], officer_user_in_db["password"])
-    await _fill_personal(client, oh, pid)
+    await _fill_personal(client, oh, pid, school_id=strict_path_config["school_id"])
     assert (await _officer_upload(client, oh, pid, strict_path_config["doc_code"])).status_code in (200, 201)
 
     # Debug: confirm the snapshot is strict before submit.
@@ -236,7 +263,7 @@ async def test_strict_path_allows_submit_when_verified(
     pid = prof["id"]
 
     oh = await _login(client, officer_user_in_db["username"], officer_user_in_db["password"])
-    await _fill_personal(client, oh, pid)
+    await _fill_personal(client, oh, pid, school_id=strict_path_config["school_id"])
     assert (await _officer_upload(client, oh, pid, strict_path_config["doc_code"])).status_code in (200, 201)
 
     # Admin verifies (officer doesn't have verify permission per PR #5 service guard).
@@ -311,7 +338,7 @@ async def test_legacy_schema_v1_profile_grandfathered(
                     ))
 
     oh = await _login(client, officer_user_in_db["username"], officer_user_in_db["password"])
-    await _fill_personal(client, oh, pid)
+    await _fill_personal(client, oh, pid, school_id=strict_path_config["school_id"])
     assert (await _officer_upload(client, oh, pid, strict_path_config["doc_code"])).status_code in (200, 201)
 
     v = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()["version"]

--- a/Backend_FastAPI/tests/api/test_admission_submit_requires_verified_docs.py
+++ b/Backend_FastAPI/tests/api/test_admission_submit_requires_verified_docs.py
@@ -317,3 +317,66 @@ async def test_legacy_schema_v1_profile_grandfathered(
     v = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()["version"]
     resp = await client.post(f"{ADMISSIONS}/{pid}/submit", json={"version": v}, headers=oh)
     assert resp.status_code == 200, f"Legacy profile should still submit, got {resp.status_code}: {resp.text[:300]}"
+
+
+@pytest.mark.asyncio
+async def test_document_debt_flag_gated_on_required_data(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    strict_path_config: dict,
+):
+    """``can_submit_with_document_debt`` must NOT be advertised while family/
+    academic data is still missing.
+
+    Those two groups hard-block submit-with-debt regardless of docs (the debt API
+    rejects them), so the flag, the (disabled) submit button and the API must all
+    agree — otherwise the response offers a debt submission that bounces.
+    """
+    prof = await _create_draft(
+        client, admin_token_headers, officer_user_in_db, strict_path_config
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+
+    # Personal + address + scores complete, mandatory doc left MISSING (so the
+    # doc-debt path would otherwise be offered) — but family/academic omitted.
+    ts_cccd = f"{int(datetime.now().timestamp()) % 10**12:012d}"
+    v = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()["version"]
+    await client.put(f"{ADMISSIONS}/{pid}", json={
+        "version": v,
+        "citizen_id": ts_cccd,
+        "gender": "male",
+        "dob": "2001-01-01",
+        "nationality": "Viet Nam",
+        "ethnicity": "Kinh",
+        "place_of_birth": "Test",
+        "permanent_province": "Tỉnh Test KV",
+        "permanent_ward": "Phường Test KV",
+        "admission_scores": {"gpa": 8.0, "subject_scores": {}},
+    }, headers=oh)
+
+    blocked = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
+    assert blocked["submit_blocked_by_data"] is True, blocked
+    assert blocked["can_submit_with_document_debt"] is False, blocked
+
+    # Supplying the required data unblocks BOTH — proving the doc-debt path was
+    # otherwise reachable and the missing family/academic was the only suppressor.
+    v = blocked["version"]
+    await client.put(f"{ADMISSIONS}/{pid}", json={
+        "version": v,
+        "family_info": [{
+            "relationship": "Cha", "full_name": "P",
+            "phone": "0901111111", "is_primary_guardian": True,
+        }],
+        "academic_history": [{
+            "school_name": "THPT", "year_from": 2019,
+            "year_to": 2022, "gpa": 8.0, "graduation_type": "THPT",
+        }],
+    }, headers=oh)
+
+    ok = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
+    assert ok["submit_blocked_by_data"] is False, ok
+    assert ok["can_submit_with_document_debt"] is True, ok

--- a/Backend_FastAPI/tests/fixtures/builders.py
+++ b/Backend_FastAPI/tests/fixtures/builders.py
@@ -240,6 +240,13 @@ async def seed_submittable_offering_config(
         "school_id": school.id,
         "academic_year": academic_year,
         "major_program_id": major.id,
+        # Chain ids so consumers building an AdmissionPath / DocumentGroup on top
+        # don't have to re-walk config→academic_info→offering→criteria.
+        "academic_info_id": academic_info.id,
+        "offering_id": offering.id,
+        "offering_type_id": offering_type.id,
+        "criteria_id": criteria.id,
+        "method_id": method.id,
     }
 
 

--- a/Backend_FastAPI/tests/unit/test_primary_choice_display.py
+++ b/Backend_FastAPI/tests/unit/test_primary_choice_display.py
@@ -1,0 +1,60 @@
+"""Unit tests for AdmissionProfileResponse.primary_choice_display (computed field).
+
+Pure schema logic — no DB. Uses ``model_construct`` to set only the fields the
+computed property reads (choices / uses_choice_engine / program_name) and passes
+duck-typed choice stand-ins (SimpleNamespace) for the display attributes.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.admission import AdmissionProfileResponse
+
+
+def _resp(**kwargs) -> AdmissionProfileResponse:
+    return AdmissionProfileResponse.model_construct(**kwargs)
+
+
+def _choice(order: int, program: str = "", path: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        display_order=order,
+        display_program_name=program,
+        display_path_name=path,
+    )
+
+
+@pytest.mark.unit
+class TestPrimaryChoiceDisplay:
+    def test_choice_engine_uses_lowest_display_order(self):
+        r = _resp(
+            choices=[_choice(2, "Dược"), _choice(1, "Điều dưỡng")],
+            uses_choice_engine=True,
+            program_name="stale lead offering",
+        )
+        assert r.primary_choice_display == "Điều dưỡng"
+
+    def test_choice_engine_falls_back_to_path_when_program_blank(self):
+        r = _resp(
+            choices=[_choice(1, "  ", "Điều dưỡng - Chính quy - Học bạ")],
+            uses_choice_engine=True,
+            program_name=None,
+        )
+        assert r.primary_choice_display == "Điều dưỡng - Chính quy - Học bạ"
+
+    def test_legacy_uses_program_name(self):
+        r = _resp(choices=[], uses_choice_engine=False, program_name="Điều dưỡng")
+        assert r.primary_choice_display == "Điều dưỡng"
+
+    def test_empty_choice_engine_is_none_not_stale_program_name(self):
+        # A choice-engine profile with no choices yet must NOT surface the
+        # denormalized program_name (which may be a stale lead/offering value).
+        r = _resp(choices=[], uses_choice_engine=True, program_name="stale")
+        assert r.primary_choice_display is None
+
+    def test_none_when_nothing_available(self):
+        r = _resp(choices=[], uses_choice_engine=False, program_name=None)
+        assert r.primary_choice_display is None
+
+    def test_legacy_blank_program_name_is_none(self):
+        r = _resp(choices=[], uses_choice_engine=False, program_name="   ")
+        assert r.primary_choice_display is None

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
@@ -58,6 +58,7 @@ import { usePermissions } from "@/hooks/usePermissions"
 
 // Layout & Components
 import { AdmissionLayout } from "./layout/AdmissionLayout"
+import { derivePriorityIssues, firstAttentionStep } from "./layout/priorityIssues"
 import { AdmissionActions } from "./AdmissionActions"
 import { StatusBanner } from "@/components/ui/StatusBanner"
 
@@ -489,20 +490,15 @@ export function AdmissionDetailClient({
   }
 
   const handleCheckCondition = () => {
-    // Navigate to the first step needing attention using backend-computed status.
-    // Phase E.4 (G0) — 8-step: 1=Personal, 2=Family, 3=Academic,
-    // 4=Priority, 5=Scores, 6=Documents, 7=Tuition, 8=Finalize.
-    // Prefer "error" steps, then fall back to "warning": family/academic
-    // (step 2/3) surface as "warning", so an error-only jump would dead-end for a
-    // draft blocked solely by them (the submit button disables on those too).
-    for (const target of ["error", "warning"] as const) {
-      for (let step = 1; step <= 8; step++) {
-        if (stepsStatusRecord[step] === target) {
-          handleStepChange(step)
-          return
-        }
-      }
-    }
+    // Route to the step that actually needs attention, driven by the SAME issue
+    // sources that feed the header "việc cần xử lý" count (validation + priority +
+    // required-data) so the CTA can never dead-end or land on an unrelated tab.
+    // Decision logic lives in the pure, unit-tested `firstAttentionStep` helper.
+    const target = firstAttentionStep(stepsStatusRecord, {
+      requiredDataCount: groupedValidationErrors?.required_data?.count ?? 0,
+      priorityIssuesCount: derivePriorityIssues(profile).length,
+    })
+    if (target !== null) handleStepChange(target)
   }
 
   if (!profile) return null

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
@@ -516,6 +516,7 @@ export function AdmissionDetailClient({
         profile={profile}
         currentStep={currentStep}
         onStepChange={handleStepChange}
+        onCheckCondition={handleCheckCondition}
         stepsStatus={stepsStatusRecord}
         validationErrors={validationErrors}
         validationSummary={validationSummary}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
@@ -574,8 +574,10 @@ export function AdmissionDetailClient({
           </div>
         )}
 
-        {/* TAB CONTENT */}
-        <div className="bg-card rounded-lg shadow-sm min-h-[500px] p-1">
+        {/* TAB CONTENT — no wrapper card: each tab renders its own Card(s), so an
+            outer bg-card/shadow here was a redundant card-in-card that boxed the
+            form. Keep only min-height so switching steps doesn't jump the layout. */}
+        <div className="min-h-[500px]">
           {currentStep === 1 && <PersonalInfoTab profile={profile} form={form} isEditable={can('edit')} />}
           {currentStep === 2 && <FamilyTab form={form} isEditable={can('edit')} />}
           {currentStep === 3 && <AcademicHistoryTab form={form} isEditable={can('edit')} />}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
@@ -489,13 +489,18 @@ export function AdmissionDetailClient({
   }
 
   const handleCheckCondition = () => {
-    // Navigate to first error step using backend-computed status.
+    // Navigate to the first step needing attention using backend-computed status.
     // Phase E.4 (G0) — 8-step: 1=Personal, 2=Family, 3=Academic,
     // 4=Priority, 5=Scores, 6=Documents, 7=Tuition, 8=Finalize.
-    for (let step = 1; step <= 8; step++) {
-      if (stepsStatusRecord[step] === "error") {
-        handleStepChange(step)
-        return
+    // Prefer "error" steps, then fall back to "warning": family/academic
+    // (step 2/3) surface as "warning", so an error-only jump would dead-end for a
+    // draft blocked solely by them (the submit button disables on those too).
+    for (const target of ["error", "warning"] as const) {
+      for (let step = 1; step <= 8; step++) {
+        if (stepsStatusRecord[step] === target) {
+          handleStepChange(step)
+          return
+        }
       }
     }
   }

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
@@ -58,7 +58,7 @@ import { usePermissions } from "@/hooks/usePermissions"
 
 // Layout & Components
 import { AdmissionLayout } from "./layout/AdmissionLayout"
-import { derivePriorityIssues, firstAttentionStep } from "./layout/priorityIssues"
+import { derivePriorityIssues, firstAttentionStep, missingRequiredDataSteps } from "./layout/priorityIssues"
 import { AdmissionActions } from "./AdmissionActions"
 import { StatusBanner } from "@/components/ui/StatusBanner"
 
@@ -495,7 +495,7 @@ export function AdmissionDetailClient({
     // required-data) so the CTA can never dead-end or land on an unrelated tab.
     // Decision logic lives in the pure, unit-tested `firstAttentionStep` helper.
     const target = firstAttentionStep(stepsStatusRecord, {
-      requiredDataCount: groupedValidationErrors?.required_data?.count ?? 0,
+      requiredDataSteps: missingRequiredDataSteps(profile),
       priorityIssuesCount: derivePriorityIssues(profile).length,
     })
     if (target !== null) handleStepChange(target)

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
@@ -9,6 +9,7 @@
 import { describe, it, expect, vi } from "vitest"
 import { render, screen, fireEvent } from "@testing-library/react"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+import type { AdmissionProfileChoiceResponse } from "@/lib/zod/admission-choices"
 
 // Mock FeeStatusLink (depends on react-query)
 vi.mock("@/components/finance", () => ({
@@ -49,7 +50,7 @@ function buildProfile(overrides: Partial<AdmissionProfileResponse> = {}): Admiss
 }
 
 /** A choice-engine nguyện vọng row with sane defaults; override per test. */
-function buildChoice(overrides: Record<string, unknown> = {}) {
+function buildChoice(overrides: Partial<AdmissionProfileChoiceResponse> = {}) {
   return {
     id: 1,
     admission_profile_id: 42,

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
@@ -119,21 +119,20 @@ describe("AdmissionHeader — dải trạng thái", () => {
     expect(screen.getByText("Chưa chọn nguyện vọng")).toBeInTheDocument()
   })
 
-  it("falls back to legacy program_name when choices empty (uses_choice_engine=false)", () => {
-    // Legacy single-NV profiles carry no choices[] but still identify the program
-    // via program_name — must NOT read "Chưa chọn nguyện vọng".
-    render(<AdmissionHeader profile={buildProfile({ uses_choice_engine: false, choices: [], program_name: "Điều dưỡng" } as Partial<AdmissionProfileResponse>)} />)
+  it("renders the BE-resolved primary_choice_display when choices empty (legacy single-NV)", () => {
+    // The header reads the SINGLE BE-resolved field (provenance — choice-engine vs
+    // legacy vs empty — is decided by the backend), so a resolved name must NOT
+    // read "Chưa chọn nguyện vọng".
+    render(<AdmissionHeader profile={buildProfile({ choices: [], primary_choice_display: "Điều dưỡng" } as Partial<AdmissionProfileResponse>)} />)
     expect(screen.getByText("Điều dưỡng")).toBeInTheDocument()
     expect(screen.queryByText("Chưa chọn nguyện vọng")).not.toBeInTheDocument()
   })
 
-  it("does NOT show program_name for a choice-engine profile with empty choices[] (reads 'Chưa chọn nguyện vọng')", () => {
-    // uses_choice_engine=true → nguyện vọng comes from choices[]; an empty choices[]
-    // genuinely has none yet, and program_name may be a stale lead/offering display
-    // value → must not masquerade as a chosen program.
-    render(<AdmissionHeader profile={buildProfile({ uses_choice_engine: true, choices: [], program_name: "Điều dưỡng" } as Partial<AdmissionProfileResponse>)} />)
+  it("reads 'Chưa chọn nguyện vọng' when choices empty and primary_choice_display is null", () => {
+    // The backend returns null for an empty choice-engine profile (no stale
+    // program_name leak) — the FE just trusts the field.
+    render(<AdmissionHeader profile={buildProfile({ choices: [], primary_choice_display: null } as Partial<AdmissionProfileResponse>)} />)
     expect(screen.getByText("Chưa chọn nguyện vọng")).toBeInTheDocument()
-    expect(screen.queryByText("Điều dưỡng")).not.toBeInTheDocument()
   })
 
   // ----- phụ trách -----

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
@@ -48,6 +48,26 @@ function buildProfile(overrides: Partial<AdmissionProfileResponse> = {}): Admiss
   } as unknown as AdmissionProfileResponse
 }
 
+/** A choice-engine nguyện vọng row with sane defaults; override per test. */
+function buildChoice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    admission_profile_id: 42,
+    admission_path_id: 7,
+    path_subject_group_config_id: 3,
+    display_order: 1,
+    decision: "pending",
+    display_path_name: "Điều dưỡng 2026 – Chính quy – Học bạ",
+    display_program_name: "Điều dưỡng",
+    display_degree_level: "Cao đẳng",
+    display_subject_group_name: "B00",
+    scores: [],
+    data_complete: false,
+    threshold_failure_reasons: [],
+    ...overrides,
+  }
+}
+
 describe("AdmissionHeader — dải trạng thái", () => {
   it("renders applicant name + #id", () => {
     render(<AdmissionHeader profile={buildProfile()} />)
@@ -91,14 +111,7 @@ describe("AdmissionHeader — dải trạng thái", () => {
   // ----- nguyện vọng (đăng ký ngành gì) -----
   it("renders the registered major (nguyện vọng) from choices", () => {
     const profile = buildProfile({
-      choices: [
-        {
-          id: 1, admission_profile_id: 42, admission_path_id: 7, path_subject_group_config_id: 3,
-          display_order: 1, decision: "pending", display_path_name: "Điều dưỡng 2026 – Chính quy – Học bạ",
-          display_program_name: "Điều dưỡng", display_degree_level: "Cao đẳng",
-          display_subject_group_name: "B00", scores: [], data_complete: false, threshold_failure_reasons: [],
-        },
-      ],
+      choices: [buildChoice()],
     } as unknown as Partial<AdmissionProfileResponse>)
     render(<AdmissionHeader profile={profile} />)
     expect(screen.getByText("Điều dưỡng")).toBeInTheDocument()
@@ -108,8 +121,11 @@ describe("AdmissionHeader — dải trạng thái", () => {
   it("shows '+N NV' for multi-NV and 'Chưa chọn nguyện vọng' when empty", () => {
     const multi = buildProfile({
       choices: [
-        { id: 1, display_order: 1, display_program_name: "Dược", display_degree_level: "Cao đẳng", display_path_name: "Dược", display_subject_group_name: "B00", decision: "pending", scores: [], data_complete: false, threshold_failure_reasons: [], admission_profile_id: 42, admission_path_id: 7, path_subject_group_config_id: 3 },
-        { id: 2, display_order: 2, display_program_name: "Điều dưỡng", display_degree_level: "Cao đẳng", display_path_name: "Điều dưỡng", display_subject_group_name: "B00", decision: "pending", scores: [], data_complete: false, threshold_failure_reasons: [], admission_profile_id: 42, admission_path_id: 8, path_subject_group_config_id: 4 },
+        buildChoice({ display_program_name: "Dược", display_path_name: "Dược" }),
+        buildChoice({
+          id: 2, display_order: 2, display_program_name: "Điều dưỡng",
+          display_path_name: "Điều dưỡng", admission_path_id: 8, path_subject_group_config_id: 4,
+        }),
       ],
     } as unknown as Partial<AdmissionProfileResponse>)
     render(<AdmissionHeader profile={multi} />)

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
@@ -1,12 +1,13 @@
 /**
- * AdmissionHeader chips — Commit 4 cockpit anchor tests.
+ * AdmissionHeader — "Dải trạng thái hồ sơ" case status header.
  *
- * Pin: review signal chips render đúng theo BE field; KHÔNG render
- * khi profile null.
+ * Pin: the header answers who · nguyện vọng · phụ trách · trạng thái · verdict ·
+ * việc cần xử lý, all BE-driven; the CTA jumps to the first blocking step; nothing
+ * renders for a null profile.
  */
 
 import { describe, it, expect, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
 // Mock FeeStatusLink (depends on react-query)
@@ -32,77 +33,121 @@ function buildProfile(overrides: Partial<AdmissionProfileResponse> = {}): Admiss
     family_info: [],
     academic_history: [],
     documents_checklist: [],
+    choices: [],
+    // Neutral priority state so derivePriorityIssues() = 0 by default (tests that
+    // want work items set validation_errors / cultural explicitly).
+    cultural_education_level: "THPT",
     missing_priority_evidence_codes: [],
-    priority_resolution_snapshot: {},
+    priority_resolution_snapshot: { kv_resolved: "KV2" },
+    grouped_validation_errors: null,
     document_stats: { verified_count: 5, submitted_count: 6, mandatory_count: 8, missing_count: 2 },
+    assigned_officer_name: "Ksor Ho Hơn",
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     ...overrides,
   } as unknown as AdmissionProfileResponse
 }
 
-describe("AdmissionHeader — Commit 4 review signal chips", () => {
-  it("renders completion chip", () => {
-    render(<AdmissionHeader profile={buildProfile({ completion_percent: 80 })} />)
-    expect(screen.getByTestId("header-chip-completion")).toHaveTextContent("80%")
+describe("AdmissionHeader — dải trạng thái", () => {
+  it("renders applicant name + #id", () => {
+    render(<AdmissionHeader profile={buildProfile()} />)
+    expect(screen.getByRole("heading")).toHaveTextContent("Nguyễn Văn A")
+    expect(screen.getByRole("heading")).toHaveTextContent("#42")
   })
 
-  it("renders eligibility chip", () => {
+  it("renders the eligibility verdict", () => {
     render(<AdmissionHeader profile={buildProfile({ eligibility_status: "eligible" })} />)
     expect(screen.getByTestId("header-chip-eligibility")).toHaveTextContent("Đủ điều kiện")
   })
 
-  it("renders ineligible eligibility chip with warning style", () => {
+  it("renders ineligible verdict", () => {
     render(<AdmissionHeader profile={buildProfile({ eligibility_status: "ineligible" })} />)
     expect(screen.getByTestId("header-chip-eligibility")).toHaveTextContent("Chưa đủ điều kiện")
   })
 
-  it("renders KV chip when snapshot.kv_resolved set", () => {
-    const profile = buildProfile({
-      priority_resolution_snapshot: { kv_resolved: "KV1" },
-    } as Partial<AdmissionProfileResponse>)
-    render(<AdmissionHeader profile={profile} />)
-    expect(screen.getByTestId("header-chip-kv")).toHaveTextContent("KV1")
+  it("renders completion %", () => {
+    render(<AdmissionHeader profile={buildProfile({ completion_percent: 80 })} />)
+    expect(screen.getByTestId("header-chip-completion")).toHaveTextContent("80%")
   })
 
-  it("renders UT bucket chip when ut_verified_bucket.applied_code set", () => {
-    const profile = buildProfile({
-      priority_resolution_snapshot: {
-        ut_verified_bucket: { applied_code: "07", applied_rate: 1.0 },
-      },
-    } as Partial<AdmissionProfileResponse>)
-    render(<AdmissionHeader profile={profile} />)
-    expect(screen.getByTestId("header-chip-ut")).toHaveTextContent("UT07")
-  })
-
-  it("renders docs ratio chip when mandatory_count > 0", () => {
-    render(<AdmissionHeader profile={buildProfile()} />)
+  it("renders docs ratio when mandatory_count > 0; hides when 0", () => {
+    const { rerender } = render(<AdmissionHeader profile={buildProfile()} />)
     expect(screen.getByTestId("header-chip-docs")).toHaveTextContent("5/8")
-  })
-
-  it("hides docs chip when mandatory_count=0", () => {
-    const profile = buildProfile({
-      document_stats: { verified_count: 0, submitted_count: 0, mandatory_count: 0, missing_count: 0 },
-    } as Partial<AdmissionProfileResponse>)
-    render(<AdmissionHeader profile={profile} />)
+    rerender(
+      <AdmissionHeader
+        profile={buildProfile({
+          document_stats: { verified_count: 0, submitted_count: 0, mandatory_count: 0, missing_count: 0 },
+        } as Partial<AdmissionProfileResponse>)}
+      />,
+    )
     expect(screen.queryByTestId("header-chip-docs")).not.toBeInTheDocument()
   })
 
-  it("renders blocker chip when validation_errors > 0", () => {
-    const profile = buildProfile({ validation_errors: ["Thiếu CCCD", "Thiếu họ tên"] })
-    render(<AdmissionHeader profile={profile} />)
-    expect(screen.getByTestId("header-chip-blockers")).toHaveTextContent("2 vấn đề")
+  it("renders KV ledger item when snapshot.kv_resolved set", () => {
+    render(<AdmissionHeader profile={buildProfile({ priority_resolution_snapshot: { kv_resolved: "KV1" } } as Partial<AdmissionProfileResponse>)} />)
+    expect(screen.getByTestId("header-chip-kv")).toHaveTextContent("KV1")
   })
 
-  it("hides blocker chip when validation_errors empty", () => {
-    render(<AdmissionHeader profile={buildProfile({ validation_errors: [] })} />)
+  // ----- nguyện vọng (đăng ký ngành gì) -----
+  it("renders the registered major (nguyện vọng) from choices", () => {
+    const profile = buildProfile({
+      choices: [
+        {
+          id: 1, admission_profile_id: 42, admission_path_id: 7, path_subject_group_config_id: 3,
+          display_order: 1, decision: "pending", display_path_name: "Điều dưỡng 2026 – Chính quy – Học bạ",
+          display_program_name: "Điều dưỡng", display_degree_level: "Cao đẳng",
+          display_subject_group_name: "B00", scores: [], data_complete: false, threshold_failure_reasons: [],
+        },
+      ],
+    } as unknown as Partial<AdmissionProfileResponse>)
+    render(<AdmissionHeader profile={profile} />)
+    expect(screen.getByText("Điều dưỡng")).toBeInTheDocument()
+    expect(screen.getByText("NV1")).toBeInTheDocument()
+  })
+
+  it("shows '+N NV' for multi-NV and 'Chưa chọn nguyện vọng' when empty", () => {
+    const multi = buildProfile({
+      choices: [
+        { id: 1, display_order: 1, display_program_name: "Dược", display_degree_level: "Cao đẳng", display_path_name: "Dược", display_subject_group_name: "B00", decision: "pending", scores: [], data_complete: false, threshold_failure_reasons: [], admission_profile_id: 42, admission_path_id: 7, path_subject_group_config_id: 3 },
+        { id: 2, display_order: 2, display_program_name: "Điều dưỡng", display_degree_level: "Cao đẳng", display_path_name: "Điều dưỡng", display_subject_group_name: "B00", decision: "pending", scores: [], data_complete: false, threshold_failure_reasons: [], admission_profile_id: 42, admission_path_id: 8, path_subject_group_config_id: 4 },
+      ],
+    } as unknown as Partial<AdmissionProfileResponse>)
+    render(<AdmissionHeader profile={multi} />)
+    expect(screen.getByText("+1 NV")).toBeInTheDocument()
+
+    render(<AdmissionHeader profile={buildProfile({ choices: [] })} />)
+    expect(screen.getByText("Chưa chọn nguyện vọng")).toBeInTheDocument()
+  })
+
+  // ----- phụ trách -----
+  it("renders the assigned officer; 'Chưa phân công' when absent", () => {
+    render(<AdmissionHeader profile={buildProfile({ assigned_officer_name: "Ksor Ho Hơn" })} />)
+    expect(screen.getByText("Ksor Ho Hơn")).toBeInTheDocument()
+    render(<AdmissionHeader profile={buildProfile({ assigned_officer_name: undefined } as Partial<AdmissionProfileResponse>)} />)
+    expect(screen.getByText("Chưa phân công")).toBeInTheDocument()
+  })
+
+  // ----- việc cần xử lý CTA -----
+  it("shows the work-items CTA and jumps to the first blocking step on click", () => {
+    const onCheckCondition = vi.fn()
+    render(<AdmissionHeader profile={buildProfile({ validation_errors: ["Thiếu CCCD", "Thiếu họ tên"] })} onCheckCondition={onCheckCondition} />)
+    const cta = screen.getByTestId("header-chip-blockers")
+    expect(cta).toHaveTextContent("việc")
+    fireEvent.click(cta)
+    expect(onCheckCondition).toHaveBeenCalledTimes(1)
+  })
+
+  it("hides the work-items CTA when nothing is blocking", () => {
+    // Neutral profile: no validation errors, priority resolved (kv set + cultural
+    // set + draft so the post-submit-kv rule doesn't fire), no required-data.
+    render(<AdmissionHeader profile={buildProfile({ status: "draft", validation_errors: [], grouped_validation_errors: null })} />)
     expect(screen.queryByTestId("header-chip-blockers")).not.toBeInTheDocument()
   })
 
-  it("renders no chips when profile=null", () => {
+  it("renders nothing but a placeholder heading when profile=null", () => {
     render(<AdmissionHeader profile={null} />)
-    expect(screen.queryByTestId("header-chip-completion")).not.toBeInTheDocument()
     expect(screen.queryByTestId("header-chip-eligibility")).not.toBeInTheDocument()
-    expect(screen.queryByTestId("header-chip-kv")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("header-chip-completion")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("header-chip-blockers")).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
@@ -119,12 +119,21 @@ describe("AdmissionHeader — dải trạng thái", () => {
     expect(screen.getByText("Chưa chọn nguyện vọng")).toBeInTheDocument()
   })
 
-  it("falls back to legacy program_name when choices empty (single-NV profile)", () => {
-    // uses_choice_engine=false legacy profiles carry no choices[] but still
-    // identify the program via program_name — must NOT read "Chưa chọn nguyện vọng".
-    render(<AdmissionHeader profile={buildProfile({ choices: [], program_name: "Điều dưỡng" } as Partial<AdmissionProfileResponse>)} />)
+  it("falls back to legacy program_name when choices empty (uses_choice_engine=false)", () => {
+    // Legacy single-NV profiles carry no choices[] but still identify the program
+    // via program_name — must NOT read "Chưa chọn nguyện vọng".
+    render(<AdmissionHeader profile={buildProfile({ uses_choice_engine: false, choices: [], program_name: "Điều dưỡng" } as Partial<AdmissionProfileResponse>)} />)
     expect(screen.getByText("Điều dưỡng")).toBeInTheDocument()
     expect(screen.queryByText("Chưa chọn nguyện vọng")).not.toBeInTheDocument()
+  })
+
+  it("does NOT show program_name for a choice-engine profile with empty choices[] (reads 'Chưa chọn nguyện vọng')", () => {
+    // uses_choice_engine=true → nguyện vọng comes from choices[]; an empty choices[]
+    // genuinely has none yet, and program_name may be a stale lead/offering display
+    // value → must not masquerade as a chosen program.
+    render(<AdmissionHeader profile={buildProfile({ uses_choice_engine: true, choices: [], program_name: "Điều dưỡng" } as Partial<AdmissionProfileResponse>)} />)
+    expect(screen.getByText("Chưa chọn nguyện vọng")).toBeInTheDocument()
+    expect(screen.queryByText("Điều dưỡng")).not.toBeInTheDocument()
   })
 
   // ----- phụ trách -----

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.test.tsx
@@ -119,6 +119,14 @@ describe("AdmissionHeader — dải trạng thái", () => {
     expect(screen.getByText("Chưa chọn nguyện vọng")).toBeInTheDocument()
   })
 
+  it("falls back to legacy program_name when choices empty (single-NV profile)", () => {
+    // uses_choice_engine=false legacy profiles carry no choices[] but still
+    // identify the program via program_name — must NOT read "Chưa chọn nguyện vọng".
+    render(<AdmissionHeader profile={buildProfile({ choices: [], program_name: "Điều dưỡng" } as Partial<AdmissionProfileResponse>)} />)
+    expect(screen.getByText("Điều dưỡng")).toBeInTheDocument()
+    expect(screen.queryByText("Chưa chọn nguyện vọng")).not.toBeInTheDocument()
+  })
+
   // ----- phụ trách -----
   it("renders the assigned officer; 'Chưa phân công' when absent", () => {
     render(<AdmissionHeader profile={buildProfile({ assigned_officer_name: "Ksor Ho Hơn" })} />)

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
@@ -75,6 +75,10 @@ export function AdmissionHeader({
   const choices = [...(profile.choices ?? [])].sort((a, b) => a.display_order - b.display_order)
   const firstChoice = choices[0]
   const extraChoices = Math.max(0, choices.length - 1)
+  // Legacy single-NV profiles (uses_choice_engine=false) carry no choices[] but
+  // still identify the selected program via the denormalized program_name. Fall
+  // back to it so those valid profiles don't falsely read "Chưa chọn nguyện vọng".
+  const legacyProgram = firstChoice ? null : profile.program_name?.trim() || null
 
   // "Việc cần xử lý" = the same count the IssueSummary panel shows (validation +
   // priority + required-data), so the header and the panel never disagree.
@@ -167,6 +171,8 @@ export function AdmissionHeader({
                 </span>
               )}
             </>
+          ) : legacyProgram ? (
+            <span className="truncate font-semibold text-foreground">{legacyProgram}</span>
           ) : (
             <span className="text-muted-foreground">Chưa chọn nguyện vọng</span>
           )}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
@@ -77,8 +77,11 @@ export function AdmissionHeader({
   const extraChoices = Math.max(0, choices.length - 1)
   // Legacy single-NV profiles (uses_choice_engine=false) carry no choices[] but
   // still identify the selected program via the denormalized program_name. Fall
-  // back to it so those valid profiles don't falsely read "Chưa chọn nguyện vọng".
-  const legacyProgram = firstChoice ? null : profile.program_name?.trim() || null
+  // back to it ONLY for those — a real choice-engine profile with an empty
+  // choices[] genuinely has no nguyện vọng yet (program_name may be a stale
+  // lead/offering display value), so it must read "Chưa chọn nguyện vọng".
+  const legacyProgram =
+    firstChoice || profile.uses_choice_engine ? null : profile.program_name?.trim() || null
 
   // "Việc cần xử lý" = the same count the IssueSummary panel shows (validation +
   // priority + required-data), so the header and the panel never disagree.

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
@@ -104,7 +104,7 @@ export function AdmissionHeader({
   return (
     <div
       className={cn(
-        "relative border-l-4 px-4 md:px-6 py-3",
+        "relative border-l-4 px-4 py-3",
         mood === "ineligible" && "border-l-warning-600 bg-gradient-to-b from-warning-50 to-transparent",
         mood === "eligible" && "border-l-success bg-gradient-to-b from-success-50 to-transparent",
         mood === "neutral" && "border-l-border",

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
@@ -10,6 +10,21 @@ import { derivePriorityIssues, issueTotalCount } from "./priorityIssues"
 import { getInitials } from "@/app/(dashboard)/admissions/_components/roster-parts"
 import { cn } from "@/lib/utils"
 
+type Mood = "eligible" | "ineligible" | "neutral"
+
+/** Single source for the eligibility-driven page mood colours (frame + bar). */
+const MOOD_STYLES: Record<Mood, { frame: string; bar: string }> = {
+  eligible: {
+    frame: "border-l-success bg-gradient-to-b from-success-50 to-transparent",
+    bar: "bg-success",
+  },
+  ineligible: {
+    frame: "border-l-warning-600 bg-gradient-to-b from-warning-50 to-transparent",
+    bar: "bg-warning-600",
+  },
+  neutral: { frame: "border-l-border", bar: "bg-primary" },
+}
+
 interface AdmissionHeaderProps {
   profile: AdmissionProfileResponse | null
   /** Jump to the first blocking step — shared with the Step-8 "Kiểm tra toàn bộ". */
@@ -59,9 +74,12 @@ export function AdmissionHeader({
   }
 
   const statusConfig = getStatusConfig(profile.status, "admission")
+  // Eligibility drives the whole page mood (single tri-state source): green = đủ,
+  // amber = chưa đủ, neutral (pending/unknown) = calm.
   const eligibility = profile.eligibility_status
-  const isEligible = eligibility === "eligible"
-  const verdictKnown = eligibility === "eligible" || eligibility === "ineligible"
+  const mood: Mood =
+    eligibility === "eligible" ? "eligible" : eligibility === "ineligible" ? "ineligible" : "neutral"
+  const isEligible = mood === "eligible"
 
   const choices = [...(profile.choices ?? [])].sort((a, b) => a.display_order - b.display_order)
   const firstChoice = choices[0]
@@ -93,17 +111,8 @@ export function AdmissionHeader({
   const completion = profile.completion_percent ?? 0
   const owner = profile.assigned_officer_name
 
-  const mood = verdictKnown ? (isEligible ? "eligible" : "ineligible") : "neutral"
-
   return (
-    <div
-      className={cn(
-        "relative border-l-4 px-4 py-3",
-        mood === "ineligible" && "border-l-warning-600 bg-gradient-to-b from-warning-50 to-transparent",
-        mood === "eligible" && "border-l-success bg-gradient-to-b from-success-50 to-transparent",
-        mood === "neutral" && "border-l-border",
-      )}
-    >
+    <div className={cn("relative border-l-4 px-4 py-3", MOOD_STYLES[mood].frame)}>
       <div className="space-y-2.5">
         {/* 1 · identity + verdict + overflow menu */}
         <div className="flex items-start justify-between gap-3">
@@ -117,7 +126,7 @@ export function AdmissionHeader({
                 so it agrees with the amber border/gradient on this detail page.
                 Rendered only for a known verdict; a "pending" default stays neutral
                 (no pill) by design. Do NOT swap to the roster token here. */}
-            {verdictKnown && (
+            {mood !== "neutral" && (
               <span
                 data-testid="header-chip-eligibility"
                 className={cn(
@@ -218,10 +227,7 @@ export function AdmissionHeader({
           <div className="flex min-w-[150px] flex-1 items-center gap-3">
             <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
               <div
-                className={cn(
-                  "h-full rounded-full",
-                  mood === "eligible" ? "bg-success" : mood === "ineligible" ? "bg-warning-600" : "bg-primary",
-                )}
+                className={cn("h-full rounded-full", MOOD_STYLES[mood].bar)}
                 style={{ width: `${completion}%` }}
               />
             </div>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from "react"
 import { AdmissionProfileResponse } from "@/lib/zod/admissions"
-import { getStatusConfig } from "@/lib/status-config"
+import { getStatusConfig, getStatusDotColor } from "@/lib/status-config"
 import { FeeStatusLink } from "@/components/finance"
 import { GraduationCap, MapPin, Award, ArrowRight } from "lucide-react"
 import { ProfileActionMenu } from "./ProfileActionMenu"
@@ -66,13 +66,9 @@ export function AdmissionHeader({
   const choices = [...(profile.choices ?? [])].sort((a, b) => a.display_order - b.display_order)
   const firstChoice = choices[0]
   const extraChoices = Math.max(0, choices.length - 1)
-  // Legacy single-NV profiles (uses_choice_engine=false) carry no choices[] but
-  // still identify the selected program via the denormalized program_name. Fall
-  // back to it ONLY for those — a real choice-engine profile with an empty
-  // choices[] genuinely has no nguyện vọng yet (program_name may be a stale
-  // lead/offering display value), so it must read "Chưa chọn nguyện vọng".
-  const legacyProgram =
-    firstChoice || profile.uses_choice_engine ? null : profile.program_name?.trim() || null
+  // BE-resolved primary program name (handles choice-engine vs legacy vs
+  // empty-choice-engine provenance) — single source, no FE heuristic.
+  const primaryProgram = profile.primary_choice_display?.trim() || null
 
   // "Việc cần xử lý" = the same count the IssueSummary panel shows (validation +
   // priority + required-data), so the header and the panel never disagree.
@@ -116,6 +112,11 @@ export function AdmissionHeader({
             <span className="ml-1.5 text-sm font-medium text-muted-foreground">#{profile.id}</span>
           </h1>
           <div className="flex flex-shrink-0 items-center gap-2">
+            {/* Verdict pill uses the page MOOD colour (amber = chưa đủ, green = đủ)
+                — deliberately softer than the roster EligibilityToken's error-red,
+                so it agrees with the amber border/gradient on this detail page.
+                Rendered only for a known verdict; a "pending" default stays neutral
+                (no pill) by design. Do NOT swap to the roster token here. */}
             {verdictKnown && (
               <span
                 data-testid="header-chip-eligibility"
@@ -152,7 +153,7 @@ export function AdmissionHeader({
                 NV{firstChoice.display_order}
               </span>
               <span className="truncate font-semibold text-foreground">
-                {firstChoice.display_program_name || firstChoice.display_path_name}
+                {primaryProgram || firstChoice.display_program_name || firstChoice.display_path_name}
               </span>
               {firstChoice.display_degree_level && (
                 <span className="hidden flex-shrink-0 text-muted-foreground sm:inline">
@@ -165,8 +166,8 @@ export function AdmissionHeader({
                 </span>
               )}
             </>
-          ) : legacyProgram ? (
-            <span className="truncate font-semibold text-foreground">{legacyProgram}</span>
+          ) : primaryProgram ? (
+            <span className="truncate font-semibold text-foreground">{primaryProgram}</span>
           ) : (
             <span className="text-muted-foreground">Chưa chọn nguyện vọng</span>
           )}
@@ -185,7 +186,9 @@ export function AdmissionHeader({
           </div>
 
           <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-foreground/80">
-            <span className="h-2 w-2 rounded-full bg-slate-400" />
+            {/* Status dot colour from the shared status-config (same source as the
+                list StatusDot) instead of a hardcoded grey. */}
+            <span className={cn("h-2 w-2 rounded-full", getStatusDotColor(profile.status))} />
             {statusConfig?.label ?? profile.status}
           </span>
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
@@ -7,6 +7,7 @@ import { FeeStatusLink } from "@/components/finance"
 import { GraduationCap, MapPin, Award, ArrowRight } from "lucide-react"
 import { ProfileActionMenu } from "./ProfileActionMenu"
 import { derivePriorityIssues, issueTotalCount } from "./priorityIssues"
+import { getInitials } from "@/app/(dashboard)/admissions/_components/roster-parts"
 import { cn } from "@/lib/utils"
 
 interface AdmissionHeaderProps {
@@ -19,16 +20,6 @@ interface AdmissionHeaderProps {
   isUnclaiming?: boolean
   onDelete?: () => void
   isDeleting?: boolean
-}
-
-/** First + last word initials, e.g. "Ksor Ho Hơn" → "KH". */
-function ownerInitials(name?: string | null): string {
-  if (!name) return "—"
-  const parts = name.trim().split(/\s+/).filter(Boolean)
-  if (parts.length === 0) return "—"
-  const first = parts[0][0] ?? ""
-  const last = parts.length > 1 ? parts[parts.length - 1][0] : ""
-  return (first + last).toUpperCase()
 }
 
 function LedgerItem({ k, className, children }: { k: string; className?: string; children: ReactNode }) {
@@ -185,7 +176,7 @@ export function AdmissionHeader({
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-t border-border/60 pt-2.5">
           <div className="flex min-w-0 items-center gap-2">
             <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-indigo-100 text-[11px] font-bold text-indigo-700">
-              {ownerInitials(owner)}
+              {owner ? getInitials(owner) : "—"}
             </span>
             <span className="truncate text-xs text-foreground md:text-sm">
               <span className="font-semibold">{owner ?? "Chưa phân công"}</span>
@@ -251,8 +242,11 @@ export function AdmissionHeader({
             </LedgerItem>
           )}
 
+          {/* KV + Đối tượng UT stay visible on every breakpoint — a manager
+              reviewing a case on mobile/tablet must not lose these priority
+              cockpit signals (the ledger row wraps rather than hiding them). */}
           {kv && (
-            <LedgerItem k="KV" className="hidden md:flex">
+            <LedgerItem k="KV">
               <span data-testid="header-chip-kv" className="inline-flex items-center gap-1 font-bold text-info-700">
                 <MapPin className="h-3 w-3" /> {kv}
               </span>
@@ -260,7 +254,7 @@ export function AdmissionHeader({
           )}
 
           {utBucket && (
-            <LedgerItem k="Đối tượng UT" className="hidden lg:flex">
+            <LedgerItem k="Đối tượng UT">
               <span data-testid="header-chip-ut" className="inline-flex items-center gap-1 font-bold text-purple-700">
                 <Award className="h-3 w-3" /> UT{utBucket}
               </span>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
@@ -78,7 +78,7 @@ export function AdmissionHeader({
   // amber = chưa đủ, neutral (pending/unknown) = calm.
   const eligibility = profile.eligibility_status
   const mood: Mood =
-    eligibility === "eligible" ? "eligible" : eligibility === "ineligible" ? "ineligible" : "neutral"
+    eligibility === "eligible" || eligibility === "ineligible" ? eligibility : "neutral"
   const isEligible = mood === "eligible"
 
   const choices = [...(profile.choices ?? [])].sort((a, b) => a.display_order - b.display_order)

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionHeader.tsx
@@ -1,14 +1,18 @@
 "use client"
 
-import { Badge } from "@/components/ui/badge"
+import type { ReactNode } from "react"
 import { AdmissionProfileResponse } from "@/lib/zod/admissions"
 import { getStatusConfig } from "@/lib/status-config"
 import { FeeStatusLink } from "@/components/finance"
-import { AlertCircle, CheckCircle2, MapPin, Award, FileCheck } from "lucide-react"
+import { GraduationCap, MapPin, Award, ArrowRight } from "lucide-react"
 import { ProfileActionMenu } from "./ProfileActionMenu"
+import { derivePriorityIssues, issueTotalCount } from "./priorityIssues"
+import { cn } from "@/lib/utils"
 
 interface AdmissionHeaderProps {
   profile: AdmissionProfileResponse | null
+  /** Jump to the first blocking step — shared with the Step-8 "Kiểm tra toàn bộ". */
+  onCheckCondition?: () => void
   onClaim?: () => void
   onUnclaim?: () => void
   isClaiming?: boolean
@@ -17,15 +21,69 @@ interface AdmissionHeaderProps {
   isDeleting?: boolean
 }
 
+/** First + last word initials, e.g. "Ksor Ho Hơn" → "KH". */
+function ownerInitials(name?: string | null): string {
+  if (!name) return "—"
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return "—"
+  const first = parts[0][0] ?? ""
+  const last = parts.length > 1 ? parts[parts.length - 1][0] : ""
+  return (first + last).toUpperCase()
+}
+
+function LedgerItem({ k, className, children }: { k: string; className?: string; children: ReactNode }) {
+  return (
+    <div className={cn("flex items-center gap-2 md:border-l md:border-border/60 md:pl-4", className)}>
+      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/80">{k}</span>
+      {children}
+    </div>
+  )
+}
+
 /**
- * Header chips — Commit 4 manager/admin cockpit.
+ * Dải trạng thái hồ sơ — the case status header.
  *
- * BE-driven, không tính FE. Mỗi chip thể hiện một signal duyệt nhanh để
- * manager/admin không phải mở từng tab xác minh.
+ * Reads top-to-bottom in the order an officer scans a case file: who · registered
+ * major (nguyện vọng) · assigned officer · workflow status · eligibility verdict ·
+ * what to do next. Eligibility is the page's mood colour (amber = chưa đủ, green =
+ * đủ); the rest stays calm. 100% BE-driven (thin client) — no eligibility/scoring
+ * computed here.
  */
-function HeaderChips({ profile }: { profile: AdmissionProfileResponse }) {
-  const blockerCount = profile.validation_errors?.length ?? 0
-  const eligibility = profile.eligibility_status ?? null
+export function AdmissionHeader({
+  profile,
+  onCheckCondition,
+  onClaim,
+  onUnclaim,
+  isClaiming = false,
+  isUnclaiming = false,
+  onDelete,
+  isDeleting = false,
+}: AdmissionHeaderProps) {
+  if (!profile) {
+    return (
+      <div className="min-h-12 px-4 md:px-6 py-3">
+        <h1 className="text-sm md:text-base font-semibold font-display">Hồ sơ #--- — Đang tải…</h1>
+      </div>
+    )
+  }
+
+  const statusConfig = getStatusConfig(profile.status, "admission")
+  const eligibility = profile.eligibility_status
+  const isEligible = eligibility === "eligible"
+  const verdictKnown = eligibility === "eligible" || eligibility === "ineligible"
+
+  const choices = [...(profile.choices ?? [])].sort((a, b) => a.display_order - b.display_order)
+  const firstChoice = choices[0]
+  const extraChoices = Math.max(0, choices.length - 1)
+
+  // "Việc cần xử lý" = the same count the IssueSummary panel shows (validation +
+  // priority + required-data), so the header and the panel never disagree.
+  const workItems = issueTotalCount(
+    profile.validation_errors?.length ?? 0,
+    derivePriorityIssues(profile).length,
+    profile.grouped_validation_errors,
+  )
+
   const snapshot = profile.priority_resolution_snapshot ?? {}
   const kv = typeof snapshot.kv_resolved === "string" ? snapshot.kv_resolved : null
   const utBucket = (() => {
@@ -36,162 +94,171 @@ function HeaderChips({ profile }: { profile: AdmissionProfileResponse }) {
     }
     return null
   })()
-  const verifiedCount = profile.document_stats?.verified_count ?? 0
-  const mandatoryCount = profile.document_stats?.mandatory_count ?? 0
-  const completionPercent = profile.completion_percent ?? 0
+  const verified = profile.document_stats?.verified_count ?? 0
+  const mandatory = profile.document_stats?.mandatory_count ?? 0
+  const completion = profile.completion_percent ?? 0
+  const owner = profile.assigned_officer_name
+
+  const mood = verdictKnown ? (isEligible ? "eligible" : "ineligible") : "neutral"
 
   return (
-    <div className="flex flex-wrap items-center gap-1.5 ml-auto">
-      {/* Completion */}
-      <Badge
-        variant="outline"
-        className="text-xs gap-1"
-        data-testid="header-chip-completion"
-        title={`Hoàn thành ${completionPercent}%`}
-      >
-        <CheckCircle2 className="w-3 h-3" />
-        {completionPercent}%
-      </Badge>
-
-      {/* Eligibility */}
-      {eligibility && (
-        <Badge
-          variant={eligibility === "eligible" ? "default" : "outline"}
-          className={`text-xs ${
-            eligibility === "eligible"
-              ? "bg-success-100 text-success-800 hover:bg-success-100"
-              : "bg-warning-50 text-warning-700 border-warning-300"
-          }`}
-          data-testid="header-chip-eligibility"
-          title={`Điều kiện: ${eligibility}`}
-        >
-          {eligibility === "eligible" ? "Đủ điều kiện" : "Chưa đủ điều kiện"}
-        </Badge>
+    <div
+      className={cn(
+        "relative border-l-4 px-4 md:px-6 py-3",
+        mood === "ineligible" && "border-l-warning-600 bg-gradient-to-b from-warning-50 to-transparent",
+        mood === "eligible" && "border-l-success bg-gradient-to-b from-success-50 to-transparent",
+        mood === "neutral" && "border-l-border",
       )}
+    >
+      <div className="space-y-2.5">
+        {/* 1 · identity + verdict + overflow menu */}
+        <div className="flex items-start justify-between gap-3">
+          <h1 className="min-w-0 truncate text-base font-semibold font-display leading-tight md:text-lg">
+            {profile.full_name ?? "Chưa có tên"}
+            <span className="ml-1.5 text-sm font-medium text-muted-foreground">#{profile.id}</span>
+          </h1>
+          <div className="flex flex-shrink-0 items-center gap-2">
+            {verdictKnown && (
+              <span
+                data-testid="header-chip-eligibility"
+                className={cn(
+                  "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full px-3 py-1 text-xs font-bold",
+                  isEligible ? "bg-success-100 text-success-800" : "bg-warning-100 text-warning-800",
+                )}
+              >
+                <span className={cn("h-2 w-2 rounded-full", isEligible ? "bg-success-600" : "bg-warning-600")} />
+                <span className="md:hidden">{isEligible ? "Đủ ĐK" : "Chưa đủ ĐK"}</span>
+                <span className="hidden md:inline">{isEligible ? "Đủ điều kiện" : "Chưa đủ điều kiện"}</span>
+              </span>
+            )}
+            <ProfileActionMenu
+              profile={profile}
+              onClaim={onClaim}
+              onUnclaim={onUnclaim}
+              isClaiming={isClaiming}
+              isUnclaiming={isUnclaiming}
+              onDelete={onDelete}
+              isDeleting={isDeleting}
+            />
+          </div>
+        </div>
 
-      {/* KV */}
-      {kv && (
-        <Badge
-          variant="outline"
-          className="text-xs gap-1 bg-info-50 border-info-200 text-info-700"
-          data-testid="header-chip-kv"
-          title="Khu vực ưu tiên"
-        >
-          <MapPin className="w-3 h-3" />
-          {kv}
-        </Badge>
-      )}
-
-      {/* UT bucket */}
-      {utBucket && (
-        <Badge
-          variant="outline"
-          className="text-xs gap-1 bg-purple-50 border-purple-200 text-purple-700"
-          data-testid="header-chip-ut"
-          title="Đối tượng ưu tiên đã duyệt"
-        >
-          <Award className="w-3 h-3" />
-          UT{utBucket}
-        </Badge>
-      )}
-
-      {/* Documents ratio */}
-      {mandatoryCount > 0 && (
-        <Badge
-          variant="outline"
-          className={`text-xs gap-1 ${
-            verifiedCount >= mandatoryCount
-              ? "bg-success-50 border-success-200 text-success-700"
-              : "bg-muted text-muted-foreground"
-          }`}
-          data-testid="header-chip-docs"
-          title="Tài liệu đã duyệt / bắt buộc"
-        >
-          <FileCheck className="w-3 h-3" />
-          {verifiedCount}/{mandatoryCount}
-        </Badge>
-      )}
-
-      {/* Blocker count */}
-      {blockerCount > 0 && (
-        <Badge
-          variant="destructive"
-          className="text-xs gap-1"
-          data-testid="header-chip-blockers"
-          title="Vấn đề cần sửa"
-        >
-          <AlertCircle className="w-3 h-3" />
-          {blockerCount} vấn đề
-        </Badge>
-      )}
-    </div>
-  )
-}
-
-export function AdmissionHeader({
-  profile,
-  onClaim,
-  onUnclaim,
-  isClaiming = false,
-  isUnclaiming = false,
-  onDelete,
-  isDeleting = false,
-}: AdmissionHeaderProps) {
-  const statusConfig = profile?.status ? getStatusConfig(profile.status, "admission") : null
-
-  return (
-    <div className="min-h-12 px-4 md:px-6 py-2 md:py-0 flex flex-wrap items-center gap-2 md:gap-3">
-      {/* E2E #9 fix 2026-05-15 — heading shows profile.id (consistent with
-          URL `/admissions/{id}`) + candidate full_name for UX. */}
-      <h1 className="text-sm md:text-base font-semibold font-display">
-        Hồ sơ #{profile?.id ?? "---"}
-        {profile?.full_name ? ` — ${profile.full_name}` : " — Chưa có tên"}
-      </h1>
-
-      <span className="text-muted-foreground hidden sm:inline">·</span>
-
-      {statusConfig && (
-        <Badge variant={statusConfig.badgeVariant} className="text-xs">
-          {statusConfig.label}
-        </Badge>
-      )}
-
-      <span className="text-muted-foreground hidden md:inline">·</span>
-
-      {profile?.id && <FeeStatusLink profileId={profile.id} variant="badge" />}
-
-      <span className="text-muted-foreground hidden md:inline">·</span>
-
-      <span className="text-xs md:text-sm text-muted-foreground hidden md:inline">
-        Phụ trách: {profile?.assigned_officer_name ?? "Chưa phân công"}
-      </span>
-
-      {profile?.assigned_reviewer_name && (
-        <>
-          <span className="text-muted-foreground hidden md:inline">·</span>
-          <span className="text-xs md:text-sm text-muted-foreground hidden md:inline">
-            Người duyệt: {profile.assigned_reviewer_name}
+        {/* 2 · nguyện vọng — "đăng ký ngành gì" */}
+        <div className="flex min-w-0 items-center gap-2 text-sm">
+          <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-indigo-50 text-indigo-600">
+            <GraduationCap className="h-3.5 w-3.5" />
           </span>
-        </>
-      )}
+          {firstChoice ? (
+            <>
+              <span className="flex-shrink-0 rounded bg-indigo-100 px-1.5 py-0.5 text-[10px] font-extrabold tracking-wide text-indigo-700">
+                NV{firstChoice.display_order}
+              </span>
+              <span className="truncate font-semibold text-foreground">
+                {firstChoice.display_program_name || firstChoice.display_path_name}
+              </span>
+              {firstChoice.display_degree_level && (
+                <span className="hidden flex-shrink-0 text-muted-foreground sm:inline">
+                  · {firstChoice.display_degree_level}
+                </span>
+              )}
+              {extraChoices > 0 && (
+                <span className="flex-shrink-0 rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-semibold text-indigo-600">
+                  +{extraChoices} NV
+                </span>
+              )}
+            </>
+          ) : (
+            <span className="text-muted-foreground">Chưa chọn nguyện vọng</span>
+          )}
+        </div>
 
-      {/* Commit 4 — review signal chips for manager/admin cockpit. */}
-      {profile && <HeaderChips profile={profile} />}
+        {/* 3 · phụ trách · trạng thái · hành động */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-t border-border/60 pt-2.5">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-indigo-100 text-[11px] font-bold text-indigo-700">
+              {ownerInitials(owner)}
+            </span>
+            <span className="truncate text-xs text-foreground md:text-sm">
+              <span className="font-semibold">{owner ?? "Chưa phân công"}</span>
+              <span className="text-muted-foreground"> · phụ trách</span>
+            </span>
+          </div>
 
-      {/* Commit 7 — overflow menu cho workflow + utility actions
-          (claim/unclaim/minor correction/delete). Gom các action ít dùng
-          để sticky bar tinh giản. */}
-      {profile && (
-        <ProfileActionMenu
-          profile={profile}
-          onClaim={onClaim}
-          onUnclaim={onUnclaim}
-          isClaiming={isClaiming}
-          isUnclaiming={isUnclaiming}
-          onDelete={onDelete}
-          isDeleting={isDeleting}
-        />
-      )}
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-foreground/80">
+            <span className="h-2 w-2 rounded-full bg-slate-400" />
+            {statusConfig?.label ?? profile.status}
+          </span>
+
+          {profile.assigned_reviewer_name && (
+            <span className="hidden text-xs text-muted-foreground lg:inline">
+              Người duyệt: {profile.assigned_reviewer_name}
+            </span>
+          )}
+
+          {workItems > 0 && (
+            <button
+              type="button"
+              data-testid="header-chip-blockers"
+              onClick={onCheckCondition}
+              className="ml-auto inline-flex items-center gap-2 rounded-lg bg-primary px-3.5 py-2 text-xs font-semibold text-primary-foreground shadow-sm transition hover:brightness-105 active:translate-y-px"
+            >
+              <span className="tabular-nums">{workItems}</span>
+              <span className="hidden sm:inline">việc cần xử lý</span>
+              <span className="sm:hidden">việc</span>
+              <ArrowRight className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+
+        {/* 4 · ledger */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 pt-0.5 text-xs">
+          <div className="flex min-w-[150px] flex-1 items-center gap-3">
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+              <div
+                className={cn(
+                  "h-full rounded-full",
+                  mood === "eligible" ? "bg-success" : mood === "ineligible" ? "bg-warning-600" : "bg-primary",
+                )}
+                style={{ width: `${completion}%` }}
+              />
+            </div>
+            <span data-testid="header-chip-completion" className="font-semibold tabular-nums text-foreground">
+              {completion}%
+            </span>
+          </div>
+
+          <LedgerItem k="Học phí">
+            <FeeStatusLink profileId={profile.id} variant="badge" />
+          </LedgerItem>
+
+          {mandatory > 0 && (
+            <LedgerItem k="Tài liệu">
+              <span
+                data-testid="header-chip-docs"
+                className={cn("font-bold tabular-nums", verified >= mandatory ? "text-success-700" : "text-warning-700")}
+              >
+                {verified}/{mandatory}
+              </span>
+            </LedgerItem>
+          )}
+
+          {kv && (
+            <LedgerItem k="KV" className="hidden md:flex">
+              <span data-testid="header-chip-kv" className="inline-flex items-center gap-1 font-bold text-info-700">
+                <MapPin className="h-3 w-3" /> {kv}
+              </span>
+            </LedgerItem>
+          )}
+
+          {utBucket && (
+            <LedgerItem k="Đối tượng UT" className="hidden lg:flex">
+              <span data-testid="header-chip-ut" className="inline-flex items-center gap-1 font-bold text-purple-700">
+                <Award className="h-3 w-3" /> UT{utBucket}
+              </span>
+            </LedgerItem>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionLayout.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionLayout.tsx
@@ -73,7 +73,10 @@ export function AdmissionLayout({
           />
        </div>
 
-       <div className="flex flex-1 container max-w-7xl mx-auto px-4 md:px-6 pt-4 md:pt-6 gap-4 md:gap-8">
+       {/* Fill the app content area (already capped at --content-max-width by the
+           shell) instead of the narrower max-w-7xl, and use a single px-4 — the
+           app <main> already pads (p-6 on lg), so the old px-6 here double-padded. */}
+       <div className="flex flex-1 px-4 pt-4 md:pt-6 gap-4 md:gap-8">
           <aside className="w-56 hidden lg:block flex-shrink-0 sticky top-24 h-fit">
              <PipelineSidebar
                 profile={profile}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionLayout.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionLayout.tsx
@@ -12,6 +12,8 @@ interface AdmissionLayoutProps {
   profile: AdmissionProfileResponse | null
   currentStep: number
   onStepChange: (step: number) => void
+  /** Jump to the first blocking step (header CTA + Step-8 "Kiểm tra toàn bộ"). */
+  onCheckCondition?: () => void
   stepsStatus: Record<number, "success" | "warning" | "error" | "locked">
   validationErrors?: string[]
   validationSummary?: {
@@ -35,6 +37,7 @@ export function AdmissionLayout({
   profile,
   currentStep,
   onStepChange,
+  onCheckCondition,
   stepsStatus,
   validationErrors = [],
   validationSummary,
@@ -51,6 +54,7 @@ export function AdmissionLayout({
        <div className="sticky top-0 z-30 bg-background border-b shadow-sm">
           <AdmissionHeader
             profile={profile}
+            onCheckCondition={onCheckCondition}
             onClaim={onClaim}
             onUnclaim={onUnclaim}
             isClaiming={isClaiming}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionLayout.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionLayout.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from "react"
 import { AdmissionHeader } from "./AdmissionHeader"
 import { PipelineSidebar } from "./PipelineSidebar"
+import { MobileStepStrip } from "./MobileStepStrip"
 import { MobileIssueDrawer } from "./MobileIssueDrawer"
 import { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
@@ -56,6 +57,15 @@ export function AdmissionLayout({
             isUnclaiming={isUnclaiming}
             onDelete={onDelete}
             isDeleting={isDeleting}
+          />
+          {/* Mobile-only step navigator — desktop uses the PipelineSidebar
+              (hidden lg:block); on mobile this keeps step overview + direct
+              jump reachable in the sticky header while content scrolls. */}
+          <MobileStepStrip
+            profile={profile}
+            currentStep={currentStep}
+            onStepChange={onStepChange}
+            stepsStatus={stepsStatus}
           />
        </div>
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionLayout.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionLayout.tsx
@@ -18,11 +18,8 @@ interface AdmissionLayoutProps {
     gpa?: { has_error: boolean; count: number }
     documents?: { has_error: boolean; count: number }
   } | null
-  groupedValidationErrors?: {
-    personal_info?: { category: string; errors: string[]; count: number }
-    documents?: { category: string; errors: string[]; count: number }
-    scores?: { category: string; errors: string[]; count: number }
-  } | null
+  // Derived from the zod contract (includes required_data) so buckets stay in sync.
+  groupedValidationErrors?: NonNullable<AdmissionProfileResponse["grouped_validation_errors"]> | null
   // Commit 7 — pass-through cho ProfileActionMenu trong header.
   onClaim?: () => void
   onUnclaim?: () => void

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/IssueSummary.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/IssueSummary.tsx
@@ -3,15 +3,11 @@
 import { useState } from "react"
 import { AlertCircle, ChevronDown, ChevronUp } from "lucide-react"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
-import { derivePriorityIssues } from "./priorityIssues"
+import { derivePriorityIssues, issueTotalCount } from "./priorityIssues"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
-interface GroupedValidationErrors {
-  personal_info?: { category: string; errors: string[]; count: number }
-  documents?: { category: string; errors: string[]; count: number }
-  scores?: { category: string; errors: string[]; count: number }
-  required_data?: { category: string; errors: string[]; count: number }
-}
+// Derived from the zod contract so all buckets stay in sync automatically.
+type GroupedValidationErrors = NonNullable<AdmissionProfileResponse["grouped_validation_errors"]>
 
 interface IssueSummaryProps {
   profile: AdmissionProfileResponse | null
@@ -29,11 +25,10 @@ export function IssueSummary({
   const [isOpen, setIsOpen] = useState(defaultOpen)
 
   const priorityIssues = derivePriorityIssues(profile)
-  // Required-data (family/academic) don't appear in validationErrors, so add
-  // their count explicitly — otherwise a draft missing ONLY these renders
+  // Required-data (family/academic) aren't in validationErrors; the shared
+  // helper folds their count in — otherwise a draft missing ONLY these renders
   // totalCount 0 and the whole panel hides (the exact "kẹt" case).
-  const requiredDataCount = groupedValidationErrors?.required_data?.count ?? 0
-  const totalCount = validationErrors.length + priorityIssues.length + requiredDataCount
+  const totalCount = issueTotalCount(validationErrors.length, priorityIssues.length, groupedValidationErrors)
 
   if (totalCount === 0) return null
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/IssueSummary.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/IssueSummary.tsx
@@ -10,6 +10,7 @@ interface GroupedValidationErrors {
   personal_info?: { category: string; errors: string[]; count: number }
   documents?: { category: string; errors: string[]; count: number }
   scores?: { category: string; errors: string[]; count: number }
+  required_data?: { category: string; errors: string[]; count: number }
 }
 
 interface IssueSummaryProps {
@@ -28,7 +29,11 @@ export function IssueSummary({
   const [isOpen, setIsOpen] = useState(defaultOpen)
 
   const priorityIssues = derivePriorityIssues(profile)
-  const totalCount = validationErrors.length + priorityIssues.length
+  // Required-data (family/academic) don't appear in validationErrors, so add
+  // their count explicitly — otherwise a draft missing ONLY these renders
+  // totalCount 0 and the whole panel hides (the exact "kẹt" case).
+  const requiredDataCount = groupedValidationErrors?.required_data?.count ?? 0
+  const totalCount = validationErrors.length + priorityIssues.length + requiredDataCount
 
   if (totalCount === 0) return null
 
@@ -63,6 +68,13 @@ export function IssueSummary({
                   title={groupedValidationErrors.personal_info.category}
                   count={groupedValidationErrors.personal_info.count}
                   errors={groupedValidationErrors.personal_info.errors}
+                />
+              )}
+              {groupedValidationErrors.required_data && groupedValidationErrors.required_data.count > 0 && (
+                <IssueGroup
+                  title={groupedValidationErrors.required_data.category}
+                  count={groupedValidationErrors.required_data.count}
+                  errors={groupedValidationErrors.required_data.errors}
                 />
               )}
               {groupedValidationErrors.documents && groupedValidationErrors.documents.count > 0 && (

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/MobileIssueDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/MobileIssueDrawer.tsx
@@ -11,6 +11,7 @@ interface GroupedValidationErrors {
   personal_info?: { category: string; errors: string[]; count: number }
   documents?: { category: string; errors: string[]; count: number }
   scores?: { category: string; errors: string[]; count: number }
+  required_data?: { category: string; errors: string[]; count: number }
 }
 
 interface MobileIssueDrawerProps {
@@ -25,7 +26,8 @@ export function MobileIssueDrawer({
   groupedValidationErrors,
 }: MobileIssueDrawerProps) {
   const priorityIssues = derivePriorityIssues(profile)
-  const totalCount = validationErrors.length + priorityIssues.length
+  const requiredDataCount = groupedValidationErrors?.required_data?.count ?? 0
+  const totalCount = validationErrors.length + priorityIssues.length + requiredDataCount
 
   if (totalCount === 0) return null
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/MobileIssueDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/MobileIssueDrawer.tsx
@@ -4,15 +4,11 @@ import { AlertCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { IssueSummary } from "./IssueSummary"
-import { derivePriorityIssues } from "./priorityIssues"
+import { derivePriorityIssues, issueTotalCount } from "./priorityIssues"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
-interface GroupedValidationErrors {
-  personal_info?: { category: string; errors: string[]; count: number }
-  documents?: { category: string; errors: string[]; count: number }
-  scores?: { category: string; errors: string[]; count: number }
-  required_data?: { category: string; errors: string[]; count: number }
-}
+// Derived from the zod contract so all buckets stay in sync automatically.
+type GroupedValidationErrors = NonNullable<AdmissionProfileResponse["grouped_validation_errors"]>
 
 interface MobileIssueDrawerProps {
   profile: AdmissionProfileResponse | null
@@ -26,8 +22,7 @@ export function MobileIssueDrawer({
   groupedValidationErrors,
 }: MobileIssueDrawerProps) {
   const priorityIssues = derivePriorityIssues(profile)
-  const requiredDataCount = groupedValidationErrors?.required_data?.count ?? 0
-  const totalCount = validationErrors.length + priorityIssues.length + requiredDataCount
+  const totalCount = issueTotalCount(validationErrors.length, priorityIssues.length, groupedValidationErrors)
 
   if (totalCount === 0) return null
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/MobileStepStrip.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/MobileStepStrip.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import { canDecide } from "@/lib/utils/admission-permissions"
+import { ADMISSION_STEPS } from "@/lib/constants/admission-steps"
+import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+
+interface MobileStepStripProps {
+  profile: AdmissionProfileResponse | null
+  currentStep: number
+  onStepChange: (step: number) => void
+  stepsStatus: Record<number, "success" | "warning" | "error" | "locked">
+}
+
+/**
+ * Mobile-only horizontal step navigator (lg:hidden). The desktop PipelineSidebar
+ * is `hidden lg:block`, so on mobile the only step navigation was the sequential
+ * "Quay lại" / "Tiếp tục" buttons — no overview of the 8 steps and no direct
+ * jump. This strip surfaces every step with its status colour and lets the user
+ * tap to jump straight to any unlocked step. Rendered inside the sticky header
+ * region so it stays reachable while the content scrolls.
+ */
+export function MobileStepStrip({
+  profile,
+  currentStep,
+  onStepChange,
+  stepsStatus,
+}: MobileStepStripProps) {
+  // Step 8 unlock override for decision-capable users — mirrors PipelineSidebar
+  // and AdmissionActions so the strip agrees with the other navigation surfaces.
+  const decide = canDecide(profile?.permissions)
+
+  return (
+    <nav
+      aria-label="Điều hướng bước hồ sơ"
+      className="lg:hidden flex gap-1.5 overflow-x-auto px-4 pb-2 pt-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+    >
+      {ADMISSION_STEPS.map((step) => {
+        const status = stepsStatus[step.id] || "locked"
+        const isActive = currentStep === step.id
+        const isStep8Override = step.id === 8 && decide
+        const isLocked = !isStep8Override && status === "locked"
+
+        return (
+          <button
+            key={step.id}
+            type="button"
+            onClick={() => !isLocked && onStepChange(step.id)}
+            disabled={isLocked}
+            aria-current={isActive ? "step" : undefined}
+            className={cn(
+              "flex flex-shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-2.5 py-1 text-xs transition-colors",
+              isActive
+                ? "border-primary bg-primary/10 font-semibold text-primary"
+                : "border-border bg-background text-muted-foreground",
+              !isActive && status === "success" && "border-success-200 text-success-700",
+              !isActive && status === "warning" && "border-warning-200 text-warning-700",
+              !isActive && status === "error" && "border-error-200 text-error-700",
+              isLocked && "cursor-not-allowed opacity-50",
+            )}
+          >
+            <span
+              className={cn(
+                "flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-semibold",
+                isActive
+                  ? "bg-primary text-primary-foreground"
+                  : status === "success"
+                    ? "bg-success-100 text-success-700"
+                    : status === "warning"
+                      ? "bg-warning-100 text-warning-700"
+                      : status === "error"
+                        ? "bg-error-100 text-error-700"
+                        : "bg-muted",
+              )}
+            >
+              {step.id}
+            </span>
+            {step.label}
+          </button>
+        )
+      })}
+    </nav>
+  )
+}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/MobileStepStrip.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/MobileStepStrip.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import { canDecide } from "@/lib/utils/admission-permissions"
+import { canDecide, isStepNavLocked } from "@/lib/utils/admission-permissions"
 import { ADMISSION_STEPS } from "@/lib/constants/admission-steps"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
@@ -26,8 +26,8 @@ export function MobileStepStrip({
   onStepChange,
   stepsStatus,
 }: MobileStepStripProps) {
-  // Step 8 unlock override for decision-capable users — mirrors PipelineSidebar
-  // and AdmissionActions so the strip agrees with the other navigation surfaces.
+  // Step-8 unlock for decision-capable users, via the shared isStepNavLocked so
+  // the strip agrees with PipelineSidebar on which steps are reachable.
   const decide = canDecide(profile?.permissions)
 
   return (
@@ -38,8 +38,7 @@ export function MobileStepStrip({
       {ADMISSION_STEPS.map((step) => {
         const status = stepsStatus[step.id] || "locked"
         const isActive = currentStep === step.id
-        const isStep8Override = step.id === 8 && decide
-        const isLocked = !isStep8Override && status === "locked"
+        const isLocked = isStepNavLocked(step.id, status, decide)
 
         return (
           <button

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/PipelineSidebar.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/PipelineSidebar.tsx
@@ -25,6 +25,7 @@ interface PipelineSidebarProps {
     personal_info?: { category: string; errors: string[]; count: number }
     documents?: { category: string; errors: string[]; count: number }
     scores?: { category: string; errors: string[]; count: number }
+    required_data?: { category: string; errors: string[]; count: number }
   } | null
   completionPercent: number
   /**
@@ -127,6 +128,7 @@ export function PipelineSidebar({
                         "w-8 h-8 rounded-full flex items-center justify-center border",
                         isActive ? "border-primary text-primary" : "border-muted bg-background",
                         status === "success" && !isActive && "bg-success-50 border-success-200 text-success-600",
+                        status === "warning" && !isActive && "bg-warning-50 border-warning-200 text-warning-600",
                         status === "error" && !isActive && "bg-error-50 border-error-200 text-error-600"
                     )}>
                         <span className="text-xs">{step.id}</span>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/PipelineSidebar.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/PipelineSidebar.tsx
@@ -21,12 +21,8 @@ interface PipelineSidebarProps {
     gpa?: { has_error: boolean; count: number }
     documents?: { has_error: boolean; count: number }
   } | null
-  groupedValidationErrors?: {
-    personal_info?: { category: string; errors: string[]; count: number }
-    documents?: { category: string; errors: string[]; count: number }
-    scores?: { category: string; errors: string[]; count: number }
-    required_data?: { category: string; errors: string[]; count: number }
-  } | null
+  // Derived from the zod contract so buckets stay in sync automatically.
+  groupedValidationErrors?: NonNullable<AdmissionProfileResponse["grouped_validation_errors"]> | null
   completionPercent: number
   /**
    * Phase E.4 (PR-1) — prop kept for backward-compat với AdmissionLayout

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/PipelineSidebar.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/PipelineSidebar.tsx
@@ -6,7 +6,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { useMemo } from "react"
 import { IssueSummary } from "./IssueSummary"
 import { derivePriorityIssues } from "./priorityIssues"
-import { canDecide } from "@/lib/utils/admission-permissions"
+import { canDecide, isStepNavLocked } from "@/lib/utils/admission-permissions"
 import { ADMISSION_STEPS } from "@/lib/constants/admission-steps"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
@@ -100,9 +100,9 @@ export function PipelineSidebar({
           const isActive = currentStep === step.id
           const isFocused = focusedSteps.includes(step.id)
           // Trust BE-aggregated `permissions.has_decision`, fallback OR-7.
+          // Step-8 unlock lives in the shared isStepNavLocked (see MobileStepStrip).
           const decide = canDecide(profile?.permissions)
-          const isStep8Override = step.id === 8 && decide
-          const isLocked = !isStep8Override && status === "locked"
+          const isLocked = isStepNavLocked(step.id, status, decide)
 
           const stepButton = (
             <button

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.test.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest"
-import { firstAttentionStep, issueTotalCount } from "./priorityIssues"
+import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+import { firstAttentionStep, issueTotalCount, missingRequiredDataSteps } from "./priorityIssues"
 
 type StepStatus = "success" | "warning" | "error" | "locked"
 
@@ -9,46 +10,43 @@ function steps(overrides: Record<number, StepStatus> = {}): Record<number, StepS
   return { ...base, ...overrides }
 }
 
-const NONE = { requiredDataCount: 0, priorityIssuesCount: 0 }
+/** Minimal profile with both required-data groups present by default. */
+function profile(overrides: Partial<AdmissionProfileResponse> = {}): AdmissionProfileResponse {
+  return { family_info: [{}], academic_history: [{}], ...overrides } as unknown as AdmissionProfileResponse
+}
+
+const NONE = { requiredDataSteps: [] as number[], priorityIssuesCount: 0 }
 
 describe("firstAttentionStep", () => {
   it("returns the first 'error' step before any warning", () => {
     // step 1 warning + step 5 error → error wins even though it's later.
-    const target = firstAttentionStep(steps({ 1: "warning", 5: "error" }), NONE)
-    expect(target).toBe(5)
+    expect(firstAttentionStep(steps({ 1: "warning", 5: "error" }), NONE)).toBe(5)
   })
 
-  it("prefers the required-data step (2/3) over an earlier NON-blocking step-1 warning", () => {
-    // The exact 'kẹt' bug: step 1 amber for blank OPTIONAL personal fields, while
-    // family/academic (the real submit blocker) are step 2/3 warnings.
-    const target = firstAttentionStep(steps({ 1: "warning", 2: "warning", 3: "warning" }), {
-      requiredDataCount: 2,
-      priorityIssuesCount: 0,
-    })
-    expect(target).toBe(2)
+  it("jumps to the earliest missing required-data step, past an earlier step-1 warning", () => {
+    // The 'kẹt' bug: step 1 amber for blank OPTIONAL personal fields, while
+    // family(2)/academic(3) are the real submit blockers → land on step 2.
+    expect(
+      firstAttentionStep(steps({ 1: "warning" }), { requiredDataSteps: [2, 3], priorityIssuesCount: 0 }),
+    ).toBe(2)
   })
 
-  it("routes to step 3 when family is complete but academic (step 3) is the required-data warning", () => {
-    const target = firstAttentionStep(steps({ 1: "warning", 3: "warning" }), {
-      requiredDataCount: 1,
-      priorityIssuesCount: 0,
-    })
-    expect(target).toBe(3)
+  it("routes to academic (step 3) when only academic is the blocker — even if step 2 is amber for an unrelated reason", () => {
+    // The exact edge the count-based version got wrong: step 2 warning (family
+    // present but incomplete, NOT a submit blocker) while academic is empty.
+    expect(
+      firstAttentionStep(steps({ 2: "warning", 3: "warning" }), { requiredDataSteps: [3], priorityIssuesCount: 0 }),
+    ).toBe(3)
   })
 
   it("routes priority issues to step 4 even when every step is success/locked (no dead-end)", () => {
     // missing_priority_evidence_codes counts toward the badge but step_status[4]
     // stays 'success' once KV is resolved → must still navigate, not no-op.
-    const target = firstAttentionStep(steps({ 8: "locked" }), {
-      requiredDataCount: 0,
-      priorityIssuesCount: 1,
-    })
-    expect(target).toBe(4)
+    expect(firstAttentionStep(steps({ 8: "locked" }), { requiredDataSteps: [], priorityIssuesCount: 1 })).toBe(4)
   })
 
   it("falls back to the first remaining 'warning' step when no error/required-data/priority", () => {
-    const target = firstAttentionStep(steps({ 6: "warning" }), NONE)
-    expect(target).toBe(6)
+    expect(firstAttentionStep(steps({ 6: "warning" }), NONE)).toBe(6)
   })
 
   it("returns null when nothing needs attention", () => {
@@ -56,21 +54,42 @@ describe("firstAttentionStep", () => {
   })
 
   it("error still wins over required-data and priority", () => {
-    const target = firstAttentionStep(steps({ 1: "error", 2: "warning" }), {
-      requiredDataCount: 2,
-      priorityIssuesCount: 3,
-    })
-    expect(target).toBe(1)
+    expect(
+      firstAttentionStep(steps({ 1: "error", 2: "warning" }), { requiredDataSteps: [2, 3], priorityIssuesCount: 3 }),
+    ).toBe(1)
   })
 
-  it("required-data count with no step-2/3 warning falls through to priority/warning", () => {
-    // Defensive: flag says required-data but steps 2/3 aren't warning (backend
-    // desync) → don't get stuck; use priority then generic warning.
-    const target = firstAttentionStep(steps({ 5: "warning" }), {
-      requiredDataCount: 1,
-      priorityIssuesCount: 0,
-    })
-    expect(target).toBe(5)
+  it("routes straight to the missing required-data step regardless of its displayed status", () => {
+    // Direct routing means a step_status desync (flag says missing but the step
+    // isn't amber) still lands on the right tab instead of a generic warning.
+    expect(
+      firstAttentionStep(steps({ 5: "warning" }), { requiredDataSteps: [3], priorityIssuesCount: 0 }),
+    ).toBe(3)
+  })
+})
+
+describe("missingRequiredDataSteps", () => {
+  it("flags family (2) + academic (3) when both empty", () => {
+    expect(
+      missingRequiredDataSteps(profile({ family_info: [], academic_history: [] } as Partial<AdmissionProfileResponse>)),
+    ).toEqual([2, 3])
+  })
+
+  it("flags only academic (3) when family is present", () => {
+    expect(
+      missingRequiredDataSteps(profile({ academic_history: [] } as Partial<AdmissionProfileResponse>)),
+    ).toEqual([3])
+  })
+
+  it("flags only family (2) when academic is present", () => {
+    expect(
+      missingRequiredDataSteps(profile({ family_info: [] } as Partial<AdmissionProfileResponse>)),
+    ).toEqual([2])
+  })
+
+  it("returns [] when both present, and [] for null", () => {
+    expect(missingRequiredDataSteps(profile())).toEqual([])
+    expect(missingRequiredDataSteps(null)).toEqual([])
   })
 })
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.test.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest"
+import { firstAttentionStep, issueTotalCount } from "./priorityIssues"
+
+type StepStatus = "success" | "warning" | "error" | "locked"
+
+/** All 8 steps "success" by default; override the ones a case cares about. */
+function steps(overrides: Record<number, StepStatus> = {}): Record<number, StepStatus> {
+  const base: Record<number, StepStatus> = { 1: "success", 2: "success", 3: "success", 4: "success", 5: "success", 6: "success", 7: "success", 8: "success" }
+  return { ...base, ...overrides }
+}
+
+const NONE = { requiredDataCount: 0, priorityIssuesCount: 0 }
+
+describe("firstAttentionStep", () => {
+  it("returns the first 'error' step before any warning", () => {
+    // step 1 warning + step 5 error → error wins even though it's later.
+    const target = firstAttentionStep(steps({ 1: "warning", 5: "error" }), NONE)
+    expect(target).toBe(5)
+  })
+
+  it("prefers the required-data step (2/3) over an earlier NON-blocking step-1 warning", () => {
+    // The exact 'kẹt' bug: step 1 amber for blank OPTIONAL personal fields, while
+    // family/academic (the real submit blocker) are step 2/3 warnings.
+    const target = firstAttentionStep(steps({ 1: "warning", 2: "warning", 3: "warning" }), {
+      requiredDataCount: 2,
+      priorityIssuesCount: 0,
+    })
+    expect(target).toBe(2)
+  })
+
+  it("routes to step 3 when family is complete but academic (step 3) is the required-data warning", () => {
+    const target = firstAttentionStep(steps({ 1: "warning", 3: "warning" }), {
+      requiredDataCount: 1,
+      priorityIssuesCount: 0,
+    })
+    expect(target).toBe(3)
+  })
+
+  it("routes priority issues to step 4 even when every step is success/locked (no dead-end)", () => {
+    // missing_priority_evidence_codes counts toward the badge but step_status[4]
+    // stays 'success' once KV is resolved → must still navigate, not no-op.
+    const target = firstAttentionStep(steps({ 8: "locked" }), {
+      requiredDataCount: 0,
+      priorityIssuesCount: 1,
+    })
+    expect(target).toBe(4)
+  })
+
+  it("falls back to the first remaining 'warning' step when no error/required-data/priority", () => {
+    const target = firstAttentionStep(steps({ 6: "warning" }), NONE)
+    expect(target).toBe(6)
+  })
+
+  it("returns null when nothing needs attention", () => {
+    expect(firstAttentionStep(steps({ 8: "locked" }), NONE)).toBeNull()
+  })
+
+  it("error still wins over required-data and priority", () => {
+    const target = firstAttentionStep(steps({ 1: "error", 2: "warning" }), {
+      requiredDataCount: 2,
+      priorityIssuesCount: 3,
+    })
+    expect(target).toBe(1)
+  })
+
+  it("required-data count with no step-2/3 warning falls through to priority/warning", () => {
+    // Defensive: flag says required-data but steps 2/3 aren't warning (backend
+    // desync) → don't get stuck; use priority then generic warning.
+    const target = firstAttentionStep(steps({ 5: "warning" }), {
+      requiredDataCount: 1,
+      priorityIssuesCount: 0,
+    })
+    expect(target).toBe(5)
+  })
+})
+
+describe("issueTotalCount", () => {
+  it("sums validation + priority + required-data counts", () => {
+    expect(issueTotalCount(2, 1, { required_data: { count: 3 } })).toBe(6)
+  })
+
+  it("treats missing/null grouped or required_data as 0", () => {
+    expect(issueTotalCount(2, 1, null)).toBe(3)
+    expect(issueTotalCount(0, 0, {})).toBe(0)
+  })
+})

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.test.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.test.ts
@@ -10,9 +10,9 @@ function steps(overrides: Record<number, StepStatus> = {}): Record<number, StepS
   return { ...base, ...overrides }
 }
 
-/** Minimal profile with both required-data groups present by default. */
+/** Minimal DRAFT profile with both required-data groups present by default. */
 function profile(overrides: Partial<AdmissionProfileResponse> = {}): AdmissionProfileResponse {
-  return { family_info: [{}], academic_history: [{}], ...overrides } as unknown as AdmissionProfileResponse
+  return { status: "draft", family_info: [{}], academic_history: [{}], ...overrides } as unknown as AdmissionProfileResponse
 }
 
 const NONE = { requiredDataSteps: [] as number[], priorityIssuesCount: 0 }
@@ -90,6 +90,16 @@ describe("missingRequiredDataSteps", () => {
   it("returns [] when both present, and [] for null", () => {
     expect(missingRequiredDataSteps(profile())).toEqual([])
     expect(missingRequiredDataSteps(null)).toEqual([])
+  })
+
+  it("returns [] on non-draft status even when family/academic empty (matches BE draft-scoped gate)", () => {
+    // A submitted/approved legacy profile is NOT submit-blocked by family/academic,
+    // so the CTA must not route to step 2/3 — let priority/other issues win.
+    expect(
+      missingRequiredDataSteps(
+        profile({ status: "submitted", family_info: [], academic_history: [] } as Partial<AdmissionProfileResponse>),
+      ),
+    ).toEqual([])
   })
 })
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
@@ -26,6 +26,12 @@ export function missingRequiredDataSteps(
   profile: AdmissionProfileResponse | null,
 ): number[] {
   if (!profile) return []
+  // Match the backend: `_missing_submit_required_data` only runs for drafts, so
+  // required_data.count / submit_blocked_by_data are 0 on non-draft statuses.
+  // A submitted/approved profile with legacy-empty family/academic is NOT
+  // submit-blocked by them, so must NOT outrank a real priority issue and send
+  // the CTA to a read-only step 2/3 dead end.
+  if (profile.status !== "draft") return []
   const steps: number[] = []
   if (!profile.family_info?.length) steps.push(2)
   if (!profile.academic_history?.length) steps.push(3)
@@ -53,17 +59,17 @@ export function firstAttentionStep(
   opts: { requiredDataSteps: number[]; priorityIssuesCount: number },
 ): number | null {
   const ALL_STEPS = [1, 2, 3, 4, 5, 6, 7, 8]
-  const firstWith = (status: StepStatus, steps: number[]) =>
-    steps.find((s) => stepsStatus[s] === status) ?? null
+  const firstWith = (status: StepStatus) =>
+    ALL_STEPS.find((s) => stepsStatus[s] === status) ?? null
 
-  const errorStep = firstWith("error", ALL_STEPS)
+  const errorStep = firstWith("error")
   if (errorStep !== null) return errorStep
 
   if (opts.requiredDataSteps.length > 0) return Math.min(...opts.requiredDataSteps)
 
   if (opts.priorityIssuesCount > 0) return 4
 
-  return firstWith("warning", ALL_STEPS)
+  return firstWith("warning")
 }
 
 /**

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
@@ -1,3 +1,4 @@
+import { ADMISSION_STEPS, STEP } from "@/lib/constants/admission-steps"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
 /**
@@ -33,8 +34,8 @@ export function missingRequiredDataSteps(
   // the CTA to a read-only step 2/3 dead end.
   if (profile.status !== "draft") return []
   const steps: number[] = []
-  if (!profile.family_info?.length) steps.push(2)
-  if (!profile.academic_history?.length) steps.push(3)
+  if (!profile.family_info?.length) steps.push(STEP.FAMILY)
+  if (!profile.academic_history?.length) steps.push(STEP.ACADEMIC)
   return steps
 }
 
@@ -58,16 +59,18 @@ export function firstAttentionStep(
   stepsStatus: Record<number, StepStatus>,
   opts: { requiredDataSteps: number[]; priorityIssuesCount: number },
 ): number | null {
-  const ALL_STEPS = [1, 2, 3, 4, 5, 6, 7, 8]
+  // Iterate in pipeline order, derived from the registry so a step add/reorder
+  // flows through automatically.
+  const orderedIds = ADMISSION_STEPS.map((s) => s.id)
   const firstWith = (status: StepStatus) =>
-    ALL_STEPS.find((s) => stepsStatus[s] === status) ?? null
+    orderedIds.find((s) => stepsStatus[s] === status) ?? null
 
   const errorStep = firstWith("error")
   if (errorStep !== null) return errorStep
 
   if (opts.requiredDataSteps.length > 0) return Math.min(...opts.requiredDataSteps)
 
-  if (opts.priorityIssuesCount > 0) return 4
+  if (opts.priorityIssuesCount > 0) return STEP.PRIORITY
 
   return firstWith("warning")
 }

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
@@ -14,6 +14,44 @@ export function issueTotalCount(
   return validationErrorsLength + priorityIssuesLength + (grouped?.required_data?.count ?? 0)
 }
 
+type StepStatus = "success" | "warning" | "error" | "locked"
+
+/**
+ * Pick the step the "việc cần xử lý" CTA should jump to. Driven by the SAME issue
+ * sources that feed {@link issueTotalCount} so the CTA can never dead-end or land
+ * on an unrelated tab. Priority order:
+ *   1. First "error" step — always a genuine blocker (personal/scores/docs).
+ *   2. Required-data (family/academic): HARD-blocks submit but only surfaces as a
+ *      step 2/3 "warning" — prefer it over an earlier NON-blocking warning (e.g.
+ *      step 1 amber for blank OPTIONAL personal fields) so the user lands on the
+ *      real blocker instead of a tab that leaves submit disabled.
+ *   3. Priority (step 4) issues (missing UT evidence / manual override): count
+ *      toward the badge but never mark step 4 error/warning once KV is resolved,
+ *      so route there explicitly instead of falling through to a dead end.
+ *   4. First remaining "warning" step.
+ * Returns null when no step needs attention.
+ */
+export function firstAttentionStep(
+  stepsStatus: Record<number, StepStatus>,
+  opts: { requiredDataCount: number; priorityIssuesCount: number },
+): number | null {
+  const ALL_STEPS = [1, 2, 3, 4, 5, 6, 7, 8]
+  const firstWith = (status: StepStatus, steps: number[]) =>
+    steps.find((s) => stepsStatus[s] === status) ?? null
+
+  const errorStep = firstWith("error", ALL_STEPS)
+  if (errorStep !== null) return errorStep
+
+  if (opts.requiredDataCount > 0) {
+    const dataStep = firstWith("warning", [2, 3])
+    if (dataStep !== null) return dataStep
+  }
+
+  if (opts.priorityIssuesCount > 0) return 4
+
+  return firstWith("warning", ALL_STEPS)
+}
+
 /**
  * Derive Priority (Step 4) issues from BE-set flags only.
  *

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
@@ -1,6 +1,20 @@
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
 /**
+ * Total count for the "Vấn đề cần sửa" badge/panel = response validation errors
+ * + derived Step-4 priority issues + required-data (family/academic) count.
+ * Centralized so IssueSummary and MobileIssueDrawer never disagree on which
+ * terms make up the badge count.
+ */
+export function issueTotalCount(
+  validationErrorsLength: number,
+  priorityIssuesLength: number,
+  grouped?: { required_data?: { count: number } } | null,
+): number {
+  return validationErrorsLength + priorityIssuesLength + (grouped?.required_data?.count ?? 0)
+}
+
+/**
  * Derive Priority (Step 4) issues from BE-set flags only.
  *
  * Trả về danh sách thông điệp Việt hóa để hiển thị trong IssueSummary /

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
@@ -1,4 +1,4 @@
-import { ADMISSION_STEPS, STEP } from "@/lib/constants/admission-steps"
+import { ADMISSION_STEP_IDS, STEP } from "@/lib/constants/admission-steps"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
 /**
@@ -59,11 +59,10 @@ export function firstAttentionStep(
   stepsStatus: Record<number, StepStatus>,
   opts: { requiredDataSteps: number[]; priorityIssuesCount: number },
 ): number | null {
-  // Iterate in pipeline order, derived from the registry so a step add/reorder
-  // flows through automatically.
-  const orderedIds = ADMISSION_STEPS.map((s) => s.id)
+  // Iterate in pipeline order (registry-derived module const), so a step
+  // add/reorder flows through automatically.
   const firstWith = (status: StepStatus) =>
-    orderedIds.find((s) => stepsStatus[s] === status) ?? null
+    ADMISSION_STEP_IDS.find((s) => stepsStatus[s] === status) ?? null
 
   const errorStep = firstWith("error")
   if (errorStep !== null) return errorStep

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/priorityIssues.ts
@@ -17,14 +17,31 @@ export function issueTotalCount(
 type StepStatus = "success" | "warning" | "error" | "locked"
 
 /**
+ * Steps whose submit-required data is still empty — family info (step 2) and
+ * academic history (step 3). Mirrors the backend submit gate
+ * `_missing_submit_required_data` (admission_service.py) so the CTA can jump to
+ * the EXACT blocking tab rather than the first amber step. Returned in step order.
+ */
+export function missingRequiredDataSteps(
+  profile: AdmissionProfileResponse | null,
+): number[] {
+  if (!profile) return []
+  const steps: number[] = []
+  if (!profile.family_info?.length) steps.push(2)
+  if (!profile.academic_history?.length) steps.push(3)
+  return steps
+}
+
+/**
  * Pick the step the "việc cần xử lý" CTA should jump to. Driven by the SAME issue
  * sources that feed {@link issueTotalCount} so the CTA can never dead-end or land
  * on an unrelated tab. Priority order:
  *   1. First "error" step — always a genuine blocker (personal/scores/docs).
- *   2. Required-data (family/academic): HARD-blocks submit but only surfaces as a
- *      step 2/3 "warning" — prefer it over an earlier NON-blocking warning (e.g.
- *      step 1 amber for blank OPTIONAL personal fields) so the user lands on the
- *      real blocker instead of a tab that leaves submit disabled.
+ *   2. Required-data: the earliest still-empty family(2)/academic(3) step. This
+ *      HARD-blocks submit but usually shows only as a step 2/3 "warning", so jump
+ *      straight to it — skipping an earlier NON-blocking warning (e.g. step 1 amber
+ *      for blank OPTIONAL fields) AND landing on the RIGHT tab when only academic
+ *      is missing while step 2 is amber for an unrelated reason.
  *   3. Priority (step 4) issues (missing UT evidence / manual override): count
  *      toward the badge but never mark step 4 error/warning once KV is resolved,
  *      so route there explicitly instead of falling through to a dead end.
@@ -33,7 +50,7 @@ type StepStatus = "success" | "warning" | "error" | "locked"
  */
 export function firstAttentionStep(
   stepsStatus: Record<number, StepStatus>,
-  opts: { requiredDataCount: number; priorityIssuesCount: number },
+  opts: { requiredDataSteps: number[]; priorityIssuesCount: number },
 ): number | null {
   const ALL_STEPS = [1, 2, 3, 4, 5, 6, 7, 8]
   const firstWith = (status: StepStatus, steps: number[]) =>
@@ -42,10 +59,7 @@ export function firstAttentionStep(
   const errorStep = firstWith("error", ALL_STEPS)
   if (errorStep !== null) return errorStep
 
-  if (opts.requiredDataCount > 0) {
-    const dataStep = firstWith("warning", [2, 3])
-    if (dataStep !== null) return dataStep
-  }
+  if (opts.requiredDataSteps.length > 0) return Math.min(...opts.requiredDataSteps)
 
   if (opts.priorityIssuesCount > 0) return 4
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/DecisionActionsPanel.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/DecisionActionsPanel.test.tsx
@@ -59,8 +59,13 @@ function buildProfile(overrides: Partial<AdmissionProfileResponse> = {}): Admiss
     available_actions: [],
     completion_percent: 100,
     applied_rules: {},
-    family_info: [],
-    academic_history: [],
+    // Default fixture = COMPLETE draft (not data-blocked): faithful to the
+    // backend, which derives submit_blocked_by_data from these two groups. Tests
+    // that exercise the required-data gate override these explicitly below.
+    family_info: [{ relationship: "father", full_name: "Nguyễn Văn A" }],
+    academic_history: [{ school: "THPT X", year: 2025 }],
+    submit_blocked_by_data: false,
+    grouped_validation_errors: null,
     documents_checklist: [],
     missing_priority_evidence_codes: [],
     priority_resolution_snapshot: {},
@@ -331,5 +336,46 @@ describe("DecisionActionsPanel — submit-with-debt (fast-track nợ giấy tờ
       acknowledge_missing_docs: true,
       document_debt_reason: "cấp lại học bạ",
     })
+  })
+})
+
+describe("DecisionActionsPanel — required-data submit gate (family/academic)", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  // Draft eligible on every other axis but missing family/academic → backend
+  // sets submit_blocked_by_data=true. submit_and_evaluate rejects these two
+  // groups UNCONDITIONALLY, so the button must be disabled up-front (not shown
+  // enabled then bounced).
+  const blockedProfile = () =>
+    buildProfile({
+      status: "draft",
+      family_info: [],
+      academic_history: [],
+      submit_blocked_by_data: true,
+      grouped_validation_errors: {
+        required_data: {
+          category: "Thông tin bắt buộc",
+          errors: ["Chưa nhập quá trình học tập", "Chưa nhập thông tin gia đình"],
+          count: 2,
+        },
+      },
+    })
+
+  it("disables the submit button + shows the missing-data reason when submit_blocked_by_data", () => {
+    renderPanel(blockedProfile(), { primaryAction: "submit", canSubmit: true, isEligible: true })
+    expect(screen.getByText("Nộp hồ sơ chính thức").closest("button")).toBeDisabled()
+    expect(screen.getByText(/Còn thiếu:.*quá trình học tập/)).toBeInTheDocument()
+  })
+
+  it("hides the doc-debt CTA while required data is still missing (it would also bounce)", () => {
+    renderPanel(blockedProfile(), {
+      primaryAction: "submit",
+      canSubmit: true,
+      isEligible: true,
+      canSubmitWithDocumentDebt: true,
+      onSubmitWithDebt: vi.fn(),
+    })
+    expect(screen.queryByText("Nộp kèm nợ giấy tờ")).not.toBeInTheDocument()
+    expect(screen.getByText(/Còn thiếu:/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/DecisionActionsPanel.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/DecisionActionsPanel.tsx
@@ -143,7 +143,8 @@ export function DecisionActionsPanel({
 }: DecisionActionsPanelProps) {
   // Draft còn thiếu dữ liệu bắt buộc (quá trình học tập / gia đình) — BE chặn
   // submit nhưng không nằm trong eligibility, nên gate nút + hiện lý do rõ ràng
-  // ở đây (bypass-aware: cờ đã tính allow_unverified_submission ở backend).
+  // ở đây. Cờ bypass-independent (BE phản ánh submit gate VÔ ĐIỀU KIỆN; không
+  // liên quan allow_unverified_submission — cái đó chỉ nới kiểm tra tài liệu).
   const submitBlockedByData = profile.submit_blocked_by_data ?? false
   const requiredDataErrors = profile.grouped_validation_errors?.required_data?.errors ?? []
 
@@ -362,10 +363,14 @@ export function DecisionActionsPanel({
     // regardless of docs — hide the doc-debt CTA (it would also be rejected) and
     // point the user at the missing data instead.
     const showDebt = canSubmitWithDocumentDebt && !!onSubmitWithDebt && !submitBlockedByData
+    // Guard the data reason on the errors list (not just the flag) so a backend
+    // desync (flag true, list empty) falls through instead of rendering "Còn
+    // thiếu: ". When other blockers also apply (!isEligible), hint at them so the
+    // user isn't bounced again after only supplying the missing data.
     const reasonNode = showDebt ? (
       <Reason>Còn thiếu giấy tờ — có thể nộp kèm nợ giấy tờ.</Reason>
-    ) : submitBlockedByData ? (
-      <Reason>Còn thiếu: {requiredDataErrors.join(" · ")}</Reason>
+    ) : submitBlockedByData && requiredDataErrors.length > 0 ? (
+      <Reason>{`Còn thiếu: ${requiredDataErrors.join(" · ")}${!isEligible ? " · và các điều kiện khác" : ""}`}</Reason>
     ) : !isEligible ? (
       <Reason>Chưa đủ điều kiện để nộp.</Reason>
     ) : undefined

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/DecisionActionsPanel.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/DecisionActionsPanel.tsx
@@ -141,12 +141,18 @@ export function DecisionActionsPanel({
   isEnrolling = false,
   canEnroll,
 }: DecisionActionsPanelProps) {
+  // Draft còn thiếu dữ liệu bắt buộc (quá trình học tập / gia đình) — BE chặn
+  // submit nhưng không nằm trong eligibility, nên gate nút + hiện lý do rõ ràng
+  // ở đây (bypass-aware: cờ đã tính allow_unverified_submission ở backend).
+  const submitBlockedByData = profile.submit_blocked_by_data ?? false
+  const requiredDataErrors = profile.grouped_validation_errors?.required_data?.errors ?? []
+
   // ----- per-action renderers (closures) -------------------------------------
   const submitButton = () => (
     <Button
       key="submit"
       size="lg"
-      disabled={!isEligible || isSubmitting}
+      disabled={!isEligible || submitBlockedByData || isSubmitting}
       onClick={onSubmit}
       className={PRIMARY_CLASS}
     >
@@ -352,9 +358,14 @@ export function DecisionActionsPanel({
     // mandatory docs, the backend grants `can_submit_with_document_debt`. Offer
     // "Nộp kèm nợ giấy tờ" alongside the (disabled) normal submit. The reason
     // line then points at the debt option instead of a dead "chưa đủ điều kiện".
-    const showDebt = canSubmitWithDocumentDebt && !!onSubmitWithDebt
+    // When required data (family/academic) is still missing, submit is blocked
+    // regardless of docs — hide the doc-debt CTA (it would also be rejected) and
+    // point the user at the missing data instead.
+    const showDebt = canSubmitWithDocumentDebt && !!onSubmitWithDebt && !submitBlockedByData
     const reasonNode = showDebt ? (
       <Reason>Còn thiếu giấy tờ — có thể nộp kèm nợ giấy tờ.</Reason>
+    ) : submitBlockedByData ? (
+      <Reason>Còn thiếu: {requiredDataErrors.join(" · ")}</Reason>
     ) : !isEligible ? (
       <Reason>Chưa đủ điều kiện để nộp.</Reason>
     ) : undefined

--- a/frontend/src/lib/constants/admission-steps.test.ts
+++ b/frontend/src/lib/constants/admission-steps.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest"
+import {
+  ADMISSION_STEPS,
+  ADMISSION_STEP_IDS,
+  STEP,
+  GROUPED_SECTION_TO_STEP,
+} from "./admission-steps"
+
+/**
+ * The pipeline step-id space is encoded in THREE places (ADMISSION_STEPS[].id,
+ * the STEP name→id map, GROUPED_SECTION_TO_STEP section→id). These pins fail if a
+ * reorder/edit touches one but not the others — turning a silent drift (CTA routes
+ * to the wrong tab) into a red test.
+ */
+describe("admission-steps registry ↔ STEP map", () => {
+  it("STEP values are exactly the ADMISSION_STEPS ids", () => {
+    const ids = ADMISSION_STEPS.map((s) => s.id)
+    expect([...Object.values(STEP)].sort((a, b) => a - b)).toEqual(ids)
+  })
+
+  it("names point at the expected positions", () => {
+    expect(STEP.FAMILY).toBe(2)
+    expect(STEP.ACADEMIC).toBe(3)
+    expect(STEP.PRIORITY).toBe(4)
+  })
+
+  it("ADMISSION_STEP_IDS mirrors the registry order", () => {
+    expect(ADMISSION_STEP_IDS).toEqual(ADMISSION_STEPS.map((s) => s.id))
+  })
+
+  it("GROUPED_SECTION_TO_STEP maps only to real, correctly-named step ids", () => {
+    const ids = new Set(ADMISSION_STEPS.map((s) => s.id))
+    for (const step of Object.values(GROUPED_SECTION_TO_STEP)) {
+      expect(ids.has(step)).toBe(true)
+    }
+    expect(GROUPED_SECTION_TO_STEP.personal_info).toBe(STEP.PERSONAL)
+    expect(GROUPED_SECTION_TO_STEP.scores).toBe(STEP.SCORES)
+    expect(GROUPED_SECTION_TO_STEP.documents).toBe(STEP.DOCUMENTS)
+  })
+})

--- a/frontend/src/lib/constants/admission-steps.ts
+++ b/frontend/src/lib/constants/admission-steps.ts
@@ -55,6 +55,9 @@ export const STEP = {
   FINALIZE: 8,
 } as const
 
+/** Pipeline step ids in order — derived once so consumers don't re-`map` per call. */
+export const ADMISSION_STEP_IDS: number[] = ADMISSION_STEPS.map((s) => s.id)
+
 /**
  * Map a `grouped_validation_errors` section key (backend `_compute_frontend_fields`,
  * admission_service.py:1878) → its pipeline step. Drives message-level ActionItems

--- a/frontend/src/lib/constants/admission-steps.ts
+++ b/frontend/src/lib/constants/admission-steps.ts
@@ -39,6 +39,23 @@ export const ADMISSION_STEPS: AdmissionStep[] = [
 ]
 
 /**
+ * Semantic step ids — name the pipeline positions so consumers (e.g. the CTA
+ * router in `priorityIssues.ts`) reference `STEP.FAMILY` instead of a bare `2`.
+ * If the 8-step model is ever reordered, update THIS map alongside
+ * `ADMISSION_STEPS` in one place rather than hunting magic numbers.
+ */
+export const STEP = {
+  PERSONAL: 1,
+  FAMILY: 2,
+  ACADEMIC: 3,
+  PRIORITY: 4,
+  SCORES: 5,
+  DOCUMENTS: 6,
+  TUITION: 7,
+  FINALIZE: 8,
+} as const
+
+/**
  * Map a `grouped_validation_errors` section key (backend `_compute_frontend_fields`,
  * admission_service.py:1878) → its pipeline step. Drives message-level ActionItems
  * in `useSubmissionReadiness` (STEP8 plan B2). Step 4 (priority) is derived

--- a/frontend/src/lib/utils/admission-permissions.test.ts
+++ b/frontend/src/lib/utils/admission-permissions.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest"
+import { canDecide, isStepNavLocked } from "./admission-permissions"
+
+describe("canDecide", () => {
+  it("trusts the BE aggregate has_decision when present", () => {
+    expect(canDecide({ has_decision: true })).toBe(true)
+    // has_decision present + false → do NOT fall back to the OR-7 (?? only
+    // triggers on null/undefined), even if an individual flag is set.
+    expect(canDecide({ has_decision: false, approve: true })).toBe(false)
+  })
+
+  it("falls back to the OR of the 7 decision flags when has_decision is absent", () => {
+    expect(canDecide({ approve: true })).toBe(true)
+    expect(canDecide({ enroll: true })).toBe(true)
+    expect(canDecide({})).toBe(false)
+    expect(canDecide(undefined)).toBe(false)
+  })
+})
+
+describe("isStepNavLocked", () => {
+  it("keeps step 8 reachable for decision-capable users even when backend-locked", () => {
+    expect(isStepNavLocked(8, "locked", true)).toBe(false)
+  })
+
+  it("locks step 8 when the user cannot decide", () => {
+    expect(isStepNavLocked(8, "locked", false)).toBe(true)
+  })
+
+  it("never treats a non-locked step 8 as locked", () => {
+    expect(isStepNavLocked(8, "success", false)).toBe(false)
+  })
+
+  it("only step 8 gets the decide override — other locked steps stay locked", () => {
+    expect(isStepNavLocked(5, "locked", true)).toBe(true)
+    expect(isStepNavLocked(1, "locked", false)).toBe(true)
+  })
+
+  it("non-locked steps are never locked regardless of decide", () => {
+    expect(isStepNavLocked(3, "warning", false)).toBe(false)
+    expect(isStepNavLocked(6, "success", true)).toBe(false)
+  })
+})

--- a/frontend/src/lib/utils/admission-permissions.ts
+++ b/frontend/src/lib/utils/admission-permissions.ts
@@ -26,3 +26,29 @@ export function canDecide(perms: AdmissionPermissions | undefined): boolean {
         perms?.enroll),
   )
 }
+
+type StepStatus = "success" | "warning" | "error" | "locked"
+
+/**
+ * Whether a step-navigation surface should DISABLE a step button. Single source
+ * of truth shared by PipelineSidebar (desktop) and MobileStepStrip so the two
+ * can't drift on which steps are reachable.
+ *
+ * Step 8 (Finalize) stays reachable for decision-capable users even when the
+ * backend marks it "locked" (ineligible) — a UI-only navigation override so a
+ * manager/admin can reach the decision surface. The BE mutation APIs
+ * (approve/reject/submit/enroll/…) still validate the state machine + IDOR
+ * independently, so this never bypasses authorization. Every other step locks
+ * strictly on the backend "locked" status.
+ *
+ * NOTE: AdmissionActions' "Tiếp tục" gate is a DIFFERENT rule (advance past
+ * step 7) — do not fold it in here.
+ */
+export function isStepNavLocked(
+  stepId: number,
+  status: StepStatus,
+  decide: boolean,
+): boolean {
+  const isStep8Override = stepId === 8 && decide
+  return !isStep8Override && status === "locked"
+}

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -1120,7 +1120,9 @@ export const admissionProfileResponseSchema = z.object({
   }).optional().nullable(),
 
   // Draft blocked from submit by missing required data (family/academic).
-  // Backend-computed (bypass-aware) — FE gates the submit button on this.
+  // Backend-computed, bypass-independent (mirrors the unconditional submit gate;
+  // allow_unverified_submission only relaxes document checks). FE gates the
+  // submit button on this.
   submit_blocked_by_data: z.boolean().optional().nullable(),
 
   /**

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -1109,8 +1109,19 @@ export const admissionProfileResponseSchema = z.object({
       category: z.string(),
       errors: z.array(z.string()),
       count: z.number().int()
+    }).optional(),
+    // Required-data bucket (family + academic history) — surfaced so the draft
+    // view can warn about groups that block submit but aren't in validation_errors.
+    required_data: z.object({
+      category: z.string(),
+      errors: z.array(z.string()),
+      count: z.number().int()
     }).optional()
   }).optional().nullable(),
+
+  // Draft blocked from submit by missing required data (family/academic).
+  // Backend-computed (bypass-aware) — FE gates the submit button on this.
+  submit_blocked_by_data: z.boolean().optional().nullable(),
 
   /**
    * Step status for sidebar navigation.

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -944,6 +944,11 @@ export const admissionProfileResponseSchema = z.object({
   // Denormalized fields for list display
   program_name: z.string().optional().nullable(),
 
+  // BE-resolved display name of the primary nguyện vọng (choice-engine: first
+  // choice's program/path; legacy: program_name; empty choice-engine: null).
+  // Single source so the header doesn't heuristically pick the display value.
+  primary_choice_display: z.string().optional().nullable(),
+
   // Học phí HK1 (Admission List v2). NOTE: listAdmissions does NOT .parse() the
   // response — these z.number() declarations are TYPE-ONLY (no runtime coercion).
   // BE sends Decimal as JSON string; the string→number conversion happens in the


### PR DESCRIPTION
## Tóm tắt

Đại tu UX trang chi tiết hồ sơ tuyển sinh `/admissions/[id]` (20 commit) — mục tiêu: đóng lỗ hổng **draft↔submit mismatch** (user thấy "sẵn sàng" nhưng submit bị chặn), làm rõ trạng thái hồ sơ, và dẫn officer tới đúng việc cần xử lý.

## Thay đổi chính

**1. Required-data surfacing (đóng draft↔submit mismatch)**
- `validation_errors`/`eligibility_status` (draft-view) trước KHÔNG gồm `family_info`/`academic_history` nhưng `submit_and_evaluate` vẫn reject → user thấy "đủ" mà nút Nộp bật lại.
- BE `_missing_submit_required_data` (gate `status=="draft"`) + FE `grouped_validation_errors.required_data` + `submit_blocked_by_data` → hiện rõ "Thiếu Quá trình học tập / Thông tin gia đình" + chặn nút Nộp kèm lý do.

**2. "Dải trạng thái hồ sơ" — case-status header (web + mobile)**
- `AdmissionHeader` đọc từ trên xuống: nguyện vọng · phụ trách · trạng thái · verdict (màu *mood* amber/xanh) · ledger (học phí/tài liệu/KV/UT) · CTA "N việc cần xử lý". Thin-client 100%.
- Nguyện vọng từ BE `primary_choice_display` (`computed_field` — provenance choice-engine/legacy/empty resolve ở 1 nguồn BE, FE hết heuristic).

**3. Điều hướng**
- `MobileStepStrip` (step navigator cho mobile) + CTA/nút "Kiểm tra toàn bộ" nhảy đúng bước chặn: `firstAttentionStep` ưu tiên error → required-data (family=2/academic=3, draft-scoped) → priority(4) → warning; step-id qua registry `ADMISSION_STEPS` (hết magic-number).

**4. Layout width**
- Gỡ card-in-card thừa + `max-w-7xl`→`--content-max-width` (1600) + giảm padding kép → form rộng hơn, hết cảm giác "đóng hộp".

## Code review

3 vòng `/code-review max` (fan-out 10 finder) → **mọi finding correctness + reuse/altitude + cleanup đã vá** (#1–#12 + P2 doc-debt gate + nợ fixture pre-existing).

Điểm cần nhớ: cờ `can_submit_with_document_debt` là **OPTIMISTIC hint** — không sync-gate được trên trục *ward async* (`_is_current_era_ward`) + *KV resolve-tại-submit* (null cho draft chưa preview); đã document rõ + test e2e đóng vòng flag↔API (API là authoritative, FE chỉ surface bounce).

## Verify

- BE **73 test** · FE **40 test** · type-check + lint sạch (0 error) · flake8 net-zero E501.
- Chrome MCP smoke local (header / CTA routing / FinalizeTab / steps 4·5·8) — render đúng, console sạch.

## ⚠️ Caveat (dev-only)

Trên **dev-clone**, nguyện vọng hiện MÃ (`2026 - hoc_ba - DOT_2`) vì major id 69 (Điều dưỡng) bị orphan khi pull DB — **prod hiển thị tên ngành thật**. Cùng artifact ở FinalizeTab ReadinessHero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
