### PR TITLE
feat(sms): §16.9 retention — dọn event tracking chi tiết sau 365 ngày (data-minimization)

### DIFF
--- a/Backend_FastAPI/alembic/versions/smsp2retidx20260705001_landing_session_started_at_idx.py
+++ b/Backend_FastAPI/alembic/versions/smsp2retidx20260705001_landing_session_started_at_idx.py
@@ -1,0 +1,28 @@
+"""index sms_landing_session.started_at cho retention DELETE (§16.9)
+
+Hỗ trợ cron `cleanup_sms_interest_events_task` (`DELETE FROM sms_landing_session
+WHERE started_at < cutoff`) — tránh seq-scan khi bảng phình theo traffic landing
+công khai. Tạo rẻ (bảng gần rỗng lúc deploy — deep-tracking còn dormant §16.9).
+
+Revision ID: smsp2retidx20260705001
+Revises: memwt20260703001
+Create Date: 2026-07-05
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "smsp2retidx20260705001"
+down_revision = "memwt20260703001"
+branch_labels = None
+depends_on = None
+
+_INDEX = "ix_sms_landing_session_started_at"
+_TABLE = "sms_landing_session"
+
+
+def upgrade() -> None:
+    op.create_index(_INDEX, _TABLE, ["started_at"])
+
+
+def downgrade() -> None:
+    op.drop_index(_INDEX, table_name=_TABLE)

--- a/Backend_FastAPI/app/celery_app.py
+++ b/Backend_FastAPI/app/celery_app.py
@@ -161,6 +161,13 @@ celery_app.conf.beat_schedule = {
         "schedule": crontab(hour=3, minute=45),  # 03:45 — dọn export hết hạn
         "options": {"queue": "default"},
     },
+    # --- SMS Phase 2 interest-event retention (§16.9 data-minimization) ---
+    "cleanup-sms-interest-events-daily": {
+        "task": "cleanup_sms_interest_events_task",
+        # 04:15 — 04:00 đã có check_ctv_attribution_expiry; giữ staggering
+        "schedule": crontab(hour=4, minute=15),
+        "options": {"queue": "default"},
+    },
 
     # --- KPI Plan Daily Actuals Sync (P4) ---
     "sync-kpi-plan-actuals-daily": {

--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -310,6 +310,12 @@ class Settings(BaseSettings):
         default=3.0, gt=0,
         validation_alias="SMS_INTEREST_K",
     )  # hệ số normalize(x)=x/(x+K); cosmetic (không đổi thứ hạng)
+    SMS_INTEREST_EVENT_RETENTION_DAYS: int = Field(
+        default=365, ge=30, le=3650,
+        validation_alias="SMS_INTEREST_EVENT_RETENTION_DAYS",
+    )  # §16.9 retention: dọn event tracking chi tiết (sms_landing_session +
+    # sms_program_view cascade) cũ hơn ngần này; GIỮ aggregate
+    # sms_contact_program_interest (recency_weight khiến view quá cũ ≈0)
 
     # -- Docker self-hosted deployment --
     # When True, skip TLS enforcement for DB/Redis connections.

--- a/Backend_FastAPI/app/models/sms/landing_session.py
+++ b/Backend_FastAPI/app/models/sms/landing_session.py
@@ -57,6 +57,7 @@ class SmsLandingSession(Base):
     )
     started_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now(),
+        index=True,  # §16.9 retention DELETE WHERE started_at < cutoff
     )
     last_heartbeat_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True,

--- a/Backend_FastAPI/app/repositories/sms_engagement_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_engagement_repository.py
@@ -115,12 +115,17 @@ class SmsEngagementRepository:
         return res.scalars().first()
 
     async def views_for_interest(
-        self, contact_id: int, major_program_id: int
+        self, contact_id: int, major_program_id: int, since: datetime
     ) -> List[Tuple[int, datetime]]:
         """(dwell_seconds, viewed_at) view NGƯỜI-THẬT của cặp (contact, ngành)
-        — để tính lại interest_score (Σ dwell_factor×recency). JOIN session +
-        LOẠI phiên bot: bot vẫn ghi program_view (audit) nhưng KHÔNG được lẫn
-        vào interest aggregate (khớp report program-interest cũng lọc bot)."""
+        TRONG cửa sổ [since, now] — để tính lại interest. JOIN session + LOẠI
+        phiên bot (bot ghi program_view cho audit nhưng KHÔNG lẫn vào interest,
+        khớp report cũng lọc bot).
+
+        `since` = cửa sổ retention (§16.9): view cũ hơn đằng nào cũng bị cron dọn
+        (+ recency≈0) → KHÔNG tính, để tương tác lại SAU purge không làm tụt
+        view_count/total_dwell (aggregate = rolling-window nhất quán, không mất
+        số liệu khi recompute-ghi-đè)."""
         res = await self.db.execute(
             select(SmsProgramView.dwell_seconds, SmsProgramView.viewed_at)
             .join(
@@ -130,6 +135,7 @@ class SmsEngagementRepository:
             .where(
                 SmsProgramView.contact_id == contact_id,
                 SmsProgramView.major_program_id == major_program_id,
+                SmsProgramView.viewed_at >= since,
                 SmsLandingSession.is_suspected_bot.is_(False),
             )
         )

--- a/Backend_FastAPI/app/services/sms_engagement_service.py
+++ b/Backend_FastAPI/app/services/sms_engagement_service.py
@@ -12,7 +12,7 @@ Bot (UA/prefetch) vẫn tạo phiên (không lộ việc phát hiện) NHƯNG b�
 interest + report. Xem SMS_MARKETING_MODULE_DESIGN.md §16.
 """
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from app.utils.tz import ensure_aware
 from typing import Mapping, Optional
@@ -192,9 +192,15 @@ class SmsEngagementService:
     async def _recompute_interest(
         self, *, contact_id: int, major_program_id: int, now: datetime
     ) -> None:
-        """Tính lại interest_score từ MỌI view của (contact, ngành) — nguồn sự
-        thật là program_view (tự lành khi 2 heartbeat đua)."""
-        views = await self.repo.views_for_interest(contact_id, major_program_id)
+        """Tính lại interest từ view của (contact, ngành) TRONG cửa sổ retention
+        — nguồn sự thật là program_view (tự lành khi 2 heartbeat đua). Cửa sổ =
+        `SMS_INTEREST_EVENT_RETENTION_DAYS`: view cũ hơn đằng nào cũng bị cron
+        §16.9 dọn (recency≈0) → không tính, để re-interact SAU purge KHÔNG làm
+        tụt view_count/total_dwell (rolling-window nhất quán, §16.9)."""
+        since = now - timedelta(days=settings.SMS_INTEREST_EVENT_RETENTION_DAYS)
+        views = await self.repo.views_for_interest(
+            contact_id, major_program_id, since=since
+        )
         if not views:
             return
         # Build 1 lần (normalize tz), rồi derive total_dwell/first/last từ đó.

--- a/Backend_FastAPI/app/tasks/__init__.py
+++ b/Backend_FastAPI/app/tasks/__init__.py
@@ -47,7 +47,10 @@ from .notification_outbox_tasks import (
     dispatch_pending_outbox,  # T0-4a skeleton; T0-4b will replace body
 )
 from .sla_tasks import auto_close_stale_rejected_leads_task
-from .sms_tasks import cleanup_sms_export_files_task
+from .sms_tasks import (
+    cleanup_sms_export_files_task,
+    cleanup_sms_interest_events_task,
+)
 
 __all__ = [
     # Email tasks
@@ -82,4 +85,5 @@ __all__ = [
     "auto_close_stale_rejected_leads_task",
     # SMS Marketing export cleanup (PR-4)
     "cleanup_sms_export_files_task",
+    "cleanup_sms_interest_events_task",
 ]

--- a/Backend_FastAPI/app/tasks/sms_tasks.py
+++ b/Backend_FastAPI/app/tasks/sms_tasks.py
@@ -7,7 +7,7 @@ hằng ngày qua Celery Beat. Xem SMS_MARKETING_MODULE_DESIGN.md §8.3 / §11.7.
 import logging
 import os
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from ..celery_app import celery_app
 from ..config import settings
@@ -86,3 +86,49 @@ def cleanup_sms_export_files_task(self):
         return {"purged": purged, "staging_orphans": orphans}
 
     return run_async_task(_cleanup, "cleanup_sms_export_files_task", log)
+
+
+async def _purge_old_interest_events(db, retention_days: int) -> int:
+    """Xoá `sms_landing_session` có ``started_at`` cũ hơn ``retention_days``
+    ngày; `sms_program_view` đi theo qua FK ``ondelete=CASCADE``. Aggregate
+    `sms_contact_program_interest` KHÔNG cascade → GIỮ nguyên. Trả số session
+    đã xoá. (Helper tách để test chạy đúng query thật.)"""
+    from sqlalchemy import delete
+
+    from app.models.sms import SmsLandingSession
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    res = await db.execute(
+        delete(SmsLandingSession).where(SmsLandingSession.started_at < cutoff)
+    )
+    return res.rowcount or 0
+
+
+@celery_app.task(
+    name="cleanup_sms_interest_events_task",
+    bind=True,
+    autoretry_for=(Exception,),
+    max_retries=2,
+    default_retry_delay=120,
+)
+def cleanup_sms_interest_events_task(self):
+    """Retention §16.9: dọn event tracking chi tiết (`sms_landing_session` +
+    `sms_program_view` cascade) cũ hơn ``SMS_INTEREST_EVENT_RETENTION_DAYS``.
+    GIỮ aggregate `sms_contact_program_interest` (không cascade). Nhất quán:
+    `_recompute_interest` chỉ tính view TRONG cửa sổ retention, nên view bị dọn
+    đằng nào cũng đã ngoài cửa sổ → recompute (kể cả khi contact tương tác lại)
+    KHÔNG lệch view_count/total_dwell/score. Data-minimization; daily Celery Beat."""
+
+    async def _cleanup():
+        retention = settings.SMS_INTEREST_EVENT_RETENTION_DAYS
+        async with task_db_session() as db:
+            deleted = await _purge_old_interest_events(db, retention)
+            await db.commit()
+        log.info(
+            "cleanup_sms_interest_events: retention=%sd deleted_sessions=%s",
+            retention,
+            deleted,
+        )
+        return {"retention_days": retention, "deleted_sessions": deleted}
+
+    return run_async_task(_cleanup, "cleanup_sms_interest_events_task", log)

--- a/Backend_FastAPI/tests/integration/test_sms_retention.py
+++ b/Backend_FastAPI/tests/integration/test_sms_retention.py
@@ -1,0 +1,220 @@
+# tests/integration/test_sms_retention.py
+"""
+Integration test §16.9 retention (SMS Phase 2 deep-engagement).
+
+`cleanup_sms_interest_events_task` / `_purge_old_interest_events` dọn event
+tracking chi tiết (`sms_landing_session` + `sms_program_view` cascade) cũ hơn
+`SMS_INTEREST_EVENT_RETENTION_DAYS`, GIỮ aggregate `sms_contact_program_interest`
+(data-minimization; profile lâu dài không đổi vì view quá cũ có recency≈0).
+
+Chạy one-off container (CLAUDE.md).
+"""
+from datetime import datetime, timedelta, timezone
+
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.config import settings
+from app.database import AsyncSessionLocal
+from app.tasks.sms_tasks import _purge_old_interest_events
+
+API = "/api/sms"
+
+
+async def _mk_contact(client, h, phone: str) -> int:
+    r = await client.post(
+        f"{API}/contacts",
+        json={"full_name": "Retention QA", "phone": phone},
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def test_retention_task_registered():
+    """Task + beat entry + config key khớp — điểm tích hợp Celery beat THẬT
+    (chống: đổi/xoá beat entry, hoặc typo tên config trong task body)."""
+    from app.celery_app import celery_app
+    from app.tasks import cleanup_sms_interest_events_task
+
+    assert (
+        cleanup_sms_interest_events_task.name
+        == "cleanup_sms_interest_events_task"
+    )
+    assert isinstance(settings.SMS_INTEREST_EVENT_RETENTION_DAYS, int)
+    entry = celery_app.conf.beat_schedule.get(
+        "cleanup-sms-interest-events-daily"
+    )
+    assert entry is not None, "beat entry retention bị xoá/đổi tên"
+    assert entry["task"] == "cleanup_sms_interest_events_task"
+
+
+async def test_views_for_interest_windowed_excludes_old(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """`views_for_interest(since=cutoff)` CHỈ trả view trong cửa sổ retention →
+    recompute aggregate KHÔNG đếm view ngoài cửa sổ, nên purge (§16.9) không làm
+    tụt view_count/total_dwell khi contact tương tác lại (finding P2)."""
+    from app.repositories.sms_engagement_repository import (
+        SmsEngagementRepository,
+    )
+
+    h = admin_token_headers
+    cid = await _mk_contact(client, h, "0987611002")
+    now = datetime.now(timezone.utc)
+    retention = settings.SMS_INTEREST_EVENT_RETENTION_DAYS
+    cutoff = now - timedelta(days=retention)
+
+    async with AsyncSessionLocal() as s:
+        prog = (
+            await s.execute(
+                text("SELECT id FROM major_program ORDER BY id LIMIT 1")
+            )
+        ).scalar()
+        assert prog is not None
+        for tag, ts, dwell in (
+            ("old", now - timedelta(days=retention + 30), 100),  # ngoài cửa sổ
+            ("new", now - timedelta(days=5), 20),  # trong cửa sổ
+        ):
+            sid = (
+                await s.execute(
+                    text(
+                        "INSERT INTO sms_landing_session (contact_id, "
+                        "session_token_hash, started_at) VALUES (:c,:t,:ts) "
+                        "RETURNING id"
+                    ),
+                    {"c": cid, "t": f"w_{tag}_{cid}", "ts": ts},
+                )
+            ).scalar()
+            await s.execute(
+                text(
+                    "INSERT INTO sms_program_view (session_id, contact_id, "
+                    "program_name_snapshot, major_program_id, dwell_seconds, "
+                    "viewed_at) VALUES (:s,:c,:n,:p,:d,:ts)"
+                ),
+                {"s": sid, "c": cid, "n": "Ngành Y", "p": prog,
+                 "d": dwell, "ts": ts},
+            )
+        await s.commit()
+
+        views = await SmsEngagementRepository(s).views_for_interest(
+            cid, prog, since=cutoff
+        )
+    # CHỈ view mới (in-window); view cũ >retention bị loại dù còn tồn tại (trước
+    # purge) → recompute không đếm nó → purge nó cũng không đổi aggregate.
+    assert len(views) == 1, "chỉ view trong cửa sổ retention"
+    assert views[0][0] == 20, "phải là view mới (dwell=20), không phải view cũ"
+
+
+async def test_purge_old_events_keeps_recent_and_aggregate(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """Session quá hạn + program_view (cascade) bị xoá; session trong hạn GIỮ;
+    aggregate interest GIỮ (không cascade)."""
+    h = admin_token_headers
+    cid = await _mk_contact(client, h, "0987611001")
+    retention = settings.SMS_INTEREST_EVENT_RETENTION_DAYS
+    now = datetime.now(timezone.utc)
+    old_at = now - timedelta(days=retention + 30)  # quá hạn
+    new_at = now - timedelta(days=10)  # trong hạn
+
+    async with AsyncSessionLocal() as s:
+        prog = (
+            await s.execute(
+                text("SELECT id FROM major_program ORDER BY id LIMIT 1")
+            )
+        ).scalar()
+        assert prog is not None, "cần 1 major_program seed cho FK interest"
+
+        old_sid = (
+            await s.execute(
+                text(
+                    "INSERT INTO sms_landing_session "
+                    "(contact_id, session_token_hash, started_at) "
+                    "VALUES (:c, :t, :ts) RETURNING id"
+                ),
+                {"c": cid, "t": f"h_old_{cid}", "ts": old_at},
+            )
+        ).scalar()
+        new_sid = (
+            await s.execute(
+                text(
+                    "INSERT INTO sms_landing_session "
+                    "(contact_id, session_token_hash, started_at) "
+                    "VALUES (:c, :t, :ts) RETURNING id"
+                ),
+                {"c": cid, "t": f"h_new_{cid}", "ts": new_at},
+            )
+        ).scalar()
+        await s.execute(
+            text(
+                "INSERT INTO sms_program_view "
+                "(session_id, contact_id, program_name_snapshot, "
+                "major_program_id, viewed_at) VALUES (:s, :c, :n, :p, :ts)"
+            ),
+            {"s": old_sid, "c": cid, "n": "Ngành X", "p": prog, "ts": old_at},
+        )
+        await s.execute(
+            text(
+                "INSERT INTO sms_contact_program_interest "
+                "(contact_id, major_program_id, view_count, interest_score) "
+                "VALUES (:c, :p, 1, 0.5)"
+            ),
+            {"c": cid, "p": prog},
+        )
+        await s.commit()
+
+    # Tiền-điều-kiện: view của session cũ TỒN TẠI trước purge → assert
+    # old_view==0 sau purge mới chứng minh CASCADE thật (không phải chưa từng có).
+    async with AsyncSessionLocal() as s:
+        pre_view = (
+            await s.execute(
+                text(
+                    "SELECT count(*) FROM sms_program_view WHERE session_id=:i"
+                ),
+                {"i": old_sid},
+            )
+        ).scalar()
+    assert pre_view == 1, "seed program_view cho session cũ phải tồn tại"
+
+    # Chạy ĐÚNG helper của task
+    async with AsyncSessionLocal() as s:
+        deleted = await _purge_old_interest_events(s, retention)
+        await s.commit()
+    assert deleted >= 1  # ít nhất session quá hạn
+
+    async with AsyncSessionLocal() as s:
+        old_sess = (
+            await s.execute(
+                text("SELECT count(*) FROM sms_landing_session WHERE id=:i"),
+                {"i": old_sid},
+            )
+        ).scalar()
+        old_view = (
+            await s.execute(
+                text(
+                    "SELECT count(*) FROM sms_program_view WHERE session_id=:i"
+                ),
+                {"i": old_sid},
+            )
+        ).scalar()
+        new_sess = (
+            await s.execute(
+                text("SELECT count(*) FROM sms_landing_session WHERE id=:i"),
+                {"i": new_sid},
+            )
+        ).scalar()
+        interest = (
+            await s.execute(
+                text(
+                    "SELECT count(*) FROM sms_contact_program_interest "
+                    "WHERE contact_id=:c"
+                ),
+                {"c": cid},
+            )
+        ).scalar()
+
+    assert old_sess == 0, "session quá hạn phải bị xoá"
+    assert old_view == 0, "program_view của session cũ phải cascade-xoá"
+    assert new_sess == 1, "session trong hạn phải GIỮ"
+    assert interest == 1, "aggregate interest phải GIỮ (không cascade)"

--- a/Documents/SMS_PHASE2_16.9_ROPA.md
+++ b/Documents/SMS_PHASE2_16.9_ROPA.md
@@ -1,0 +1,63 @@
+# SMS Phase 2 — Bản ghi hoạt động xử lý dữ liệu / mini-DPIA (§16.9)
+
+> ⚠️ **Không phải tư vấn pháp lý.** Đây là bản ghi kỹ thuật hỗ trợ tuân thủ; nội
+> dung pháp lý (câu chữ, đủ/thiếu) cần luật sư/DPO rà. Trách nhiệm cuối thuộc
+> người vận hành (chủ dự án). Ngày lập: 2026-07-05.
+
+## 1. Hoạt động xử lý
+Đo mức "quan tâm ngành" của người dùng qua hành vi trên landing tuyển sinh: khi
+khách bấm link tư vấn (consult) hoặc link chiến dịch (campaign) rồi xem trang
+ngành, hệ thống ghi **thời lượng xem (dwell)** theo từng ngành và tổng hợp thành
+`interest_score(contact, ngành)`.
+
+## 2. Mục đích & bản chất
+- **Mục đích**: khảo sát để tư vấn tuyển sinh phù hợp hơn cho từng liên hệ.
+- **Bản chất**: lập hồ sơ hành vi gắn đích danh (profiling) theo `contact` (khóa
+  = số điện thoại đã chuẩn hóa). KHÔNG bán/chia sẻ; chỉ officer/admin nội bộ xem.
+
+## 3. Dữ liệu xử lý (tối thiểu hóa)
+| Trường | Ghi chú |
+|---|---|
+| `contact_id` (theo phone) | định danh liên hệ |
+| ngành đã xem + `dwell_seconds` | tín hiệu quan tâm |
+| `interest_score` (aggregate) | điểm tổng hợp §18.F |
+| `ip_hash` = HMAC-SHA256(IP) | **KHÔNG lưu IP thô** |
+| `session_token_hash`, `user_agent` | kỹ thuật/chống gian lận |
+KHÔNG thu thập nội dung nhạy cảm, KHÔNG dữ liệu ngoài phạm vi trên.
+
+## 4. Chủ thể dữ liệu
+Khách/phụ huynh đã được officer gửi link tư vấn hoặc nhận link chiến dịch (đã có
+quan hệ tuyển sinh) và tự bấm vào link.
+
+## 5. Lưu trữ (retention)
+- **Event chi tiết** (`sms_landing_session`, `sms_program_view`): **dọn tự động
+  sau 365 ngày** (`SMS_INTEREST_EVENT_RETENTION_DAYS`, Celery beat 04:00 hằng
+  ngày — `cleanup_sms_interest_events_task`).
+- **Aggregate** (`sms_contact_program_interest`): giữ dài hạn (profile). Được
+  recompute theo **cửa sổ retention** (chỉ view trong N ngày gần nhất) → xoá
+  event ngoài cửa sổ KHÔNG làm lệch số liệu kể cả khi khách tương tác lại sau dọn.
+
+## 6. Biện pháp giảm thiểu rủi ro
+- IP băm (không IP thô) · dữ liệu tối thiểu (chỉ tên ngành + thời lượng) ·
+  suppression opt-out toàn cục theo phone · loại bot khỏi số liệu · token chỉ lưu
+  hash · retention 365 ngày cho event chi tiết.
+
+## 7. Quyết định vận hành (chủ dự án, 2026-07-05)
+Chủ dự án chọn **ghi nhận mặc định (default-on), landing đơn giản, KHÔNG hiển thị
+thông báo riêng và KHÔNG nút từ chối riêng cho tracking**, xem đây là **khảo sát**
+nội bộ phục vụ tư vấn. Chủ dự án **nhận rủi ro** này.
+
+> **Đã được cảnh báo (ghi nhận):** Luật Bảo vệ dữ liệu cá nhân 91/2025/QH15 (hiệu
+> lực 01-01-2026) + NĐ 356/2025 nghiêng về **đồng ý trước (opt-in) + minh bạch**
+> khi lập hồ sơ hành vi người xác định danh tính. Phương án "default-on không
+> thông báo" là rủi ro hơn "notice + opt-out". Nếu muốn hạ rủi ro sau này: thêm 1
+> dòng thông báo minh bạch + tôn trọng opt-out cho tracking (đã có sẵn hạ tầng).
+
+## 8. Bên thứ ba
+Không chia sẻ dữ liệu interest cho bên thứ ba. (Gửi tin quảng cáo Phase 1 qua nhà
+mạng là luồng riêng, có hợp đồng/attestation riêng — không thuộc phạm vi bản ghi
+này.)
+
+## 9. Cơ sở tham chiếu luật (nguồn nhà nước)
+- Luật BVDLCN 91/2025/QH15 (01-01-2026) · NĐ 356/2025/NĐ-CP · NĐ 91/2020/NĐ-CP
+  (chống tin rác, opt-out). Xem §17 `SMS_MARKETING_MODULE_DESIGN.md`.


### PR DESCRIPTION
## Tóm tắt
Phase 2 §16.9 **data-minimization**: dọn tự động event tracking chi tiết (deep-engagement) cũ hơn `SMS_INTEREST_EVENT_RETENTION_DAYS` (mặc định 365), GIỮ hồ sơ tổng hợp (aggregate) `sms_contact_program_interest`.

## Nội dung
- **Config** `SMS_INTEREST_EVENT_RETENTION_DAYS` (ge=30, le=3650, default 365).
- **Celery beat task** `cleanup_sms_interest_events_task` (04:15 hằng ngày) + helper `_purge_old_interest_events` (tách để test chạy query thật): xoá `sms_landing_session` cũ hơn cửa sổ → `sms_program_view` đi theo qua FK `ondelete=CASCADE`. Aggregate KHÔNG cascade → giữ.
- **Index** `sms_landing_session.started_at` (migration `smsp2retidx20260705001`) cho DELETE range — tránh seq-scan khi bảng phình.
- **Windowing interest recompute** (`views_for_interest(since=now-retention)`): aggregate là **rolling-window** — chỉ tính view trong cửa sổ retention. Đảm bảo purge event ngoài cửa sổ KHÔNG làm lệch `view_count`/`total_dwell`/`score` kể cả khi contact tương tác lại (vá finding P2 aggregate-drift). Cũng đúng recency-philosophy hơn (view rất cũ không thổi phồng count thô).
- **ROPA/mini-DPIA** (`Documents/SMS_PHASE2_16.9_ROPA.md`): bản ghi hoạt động xử lý — ghi quyết định owner (ghi nhận mặc định/silent, coi là khảo sát, nhận rủi ro; đã flag Luật 91/2025 nghiêng opt-in) + biện pháp giảm thiểu (ip_hash, min-data, retention 365d, opt-out).

## Review
Đã qua **/code-review max** (correctness sạch; vá 5 low: beat 04:15 tránh đụng CTV-expiry, index started_at, test mạnh hơn) + **follow-up finding P2** (window interest recompute — nếu không, purge làm tụt raw counts khi re-interact).

## Verify
- ✅ BE **24 test pass** (engagement 12 + retention 3 gồm test windowing + consult 9) + flake8 mã-mới sạch.
- ✅ Migration index round-trip verified (dev).

## ⚠️ Deploy KHÔNG code-only
- **1 migration** `smsp2retidx20260705001` (tạo index — AN TOÀN, bảng `sms_landing_session` gần-rỗng vì deep-tracking còn dormant §16.9).
- **Restart backend** (đổi `_recompute_interest` — interest windowing) + **restart celery-beat** (nạp beat schedule mới).
- Prod = main = `b924da75` → range `prod..main` = chỉ PR này (sạch, không kéo theo gì).

🤖 Generated with [Claude Code](https://claude.com/claude-code)