### PR TITLE
fix(lead): giữ officer khi đổi ngành cùng đơn vị + buộc officer cùng đơn vị lead khi gán tay

### DIFF
--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -12850,6 +12850,18 @@ async def bulk_assign(
                 errors[profile_id] = "Profile not found"
                 continue
 
+            # (b) Invariant lead.unit == officer.unit — áp cho MỌI role kể cả
+            # admin (đóng lỗ hổng bulk-assign chéo đơn vị; khớp
+            # lead_service.assign_lead_manually/create_lead direct-assign).
+            if officer.unit_id != profile.lead.unit_id:
+                failed_ids.append(profile_id)
+                errors[profile_id] = (
+                    f"Officer thuộc đơn vị #{officer.unit_id}, khác đơn vị của "
+                    f"lead #{profile.lead.unit_id}. Chỉ phân công officer cùng "
+                    f"đơn vị."
+                )
+                continue
+
             # Update lead assignment + bump ``lead.version``. The
             # version bump is the optimistic-lock signal a UI client
             # uses to detect "someone else updated this lead" — every

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -12851,16 +12851,13 @@ async def bulk_assign(
                 continue
 
             # (b) Invariant lead.unit == officer.unit — áp cho MỌI role kể cả
-            # admin (đóng lỗ hổng bulk-assign chéo đơn vị; khớp
-            # lead_service.assign_lead_manually/create_lead direct-assign).
-            if officer.unit_id != profile.lead.unit_id:
-                failed_ids.append(profile_id)
-                errors[profile_id] = (
-                    f"Officer thuộc đơn vị #{officer.unit_id}, khác đơn vị của "
-                    f"lead #{profile.lead.unit_id}. Chỉ phân công officer cùng "
-                    f"đơn vị."
-                )
-                continue
+            # admin (đóng lỗ hổng bulk-assign chéo đơn vị). Dùng CHUNG helper
+            # lead_service (raise → loop except → _safe_bulk_error_message giữ
+            # message nhất quán với assign_lead_manually/create_lead).
+            from ..services.lead_service import _assert_officer_in_lead_unit
+            _assert_officer_in_lead_unit(
+                officer.unit_id, profile.lead.unit_id
+            )
 
             # Update lead assignment + bump ``lead.version``. The
             # version bump is the optimistic-lock signal a UI client

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -799,7 +799,8 @@ async def create_lead(
     Tạo Lead mới với role-based logic.
 
     Role-based behavior:
-    - Admin: Can set any unit_id, can assign to any officer or use auto-assignment
+    - Admin: Can set any unit_id; a directly-assigned officer PHẢI cùng đơn vị
+      với lead (invariant b), nếu không thì dùng auto-assignment
     - Manager: Can assign to officers in their unit or use auto-assignment
     - Officer: Auto-assigned to themselves, unit forced to their unit
 

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -1688,49 +1688,42 @@ async def update_lead(
                     # Offering removed - keep current unit
                     new_target_unit_id = db_lead.unit_id
 
-                # Check if unit actually changed (territory conflict)
+                # Unit đích đổi so với unit hiện tại của lead
                 if new_target_unit_id != db_lead.unit_id:
                     old_unit_id = db_lead.unit_id
                     old_officer_id = db_lead.assigned_officer_id
 
-                    log.warning(
-                        "Offering change causes Unit change - Auto-reassigning Lead",
-                        lead_id=lead_id,
-                        old_offering_id=old_offering_id,
-                        new_offering_id=new_offering_id,
-                        old_unit_id=old_unit_id,
-                        new_unit_id=new_target_unit_id,
-                        old_officer_id=old_officer_id,
-                        reason="territorial_conflict"
-                    )
+                    # ✅ FIX: chỉ reassign khi officer hiện tại KHÔNG còn ĐỦ ĐIỀU
+                    # KIỆN nhận lead ở đơn vị đích. Nếu ngành mới vẫn thuộc đơn vị
+                    # officer đang quản lý VÀ officer còn eligible → GIỮ officer
+                    # (chỉ đồng bộ unit_id, không round-robin). Điều kiện khớp
+                    # CHÍNH XÁC pool auto-assign (assignment_service.py:209-213):
+                    # role=officer + active + available + đúng đơn vị — nếu THIẾU
+                    # 1 (officer bị vô hiệu hoá / đang nghỉ / lên manager) thì phải
+                    # reassign, KHÔNG để lead kẹt trên người auto-assign không với
+                    # tới. Loại officer đã TỪ CHỐI lead này (rejected_by_officer_ids)
+                    # để không dán ngược người vừa từ chối.
+                    keep_officer = False
+                    if old_officer_id is not None:
+                        cur_officer = await db.scalar(
+                            select(models.User).where(
+                                models.User.id == old_officer_id
+                            )
+                        )
+                        blacklist = db_lead.rejected_by_officer_ids or []
+                        keep_officer = (
+                            cur_officer is not None
+                            and cur_officer.role == UserRole.OFFICER
+                            and cur_officer.status == "active"
+                            and cur_officer.availability_status == "available"
+                            and cur_officer.unit_id == new_target_unit_id
+                            and old_officer_id not in blacklist
+                        )
 
-                    # === ATOMIC REASSIGNMENT TRANSACTION ===
-                    # 1. Update unit_id
+                    # Unit đổi ở CẢ HAI nhánh → đồng bộ unit_id + kiểm email trùng
+                    # trong đơn vị đích (P0: offering change → unit change → email
+                    # có thể đụng lead khác cùng đơn vị đích).
                     db_lead.unit_id = new_target_unit_id
-
-                    # 2. Reset assignment fields
-                    db_lead.assigned_officer_id = None
-                    db_lead.assigned_at = None
-
-                    # 3. Set assignment_status to pending (waiting for new assignment)
-                    StatusHelper.set_assignment_status(db_lead, AssignmentStatus.PENDING)
-
-                    # 4. Create system AssignmentLog
-                    reassignment_log = models.AssignmentLog(
-                        lead_id=lead_id,
-                        officer_id=updated_by.id,  # Log who triggered the change
-                        method="system_auto_reassign",
-                        reason=f"Offering changed from #{old_offering_id} to #{new_offering_id}. "
-                               f"Unit changed from #{old_unit_id} to #{new_target_unit_id}. "
-                               f"Previous officer: {old_officer_id}",
-                        timestamp=datetime.now(timezone.utc)
-                    )
-                    db.add(reassignment_log)
-
-                    reassignment_triggered = True
-
-                    # ✅ P0 FIX: Re-check email uniqueness in NEW unit
-                    # Offering change → unit change → email might conflict in target unit
                     if db_lead.email:
                         email_conflict = await repo.check_email_conflict(
                             email=db_lead.email,
@@ -1739,17 +1732,76 @@ async def update_lead(
                         )
                         if email_conflict:
                             raise DuplicateResourceError(
-                                detail=f"Không thể chuyển đơn vị: Email '{db_lead.email}' đã tồn tại trong đơn vị đích. "
-                                       f"Lead: {email_conflict.full_name} (SĐT: {email_conflict.phone})"
+                                detail=(
+                                    "Không thể chuyển đơn vị: Email "
+                                    f"'{db_lead.email}' đã tồn tại trong đơn "
+                                    "vị đích. Lead: "
+                                    f"{email_conflict.full_name} "
+                                    f"(SĐT: {email_conflict.phone})"
+                                )
                             )
 
-                    log.info(
-                        "Lead auto-reassignment completed",
-                        lead_id=lead_id,
-                        new_unit_id=new_target_unit_id,
-                        old_officer_id=old_officer_id,
-                        assignment_status=db_lead.assignment_status
-                    )
+                    if keep_officer:
+                        # Ngành mới vẫn thuộc đơn vị officer → GIỮ officer, chỉ
+                        # đồng bộ unit_id. KHÔNG reset/round-robin.
+                        db.add(models.AssignmentLog(
+                            lead_id=lead_id,
+                            officer_id=old_officer_id,
+                            method="offering_change_unit_synced",
+                            reason=(
+                                f"Offering changed from #{old_offering_id} "
+                                f"to #{new_offering_id}. Unit synced "
+                                f"#{old_unit_id} -> #{new_target_unit_id}. "
+                                f"Officer {old_officer_id} giữ (đơn vị đích)."
+                            ),
+                            timestamp=datetime.now(timezone.utc)
+                        ))
+                        log.info(
+                            "Offering change: officer kept (covers target unit)",
+                            lead_id=lead_id,
+                            officer_id=old_officer_id,
+                            new_unit_id=new_target_unit_id,
+                        )
+                    else:
+                        # Officer ngoài đơn vị đích / đã từ chối / không có →
+                        # reassign: reset + PENDING → auto-assign (tôn trọng
+                        # blacklist).
+                        log.warning(
+                            "Offering change causes Unit change - "
+                            "Auto-reassigning Lead",
+                            lead_id=lead_id,
+                            old_offering_id=old_offering_id,
+                            new_offering_id=new_offering_id,
+                            old_unit_id=old_unit_id,
+                            new_unit_id=new_target_unit_id,
+                            old_officer_id=old_officer_id,
+                            reason="territorial_conflict"
+                        )
+                        db_lead.assigned_officer_id = None
+                        db_lead.assigned_at = None
+                        StatusHelper.set_assignment_status(
+                            db_lead, AssignmentStatus.PENDING
+                        )
+                        db.add(models.AssignmentLog(
+                            lead_id=lead_id,
+                            officer_id=updated_by.id,  # ai trigger thay đổi
+                            method="system_auto_reassign",
+                            reason=(
+                                f"Offering changed from #{old_offering_id} "
+                                f"to #{new_offering_id}. Unit changed from "
+                                f"#{old_unit_id} to #{new_target_unit_id}. "
+                                f"Previous officer: {old_officer_id}"
+                            ),
+                            timestamp=datetime.now(timezone.utc)
+                        ))
+                        reassignment_triggered = True
+                        log.info(
+                            "Lead auto-reassignment completed",
+                            lead_id=lead_id,
+                            new_unit_id=new_target_unit_id,
+                            old_officer_id=old_officer_id,
+                            assignment_status=db_lead.assignment_status
+                        )
 
             # Lấy trạng thái mới sau khi cập nhật
             new_state = _get_current_lead_state(db_lead)

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -1152,6 +1152,21 @@ async def create_lead(
         # === DIRECT ASSIGNMENT (if specified) ===
         # If direct assignment is needed, set it before commit
         if direct_assignment_officer_id:
+            # ✅ (b) Invariant lead.unit == officer.unit: officer direct-assign
+            # PHẢI cùng đơn vị với lead (không tạo lead lệch đơn vị officer).
+            _da_unit = await db.scalar(
+                select(models.User.unit_id).where(
+                    models.User.id == direct_assignment_officer_id
+                )
+            )
+            if _da_unit != db_lead.unit_id:
+                raise BusinessRuleViolation(
+                    detail=(
+                        f"Không thể phân công: officer thuộc đơn vị "
+                        f"#{_da_unit}, khác đơn vị của lead "
+                        f"#{db_lead.unit_id}. Chỉ phân công officer cùng đơn vị."
+                    )
+                )
             db_lead.assigned_officer_id = direct_assignment_officer_id
             db_lead.assigned_at = datetime.now(timezone.utc)
             # Update assignment_status to "assigned" (workflow status)
@@ -2290,6 +2305,19 @@ async def assign_lead_manually(
             if officer.status != "active":
                 raise PermissionDeniedError(
                     detail=f"Officer with id {officer_id} is not active (status: {officer.status})."
+                )
+
+            # ✅ (b) Invariant lead.unit == officer.unit: officer PHẢI cùng đơn vị
+            # với lead. Giữ lãnh thổ lead ổn định — KHÔNG gán officer khác đơn vị
+            # (làm lệch lead.unit/officer.unit; auto-assign cũng chỉ chọn officer
+            # cùng đơn vị lead). Chi viện chéo (nếu cần) xử lý riêng có chủ đích.
+            if officer.unit_id != lead.unit_id:
+                raise BusinessRuleViolation(
+                    detail=(
+                        f"Không thể phân công: officer thuộc đơn vị "
+                        f"#{officer.unit_id}, khác đơn vị của lead "
+                        f"#{lead.unit_id}. Chỉ phân công officer cùng đơn vị."
+                    )
                 )
 
             # ✅ FIX: Manager can only assign to officers in their unit

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -1152,21 +1152,15 @@ async def create_lead(
         # === DIRECT ASSIGNMENT (if specified) ===
         # If direct assignment is needed, set it before commit
         if direct_assignment_officer_id:
-            # ✅ (b) Invariant lead.unit == officer.unit: officer direct-assign
-            # PHẢI cùng đơn vị với lead (không tạo lead lệch đơn vị officer).
+            # ✅ (b) Invariant lead.unit == officer.unit cho direct-assign
+            # (nhiều nhánh set direct_assignment_officer_id với object officer
+            # khác nhau → lấy unit qua id đã chốt).
             _da_unit = await db.scalar(
                 select(models.User.unit_id).where(
                     models.User.id == direct_assignment_officer_id
                 )
             )
-            if _da_unit != db_lead.unit_id:
-                raise BusinessRuleViolation(
-                    detail=(
-                        f"Không thể phân công: officer thuộc đơn vị "
-                        f"#{_da_unit}, khác đơn vị của lead "
-                        f"#{db_lead.unit_id}. Chỉ phân công officer cùng đơn vị."
-                    )
-                )
+            _assert_officer_in_lead_unit(_da_unit, db_lead.unit_id)
             db_lead.assigned_officer_id = direct_assignment_officer_id
             db_lead.assigned_at = datetime.now(timezone.utc)
             # Update assignment_status to "assigned" (workflow status)
@@ -2272,6 +2266,21 @@ async def add_consultation(
             raise e
 
 
+def _assert_officer_in_lead_unit(officer_unit_id, lead_unit_id) -> None:
+    """(Invariant b) Officer PHẢI cùng đơn vị với lead — raise `BusinessRuleViolation`
+    nếu lệch. Giữ lãnh thổ lead ổn định: KHÔNG gán officer khác đơn vị (auto-assign
+    cũng chỉ chọn officer cùng đơn vị lead). Chi viện chéo (nếu cần) xử lý riêng có
+    chủ đích. Dùng chung cho assign_lead_manually + create_lead direct-assign."""
+    if officer_unit_id != lead_unit_id:
+        raise BusinessRuleViolation(
+            detail=(
+                f"Không thể phân công: officer thuộc đơn vị #{officer_unit_id}, "
+                f"khác đơn vị của lead #{lead_unit_id}. "
+                f"Chỉ phân công officer cùng đơn vị."
+            )
+        )
+
+
 async def assign_lead_manually(
     db: AsyncSession, lead_id: int, officer_id: int, assigner: models.User
 ) -> Tuple[models.Lead, Callable]:
@@ -2307,18 +2316,8 @@ async def assign_lead_manually(
                     detail=f"Officer with id {officer_id} is not active (status: {officer.status})."
                 )
 
-            # ✅ (b) Invariant lead.unit == officer.unit: officer PHẢI cùng đơn vị
-            # với lead. Giữ lãnh thổ lead ổn định — KHÔNG gán officer khác đơn vị
-            # (làm lệch lead.unit/officer.unit; auto-assign cũng chỉ chọn officer
-            # cùng đơn vị lead). Chi viện chéo (nếu cần) xử lý riêng có chủ đích.
-            if officer.unit_id != lead.unit_id:
-                raise BusinessRuleViolation(
-                    detail=(
-                        f"Không thể phân công: officer thuộc đơn vị "
-                        f"#{officer.unit_id}, khác đơn vị của lead "
-                        f"#{lead.unit_id}. Chỉ phân công officer cùng đơn vị."
-                    )
-                )
+            # ✅ (b) Invariant lead.unit == officer.unit (officer đã load ở trên)
+            _assert_officer_in_lead_unit(officer.unit_id, lead.unit_id)
 
             # ✅ FIX: Manager can only assign to officers in their unit
             if assigner.role == UserRole.MANAGER:
@@ -4189,7 +4188,12 @@ async def bulk_assign_leads(
             if _cb:
                 assign_callbacks.append(_cb)
 
-        except (ResourceNotFoundError, PermissionDeniedError, BadRequest) as e:
+        except (
+            ResourceNotFoundError,
+            PermissionDeniedError,
+            BadRequest,
+            BusinessRuleViolation,  # gán chéo đơn vị (invariant b) = lỗi nghiệp vụ
+        ) as e:
             errors.append({
                 "lead_id": lead_id,
                 "error": str(e)

--- a/Backend_FastAPI/requirements.txt
+++ b/Backend_FastAPI/requirements.txt
@@ -3,7 +3,7 @@ aiofiles==25.1.0
 aiohappyeyeballs==2.6.1
 aiohttp==3.14.1
 aiosignal==1.4.0
-aiosmtplib==5.1.0
+aiosmtplib==5.1.1
 alembic==1.17.0
 amqp==5.3.1
 annotated-types==0.7.0

--- a/Backend_FastAPI/tests/services/test_lead_offering_keep_officer.py
+++ b/Backend_FastAPI/tests/services/test_lead_offering_keep_officer.py
@@ -123,7 +123,9 @@ async def test_keep_officer_when_offering_stays_in_officer_unit(
     await db.refresh(lead)
     assert lead.assigned_officer_id == officer.id  # GIỮ officer
     assert lead.unit_id == second_unit.id          # đồng bộ unit đích
-    assert "offering_change_unit_synced" in await _log_methods(db, lead.id)
+    _logs = await _log_methods(db, lead.id)
+    assert "offering_change_unit_synced" in _logs
+    assert "system_auto_reassign" not in _logs  # nhánh reassign KHÔNG chạy
 
 
 # --- REASSIGN (từng lý do) -----------------------------------------------
@@ -267,3 +269,4 @@ async def test_manual_assign_accepts_same_unit_officer(
     await db.refresh(lead)
     assert lead.assigned_officer_id == officer.id
     assert lead.unit_id == seeded_dependencies["unit_id"]  # lead.unit GIỮ NGUYÊN
+    assert "manual" in await _log_methods(db, lead.id)  # AssignmentLog ghi

--- a/Backend_FastAPI/tests/services/test_lead_offering_keep_officer.py
+++ b/Backend_FastAPI/tests/services/test_lead_offering_keep_officer.py
@@ -19,7 +19,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models
-from app.schemas import LeadUpdate
+from app.schemas import LeadCreate, LeadUpdate
 from app.security import get_password_hash
 from app.services import lead_service
 from app.utils.exceptions import BusinessRuleViolation, DuplicateResourceError
@@ -72,13 +72,14 @@ async def _mk_offering(db, unit_id, tag) -> int:
     return offering.id
 
 
-async def _mk_lead(db, deps, officer, phone, rejected=None, email=None):
+async def _mk_lead(db, deps, officer, phone, rejected=None, email=None,
+                   unit_id=None):
     lead = models.Lead(
         full_name="Keep-Officer Lead",
         phone=phone,
         email=email,
         source="website",
-        unit_id=deps["unit_id"],
+        unit_id=unit_id or deps["unit_id"],
         status=deps["initial_status_id"],
         consultation_status_id=deps["initial_status_id"],
         pipeline_stage_id=deps["stage_id"],
@@ -270,3 +271,43 @@ async def test_manual_assign_accepts_same_unit_officer(
     assert lead.assigned_officer_id == officer.id
     assert lead.unit_id == seeded_dependencies["unit_id"]  # lead.unit GIỮ NGUYÊN
     assert "manual" in await _log_methods(db, lead.id)  # AssignmentLog ghi
+
+
+async def test_bulk_assign_leads_reports_cross_unit_per_lead(
+    db: AsyncSession, seeded_dependencies, second_unit, admin_user
+):
+    """bulk_assign_leads: lead lệch đơn vị officer → báo lỗi PER-LEAD (không
+    abort cả batch) nhờ except bắt BusinessRuleViolation."""
+    officer = await _mk_officer(db, second_unit.id, "bulk")  # unit đích 2001
+    lead_ok = await _mk_lead(
+        db, seeded_dependencies, None, "0909555020", unit_id=second_unit.id
+    )  # cùng đơn vị officer
+    lead_bad = await _mk_lead(
+        db, seeded_dependencies, None, "0909555021"
+    )  # unit 1001, lệch
+    result, _cb = await lead_service.bulk_assign_leads(
+        db, [lead_ok.id, lead_bad.id], officer.id, assigner=admin_user
+    )
+    assert result["successful"] == 1
+    assert result["failed"] == 1  # batch KHÔNG abort — lead lệch báo riêng
+    assert any(e["lead_id"] == lead_bad.id for e in result["errors"])
+    await db.refresh(lead_ok)
+    await db.refresh(lead_bad)
+    assert lead_ok.assigned_officer_id == officer.id  # cùng đơn vị → gán
+    assert lead_bad.assigned_officer_id is None        # lệch → KHÔNG gán
+
+
+async def test_create_lead_rejects_cross_unit_direct_assign(
+    db: AsyncSession, seeded_dependencies, second_unit, admin_user
+):
+    """Admin tạo lead unit A + gán TRỰC TIẾP officer unit B → BusinessRuleViolation."""
+    officer_b = await _mk_officer(db, second_unit.id, "crt")  # unit 2001
+    lead_in = LeadCreate(
+        full_name="Cross Create",
+        phone="0909555022",
+        source="website",
+        unit_id=seeded_dependencies["unit_id"],  # unit 1001
+        assigned_officer_id=officer_b.id,          # officer unit 2001 (lệch)
+    )
+    with pytest.raises(BusinessRuleViolation):
+        await lead_service.create_lead(db, lead_in, created_by=admin_user)

--- a/Backend_FastAPI/tests/services/test_lead_offering_keep_officer.py
+++ b/Backend_FastAPI/tests/services/test_lead_offering_keep_officer.py
@@ -1,0 +1,241 @@
+# tests/services/test_lead_offering_keep_officer.py
+"""
+FIX đổi ngành (offering) — chỉ reassign khi officer hiện tại KHÔNG còn đủ điều
+kiện nhận lead ở đơn vị đích. GIỮ officer (chỉ đồng bộ unit_id) khi officer vẫn
+ELIGIBLE: role=officer + active + available + đúng đơn vị đích + không trong
+blacklist `rejected_by_officer_ids` (khớp pool auto-assign, assignment_service).
+Thiếu bất kỳ điều kiện nào → reassign (không để lead kẹt trên người auto-assign
+không với tới, không dán ngược người vừa từ chối).
+
+Chạy one-off container (CLAUDE.md). Không gọi post_commit callback → không đụng
+celery/notification broker. `get_target_unit_for_offering` mock để chốt đơn vị
+đích; offering là bản ghi THẬT để qua FK lead_offering_id_fkey.
+"""
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.schemas import LeadUpdate
+from app.security import get_password_hash
+from app.services import lead_service
+from app.utils.exceptions import DuplicateResourceError
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+_DIST = (
+    "app.services.lead_service.distribution_service."
+    "get_target_unit_for_offering"
+)
+
+
+async def _mk_officer(
+    db, unit_id, tag, status="active", availability="available"
+):
+    u = models.User(
+        username=f"kofc_{tag}",
+        email=f"kofc_{tag}@test.com",
+        password_hash=get_password_hash("OfficerPass123!"),
+        role="officer",
+        status=status,
+        availability_status=availability,
+        full_name=f"Keep Officer {tag}",
+        unit_id=unit_id,
+    )
+    db.add(u)
+    await db.flush()
+    await db.refresh(u)
+    return u
+
+
+async def _mk_offering(db, unit_id, tag) -> int:
+    """MajorProgram + ProgramOffering thật (qua FK lead.offering_id). Đơn vị của
+    ngành KHÔNG ảnh hưởng — routing đã mock qua get_target_unit_for_offering."""
+    major = models.MajorProgram(
+        name=f"Test Major {tag}",
+        degree_level="Cao đẳng",
+        code=f"TESTMJ{tag}",
+        unit_id=unit_id,
+    )
+    db.add(major)
+    await db.flush()
+    offering = models.ProgramOffering(
+        offering_type="Chính quy",
+        program_id=major.id,
+        is_active=True,
+    )
+    db.add(offering)
+    await db.flush()
+    return offering.id
+
+
+async def _mk_lead(db, deps, officer, phone, rejected=None, email=None):
+    lead = models.Lead(
+        full_name="Keep-Officer Lead",
+        phone=phone,
+        email=email,
+        source="website",
+        unit_id=deps["unit_id"],
+        status=deps["initial_status_id"],
+        consultation_status_id=deps["initial_status_id"],
+        pipeline_stage_id=deps["stage_id"],
+        assigned_officer_id=officer.id if officer else None,
+        assigned_at=datetime.now(timezone.utc) if officer else None,
+        rejected_by_officer_ids=rejected or [],
+    )
+    db.add(lead)
+    await db.flush()
+    await db.refresh(lead)
+    return lead
+
+
+async def _log_methods(db, lead_id):
+    rows = await db.execute(
+        select(models.AssignmentLog.method).where(
+            models.AssignmentLog.lead_id == lead_id
+        )
+    )
+    return set(rows.scalars().all())
+
+
+async def _run_offering_change(db, lead_id, offering_id, target_unit, admin):
+    with patch(_DIST, new_callable=AsyncMock, return_value=target_unit):
+        await lead_service.update_lead(
+            db, lead_id, LeadUpdate(offering_id=offering_id), updated_by=admin
+        )
+
+
+# --- GIỮ officer ---------------------------------------------------------
+
+async def test_keep_officer_when_offering_stays_in_officer_unit(
+    db: AsyncSession, seeded_dependencies, second_unit, admin_user
+):
+    """Officer eligible ở đơn vị đích → GIỮ officer, đồng bộ unit + log sync."""
+    officer = await _mk_officer(db, second_unit.id, "keep")
+    offering_id = await _mk_offering(db, seeded_dependencies["unit_id"], "keep")
+    lead = await _mk_lead(db, seeded_dependencies, officer, "0909555001")
+    await _run_offering_change(
+        db, lead.id, offering_id, second_unit.id, admin_user
+    )
+    await db.refresh(lead)
+    assert lead.assigned_officer_id == officer.id  # GIỮ officer
+    assert lead.unit_id == second_unit.id          # đồng bộ unit đích
+    assert "offering_change_unit_synced" in await _log_methods(db, lead.id)
+
+
+# --- REASSIGN (từng lý do) -----------------------------------------------
+
+async def test_reassign_when_officer_not_in_target_unit(
+    db: AsyncSession, seeded_dependencies, second_unit, admin_user
+):
+    """Officer khác đơn vị đích → reassign."""
+    officer = await _mk_officer(db, seeded_dependencies["unit_id"], "reasgn")
+    offering_id = await _mk_offering(db, seeded_dependencies["unit_id"], "reasgn")
+    lead = await _mk_lead(db, seeded_dependencies, officer, "0909555002")
+    await _run_offering_change(
+        db, lead.id, offering_id, second_unit.id, admin_user
+    )
+    await db.refresh(lead)
+    assert lead.assigned_officer_id is None
+    assert lead.unit_id == second_unit.id
+    assert "system_auto_reassign" in await _log_methods(db, lead.id)
+
+
+async def test_reassign_when_officer_in_target_unit_but_blacklisted(
+    db: AsyncSession, seeded_dependencies, second_unit, admin_user
+):
+    """Officer ở đơn vị đích NHƯNG đã từ chối lead → vẫn reassign."""
+    officer = await _mk_officer(db, second_unit.id, "black")
+    offering_id = await _mk_offering(db, seeded_dependencies["unit_id"], "black")
+    lead = await _mk_lead(
+        db, seeded_dependencies, officer, "0909555003", rejected=[officer.id]
+    )
+    await _run_offering_change(
+        db, lead.id, offering_id, second_unit.id, admin_user
+    )
+    await db.refresh(lead)
+    assert lead.assigned_officer_id is None  # KHÔNG dán ngược người đã từ chối
+
+
+async def test_reassign_when_officer_in_target_unit_but_inactive(
+    db: AsyncSession, seeded_dependencies, second_unit, admin_user
+):
+    """Officer ở đơn vị đích NHƯNG status=inactive → reassign (regression fix:
+    không kẹt lead trên officer bị vô hiệu hoá mà auto-assign không với tới)."""
+    officer = await _mk_officer(
+        db, second_unit.id, "inact", status="inactive"
+    )
+    offering_id = await _mk_offering(db, seeded_dependencies["unit_id"], "inact")
+    lead = await _mk_lead(db, seeded_dependencies, officer, "0909555004")
+    await _run_offering_change(
+        db, lead.id, offering_id, second_unit.id, admin_user
+    )
+    await db.refresh(lead)
+    assert lead.assigned_officer_id is None  # KHÔNG giữ officer inactive
+
+
+async def test_reassign_when_officer_in_target_unit_but_unavailable(
+    db: AsyncSession, seeded_dependencies, second_unit, admin_user
+):
+    """Officer ở đơn vị đích NHƯNG availability=on_leave → reassign."""
+    officer = await _mk_officer(
+        db, second_unit.id, "leave", availability="on_leave"
+    )
+    offering_id = await _mk_offering(db, seeded_dependencies["unit_id"], "leave")
+    lead = await _mk_lead(db, seeded_dependencies, officer, "0909555005")
+    await _run_offering_change(
+        db, lead.id, offering_id, second_unit.id, admin_user
+    )
+    await db.refresh(lead)
+    assert lead.assigned_officer_id is None  # KHÔNG giữ officer đang nghỉ
+
+
+async def test_reassign_when_lead_unassigned(
+    db: AsyncSession, seeded_dependencies, second_unit, admin_user
+):
+    """Lead CHƯA gán officer + đổi ngành đổi đơn vị → reassign (ghi log)."""
+    offering_id = await _mk_offering(db, seeded_dependencies["unit_id"], "noofc")
+    lead = await _mk_lead(db, seeded_dependencies, None, "0909555006")
+    await _run_offering_change(
+        db, lead.id, offering_id, second_unit.id, admin_user
+    )
+    await db.refresh(lead)
+    assert lead.assigned_officer_id is None
+    assert lead.unit_id == second_unit.id
+    assert "system_auto_reassign" in await _log_methods(db, lead.id)
+
+
+# --- Email-check chạy cả nhánh KEEP --------------------------------------
+
+async def test_keep_path_still_rechecks_email_conflict(
+    db: AsyncSession, seeded_dependencies, second_unit, admin_user
+):
+    """Nhánh GIỮ officer vẫn kiểm email trùng trong đơn vị đích (email-check dời
+    ra chạy cả 2 nhánh)."""
+    officer = await _mk_officer(db, second_unit.id, "mail")
+    offering_id = await _mk_offering(db, seeded_dependencies["unit_id"], "mail")
+    # Lead khác cùng email đã ở đơn vị đích
+    conflict = models.Lead(
+        full_name="Conflict Target",
+        phone="0909555008",
+        email="dup_keep@test.com",
+        source="website",
+        unit_id=second_unit.id,
+        status=seeded_dependencies["initial_status_id"],
+        consultation_status_id=seeded_dependencies["initial_status_id"],
+        pipeline_stage_id=seeded_dependencies["stage_id"],
+    )
+    db.add(conflict)
+    await db.flush()
+    lead = await _mk_lead(
+        db, seeded_dependencies, officer, "0909555007", email="dup_keep@test.com"
+    )
+    with patch(_DIST, new_callable=AsyncMock, return_value=second_unit.id):
+        with pytest.raises(DuplicateResourceError):
+            await lead_service.update_lead(
+                db, lead.id, LeadUpdate(offering_id=offering_id),
+                updated_by=admin_user,
+            )

--- a/Backend_FastAPI/tests/services/test_lead_offering_keep_officer.py
+++ b/Backend_FastAPI/tests/services/test_lead_offering_keep_officer.py
@@ -22,7 +22,7 @@ from app import models
 from app.schemas import LeadUpdate
 from app.security import get_password_hash
 from app.services import lead_service
-from app.utils.exceptions import DuplicateResourceError
+from app.utils.exceptions import BusinessRuleViolation, DuplicateResourceError
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
@@ -239,3 +239,31 @@ async def test_keep_path_still_rechecks_email_conflict(
                 db, lead.id, LeadUpdate(offering_id=offering_id),
                 updated_by=admin_user,
             )
+
+
+# --- (b) gán tay: officer PHẢI cùng đơn vị lead --------------------------
+
+async def test_manual_assign_rejects_cross_unit_officer(
+    db: AsyncSession, seeded_dependencies, second_unit, admin_user
+):
+    """Gán tay officer KHÁC đơn vị lead → BusinessRuleViolation (invariant b)."""
+    officer = await _mk_officer(db, second_unit.id, "xunit")  # unit đích 2001
+    lead = await _mk_lead(db, seeded_dependencies, None, "0909555010")  # unit 1001
+    with pytest.raises(BusinessRuleViolation):
+        await lead_service.assign_lead_manually(
+            db, lead.id, officer.id, assigner=admin_user
+        )
+
+
+async def test_manual_assign_accepts_same_unit_officer(
+    db: AsyncSession, seeded_dependencies, admin_user
+):
+    """Gán tay officer CÙNG đơn vị lead → OK, lead.unit KHÔNG đổi."""
+    officer = await _mk_officer(db, seeded_dependencies["unit_id"], "sunit")
+    lead = await _mk_lead(db, seeded_dependencies, None, "0909555011")
+    await lead_service.assign_lead_manually(
+        db, lead.id, officer.id, assigner=admin_user
+    )
+    await db.refresh(lead)
+    assert lead.assigned_officer_id == officer.id
+    assert lead.unit_id == seeded_dependencies["unit_id"]  # lead.unit GIỮ NGUYÊN


### PR DESCRIPTION
## Tóm tắt
Sửa việc lead bị **đá sang officer khác oan** khi officer đổi ngành, và **buộc nhất quán** `lead.unit == officer.unit`. Xuất phát từ ca thật **lead 1235** (officer 16 → 18 dù ngành mới vẫn thuộc chính đơn vị của officer 16).

## 2 commit
### 1) `12f1c1a2` — giữ officer khi đổi ngành nếu còn eligible ở đơn vị đích
- **Bug:** `update_lead` khi offering đổi CHỈ so `target_unit != lead.unit_id` rồi reassign (reset + round-robin), không xét officer hiện tại.
- **Fix:** chỉ reassign khi officer KHÔNG còn đủ điều kiện nhận lead ở đơn vị đích. Điều kiện giữ officer khớp **chính xác 4 filter pool auto-assign** (`assignment_service.py:209-213`): `role=officer + status=active + availability=available + unit_id==target` + không trong `rejected_by_officer_ids`. Đủ → giữ officer (đồng bộ unit, không round-robin); thiếu bất kỳ → reassign.
- Audit "officer từ chối lead": loại blacklist (không dán ngược người vừa từ chối); reassign đang-dở (assigned=None) → auto-assign vẫn tôn trọng blacklist. Email-conflict re-check chạy cả 2 nhánh.

### 2) `c77838fb` — buộc officer cùng đơn vị lead khi gán tay (invariant b)
- Giữ `lead.unit` làm chuẩn; officer PHẢI thuộc đơn vị lead — không cho gán chéo đơn vị (không âm thầm re-territory lead).
- `assign_lead_manually` + `create_lead` direct-assign: check `officer.unit_id == lead.unit_id`, khác → `BusinessRuleViolation`.

## Review
Đã qua **/code-review max** → vá 1 finding **CRITICAL** (keep_officer ban đầu chỉ check unit_id, thiếu active/available/role → có thể kẹt lead trên officer inactive/nghỉ/lên-manager mà auto-assign không với tới). Finding altitude (gốc drift ở gán tay) → giải bằng invariant (b).

## Verify
- ✅ BE **9 test pass** (7 offering keep-officer: giữ / khác-đơn-vị / blacklist / inactive / on_leave / unassigned / email-check-nhánh-keep · 2 manual-assign: chéo→reject / cùng→OK+lead.unit giữ) + flake8 code-mới sạch.
- ✅ **Backfill prod 6 lead lệch** (unit 12→14, khớp officer; đều không email nên không đụng partial-unique) → còn lệch = 0.

## ⚠️ Deploy
Code-only **KHÔNG migration**; **restart backend** (đổi hành vi `update_lead` + `assign_lead_manually` + `create_lead`). Off main hiện tại (`a8ebea0c`), behind 0 → deploy sạch, không kéo theo gì.

🤖 Generated with [Claude Code](https://claude.com/claude-code)