### PR TITLE
fix(notif): quota zalo_bot theo THÁNG thay vì NGÀY (khử chặn oan + overshoot)

### DIFF
--- a/Backend_FastAPI/alembic/versions/zbmonthlyseed20260706_backfill_zalo_bot_monthly_quota.py
+++ b/Backend_FastAPI/alembic/versions/zbmonthlyseed20260706_backfill_zalo_bot_monthly_quota.py
@@ -1,0 +1,93 @@
+"""Backfill zalo_bot MONTHLY quota from this month's sends (daily->monthly cutover)
+
+Revision ID: zbmonthlyseed20260706
+Revises: smsp2retidx20260705001
+Create Date: 2026-07-06
+
+The notification quota for the ``zalo_bot`` channel switched from a DAILY cap to
+a MONTHLY cap (Zalo Bot free tier = 3000 msg/month, no hard daily cap).
+``check_quota`` now reads ONLY the monthly row, so a mid-month cutover would
+forget any messages already sent this month under the old daily counter and
+could allow a full month's allowance ON TOP of them -- overshooting the
+provider's 3000/month cap.
+
+This one-time data migration seeds the current month's monthly ``zalo_bot``
+quota row with the count of messages already sent this month (from
+``notification_delivery``), BEFORE the new monthly enforcement starts serving
+(it runs in the entrypoint ``alembic upgrade head`` before uvicorn/celery
+process any delivery). Idempotent + race-safe: ``ON CONFLICT`` keeps the
+GREATEST of the existing and backfilled count, so the app / beat task lazily
+creating the row concurrently cannot lower it.
+
+Leftover daily ``zalo_bot`` rows are intentionally NOT deleted (kept for
+rollback safety -- the reverted daily code resumes from them). They no longer
+affect enforcement; at worst they cause a transient, self-healing admin-
+dashboard duplicate on the cutover day only.
+"""
+import os
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic. (<=32 chars for version_num column.)
+revision = "zbmonthlyseed20260706"
+down_revision = "smsp2retidx20260705001"
+branch_labels = None
+depends_on = None
+
+
+def _seed_sql(limit: int) -> str:
+    """Build the backfill statement.
+
+    ``limit`` is ``int()``-coerced from config, so inlining it as a literal is
+    injection-safe AND avoids a prepared-statement parameter being deduced as
+    both integer (the ``quota_limit`` column) and bigint (compared against
+    ``count(*)``), which asyncpg rejects as an ambiguous type.
+    """
+    return f"""
+    INSERT INTO notification_quota
+        (channel, provider, period, period_start, quota_limit, quota_used, blocked)
+    SELECT
+        'zalo_bot', 'zalo_bot', 'monthly',
+        date_trunc('month', CURRENT_DATE)::date,
+        {limit},
+        s.cnt,
+        s.cnt >= {limit}
+    FROM (
+        SELECT count(*) AS cnt
+        FROM notification_delivery
+        WHERE channel = 'zalo_bot'
+          AND status IN ('sent', 'delivered', 'read')
+          AND created_at >= date_trunc('month', CURRENT_DATE)
+    ) s
+    ON CONFLICT (channel, provider, period, period_start)
+    DO UPDATE SET
+        quota_used = GREATEST(
+            notification_quota.quota_used, EXCLUDED.quota_used
+        ),
+        blocked = GREATEST(
+            notification_quota.quota_used, EXCLUDED.quota_used
+        ) >= notification_quota.quota_limit,
+        updated_at = now()
+    """
+
+
+_DOWNGRADE_SQL = """
+DELETE FROM notification_quota
+WHERE channel = 'zalo_bot'
+  AND period = 'monthly'
+  AND period_start = date_trunc('month', CURRENT_DATE)::date
+"""
+
+
+def upgrade() -> None:
+    # Read the limit from the same env var Settings uses, defaulting to the
+    # config default so the seeded row's cap matches the running app.
+    limit = int(os.environ.get("ZALO_BOT_MONTHLY_QUOTA") or 2800)
+    op.get_bind().execute(sa.text(_seed_sql(limit)))
+
+
+def downgrade() -> None:
+    # Remove only the current month's seeded monthly row; the untouched daily
+    # rows let the reverted daily-quota code resume without data loss.
+    op.get_bind().execute(sa.text(_DOWNGRADE_SQL))

--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -688,18 +688,13 @@ class Settings(BaseSettings):
     ZALO_BOT_WEBHOOK_SECRET: str = Field(
         default="", validation_alias="ZALO_BOT_WEBHOOK_SECRET"
     )  # X-Bot-Api-Secret-Token header value — DO NOT log
-    ZALO_BOT_DAILY_QUOTA: int = Field(
-        default=80, validation_alias="ZALO_BOT_DAILY_QUOTA"
-    )  # DEPRECATED (no longer read): superseded by ZALO_BOT_MONTHLY_QUOTA.
-    # Zalo Bot Platform has NO hard daily cap — the free tier limit is
-    # 3000 msg/MONTH (verified bot.zapps.me docs). A daily cap wasted the
-    # monthly budget on uneven traffic. Field kept only so a stale env var
-    # doesn't break startup.
     ZALO_BOT_MONTHLY_QUOTA: int = Field(
         default=2800, validation_alias="ZALO_BOT_MONTHLY_QUOTA"
     )  # Zalo Bot free tier = 3000 msg/month; 2800 leaves ~7% safety margin.
-    # MONTHLY (not daily) so bursty admission-season traffic borrows quota
-    # across low days instead of hitting an artificial per-day wall.
+    # MONTHLY (not daily): Zalo Bot Platform has NO hard daily cap (verified
+    # bot.zapps.me docs), so a per-day limit wasted the monthly budget on
+    # bursty admission-season traffic. (Old ZALO_BOT_DAILY_QUOTA removed —
+    # extra="ignore" tolerates any stale env var.)
 
     # -- MoMo Payment Gateway Settings --
     # Get credentials from MoMo merchant portal

--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -690,7 +690,16 @@ class Settings(BaseSettings):
     )  # X-Bot-Api-Secret-Token header value — DO NOT log
     ZALO_BOT_DAILY_QUOTA: int = Field(
         default=80, validation_alias="ZALO_BOT_DAILY_QUOTA"
-    )  # v5 Finding 6: 80/day for 20% margin under Zalo Basic ceiling 100/day (3000/month)
+    )  # DEPRECATED (no longer read): superseded by ZALO_BOT_MONTHLY_QUOTA.
+    # Zalo Bot Platform has NO hard daily cap — the free tier limit is
+    # 3000 msg/MONTH (verified bot.zapps.me docs). A daily cap wasted the
+    # monthly budget on uneven traffic. Field kept only so a stale env var
+    # doesn't break startup.
+    ZALO_BOT_MONTHLY_QUOTA: int = Field(
+        default=2800, validation_alias="ZALO_BOT_MONTHLY_QUOTA"
+    )  # Zalo Bot free tier = 3000 msg/month; 2800 leaves ~7% safety margin.
+    # MONTHLY (not daily) so bursty admission-season traffic borrows quota
+    # across low days instead of hitting an artificial per-day wall.
 
     # -- MoMo Payment Gateway Settings --
     # Get credentials from MoMo merchant portal

--- a/Backend_FastAPI/app/repositories/notification_quota_repository.py
+++ b/Backend_FastAPI/app/repositories/notification_quota_repository.py
@@ -5,7 +5,7 @@ Phase D1: Repository for NotificationQuota CRUD and quota checks.
 from datetime import date, datetime, timezone
 from typing import List, Optional, Tuple
 
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -125,21 +125,28 @@ class NotificationQuotaRepository(BaseRepository[NotificationQuota]):
             return False  # No quota configured = unlimited
         return quota.blocked or quota.quota_used >= quota.quota_limit
 
-    async def get_all_quotas(
+    async def get_current_quotas(
         self,
-        period_starts: Optional[List[date]] = None,
+        windows: Optional[List[Tuple[str, date]]] = None,
     ) -> List[NotificationQuota]:
-        """Get all quota records whose ``period_start`` is in ``period_starts``.
+        """Get quota records matching any ``(period, period_start)`` window.
 
-        Defaults to today's rows. Callers pass multiple dates (e.g. today +
-        first-of-month) to fetch both daily and monthly channels in one query.
+        Each window targets one channel-class's CURRENT period exactly, so a
+        stale same-``period_start`` row of a different period (e.g. a daily row
+        created on the 1st of the month) is not accidentally returned alongside
+        a monthly row. Defaults to today's daily window.
         """
-        if not period_starts:
-            period_starts = [date.today()]
+        if not windows:
+            windows = [("daily", date.today())]
 
+        conditions = [
+            (NotificationQuota.period == period)
+            & (NotificationQuota.period_start == period_start)
+            for period, period_start in windows
+        ]
         query = (
             select(NotificationQuota)
-            .where(NotificationQuota.period_start.in_(period_starts))
+            .where(or_(*conditions))
             .order_by(NotificationQuota.channel)
         )
         result = await self.db.execute(query)

--- a/Backend_FastAPI/app/repositories/notification_quota_repository.py
+++ b/Backend_FastAPI/app/repositories/notification_quota_repository.py
@@ -127,15 +127,19 @@ class NotificationQuotaRepository(BaseRepository[NotificationQuota]):
 
     async def get_all_quotas(
         self,
-        period_start: Optional[date] = None,
+        period_starts: Optional[List[date]] = None,
     ) -> List[NotificationQuota]:
-        """Get all quota records for a given period."""
-        if period_start is None:
-            period_start = date.today()
+        """Get all quota records whose ``period_start`` is in ``period_starts``.
+
+        Defaults to today's rows. Callers pass multiple dates (e.g. today +
+        first-of-month) to fetch both daily and monthly channels in one query.
+        """
+        if not period_starts:
+            period_starts = [date.today()]
 
         query = (
             select(NotificationQuota)
-            .where(NotificationQuota.period_start == period_start)
+            .where(NotificationQuota.period_start.in_(period_starts))
             .order_by(NotificationQuota.channel)
         )
         result = await self.db.execute(query)

--- a/Backend_FastAPI/app/services/notification_quota_service.py
+++ b/Backend_FastAPI/app/services/notification_quota_service.py
@@ -30,12 +30,12 @@ async def check_quota(
     Check if channel has available quota. Returns True if OK to send.
 
     The period (daily vs monthly) and limit are resolved per-channel by
-    ``_get_channel_quota_config`` — zalo_bot is MONTHLY, zalo (ZNS) is daily.
+    ``get_channel_quota_config`` — zalo_bot is MONTHLY, zalo (ZNS) is daily.
     Channels with no configured quota are unlimited.
 
     Fast path: Redis cache. Slow path: DB lookup.
     """
-    cfg = _get_channel_quota_config(channel)
+    cfg = get_channel_quota_config(channel)
     if cfg is None:
         return True  # No quota configured for this channel = unlimited
 
@@ -78,7 +78,7 @@ async def record_send(
     provider: str = "default",
 ) -> None:
     """Record a successful send, incrementing quota_used for the channel's period."""
-    cfg = _get_channel_quota_config(channel)
+    cfg = get_channel_quota_config(channel)
     if cfg is None:
         return  # No quota configured for this channel
 
@@ -177,12 +177,16 @@ async def get_quota_summary(
     like zalo_bot) so the health dashboard shows every channel's live usage.
     """
     repo = NotificationQuotaRepository(db)
+    # Fetch each channel-class's CURRENT period as an exact (period, period_start)
+    # window. Filtering by period_start alone would also match a stale same-date
+    # row of a DIFFERENT period (e.g. a daily row created on the 1st of the
+    # month), producing duplicate/conflicting rows for one channel.
     if period_start is None:
         today = date.today()
-        period_starts = list({today, today.replace(day=1)})
+        windows = [("daily", today), ("monthly", today.replace(day=1))]
     else:
-        period_starts = [period_start]
-    quotas = await repo.get_all_quotas(period_starts=period_starts)
+        windows = [("daily", period_start), ("monthly", period_start)]
+    quotas = await repo.get_current_quotas(windows)
     return [
         {
             "id": q.id,
@@ -243,7 +247,7 @@ async def get_health_summary(db: AsyncSession) -> Dict:
     }
 
 
-def _get_channel_quota_config(
+def get_channel_quota_config(
     channel: str,
 ) -> Optional[Tuple[str, date, int]]:
     """Resolve ``(period, period_start, limit)`` for a channel's quota.

--- a/Backend_FastAPI/app/services/notification_quota_service.py
+++ b/Backend_FastAPI/app/services/notification_quota_service.py
@@ -5,8 +5,8 @@ Phase D1: Quota management service.
 Redis cache for fast quota check → DB fallback → sync from provider.
 """
 import structlog
-from datetime import date, datetime, timezone
-from typing import Dict, List, Optional
+from datetime import date
+from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -29,11 +29,20 @@ async def check_quota(
     """
     Check if channel has available quota. Returns True if OK to send.
 
+    The period (daily vs monthly) and limit are resolved per-channel by
+    ``_get_channel_quota_config`` — zalo_bot is MONTHLY, zalo (ZNS) is daily.
+    Channels with no configured quota are unlimited.
+
     Fast path: Redis cache. Slow path: DB lookup.
     """
+    cfg = _get_channel_quota_config(channel)
+    if cfg is None:
+        return True  # No quota configured for this channel = unlimited
 
-    today = date.today()
-    cache_key = _QUOTA_CACHE_KEY.format(channel=channel, date=today.isoformat())
+    period, period_start, _limit = cfg
+    # Cache key is scoped to the period_start, so a monthly channel caches
+    # per-month and a daily channel per-day without key collisions.
+    cache_key = _QUOTA_CACHE_KEY.format(channel=channel, date=period_start.isoformat())
 
     # Fast path: check Redis cache
     try:
@@ -42,11 +51,15 @@ async def check_quota(
         if cached is not None:
             return cached != "blocked"
     except Exception as e:
-        log.warning("Redis quota cache read failed, falling through to DB", error=str(e))
+        log.warning(
+            "Redis quota cache read failed, falling through to DB", error=str(e)
+        )
 
     # Slow path: DB check
     repo = NotificationQuotaRepository(db)
-    over = await repo.is_over_quota(channel, provider, period_start=today)
+    over = await repo.is_over_quota(
+        channel, provider, period=period, period_start=period_start
+    )
 
     # Cache result
     try:
@@ -64,37 +77,43 @@ async def record_send(
     channel: str,
     provider: str = "default",
 ) -> None:
-    """Record a successful send, incrementing quota_used."""
-    today = date.today()
+    """Record a successful send, incrementing quota_used for the channel's period."""
+    cfg = _get_channel_quota_config(channel)
+    if cfg is None:
+        return  # No quota configured for this channel
+
+    period, period_start, limit = cfg
     repo = NotificationQuotaRepository(db)
 
-    # Ensure quota row exists for today
-    quota = await repo.get_current_quota(channel, provider, period_start=today)
+    # Ensure quota row exists for the current period
+    quota = await repo.get_current_quota(
+        channel, provider, period=period, period_start=period_start
+    )
     if quota is None:
-        # Auto-create with configured limit
-        limit = _get_channel_limit(channel)
-        if limit is None:
-            return  # No quota configured for this channel
+        # Auto-create with configured limit for this period
         await repo.upsert_quota(
             channel=channel,
             provider=provider,
-            period="daily",
-            period_start=today,
+            period=period,
+            period_start=period_start,
             quota_limit=limit,
             quota_used=1,
         )
         return
 
-    updated = await repo.increment_used(channel, provider, period_start=today)
+    updated = await repo.increment_used(
+        channel, provider, period=period, period_start=period_start
+    )
     if updated and updated.quota_used >= updated.quota_limit:
         # Block and invalidate cache
         updated.blocked = True
         await db.flush()
-        await _invalidate_quota_cache(channel, today)
+        await _invalidate_quota_cache(channel, period_start)
         log.warning(
             "Channel quota exhausted",
             channel=channel,
             provider=provider,
+            period=period,
             used=updated.quota_used,
             limit=updated.quota_limit,
         )
@@ -151,9 +170,19 @@ async def get_quota_summary(
     db: AsyncSession,
     period_start: Optional[date] = None,
 ) -> List[Dict]:
-    """Get quota summary for all channels."""
+    """Get quota summary for the current period(s) of all channels.
+
+    When ``period_start`` is None (default), returns rows for BOTH the current
+    day (daily channels) and the first of the current month (monthly channels
+    like zalo_bot) so the health dashboard shows every channel's live usage.
+    """
     repo = NotificationQuotaRepository(db)
-    quotas = await repo.get_all_quotas(period_start=period_start)
+    if period_start is None:
+        today = date.today()
+        period_starts = list({today, today.replace(day=1)})
+    else:
+        period_starts = [period_start]
+    quotas = await repo.get_all_quotas(period_starts=period_starts)
     return [
         {
             "id": q.id,
@@ -214,15 +243,27 @@ async def get_health_summary(db: AsyncSession) -> Dict:
     }
 
 
-def _get_channel_limit(channel: str) -> Optional[int]:
-    """Get configured quota limit for a channel."""
-    limits = {
-        "zalo": settings.ZALO_DAILY_QUOTA_LIMIT,
-        # v5 Step 14: zalo_bot daily quota — defaults to 80 (20% margin
-        # under the Zalo Basic free tier 100/day ceiling).
-        "zalo_bot": settings.ZALO_BOT_DAILY_QUOTA,
-    }
-    return limits.get(channel)
+def _get_channel_quota_config(
+    channel: str,
+) -> Optional[Tuple[str, date, int]]:
+    """Resolve ``(period, period_start, limit)`` for a channel's quota.
+
+    Returns None for channels with no configured quota (treated as unlimited).
+
+    - ``zalo_bot`` → **MONTHLY** (period_start = first of current month). The
+      Zalo Bot Platform free tier caps at 3000 msg/MONTH with **no** hard daily
+      ceiling, so a daily cap wasted the monthly budget on uneven (bursty
+      admission-season) traffic. A monthly period lets quiet days' unused
+      allowance carry to busy days within the same month.
+    - ``zalo`` (ZNS) → daily. The ZNS provider enforces a per-day quota that we
+      sync from each send response (see ``sync_zalo_quota``).
+    """
+    today = date.today()
+    if channel == "zalo_bot":
+        return ("monthly", today.replace(day=1), settings.ZALO_BOT_MONTHLY_QUOTA)
+    if channel == "zalo":
+        return ("daily", today, settings.ZALO_DAILY_QUOTA_LIMIT)
+    return None
 
 
 async def _invalidate_quota_cache(channel: str, day: date) -> None:

--- a/Backend_FastAPI/app/services/notification_quota_service.py
+++ b/Backend_FastAPI/app/services/notification_quota_service.py
@@ -166,26 +166,16 @@ async def sync_zalo_quota(
     )
 
 
-async def get_quota_summary(
-    db: AsyncSession,
-    period_start: Optional[date] = None,
-) -> List[Dict]:
-    """Get quota summary for the current period(s) of all channels.
+async def get_quota_summary(db: AsyncSession) -> List[Dict]:
+    """Get the CURRENT-period quota row for every channel.
 
-    When ``period_start`` is None (default), returns rows for BOTH the current
-    day (daily channels) and the first of the current month (monthly channels
-    like zalo_bot) so the health dashboard shows every channel's live usage.
+    Daily channels are read at today; monthly channels (zalo_bot) at the first
+    of the current month. Fetched as exact ``(period, period_start)`` windows
+    so a stale same-date row of a different period is never pulled in.
     """
     repo = NotificationQuotaRepository(db)
-    # Fetch each channel-class's CURRENT period as an exact (period, period_start)
-    # window. Filtering by period_start alone would also match a stale same-date
-    # row of a DIFFERENT period (e.g. a daily row created on the 1st of the
-    # month), producing duplicate/conflicting rows for one channel.
-    if period_start is None:
-        today = date.today()
-        windows = [("daily", today), ("monthly", today.replace(day=1))]
-    else:
-        windows = [("daily", period_start), ("monthly", period_start)]
+    today = date.today()
+    windows = [("daily", today), ("monthly", today.replace(day=1))]
     quotas = await repo.get_current_quotas(windows)
     return [
         {

--- a/Backend_FastAPI/app/tasks/delivery_tasks.py
+++ b/Backend_FastAPI/app/tasks/delivery_tasks.py
@@ -511,9 +511,10 @@ def reconcile_stale_deliveries(self):
 )
 def sync_notification_quotas(self):
     """
-    Celery Beat task: sync quota records (create today's row if missing).
+    Celery Beat task: ensure the current-period quota row exists for each
+    configured channel — daily for ZNS ('zalo'), MONTHLY for 'zalo_bot'.
 
-    Runs every 6 hours. Ensures daily quota rows exist for configured channels.
+    Runs every 6 hours.
     """
     task_name = "sync_notification_quotas"
     task_log = logging.getLogger(task_name)
@@ -549,24 +550,29 @@ def sync_notification_quotas(self):
                     synced += 1
                     await session.commit()
 
-                # zalo_bot uses a MONTHLY quota (Zalo Bot free tier =
-                # 3000 msg/month, no hard daily cap). Ensure this month's
-                # row when ENABLED; skipped while gated off to avoid empty
-                # rows for an unused channel.
-                month_start = today.replace(day=1)
-                zalo_bot_quota = await repo.get_current_quota(
-                    "zalo_bot", "zalo_bot", "monthly", month_start,
+                # zalo_bot uses a MONTHLY quota — derive (period, period_start,
+                # limit) from the shared resolver so this stays in lockstep with
+                # check_quota/record_send (single source of truth). Skipped while
+                # gated off to avoid empty rows for an unused channel.
+                from app.services.notification_quota_service import (
+                    get_channel_quota_config,
                 )
-                if zalo_bot_quota is None and settings.ZALO_BOT_ENABLED:
-                    await repo.upsert_quota(
-                        channel="zalo_bot",
-                        provider="zalo_bot",
-                        period="monthly",
-                        period_start=month_start,
-                        quota_limit=settings.ZALO_BOT_MONTHLY_QUOTA,
+                zb_cfg = get_channel_quota_config("zalo_bot")
+                if zb_cfg is not None and settings.ZALO_BOT_ENABLED:
+                    zb_period, zb_start, zb_limit = zb_cfg
+                    zalo_bot_quota = await repo.get_current_quota(
+                        "zalo_bot", "zalo_bot", zb_period, zb_start,
                     )
-                    synced += 1
-                    await session.commit()
+                    if zalo_bot_quota is None:
+                        await repo.upsert_quota(
+                            channel="zalo_bot",
+                            provider="zalo_bot",
+                            period=zb_period,
+                            period_start=zb_start,
+                            quota_limit=zb_limit,
+                        )
+                        synced += 1
+                        await session.commit()
 
                 task_log.info(f"Quota sync done: {synced} rows created")
                 return {"synced": synced}

--- a/Backend_FastAPI/app/tasks/delivery_tasks.py
+++ b/Backend_FastAPI/app/tasks/delivery_tasks.py
@@ -549,19 +549,21 @@ def sync_notification_quotas(self):
                     synced += 1
                     await session.commit()
 
-                # v5 Step 13: ensure zalo_bot quota row when ENABLED.
-                # Skipped while the channel is gated off so we don't
-                # accumulate empty rows for an unused channel.
+                # zalo_bot uses a MONTHLY quota (Zalo Bot free tier =
+                # 3000 msg/month, no hard daily cap). Ensure this month's
+                # row when ENABLED; skipped while gated off to avoid empty
+                # rows for an unused channel.
+                month_start = today.replace(day=1)
                 zalo_bot_quota = await repo.get_current_quota(
-                    "zalo_bot", "zalo_bot", "daily", today,
+                    "zalo_bot", "zalo_bot", "monthly", month_start,
                 )
                 if zalo_bot_quota is None and settings.ZALO_BOT_ENABLED:
                     await repo.upsert_quota(
                         channel="zalo_bot",
                         provider="zalo_bot",
-                        period="daily",
-                        period_start=today,
-                        quota_limit=settings.ZALO_BOT_DAILY_QUOTA,
+                        period="monthly",
+                        period_start=month_start,
+                        quota_limit=settings.ZALO_BOT_MONTHLY_QUOTA,
                     )
                     synced += 1
                     await session.commit()

--- a/Backend_FastAPI/tests/unit/test_notification_d1.py
+++ b/Backend_FastAPI/tests/unit/test_notification_d1.py
@@ -319,14 +319,14 @@ class TestNotificationQuotaRepository:
 # ---------------------------------------------------------------------------
 
 class TestChannelQuotaConfig:
-    """Test _get_channel_quota_config period/limit resolution."""
+    """Test get_channel_quota_config period/limit resolution."""
 
     def test_zalo_bot_is_monthly(self):
         from datetime import date
         from app.config import settings
-        from app.services.notification_quota_service import _get_channel_quota_config
+        from app.services.notification_quota_service import get_channel_quota_config
 
-        cfg = _get_channel_quota_config("zalo_bot")
+        cfg = get_channel_quota_config("zalo_bot")
         assert cfg is not None
         period, period_start, limit = cfg
         assert period == "monthly"
@@ -336,9 +336,9 @@ class TestChannelQuotaConfig:
     def test_zalo_is_daily(self):
         from datetime import date
         from app.config import settings
-        from app.services.notification_quota_service import _get_channel_quota_config
+        from app.services.notification_quota_service import get_channel_quota_config
 
-        cfg = _get_channel_quota_config("zalo")
+        cfg = get_channel_quota_config("zalo")
         assert cfg is not None
         period, period_start, limit = cfg
         assert period == "daily"
@@ -346,10 +346,10 @@ class TestChannelQuotaConfig:
         assert limit == settings.ZALO_DAILY_QUOTA_LIMIT
 
     def test_unknown_channel_is_unlimited(self):
-        from app.services.notification_quota_service import _get_channel_quota_config
+        from app.services.notification_quota_service import get_channel_quota_config
 
-        assert _get_channel_quota_config("email") is None
-        assert _get_channel_quota_config("browser") is None
+        assert get_channel_quota_config("email") is None
+        assert get_channel_quota_config("browser") is None
 
 
 class TestZaloBotMonthlyQuota:
@@ -418,3 +418,78 @@ class TestZaloBotMonthlyQuota:
             await record_send(mock_db, "email")
             repo_instance.get_current_quota.assert_not_awaited()
             repo_instance.upsert_quota.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_record_send_blocks_when_quota_reached(self):
+        """Reaching the monthly limit → blocked=True + cache invalidated (core enforcement)."""
+        from app.services.notification_quota_service import record_send
+
+        mock_db = AsyncMock()
+        mock_quota = MagicMock()  # existing row → increment path
+        mock_updated = MagicMock()
+        mock_updated.quota_used = 2800
+        mock_updated.quota_limit = 2800
+        mock_updated.blocked = False
+
+        with patch(
+            "app.services.notification_quota_service.NotificationQuotaRepository"
+        ) as MockRepo, patch(
+            "app.services.notification_quota_service._invalidate_quota_cache",
+            new_callable=AsyncMock,
+        ) as mock_invalidate:
+            repo_instance = AsyncMock()
+            repo_instance.get_current_quota = AsyncMock(return_value=mock_quota)
+            repo_instance.increment_used = AsyncMock(return_value=mock_updated)
+            MockRepo.return_value = repo_instance
+
+            await record_send(mock_db, "zalo_bot", provider="zalo_bot")
+
+            assert mock_updated.blocked is True       # channel blocked at limit
+            mock_db.flush.assert_awaited_once()        # persisted
+            mock_invalidate.assert_awaited_once()      # cache cleared
+
+
+class TestQuotaSummaryWindows:
+    """get_quota_summary fetches each channel's CURRENT period exactly (no stale rows)."""
+
+    @pytest.mark.asyncio
+    async def test_get_quota_summary_queries_both_period_windows(self):
+        from datetime import date
+        from app.services.notification_quota_service import get_quota_summary
+
+        mock_db = AsyncMock()
+        with patch(
+            "app.services.notification_quota_service.NotificationQuotaRepository"
+        ) as MockRepo:
+            repo_instance = AsyncMock()
+            repo_instance.get_current_quotas = AsyncMock(return_value=[])
+            MockRepo.return_value = repo_instance
+
+            await get_quota_summary(mock_db)
+
+            repo_instance.get_current_quotas.assert_awaited_once()
+            windows = repo_instance.get_current_quotas.call_args[0][0]
+            today = date.today()
+            # Daily channels queried at today; monthly at first-of-month — as
+            # (period, period_start) pairs so a stale same-date daily row is
+            # NOT pulled in with the monthly row.
+            assert ("daily", today) in windows
+            assert ("monthly", today.replace(day=1)) in windows
+
+    @pytest.mark.asyncio
+    async def test_get_current_quotas_returns_matched_rows(self):
+        from datetime import date
+        from app.repositories.notification_quota_repository import NotificationQuotaRepository
+
+        mock_db = AsyncMock()
+        row = MagicMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all = MagicMock(return_value=[row])
+        mock_result = MagicMock()
+        mock_result.scalars = MagicMock(return_value=mock_scalars)
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        repo = NotificationQuotaRepository(mock_db)
+        result = await repo.get_current_quotas([("monthly", date(2026, 7, 1))])
+        assert result == [row]
+        mock_db.execute.assert_awaited_once()

--- a/Backend_FastAPI/tests/unit/test_notification_d1.py
+++ b/Backend_FastAPI/tests/unit/test_notification_d1.py
@@ -312,3 +312,109 @@ class TestNotificationQuotaRepository:
         repo = NotificationQuotaRepository(mock_db)
         result = await repo.is_over_quota("zalo")
         assert result is True
+
+
+# ---------------------------------------------------------------------------
+# D1-5: Per-channel quota period resolution (zalo_bot = MONTHLY)
+# ---------------------------------------------------------------------------
+
+class TestChannelQuotaConfig:
+    """Test _get_channel_quota_config period/limit resolution."""
+
+    def test_zalo_bot_is_monthly(self):
+        from datetime import date
+        from app.config import settings
+        from app.services.notification_quota_service import _get_channel_quota_config
+
+        cfg = _get_channel_quota_config("zalo_bot")
+        assert cfg is not None
+        period, period_start, limit = cfg
+        assert period == "monthly"
+        assert period_start == date.today().replace(day=1)  # first of month
+        assert limit == settings.ZALO_BOT_MONTHLY_QUOTA
+
+    def test_zalo_is_daily(self):
+        from datetime import date
+        from app.config import settings
+        from app.services.notification_quota_service import _get_channel_quota_config
+
+        cfg = _get_channel_quota_config("zalo")
+        assert cfg is not None
+        period, period_start, limit = cfg
+        assert period == "daily"
+        assert period_start == date.today()
+        assert limit == settings.ZALO_DAILY_QUOTA_LIMIT
+
+    def test_unknown_channel_is_unlimited(self):
+        from app.services.notification_quota_service import _get_channel_quota_config
+
+        assert _get_channel_quota_config("email") is None
+        assert _get_channel_quota_config("browser") is None
+
+
+class TestZaloBotMonthlyQuota:
+    """zalo_bot enforces a MONTHLY quota window, not daily."""
+
+    @pytest.mark.asyncio
+    async def test_check_quota_zalo_bot_queries_monthly_period(self):
+        from datetime import date
+        from app.services.notification_quota_service import check_quota
+
+        mock_db = AsyncMock()
+        with patch(
+            "app.services.notification_quota_service.NotificationQuotaRepository"
+        ) as MockRepo, patch(
+            "app.services.notification_quota_service.database"
+        ) as mock_database:
+            mock_redis = AsyncMock()
+            mock_redis.get = AsyncMock(return_value=None)  # cache miss → DB
+            mock_database.get_redis = AsyncMock(return_value=mock_redis)
+
+            repo_instance = AsyncMock()
+            repo_instance.is_over_quota = AsyncMock(return_value=False)
+            MockRepo.return_value = repo_instance
+
+            result = await check_quota(mock_db, "zalo_bot", provider="zalo_bot")
+            assert result is True
+            # Verify it checked the MONTHLY window (first of month), not daily
+            kwargs = repo_instance.is_over_quota.call_args[1]
+            assert kwargs["period"] == "monthly"
+            assert kwargs["period_start"] == date.today().replace(day=1)
+
+    @pytest.mark.asyncio
+    async def test_record_send_zalo_bot_creates_monthly_row(self):
+        from datetime import date
+        from app.config import settings
+        from app.services.notification_quota_service import record_send
+
+        mock_db = AsyncMock()
+        with patch(
+            "app.services.notification_quota_service.NotificationQuotaRepository"
+        ) as MockRepo:
+            repo_instance = AsyncMock()
+            repo_instance.get_current_quota = AsyncMock(return_value=None)
+            MockRepo.return_value = repo_instance
+
+            await record_send(mock_db, "zalo_bot", provider="zalo_bot")
+            repo_instance.upsert_quota.assert_awaited_once()
+            kwargs = repo_instance.upsert_quota.call_args[1]
+            assert kwargs["period"] == "monthly"
+            assert kwargs["period_start"] == date.today().replace(day=1)
+            assert kwargs["quota_limit"] == settings.ZALO_BOT_MONTHLY_QUOTA
+            assert kwargs["quota_used"] == 1
+
+    @pytest.mark.asyncio
+    async def test_record_send_unknown_channel_is_noop(self):
+        """Channel with no quota config → record_send does nothing (no repo call)."""
+        from app.services.notification_quota_service import record_send
+
+        mock_db = AsyncMock()
+        with patch(
+            "app.services.notification_quota_service.NotificationQuotaRepository"
+        ) as MockRepo:
+            repo_instance = AsyncMock()
+            MockRepo.return_value = repo_instance
+
+            await record_send(mock_db, "email")
+            repo_instance.get_current_quota.assert_not_awaited()
+            repo_instance.upsert_quota.assert_not_awaited()


### PR DESCRIPTION
## Vấn đề (điều tra từ sự cố thật)
Officer **Thu Hiền** phản ánh không nhận tin Zalo bot (04-07). Điều tra: binding của cô ấy đúng — nguyên nhân là **quota kênh `zalo_bot` cạn**. Hệ hardcode quota **DAILY 80** (`notification_quota_service`, `period="daily"`), nhưng **Zalo Bot free tier = 3000 tin/THÁNG, KHÔNG có trần cứng theo ngày** (verified tại `bot.zapps.me/docs`; API không ghi per-day cap).

Trần 80/ngày là **tự-áp**, sai 2 điểm:
- Toán học chặn ở **2400/tháng** (80×30) → phí 600 (20%) không bao giờ dùng.
- Tải **bursty** mùa tuyển sinh: ngày cao điểm mất tin dù tháng chưa tới 3000 (04-07: cạn 08:49 UTC → 15 tin dead/fail, 3 officer). Officer VẪN nhận in-app + email — chỉ mất push Zalo.

## Thay đổi
Đổi quota `zalo_bot` **daily → monthly** (2800, ~7% margin dưới 3000). Tải thấp ngày này bù ngày cao điểm trong tháng.

- **`config.py`**: thêm `ZALO_BOT_MONTHLY_QUOTA=2800`; xoá dead `ZALO_BOT_DAILY_QUOTA` (`extra="ignore"` nên an toàn).
- **`notification_quota_service.py`**: helper `get_channel_quota_config(channel) → (period, period_start, limit)` (zalo_bot=monthly đầu-tháng, zalo=daily, khác=unlimited); `check_quota`/`record_send` period-aware; Redis cache key scope theo `period_start`.
- **`notification_quota_repository.py`**: `get_current_quotas(windows: [(period, period_start)])` lọc theo **cặp** qua `or_()` (không kéo row stale khác period).
- **`delivery_tasks.py`**: sync beat tái dùng resolver (1 nguồn sự thật).
- **Migration `zbmonthlyseed20260706`**: seed row tháng hiện tại = `count(zalo_bot sent/delivered/read từ đầu tháng)` — chạy **tự động** trong entrypoint TRƯỚC khi app phục vụ ⇒ chuyển daily→monthly **không quên usage cũ → không vượt 3000**. Idempotent (ON CONFLICT GREATEST), rollback-safe.

## Review & Verify
- ✅ **2 vòng `/code-review max`** (10+ finder). Vòng 1 bắt **1 bug thật** (get_quota_summary lọc `period_start IN` không lọc period → dashboard gộp nhầm nondeterministic) → đã vá. Vòng 2 xác nhận fix ĐÚNG + vá 1 latent (bỏ param thừa).
- ✅ **Finding P2 (overshoot)** nâng từ manual seed → **Alembic migration tự động** (đúng gợi ý "explicit backfill/migration before switching enforcement").
- ✅ **22 unit test** (12 cũ + 10 mới: config helper, monthly check/record, block-khi-hết-quota, summary 2-window, repo). flake8 net-clean.
- ✅ **Migration roundtrip dev PASS**: upgrade→seeded 308/2800→downgrade→0 row→alembic current về down_revision (no drift). Idempotent 308=308.

## Deploy
Code + **1 data-migration** (entrypoint tự `alembic upgrade head` → seed). **Không cần bước tay.** No Casbin. Flag: không (đổi logic quota trực tiếp).
- ⚠️ Residual **display-only** (deploy day: dashboard hiện dup zalo_bot 1 ngày, tự lành D+1) — chấp nhận để giữ rollback-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)