### PR TITLE
feat(sms): admin interest UI + drill-down ngành→SĐT + preview segment + UX

### DIFF
--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -283,9 +283,10 @@ class Settings(BaseSettings):
     )  # re-download tới expires_at; cleanup job xoá file + set purged_at
     # -- Landing page công khai /lp/{code} (PR-5) --
     SMS_LANDING_SCHOOL_NAME: str = Field(
-        default="Nhà trường",
+        default="Cao đẳng Bách khoa Tây Nguyên",
         validation_alias="SMS_LANDING_SCHOOL_NAME",
-    )  # tên trường hiển thị header landing (nhận diện, chống nghi lừa đảo)
+    )  # tên trường hiển thị header landing (nhận diện, chống nghi lừa đảo).
+    # Default = tên thật (hệ thống phục vụ 1 trường); env vẫn override được.
     SMS_LANDING_CONSENT_NOTICE: str = Field(
         default=(
             "Bạn nhận tin này vì đã đăng ký/quan tâm tuyển sinh. "

--- a/Backend_FastAPI/app/repositories/sms_engagement_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_engagement_repository.py
@@ -22,6 +22,7 @@ from app.models.major_program import MajorProgram
 from app.models.sms import (
     SmsCampaignRecipient,
     SmsConsultLink,
+    SmsContact,
     SmsContactProgramInterest,
     SmsLandingSession,
     SmsProgramView,
@@ -335,6 +336,93 @@ class SmsEngagementRepository:
         )
         r = res.first()
         return int(r[0]), int(r[1]), int(r[2])
+
+    async def program_contacts(
+        self,
+        *,
+        major_program_id: int,
+        campaign_id: Optional[int] = None,
+        group_id: Optional[int] = None,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+        skip: int = 0,
+        limit: int = 50,
+    ) -> Tuple[int, List[Tuple]]:
+        """(total_distinct_contacts, rows[(contact_id, full_name, phone_normalized,
+        view_count, total_dwell, first_viewed, last_viewed, interest_score)]) cho 1
+        ngành TRONG scope campaign/group/date; rank total_dwell desc.
+
+        GROUP BY CONTACT (không theo session/view). Build TRÊN sms_program_view
+        (giống program_interest_report) → giữ contact đã xem nhưng chưa heartbeat
+        + số KHỚP report. LEFT JOIN sms_contact_program_interest chỉ để lấy
+        interest_score GLOBAL (NULL→0, không fan-out vì (contact,program) unique).
+        first/last = min/max(viewed_at) TRONG scope. Bot loại qua _report_conds."""
+        conds = self._report_conds(
+            campaign_id=campaign_id,
+            group_id=group_id,
+            major_program_id=major_program_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        total = await self.db.scalar(
+            select(func.count(func.distinct(SmsProgramView.contact_id)))
+            .select_from(self._report_from(group_id=group_id))
+            .where(and_(*conds))
+        )
+        total_dwell = func.coalesce(func.sum(SmsProgramView.dwell_seconds), 0)
+        from_clause = (
+            self._report_from(group_id=group_id)
+            .join(
+                SmsContact.__table__,
+                SmsContact.id == SmsProgramView.contact_id,
+            )
+            .outerjoin(
+                SmsContactProgramInterest.__table__,
+                and_(
+                    SmsContactProgramInterest.contact_id
+                    == SmsProgramView.contact_id,
+                    SmsContactProgramInterest.major_program_id
+                    == SmsProgramView.major_program_id,
+                ),
+            )
+        )
+        res = await self.db.execute(
+            select(
+                SmsContact.id,
+                SmsContact.full_name,
+                SmsContact.phone_normalized,
+                func.count().label("view_count"),
+                total_dwell.label("total_dwell"),
+                func.min(SmsProgramView.viewed_at).label("first_viewed"),
+                func.max(SmsProgramView.viewed_at).label("last_viewed"),
+                func.coalesce(
+                    func.max(SmsContactProgramInterest.interest_score), 0.0
+                ).label("score"),
+            )
+            .select_from(from_clause)
+            .where(and_(*conds))
+            .group_by(
+                SmsContact.id,
+                SmsContact.full_name,
+                SmsContact.phone_normalized,
+            )
+            .order_by(total_dwell.desc())
+            .offset(skip)
+            .limit(limit)
+        )
+        return int(total or 0), [
+            (
+                r.id,
+                r.full_name,
+                r.phone_normalized,
+                int(r.view_count),
+                int(r.total_dwell),
+                r.first_viewed,
+                r.last_viewed,
+                float(r.score or 0.0),
+            )
+            for r in res.all()
+        ]
 
     # ---------------------------------------------------------------
     # Hồ sơ sở thích 1 contact

--- a/Backend_FastAPI/app/repositories/sms_engagement_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_engagement_repository.py
@@ -406,7 +406,9 @@ class SmsEngagementRepository:
                 SmsContact.full_name,
                 SmsContact.phone_normalized,
             )
-            .order_by(total_dwell.desc())
+            # Tiebreaker SmsContact.id: nhiều contact xem-chưa-heartbeat có
+            # dwell=0 (ties) → offset/limit ổn định giữa các trang (không lặp/sót).
+            .order_by(total_dwell.desc(), SmsContact.id)
             .offset(skip)
             .limit(limit)
         )
@@ -419,7 +421,7 @@ class SmsEngagementRepository:
                 int(r.total_dwell),
                 r.first_viewed,
                 r.last_viewed,
-                float(r.score or 0.0),
+                float(r.score),
             )
             for r in res.all()
         ]

--- a/Backend_FastAPI/app/routers/sms_campaigns.py
+++ b/Backend_FastAPI/app/routers/sms_campaigns.py
@@ -82,6 +82,20 @@ async def update_campaign(
     return campaign
 
 
+@router.post("/campaigns/measure", response_model=sms_schemas.SmsMeasureResult)
+async def measure_template(
+    payload: sms_schemas.SmsMeasureRequest,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    """Đo encoding/length/segments + preview tin cuối cho form soạn campaign
+    (chưa gắn recipient). Dùng CÙNG nguồn optout (settings.SMS_OPTOUT_INSTRUCTION)
+    với build để số đo khớp. Read-only → không commit."""
+    return SmsCampaignService(db).measure_template(
+        payload.template, sample_full_name=payload.sample_full_name
+    )
+
+
 # =====================================================================
 # Campaign ↔ group
 # =====================================================================

--- a/Backend_FastAPI/app/routers/sms_reports.py
+++ b/Backend_FastAPI/app/routers/sms_reports.py
@@ -124,3 +124,31 @@ async def contact_interests(
 ):
     """Hồ sơ 'quan tâm ngành' của 1 contact (rank tổng dwell desc)."""
     return await SmsReportService(db).contact_interests(contact_id)
+
+
+@router.get(
+    "/reports/program-interest/{major_program_id}/contacts",
+    response_model=sms_schemas.SmsProgramContactsResponse,
+)
+async def report_program_contacts(
+    major_program_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+    campaign_id: Optional[int] = Query(None, ge=1, le=_MAX_ID),
+    group_id: Optional[int] = Query(None, ge=1, le=_MAX_ID),
+    date_from: Optional[datetime] = Query(None),
+    date_to: Optional[datetime] = Query(None),
+    skip: int = Query(0, ge=0, le=_MAX_ID),
+    limit: int = Query(50, ge=1, le=200),
+):
+    """Drill-down: contact nào quan tâm 1 ngành (masked phone §16.9). CÙNG filter
+    với /reports/program-interest → số khớp dòng ngành đã bấm. Read-only."""
+    return await SmsReportService(db).program_contacts(
+        major_program_id=major_program_id,
+        campaign_id=campaign_id,
+        group_id=group_id,
+        date_from=date_from,
+        date_to=date_to,
+        skip=skip,
+        limit=limit,
+    )

--- a/Backend_FastAPI/app/schemas/sms.py
+++ b/Backend_FastAPI/app/schemas/sms.py
@@ -469,6 +469,39 @@ class SmsPreflightReport(BaseModel):
     preview: List[str] = Field(default_factory=list)
 
 
+class SmsMeasureRequest(BaseModel):
+    """Đo thử 1 template soạn dở (chưa gắn recipient) cho form soạn campaign.
+    `sample_full_name` tùy chọn — bỏ trống → render dùng NAME_FALLBACK
+    (worst-case tiếng Việt → UCS2)."""
+
+    template: str = Field(..., min_length=1, max_length=2000)
+    sample_full_name: Optional[str] = Field(None, max_length=255)
+
+    @field_validator("template")
+    @classmethod
+    def _v_template(cls, v):
+        return _strip_required_text(v)
+
+
+class SmsMeasureResult(BaseModel):
+    """Kết quả đo/preview template. Phân 2 tầng cho FE:
+    - BLOCKING (sẽ bị `_validate_content` từ chối khi LƯU): `unknown_vars`
+      (biến lạ) + `has_internal_sentinel` (template chứa __SMS_LINK__).
+    - SOFT (`warnings`) + `optout_configured`: optout chưa cấu hình/placeholder
+      />160 (build sẽ chặn), tin vượt 1 segment."""
+
+    encoding: str
+    length: int
+    segments: int
+    is_over_limit: bool
+    preview: str
+    has_link: bool
+    unknown_vars: List[str] = Field(default_factory=list)
+    has_internal_sentinel: bool = False
+    optout_configured: bool = True
+    warnings: List[str] = Field(default_factory=list)
+
+
 class SmsAttestationCreate(BaseModel):
     """Ghi attestation consent/DNC/opt-out-channel cho build_revision hiện
     tại (gate export PR-4)."""
@@ -662,6 +695,33 @@ class SmsContactInterestList(BaseModel):
 
     contact_id: int
     items: List[SmsContactInterestRow] = Field(default_factory=list)
+
+
+class SmsProgramContactRow(BaseModel):
+    """1 contact quan tâm 1 ngành (drill-down §16.7). PII masked (§16.9).
+
+    `view_count`/`total_dwell_seconds`/`first_viewed_at`/`last_viewed_at` là số
+    liệu TRONG scope filter (khớp dòng report đã bấm). `interest_score` là điểm
+    GLOBAL rolling (ngoài scope) — chỉ làm bối cảnh 'nóng tổng thể'; NULL (contact
+    đã xem nhưng chưa heartbeat) → 0.0."""
+
+    contact_id: int
+    full_name: str
+    phone_masked: str
+    view_count: int = 0
+    total_dwell_seconds: int = 0
+    interest_score: float = 0.0
+    first_viewed_at: Optional[datetime] = None
+    last_viewed_at: Optional[datetime] = None
+
+
+class SmsProgramContactsResponse(BaseModel):
+    """Danh sách contact quan tâm 1 ngành (drill-down từ report ngành nóng).
+    `total` = distinct contact trong scope (cho phân trang), rank total_dwell desc."""
+
+    major_program_id: int
+    total: int = 0
+    items: List[SmsProgramContactRow] = Field(default_factory=list)
 
 
 # --- P2-3 consult officer (§16.7) ---

--- a/Backend_FastAPI/app/services/sms_campaign_service.py
+++ b/Backend_FastAPI/app/services/sms_campaign_service.py
@@ -143,35 +143,39 @@ class SmsCampaignService:
     # ===============================================================
     # Measure/preview template (form soạn campaign — chưa recipient)
     # ===============================================================
-    def _resolve_optout_for_measure(self) -> Tuple[str, List[str], bool]:
-        """Mirror 3 kiểm tra optout của `build()` NHƯNG không raise → measure
-        vẫn đo được (footer placeholder cũng có độ dài); điều kiện build-sẽ-chặn
-        trả dưới dạng warning + optout_ok=False."""
-        footer = (settings.SMS_OPTOUT_INSTRUCTION or "").strip()
-        warnings: List[str] = []
-        ok = True
+    def _optout_violations(self, footer: str) -> List[str]:
+        """3 luật optout NĐ91 (build gate + measure warning DÙNG CHUNG → không
+        drift). Trả list mô tả vi phạm (rỗng = hợp lệ). `footer` đã strip."""
+        violations: List[str] = []
         if not footer:
-            warnings.append(
-                "Chưa cấu hình SMS_OPTOUT_INSTRUCTION — build sẽ bị chặn; "
-                "số đo CHƯA gồm hướng dẫn từ chối."
+            violations.append(
+                "Chưa cấu hình hướng dẫn từ chối (SMS_OPTOUT_INSTRUCTION) — "
+                "bắt buộc footer từ chối NĐ91."
             )
-            ok = False
-            return footer, warnings, ok
+            return violations
         if settings.APP_ENV == "production" and (
             footer == SMS_OPTOUT_INSTRUCTION_DEFAULT.strip()
             or re.search(r"[xX]{3,}", footer)
         ):
-            warnings.append(
-                "SMS_OPTOUT_INSTRUCTION còn là placeholder — production build "
-                "sẽ bị chặn."
+            violations.append(
+                "SMS_OPTOUT_INSTRUCTION còn là placeholder (vd 'xxxx') — "
+                "production phải đặt kênh từ chối SMS/điện thoại thật."
             )
-            ok = False
         if len(footer) > 160:
-            warnings.append(
-                "SMS_OPTOUT_INSTRUCTION > 160 ký tự — build sẽ bị chặn."
+            violations.append(
+                "Hướng dẫn từ chối quá dài (>160 ký tự) — rút gọn để khớp bản "
+                "ghi audit và tiết kiệm segment."
             )
-            ok = False
-        return footer, warnings, ok
+        return violations
+
+    def _resolve_optout_for_measure(self) -> Tuple[str, List[str], bool]:
+        """Dùng CHUNG `_optout_violations` với build() (không drift) nhưng KHÔNG
+        raise → measure vẫn đo được (footer placeholder cũng có độ dài); điều
+        kiện build-sẽ-chặn trả dưới dạng warning + optout_ok=False."""
+        footer = (settings.SMS_OPTOUT_INSTRUCTION or "").strip()
+        violations = self._optout_violations(footer)
+        warnings = [f"{v} (build sẽ bị chặn)" for v in violations]
+        return footer, warnings, not violations
 
     def measure_template(
         self, template: str, *, sample_full_name: Optional[str] = None
@@ -492,27 +496,12 @@ class SmsCampaignService:
         link = has_link(campaign.sms_template)
         # --- Compliance fail-closed (NĐ91) ---
         # [QC] LUÔN được chèn (assemble_skeleton); optout PHẢI cấu hình thật.
+        # Cùng `_optout_violations` với measure preview → không drift; ≤160 khớp
+        # cột optout_instruction_snapshot String(160) (audit KHỚP tin cuối).
         optout_instruction = (settings.SMS_OPTOUT_INSTRUCTION or "").strip()
-        if not optout_instruction:
-            raise BusinessRuleViolation(
-                detail="Chưa cấu hình hướng dẫn từ chối "
-                "(SMS_OPTOUT_INSTRUCTION) — bắt buộc footer từ chối NĐ91."
-            )
-        if settings.APP_ENV == "production" and (
-            optout_instruction == SMS_OPTOUT_INSTRUCTION_DEFAULT.strip()
-            or re.search(r"[xX]{3,}", optout_instruction)
-        ):
-            raise BusinessRuleViolation(
-                detail="SMS_OPTOUT_INSTRUCTION còn là placeholder (vd 'xxxx') — "
-                "production phải đặt kênh từ chối SMS/điện thoại thật."
-            )
-        # Footer ≤160 (khớp cột optout_instruction_snapshot String(160)) → bản
-        # ghi audit KHỚP đúng footer trong tin cuối, không cắt ngầm.
-        if len(optout_instruction) > 160:
-            raise BusinessRuleViolation(
-                detail="Hướng dẫn từ chối quá dài (>160 ký tự) — rút gọn để "
-                "khớp bản ghi audit và tiết kiệm segment."
-            )
+        violations = self._optout_violations(optout_instruction)
+        if violations:
+            raise BusinessRuleViolation(detail=violations[0])
         # Token secret/keyring (prod) — chỉ cần khi có {link}.
         if link:
             ensure_token_secrets_configured()

--- a/Backend_FastAPI/app/services/sms_campaign_service.py
+++ b/Backend_FastAPI/app/services/sms_campaign_service.py
@@ -141,6 +141,75 @@ class SmsCampaignService:
         return campaign
 
     # ===============================================================
+    # Measure/preview template (form soạn campaign — chưa recipient)
+    # ===============================================================
+    def _resolve_optout_for_measure(self) -> Tuple[str, List[str], bool]:
+        """Mirror 3 kiểm tra optout của `build()` NHƯNG không raise → measure
+        vẫn đo được (footer placeholder cũng có độ dài); điều kiện build-sẽ-chặn
+        trả dưới dạng warning + optout_ok=False."""
+        footer = (settings.SMS_OPTOUT_INSTRUCTION or "").strip()
+        warnings: List[str] = []
+        ok = True
+        if not footer:
+            warnings.append(
+                "Chưa cấu hình SMS_OPTOUT_INSTRUCTION — build sẽ bị chặn; "
+                "số đo CHƯA gồm hướng dẫn từ chối."
+            )
+            ok = False
+            return footer, warnings, ok
+        if settings.APP_ENV == "production" and (
+            footer == SMS_OPTOUT_INSTRUCTION_DEFAULT.strip()
+            or re.search(r"[xX]{3,}", footer)
+        ):
+            warnings.append(
+                "SMS_OPTOUT_INSTRUCTION còn là placeholder — production build "
+                "sẽ bị chặn."
+            )
+            ok = False
+        if len(footer) > 160:
+            warnings.append(
+                "SMS_OPTOUT_INSTRUCTION > 160 ký tự — build sẽ bị chặn."
+            )
+            ok = False
+        return footer, warnings, ok
+
+    def measure_template(
+        self, template: str, *, sample_full_name: Optional[str] = None
+    ) -> sms_schemas.SmsMeasureResult:
+        """Đo skeleton = assemble_skeleton([QC]+body+optout, sentinel link) +
+        measure_skeleton — CÙNG hàm build dùng → số khớp. Tên rỗng → NAME_FALLBACK.
+
+        ⚠ Sentinel gate: `render_body` GỠ ÂM THẦM __SMS_LINK__ → preview trông
+        'ổn' nhưng `_validate_content` (create/update) lại REJECT → drift. Vì vậy
+        set `has_internal_sentinel` TRƯỚC khi assemble để FE cảnh báo lỗi-chặn-lưu
+        (cùng tinh thần `unknown_vars`)."""
+        unknown = sorted(find_unknown_vars(template))
+        has_sentinel = LINK_SENTINEL in (template or "")
+        link = has_link(template)
+        footer, warnings, optout_ok = self._resolve_optout_for_measure()
+        skeleton = assemble_skeleton(
+            template, sample_full_name or "", optout_instruction=footer
+        )
+        encoding, length, segments, is_over = measure_skeleton(skeleton)
+        if is_over:
+            warnings.append(
+                f"Tin vượt 1 đoạn ({segments} đoạn, {encoding}) — rút gọn nội "
+                "dung để export không bị chặn."
+            )
+        return sms_schemas.SmsMeasureResult(
+            encoding=encoding,
+            length=length,
+            segments=segments,
+            is_over_limit=is_over,
+            preview=preview_message(skeleton),
+            has_link=link,
+            unknown_vars=unknown,
+            has_internal_sentinel=has_sentinel,
+            optout_configured=optout_ok,
+            warnings=warnings,
+        )
+
+    # ===============================================================
     # CRUD campaign
     # ===============================================================
     async def create_campaign(

--- a/Backend_FastAPI/app/services/sms_report_service.py
+++ b/Backend_FastAPI/app/services/sms_report_service.py
@@ -255,3 +255,52 @@ class SmsReportService:
                 for r, name in rows
             ],
         )
+
+    async def program_contacts(
+        self,
+        *,
+        major_program_id: int,
+        campaign_id: Optional[int] = None,
+        group_id: Optional[int] = None,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+        skip: int = 0,
+        limit: int = 50,
+    ) -> sms_schemas.SmsProgramContactsResponse:
+        """Drill-down: contact nào quan tâm 1 ngành (masked phone §16.9). Cùng
+        filter với program_interest_report → số khớp dòng ngành đã bấm."""
+        total, rows = await self.engagement_repo.program_contacts(
+            major_program_id=major_program_id,
+            campaign_id=campaign_id,
+            group_id=group_id,
+            date_from=date_from,
+            date_to=date_to,
+            skip=skip,
+            limit=limit,
+        )
+        return sms_schemas.SmsProgramContactsResponse(
+            major_program_id=major_program_id,
+            total=total,
+            items=[
+                sms_schemas.SmsProgramContactRow(
+                    contact_id=cid,
+                    full_name=full_name,
+                    phone_masked=mask_phone(phone_norm),
+                    view_count=vc,
+                    total_dwell_seconds=dwell,
+                    interest_score=score,
+                    first_viewed_at=first,
+                    last_viewed_at=last,
+                )
+                for (
+                    cid,
+                    full_name,
+                    phone_norm,
+                    vc,
+                    dwell,
+                    first,
+                    last,
+                    score,
+                ) in rows
+            ],
+        )

--- a/Backend_FastAPI/tests/integration/test_sms_engagement.py
+++ b/Backend_FastAPI/tests/integration/test_sms_engagement.py
@@ -497,6 +497,244 @@ async def test_report_deleted_programs_not_merged(
     assert rep.json()["total_dwell_seconds"] == 120
 
 
+# ---------------------------------------------------------------------
+# Drill-down: contact nào quan tâm 1 ngành (§16.7) + measure template
+# ---------------------------------------------------------------------
+async def _view_beat(client, code, major_id, dwell, *, ua=None):
+    """1 session mới (theo code) → mở ngành → đẩy viewed_at về quá khứ (tránh
+    clamp) → heartbeat dwell. Trả program_view_id."""
+    headers = ua or _H
+    token = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=headers)
+    ).json()["session_token"]
+    vid = (
+        await client.post(
+            f"{PUB}/landing/{code}/program-view",
+            json={"session_token": token, "major_program_id": major_id},
+            headers=headers,
+        )
+    ).json()["program_view_id"]
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text(
+                "UPDATE sms_program_view SET viewed_at = now() - "
+                "interval '1 hour' WHERE id=:i"
+            ),
+            {"i": vid},
+        )
+        await s.commit()
+    await client.post(
+        f"{PUB}/landing/{code}/heartbeat",
+        json={"session_token": token, "program_view_id": vid,
+              "dwell_seconds": dwell},
+        headers=headers,
+    )
+    return vid
+
+
+async def _setup_multi(client, h):
+    """group + 2 contact granted + campaign {link} + build + handoff (past).
+    Trả (campaign_id, {contact_id: raw_code}, (contact_a, contact_b))."""
+    gid = await _mk_group(client, h, "Drill Nhom")
+    ca = await _mk_contact(client, h, "Phu huynh A", "0981111111")
+    cb = await _mk_contact(client, h, "Phu huynh B", "0982222222")
+    for cid_ in (ca, cb):
+        await client.post(
+            f"{API}/contacts/{cid_}/groups", json={"group_id": gid}, headers=h
+        )
+    r = await client.post(
+        f"{API}/campaigns",
+        json={
+            "name": "Drill QA",
+            "sms_template": "Chao {full_name}, xem {link}",
+            "landing_headline": "Tuyển sinh 2026",
+            "landing_body": "Thông tin chi tiết.",
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    camp = r.json()["id"]
+    await client.post(
+        f"{API}/campaigns/{camp}/groups", json={"group_id": gid}, headers=h
+    )
+    rb = await client.post(f"{API}/campaigns/{camp}/build", headers=h)
+    assert rb.status_code == 200, rb.text
+    async with AsyncSessionLocal() as s:
+        rows = (
+            await s.execute(
+                text(
+                    "SELECT contact_id, token_ciphertext, token_key_version "
+                    "FROM sms_campaign_recipient WHERE campaign_id=:c"
+                ),
+                {"c": camp},
+            )
+        ).all()
+        await s.execute(
+            text(
+                "UPDATE sms_campaign_recipient SET handed_off_at = now() - "
+                "interval '1 hour' WHERE campaign_id=:c"
+            ),
+            {"c": camp},
+        )
+        await s.commit()
+    codes = {cid_: decrypt_code(ct, kv) for cid_, ct, kv in rows}
+    assert all(codes.values()), "decrypt token thất bại"
+    return camp, codes, (ca, cb)
+
+
+async def test_program_contacts_drilldown(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """Endpoint A2 — 2 contact KHÁC NHAU cùng ngành 1 → 2 hàng, rank scoped
+    total_dwell desc; số khớp report; bot loại; mask phone; filter+pagination."""
+    h = admin_token_headers
+    camp, codes, (ca, cb) = await _setup_multi(client, h)
+    # A: 40s ; B: 120s (B nóng hơn)
+    await _view_beat(client, codes[ca], 1, 40)
+    await _view_beat(client, codes[cb], 1, 120)
+
+    base = f"{API}/reports/program-interest/1/contacts"
+    body = (await client.get(base, headers=h)).json()
+    assert body["major_program_id"] == 1
+    assert body["total"] == 2
+    items = body["items"]
+    assert len(items) == 2
+    # rank scoped total_dwell desc → B trước A
+    assert items[0]["contact_id"] == cb and items[0]["total_dwell_seconds"] == 120
+    assert items[1]["contact_id"] == ca and items[1]["total_dwell_seconds"] == 40
+    # mask phone — KHÔNG lộ số đầy đủ
+    for it in items:
+        assert "*" in it["phone_masked"]
+    assert "0981111111" not in {it["phone_masked"] for it in items}
+
+    # đối chiếu tổng KHỚP dòng report ngành 1
+    rep = (
+        await client.get(
+            f"{API}/reports/program-interest?major_program_id=1", headers=h
+        )
+    ).json()
+    assert rep["items"][0]["distinct_contacts"] == 2
+    assert rep["items"][0]["total_dwell_seconds"] == 160  # 40 + 120
+    assert (
+        sum(it["total_dwell_seconds"] for it in items)
+        == rep["items"][0]["total_dwell_seconds"]
+    )
+
+    # bot session xem ngành 1 (code A) → KHÔNG được đếm (kế thừa _report_conds)
+    await _view_beat(client, codes[ca], 1, 500, ua={"User-Agent": _UA_BOT})
+    r2 = (await client.get(base, headers=h)).json()
+    assert r2["total"] == 2  # không thêm contact
+    a_row = next(it for it in r2["items"] if it["contact_id"] == ca)
+    assert a_row["total_dwell_seconds"] == 40  # bot 500s KHÔNG cộng
+
+    # pagination: limit=1 → 1 item, total vẫn 2, nóng nhất đứng đầu
+    r1 = (await client.get(f"{base}?limit=1", headers=h)).json()
+    assert r1["total"] == 2 and len(r1["items"]) == 1
+    assert r1["items"][0]["contact_id"] == cb
+
+    # filter campaign_id: đúng camp → 2; camp khác → 0
+    rc = (await client.get(f"{base}?campaign_id={camp}", headers=h)).json()
+    assert rc["total"] == 2
+    rc0 = (await client.get(f"{base}?campaign_id=999999", headers=h)).json()
+    assert rc0["total"] == 0 and rc0["items"] == []
+
+
+async def test_program_contacts_groups_by_contact_not_session(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """CHỐNG group-by-session sai: 2 session của CÙNG 1 contact cùng ngành 1 →
+    vẫn 1 hàng aggregate (view_count/total_dwell cộng dồn), KHÔNG 2 hàng."""
+    h = admin_token_headers
+    _cid, code, contact_id = await _setup(client, h)
+    await _view_beat(client, code, 1, 30)  # session 1
+    await _view_beat(client, code, 1, 50)  # session 2 (cùng contact)
+
+    body = (
+        await client.get(
+            f"{API}/reports/program-interest/1/contacts", headers=h
+        )
+    ).json()
+    assert body["total"] == 1
+    assert len(body["items"]) == 1
+    it = body["items"][0]
+    assert it["contact_id"] == contact_id
+    assert it["view_count"] == 2          # 2 view
+    assert it["total_dwell_seconds"] == 80  # 30 + 50
+
+
+async def test_program_contacts_view_without_heartbeat(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """Contact chỉ MỞ ngành (chưa heartbeat) → vẫn xuất hiện (build trên
+    program_view), interest_score=0 (LEFT JOIN NULL→coalesce), first/last non-null."""
+    h = admin_token_headers
+    _cid, code, contact_id = await _setup(client, h)
+    token = (
+        await client.post(f"{PUB}/landing/{code}/session", headers=_H)
+    ).json()["session_token"]
+    await client.post(
+        f"{PUB}/landing/{code}/program-view",
+        json={"session_token": token, "major_program_id": 1},
+        headers=_H,
+    )
+    body = (
+        await client.get(
+            f"{API}/reports/program-interest/1/contacts", headers=h
+        )
+    ).json()
+    assert body["total"] == 1
+    it = body["items"][0]
+    assert it["contact_id"] == contact_id
+    assert it["view_count"] == 1
+    assert it["total_dwell_seconds"] == 0
+    assert it["interest_score"] == 0.0  # chưa heartbeat → không có interest row
+    assert it["first_viewed_at"] is not None  # scoped min(viewed_at)
+    assert it["last_viewed_at"] is not None
+
+
+async def test_measure_template(
+    client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
+):
+    """Endpoint A1 — GSM7 vs UCS2, has_link, unknown_vars, sentinel drift, auth."""
+    h = admin_token_headers
+    base = f"{API}/campaigns/measure"
+
+    # GSM7 (không dấu) + {link}
+    g = (
+        await client.post(base, json={"template": "Chao ban xem {link}"}, headers=h)
+    )
+    assert g.status_code == 200, g.text
+    gb = g.json()
+    assert gb["encoding"] == "GSM7"
+    assert gb["has_link"] is True
+    assert gb["unknown_vars"] == []
+    assert gb["has_internal_sentinel"] is False
+    assert gb["segments"] >= 1
+
+    # UCS2 (tiếng Việt có dấu)
+    u = (
+        await client.post(base, json={"template": "Chào bạn, xem {link}"}, headers=h)
+    ).json()
+    assert u["encoding"] == "UCS2"
+
+    # biến lạ {foo} → unknown_vars
+    bad = (
+        await client.post(base, json={"template": "Xin chao {foo}"}, headers=h)
+    ).json()
+    assert "{foo}" in bad["unknown_vars"]
+
+    # sentinel nội bộ __SMS_LINK__ → has_internal_sentinel (drift gate #3)
+    sent = (
+        await client.post(base, json={"template": "Xem __SMS_LINK__ ngay"}, headers=h)
+    ).json()
+    assert sent["has_internal_sentinel"] is True
+
+    # auth: de-auth thật (client giữ cookie phiên từ fixture) → 401/403
+    client.cookies.clear()
+    anon = await client.post(base, json={"template": "Chao"})
+    assert anon.status_code in (401, 403)
+
+
 async def test_heartbeat_rejects_cross_session_view(
     client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies
 ):

--- a/frontend/src/app/(dashboard)/admin/sms/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/sms/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation"
+
+/**
+ * `/admin/sms` không có trang tổng quan riêng (chỉ có contacts/campaigns/reports
+ * /opt-out). Redirect về danh sách chiến dịch để breadcrumb/segment "sms" không
+ * dẫn tới 404.
+ */
+export default function SmsIndexPage() {
+  redirect("/admin/sms/campaigns")
+}

--- a/frontend/src/components/sms/admin/SmsClickReportPanel.tsx
+++ b/frontend/src/components/sms/admin/SmsClickReportPanel.tsx
@@ -256,10 +256,12 @@ export function SmsClickReportPanel() {
                 ))}
               </div>
             ) : !data || data.buckets.length === 0 ? (
-              <p className="text-muted-foreground py-8 text-center text-sm">
+              <p className="text-muted-foreground mx-auto max-w-md py-8 text-center text-sm">
                 {isFetching
                   ? "Đang tải…"
-                  : "Chưa có lượt click nào trong phạm vi đã chọn."}
+                  : data && data.recipients_handed_off === 0
+                    ? "Báo cáo chỉ tính click của người nhận đã BÀN GIAO gửi (handed-off). Chưa có chiến dịch nào bàn giao trong phạm vi đã chọn — hãy export & bàn giao một chiến dịch để bắt đầu đo click."
+                    : "Chưa có lượt click nào trong phạm vi đã chọn."}
               </p>
             ) : (
               <div className="overflow-x-auto">

--- a/frontend/src/components/sms/admin/SmsProgramInterestPanel.tsx
+++ b/frontend/src/components/sms/admin/SmsProgramInterestPanel.tsx
@@ -4,6 +4,7 @@
 import { useMemo, useState } from "react"
 import { AlertCircle, RotateCcw } from "lucide-react"
 
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -15,6 +16,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Table,
@@ -26,9 +34,11 @@ import {
 } from "@/components/ui/table"
 import {
   useSmsCampaignList,
+  useSmsProgramContacts,
   useSmsProgramInterest,
 } from "@/hooks/useSmsAdmin"
 import type { SmsProgramInterestParams } from "@/lib/api/sms"
+import type { SmsProgramInterestRow } from "@/lib/zod/sms"
 
 import { campaignStatusLabel, formatDwell, formatInt } from "./labels"
 import { SmsSummaryCard } from "./SmsSummaryCard"
@@ -55,6 +65,8 @@ export function SmsProgramInterestPanel() {
   const [campaignId, setCampaignId] = useState<string>(ALL)
   const [dateFrom, setDateFrom] = useState<string>("")
   const [dateTo, setDateTo] = useState<string>("")
+  const [selectedProgram, setSelectedProgram] =
+    useState<SmsProgramInterestRow | null>(null)
 
   const { data: campaignData } = useSmsCampaignList({ limit: 200 })
 
@@ -224,9 +236,24 @@ export function SmsProgramInterestPanel() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {data.items.map((row, i) => (
+                    {data.items.map((row, i) => {
+                      const drillable = row.major_program_id !== null
+                      return (
                       <TableRow
                         key={row.major_program_id ?? `deleted-${i}`}
+                        onClick={
+                          drillable
+                            ? () => setSelectedProgram(row)
+                            : undefined
+                        }
+                        className={
+                          drillable ? "hover:bg-muted/50 cursor-pointer" : undefined
+                        }
+                        title={
+                          drillable
+                            ? "Xem danh sách người quan tâm ngành này"
+                            : undefined
+                        }
                       >
                         <TableCell className="text-muted-foreground text-right tabular-nums">
                           {i + 1}
@@ -247,7 +274,8 @@ export function SmsProgramInterestPanel() {
                           {formatDwell(Math.round(row.avg_dwell_seconds))}
                         </TableCell>
                       </TableRow>
-                    ))}
+                      )
+                    })}
                   </TableBody>
                 </Table>
               </div>
@@ -255,6 +283,97 @@ export function SmsProgramInterestPanel() {
           </CardContent>
         </Card>
       )}
+
+      <ProgramContactsSheet
+        program={selectedProgram}
+        params={params}
+        onClose={() => setSelectedProgram(null)}
+      />
     </div>
+  )
+}
+
+/** Drawer liệt kê contact quan tâm 1 ngành (§16.7) — số ẩn (masked) theo §16.9.
+ * Fetch cùng `params` (campaign/ngày) với bảng → số khớp dòng ngành đã bấm. */
+function ProgramContactsSheet({
+  program,
+  params,
+  onClose,
+}: {
+  program: SmsProgramInterestRow | null
+  params: SmsProgramInterestParams
+  onClose: () => void
+}) {
+  const programId = program?.major_program_id ?? null
+  const { data, isLoading, isError, refetch, isFetching } =
+    useSmsProgramContacts(programId, params, program !== null)
+
+  return (
+    <Sheet open={program !== null} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle className="truncate">
+            {program?.program_name ?? "Ngành"}
+          </SheetTitle>
+          <SheetDescription>
+            Liên hệ đã xem ngành này (số điện thoại ẩn theo quy định bảo mật).
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-4">
+          {isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-16 w-full" />
+              ))}
+            </div>
+          ) : isError ? (
+            <div className="text-muted-foreground flex flex-col items-center gap-2 py-8 text-center text-sm">
+              <AlertCircle className="text-destructive h-6 w-6" />
+              <span>Không tải được danh sách.</span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => refetch()}
+                disabled={isFetching}
+              >
+                Thử lại
+              </Button>
+            </div>
+          ) : !data || data.items.length === 0 ? (
+            <p className="text-muted-foreground py-8 text-center text-sm">
+              Chưa có liên hệ nào quan tâm ngành này trong phạm vi đã chọn.
+            </p>
+          ) : (
+            <>
+              <p className="text-muted-foreground mb-3 text-xs">
+                {formatInt(data.total)} người quan tâm
+                {data.items.length < data.total
+                  ? ` (hiển thị ${data.items.length})`
+                  : ""}
+              </p>
+              <ul className="space-y-2">
+                {data.items.map((c) => (
+                  <li key={c.contact_id} className="rounded border p-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                        {c.full_name}
+                      </span>
+                      <Badge variant="secondary" className="shrink-0">
+                        {formatDwell(c.total_dwell_seconds)}
+                      </Badge>
+                    </div>
+                    <div className="text-muted-foreground mt-1 flex items-center justify-between gap-2 text-xs tabular-nums">
+                      <span>{c.phone_masked}</span>
+                      <span>{formatInt(c.view_count)} lượt xem</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/frontend/src/components/sms/admin/SmsProgramInterestPanel.tsx
+++ b/frontend/src/components/sms/admin/SmsProgramInterestPanel.tsx
@@ -40,7 +40,12 @@ import {
 import type { SmsProgramInterestParams } from "@/lib/api/sms"
 import type { SmsProgramInterestRow } from "@/lib/zod/sms"
 
-import { campaignStatusLabel, formatDwell, formatInt } from "./labels"
+import {
+  campaignStatusLabel,
+  formatDateTimeVN,
+  formatDwell,
+  formatInt,
+} from "./labels"
 import { SmsSummaryCard } from "./SmsSummaryCard"
 
 const ALL = "all"
@@ -366,6 +371,12 @@ function ProgramContactsSheet({
                     <div className="text-muted-foreground mt-1 flex items-center justify-between gap-2 text-xs tabular-nums">
                       <span>{c.phone_masked}</span>
                       <span>{formatInt(c.view_count)} lượt xem</span>
+                    </div>
+                    <div className="text-muted-foreground mt-1 flex items-center justify-between gap-2 text-xs">
+                      <span>Điểm quan tâm {c.interest_score.toFixed(2)}</span>
+                      {c.last_viewed_at && (
+                        <span>Xem gần nhất: {formatDateTimeVN(c.last_viewed_at)}</span>
+                      )}
                     </div>
                   </li>
                 ))}

--- a/frontend/src/components/sms/admin/campaigns/SmsCampaignFormDialog.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsCampaignFormDialog.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/lib/zod/sms"
 
 import { LANDING_TYPE_OPTIONS, isoToDatetimeLocal } from "../labels"
+import { SmsTemplatePreview } from "./SmsTemplatePreview"
 
 interface Props {
   open: boolean
@@ -88,6 +89,7 @@ export function SmsCampaignFormDialog({
     defaultValues: DEFAULTS,
   })
   const landingType = form.watch("landing_type")
+  const smsTemplate = form.watch("sms_template")
 
   useEffect(() => {
     if (!open) return
@@ -247,6 +249,8 @@ export function SmsCampaignFormDialog({
                 </FormItem>
               )}
             />
+
+            <SmsTemplatePreview template={smsTemplate ?? ""} />
 
             <FormField
               control={form.control}

--- a/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
@@ -9,6 +9,12 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { PageHeader } from "@/components/layouts/PageHeader"
 import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { useSmsCampaign } from "@/hooks/useSmsCampaigns"
 
 import { campaignStatusLabel } from "../labels"
@@ -69,7 +75,25 @@ export function SmsCampaignWorkspace({ campaignId }: { campaignId: number }) {
             <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
               <Pencil className="mr-2 h-4 w-4" /> Sửa
             </Button>
-          ) : undefined
+          ) : (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {/* span để tooltip vẫn hiện dù Button disabled không nhận
+                      pointer/focus event */}
+                  <span tabIndex={0}>
+                    <Button variant="outline" size="sm" disabled>
+                      <Pencil className="mr-2 h-4 w-4" /> Sửa
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  Chỉ sửa nội dung khi chiến dịch ở trạng thái nháp. Gỡ hết nhóm
+                  khỏi chiến dịch để đưa về nháp rồi sửa.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )
         }
       />
 

--- a/frontend/src/components/sms/admin/campaigns/SmsTemplatePreview.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsTemplatePreview.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { AlertTriangle, Info, Loader2 } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { useMeasureSmsTemplate } from "@/hooks/useSmsCampaigns"
+import { useDebouncedValue } from "@/lib/hooks/use-debounced-value"
+
+/**
+ * Preview tin cuối + đếm ký tự/đoạn LIVE cho form soạn campaign (§7). Đo qua BE
+ * (cùng logic với build → số khớp). Phân 2 tầng:
+ * - Lỗi-chặn-lưu (đỏ): biến lạ / chứa __SMS_LINK__ (mirror gate _validate_content).
+ * - Cảnh báo mềm (vàng): optout chưa cấu hình, tin vượt 1 đoạn.
+ * KHÔNG tự chặn submit — build/preflight/create-gate là cổng cuối.
+ */
+export function SmsTemplatePreview({ template }: { template: string }) {
+  const debounced = useDebouncedValue(template, 400)
+  const { data, isFetching, isError } = useMeasureSmsTemplate(debounced)
+
+  if (!debounced.trim()) return null
+
+  const blocking =
+    !!data && (data.unknown_vars.length > 0 || data.has_internal_sentinel)
+
+  return (
+    <div className="bg-muted/40 space-y-2 rounded-md border p-3 text-xs">
+      <div className="flex items-center gap-2">
+        <span className="text-muted-foreground font-medium">Xem trước tin</span>
+        {isFetching && (
+          <Loader2 className="text-muted-foreground h-3 w-3 animate-spin" />
+        )}
+      </div>
+
+      {isError ? (
+        <p className="text-muted-foreground">Không đo được tin (thử lại sau).</p>
+      ) : data ? (
+        <>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">{data.length} ký tự</Badge>
+            <Badge variant={data.is_over_limit ? "destructive" : "secondary"}>
+              {data.segments} đoạn
+            </Badge>
+            <Badge variant="outline">{data.encoding}</Badge>
+            {data.has_link && <Badge variant="outline">có {"{link}"}</Badge>}
+          </div>
+
+          <p className="bg-background text-foreground rounded border p-2 break-words whitespace-pre-wrap">
+            {data.preview}
+          </p>
+
+          {blocking && (
+            <div className="text-destructive flex items-start gap-1.5">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <div>
+                <p className="font-medium">Nội dung sẽ bị từ chối khi lưu:</p>
+                <ul className="list-inside list-disc">
+                  {data.unknown_vars.map((v) => (
+                    <li key={v}>Biến không hợp lệ: {v}</li>
+                  ))}
+                  {data.has_internal_sentinel && (
+                    <li>Chứa chuỗi nội bộ __SMS_LINK__ (sẽ bị gỡ)</li>
+                  )}
+                </ul>
+              </div>
+            </div>
+          )}
+
+          {data.warnings.length > 0 && (
+            <div className="flex items-start gap-1.5 text-amber-600 dark:text-amber-500">
+              <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <ul className="list-inside list-disc">
+                {data.warnings.map((w) => (
+                  <li key={w}>{w}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      ) : (
+        <p className="text-muted-foreground">Đang đo…</p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/sms/admin/contacts/SmsContactDetailDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsContactDetailDialog.tsx
@@ -2,7 +2,7 @@
 "use client"
 
 import { useState } from "react"
-import { Pencil, Plus, ShieldCheck } from "lucide-react"
+import { GraduationCap, Pencil, Plus, ShieldCheck } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -25,8 +25,10 @@ import { Skeleton } from "@/components/ui/skeleton"
 import {
   useAddContactToGroup,
   useConsentEvents,
+  useContactSmsInterests,
   useSmsContactGroups,
 } from "@/hooks/useSmsContacts"
+import { formatDwell } from "@/lib/format"
 import type { SmsContact } from "@/lib/zod/sms"
 
 import {
@@ -68,6 +70,8 @@ export function SmsContactDetailDialog({ open, onOpenChange, contact }: Props) {
 
   const contactId = open && contact ? contact.id : null
   const { data: events, isLoading: eventsLoading } = useConsentEvents(contactId)
+  const { data: interests, isLoading: interestsLoading } =
+    useContactSmsInterests(contactId, open)
   // Chỉ tải danh sách nhóm cho picker khi dialog mở (tránh fetch thừa lúc tab
   // liên hệ render mà chưa mở chi tiết).
   const { data: groupsData } = useSmsContactGroups({ limit: 200 }, { enabled: open })
@@ -215,6 +219,42 @@ export function SmsContactDetailDialog({ open, onOpenChange, contact }: Props) {
                   </div>
                 ))}
               </div>
+            )}
+          </div>
+
+          {/* Quan tâm ngành (§16.7) — ngành khách đã xem qua landing */}
+          <div className="space-y-2 border-t pt-3">
+            <p className="text-sm font-medium">Quan tâm ngành</p>
+            {interestsLoading ? (
+              <div className="space-y-2">
+                {Array.from({ length: 2 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-full" />
+                ))}
+              </div>
+            ) : !interests || interests.items.length === 0 ? (
+              <p className="text-muted-foreground py-2 text-sm">
+                Chưa có dữ liệu quan tâm ngành (khách chưa xem trang ngành nào).
+              </p>
+            ) : (
+              <ul className="max-h-64 space-y-2 overflow-y-auto">
+                {interests.items.map((it) => (
+                  <li
+                    key={it.major_program_id}
+                    className="flex items-center gap-3 rounded border p-2"
+                  >
+                    <GraduationCap className="text-primary h-4 w-4 shrink-0" />
+                    <span
+                      title={it.program_name}
+                      className="min-w-0 flex-1 truncate text-sm font-medium"
+                    >
+                      {it.program_name}
+                    </span>
+                    <Badge variant="secondary" className="shrink-0">
+                      {formatDwell(it.total_dwell_seconds)}
+                    </Badge>
+                  </li>
+                ))}
+              </ul>
             )}
           </div>
         </DialogContent>

--- a/frontend/src/components/sms/programIcon.test.ts
+++ b/frontend/src/components/sms/programIcon.test.ts
@@ -1,0 +1,21 @@
+import { GraduationCap, HeartPulse, Monitor, Pill } from "lucide-react"
+import { describe, expect, it } from "vitest"
+
+import { programGlyph, programLucideIcon } from "./programIcon"
+
+describe("programLucideIcon", () => {
+  it("khớp tên ngành → icon đặc thù (luật khớp trước thắng)", () => {
+    expect(programLucideIcon("Dược")).toBe(Pill)
+    expect(programLucideIcon("Điều dưỡng")).toBe(HeartPulse)
+    expect(programLucideIcon("Công nghệ thông tin")).toBe(Monitor)
+  })
+  it("không khớp luật nào → fallback GraduationCap", () => {
+    expect(programLucideIcon("Ngành nào đó rất lạ")).toBe(GraduationCap)
+  })
+})
+
+describe("programGlyph", () => {
+  it("bọc icon trong object .Icon (idiom react-compiler)", () => {
+    expect(programGlyph("Dược").Icon).toBe(Pill)
+  })
+})

--- a/frontend/src/components/sms/smsContent.test.ts
+++ b/frontend/src/components/sms/smsContent.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isStrongTuition,
+  programTuition,
+  tuitionLevelLabel,
+  tuitionTier,
+} from "./smsContent"
+
+describe("tuitionTier", () => {
+  it("suy mức ưu đãi mạnh nhất theo mã (free > 70 > 30)", () => {
+    expect(tuitionTier("6720301")).toBe("70") // Điều dưỡng (cd70)
+    expect(tuitionTier("6720201")).toBe("70") // Dược (cd70)
+    expect(tuitionTier("6720102")).toBe("30") // YHCT (cd30)
+    expect(tuitionTier("5510216")).toBe("free") // Ô tô TC (thcsFree)
+  })
+  it("mã không có dữ liệu → null", () => {
+    expect(tuitionTier("0000000")).toBeNull()
+  })
+})
+
+describe("isStrongTuition", () => {
+  it("free/70 = mạnh; 30/null = không", () => {
+    expect(isStrongTuition("free")).toBe(true)
+    expect(isStrongTuition("70")).toBe(true)
+    expect(isStrongTuition("30")).toBe(false)
+    expect(isStrongTuition(null)).toBe(false)
+  })
+})
+
+describe("programTuition", () => {
+  it("trả object học phí theo mã; null nếu không có", () => {
+    expect(programTuition("6720201")?.total).toBe("48.000.000 đ")
+    expect(programTuition("0000000")).toBeNull()
+  })
+})
+
+describe("tuitionLevelLabel", () => {
+  it("nhãn ngắn (card) vs dài (hero) theo mức", () => {
+    expect(tuitionLevelLabel("free", "card")).toBe("Miễn 100%")
+    expect(tuitionLevelLabel("free", "hero")).toBe("Miễn 100% học phí")
+    expect(tuitionLevelLabel("70", "card")).toBe("Giảm 70%")
+    expect(tuitionLevelLabel("30", "card")).toBe("Ưu đãi 30%")
+    expect(tuitionLevelLabel(null, "card")).toBe("Học bổng")
+    expect(tuitionLevelLabel(null, "hero")).toBe("Học bổng đầu vào")
+  })
+})

--- a/frontend/src/components/sms/smsPrograms.test.ts
+++ b/frontend/src/components/sms/smsPrograms.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import type { SmsLandingProgram } from "@/lib/zod/sms"
+
+import { dedupeByName, groupPrograms } from "./smsPrograms"
+
+function mk(
+  id: number,
+  name: string,
+  code: string,
+  degree_level: string,
+): SmsLandingProgram {
+  return { id, name, code, degree_level, is_heavy: false }
+}
+
+describe("groupPrograms", () => {
+  it("gộp biến thể CÙNG TÊN thành 1 card + chọn mức ưu đãi mạnh nhất", () => {
+    const groups = groupPrograms([
+      mk(1, "Ô tô", "6510216", "Cao đẳng"), // cd70 → "70"
+      mk(2, "Ô tô", "5510216", "Trung cấp"), // thcsFree → "free"
+    ])
+    const cards = groups.flatMap((g) => g.items)
+    const oto = cards.find((c) => c.name === "Ô tô")
+    expect(oto?.variants).toHaveLength(2) // 2 biến thể trong 1 card
+    expect(oto?.level).toBe("free") // free > 70
+  })
+
+  it("ngành khác tên → card riêng", () => {
+    const groups = groupPrograms([
+      mk(1, "Dược", "6720201", "Cao đẳng"),
+      mk(2, "Điều dưỡng", "6720301", "Cao đẳng"),
+    ])
+    const names = groups.flatMap((g) => g.items).map((c) => c.name)
+    expect(names).toContain("Dược")
+    expect(names).toContain("Điều dưỡng")
+  })
+})
+
+describe("dedupeByName", () => {
+  it("giữ mục ĐẦU của mỗi tên", () => {
+    const out = dedupeByName([
+      mk(1, "A", "c1", "Cao đẳng"),
+      mk(2, "A", "c2", "Trung cấp"),
+      mk(3, "B", "c3", "Cao đẳng"),
+    ])
+    expect(out.map((p) => p.id)).toEqual([1, 3])
+  })
+
+  it("loại các tên trong exclude", () => {
+    const out = dedupeByName(
+      [mk(1, "A", "c1", "Cao đẳng"), mk(2, "B", "c2", "Cao đẳng")],
+      ["A"],
+    )
+    expect(out.map((p) => p.name)).toEqual(["B"])
+  })
+})

--- a/frontend/src/components/sms/smsPrograms.test.ts
+++ b/frontend/src/components/sms/smsPrograms.test.ts
@@ -15,14 +15,16 @@ function mk(
 
 describe("groupPrograms", () => {
   it("gộp biến thể CÙNG TÊN thành 1 card + chọn mức ưu đãi mạnh nhất", () => {
+    // free ĐỨNG TRƯỚC 70 để bug 'last-value-wins' (gán đè, bỏ TUITION_RANK) lộ
+    // ra: last-wins sẽ cho "70", chỉ max-rank đúng mới cho "free".
     const groups = groupPrograms([
-      mk(1, "Ô tô", "6510216", "Cao đẳng"), // cd70 → "70"
-      mk(2, "Ô tô", "5510216", "Trung cấp"), // thcsFree → "free"
+      mk(1, "Ô tô", "5510216", "Trung cấp"), // thcsFree → "free"
+      mk(2, "Ô tô", "6510216", "Cao đẳng"), // cd70 → "70"
     ])
     const cards = groups.flatMap((g) => g.items)
     const oto = cards.find((c) => c.name === "Ô tô")
     expect(oto?.variants).toHaveLength(2) // 2 biến thể trong 1 card
-    expect(oto?.level).toBe("free") // free > 70
+    expect(oto?.level).toBe("free") // free > 70 (max-rank, không phải last-wins)
   })
 
   it("ngành khác tên → card riêng", () => {

--- a/frontend/src/hooks/useSmsAdmin.ts
+++ b/frontend/src/hooks/useSmsAdmin.ts
@@ -18,12 +18,14 @@ import {
   createManualOptOut,
   getSmsCampaignDashboard,
   getSmsClickReport,
+  getSmsProgramContacts,
   getSmsProgramInterestReport,
   listSmsCampaigns,
   listSmsOptOuts,
   type ManualOptOutPayload,
   type SmsCampaignListParams,
   type SmsClickReportParams,
+  type SmsProgramContactsParams,
   type SmsProgramInterestParams,
   type SmsOptOutListParams,
 } from "@/lib/api/sms"
@@ -45,6 +47,8 @@ export const smsAdminKeys = {
     [...smsAdminKeys.all, "opt-outs", params] as const,
   programInterest: (params: SmsProgramInterestParams) =>
     [...smsAdminKeys.all, "program-interest", params] as const,
+  programContacts: (programId: number, params: SmsProgramContactsParams) =>
+    [...smsAdminKeys.all, "program-contacts", programId, params] as const,
 }
 
 // ---------------------------------------------------------------------
@@ -79,6 +83,20 @@ export function useSmsProgramInterest(params: SmsProgramInterestParams) {
   return useQuery({
     queryKey: smsAdminKeys.programInterest(params),
     queryFn: () => getSmsProgramInterestReport(params),
+    staleTime: 60 * 1000,
+  })
+}
+
+/** Drill-down contact theo ngành. `enabled` để chỉ fetch khi mở drawer. */
+export function useSmsProgramContacts(
+  programId: number | null,
+  params: SmsProgramContactsParams,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: smsAdminKeys.programContacts(programId ?? 0, params),
+    queryFn: () => getSmsProgramContacts(programId as number, params),
+    enabled: enabled && programId != null && programId > 0,
     staleTime: 60 * 1000,
   })
 }

--- a/frontend/src/hooks/useSmsCampaigns.ts
+++ b/frontend/src/hooks/useSmsCampaigns.ts
@@ -21,6 +21,7 @@ import {
   getSmsCampaignPreflight,
   listCampaignGroups,
   listSmsCampaignsFull,
+  measureSmsTemplate,
   updateSmsCampaign,
   type SmsCampaignListParams,
 } from "@/lib/api/sms"
@@ -87,6 +88,31 @@ export function useSmsCampaignPreflight(
     queryFn: () => getSmsCampaignPreflight(campaignId as number),
     enabled: campaignId != null && (options.enabled ?? true),
     staleTime: 30 * 1000,
+  })
+}
+
+/** Đo/preview template LIVE cho form soạn campaign. `template` nên là giá trị
+ * đã DEBOUNCE (component lo debounce) — hook chỉ query khi non-rỗng. */
+export function useMeasureSmsTemplate(
+  template: string,
+  sampleFullName?: string,
+) {
+  return useQuery({
+    queryKey: [
+      ...smsCampaignKeys.all,
+      "measure",
+      template,
+      sampleFullName ?? "",
+    ],
+    queryFn: () =>
+      measureSmsTemplate({
+        template,
+        sample_full_name: sampleFullName?.trim() || undefined,
+      }),
+    enabled: template.trim().length > 0,
+    placeholderData: keepPreviousData,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
   })
 }
 

--- a/frontend/src/hooks/useSmsContacts.ts
+++ b/frontend/src/hooks/useSmsContacts.ts
@@ -18,6 +18,7 @@ import {
   createSmsContact,
   createSmsContactGroup,
   getSmsContactGroup,
+  getSmsContactInterests,
   listConsentEvents,
   listGroupContacts,
   listSmsContactGroups,
@@ -56,6 +57,8 @@ export const smsContactKeys = {
     [...smsContactKeys.all, "contacts", p] as const,
   consentEvents: (contactId: number) =>
     [...smsContactKeys.all, "consent-events", contactId] as const,
+  interests: (contactId: number) =>
+    [...smsContactKeys.all, "interests", contactId] as const,
 }
 
 function invalidateContacts(qc: ReturnType<typeof useQueryClient>) {
@@ -116,6 +119,21 @@ export function useConsentEvents(contactId: number | null) {
     queryFn: () => listConsentEvents(contactId as number, { limit: 100 }),
     enabled: contactId != null,
     staleTime: 30 * 1000,
+  })
+}
+
+/** Hồ sơ "quan tâm ngành" của 1 contact. `enabled` để lazy-fetch khi mở chi
+ * tiết. BE gác quyền (require_admin) → dùng kết quả API, không đoán theo role. */
+export function useContactSmsInterests(
+  contactId: number | null,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: smsContactKeys.interests(contactId ?? 0),
+    queryFn: () => getSmsContactInterests(contactId as number),
+    enabled: enabled && contactId != null && contactId > 0,
+    staleTime: 60 * 1000,
+    retry: false,
   })
 }
 

--- a/frontend/src/lib/api/sms.ts
+++ b/frontend/src/lib/api/sms.ts
@@ -23,6 +23,7 @@ import {
   smsExportBatchSchema,
   smsExportResultSchema,
   smsPreflightReportSchema,
+  smsMeasureResultSchema,
   smsConsentEventListSchema,
   smsConsentEventSchema,
   smsContactGroupListSchema,
@@ -34,6 +35,7 @@ import {
   smsOptOutListSchema,
   smsOptOutSchema,
   smsProgramInterestReportSchema,
+  smsProgramContactsResponseSchema,
   smsContactInterestListSchema,
   smsConsultLinkResponseSchema,
   smsLeadInterestResponseSchema,
@@ -53,6 +55,7 @@ import {
   type SmsExportBatchList,
   type SmsExportResult,
   type SmsPreflightReport,
+  type SmsMeasureResult,
   type SmsConsentEvent,
   type SmsConsentEventCreateInput,
   type SmsConsentEventList,
@@ -71,6 +74,7 @@ import {
   type SmsOptOut,
   type SmsOptOutList,
   type SmsProgramInterestReport,
+  type SmsProgramContactsResponse,
   type SmsContactInterestList,
   type SmsConsultLinkResponse,
   type SmsLeadInterestResponse,
@@ -216,6 +220,24 @@ export async function getSmsContactInterests(
     `/api/sms/contacts/${contactId}/interests`,
   )
   return smsContactInterestListSchema.parse(res.data)
+}
+
+export interface SmsProgramContactsParams extends SmsProgramInterestParams {
+  skip?: number
+  limit?: number
+}
+
+/** Drill-down: contact nào quan tâm 1 ngành (masked phone §16.9). Cùng filter
+ * (campaign/nhóm/ngày) với report ngành nóng → số khớp dòng ngành đã bấm. */
+export async function getSmsProgramContacts(
+  programId: number,
+  params: SmsProgramContactsParams = {},
+): Promise<SmsProgramContactsResponse> {
+  const res = await api.get<SmsProgramContactsResponse>(
+    `/api/sms/reports/program-interest/${programId}/contacts`,
+    { params },
+  )
+  return smsProgramContactsResponseSchema.parse(res.data)
 }
 
 // =====================================================================
@@ -539,6 +561,23 @@ export async function getSmsCampaignPreflight(
     `/api/sms/campaigns/${campaignId}/preflight`,
   )
   return smsPreflightReportSchema.parse(res.data)
+}
+
+export interface MeasureTemplatePayload {
+  template: string
+  sample_full_name?: string
+}
+
+/** Đo/preview 1 template soạn dở (chưa gắn campaign) — encoding/length/segments
+ * + tin cuối mẫu + cảnh báo biến lạ/sentinel. Cùng logic đo với build. */
+export async function measureSmsTemplate(
+  payload: MeasureTemplatePayload,
+): Promise<SmsMeasureResult> {
+  const res = await api.post<SmsMeasureResult>(
+    `/api/sms/campaigns/measure`,
+    payload,
+  )
+  return smsMeasureResultSchema.parse(res.data)
 }
 
 // =====================================================================

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -109,6 +109,30 @@ export type SmsContactInterestList = z.infer<
   typeof smsContactInterestListSchema
 >
 
+// Drill-down: contact nào quan tâm 1 ngành (§16.7). PII masked (§16.9).
+// interest_score = điểm GLOBAL non-null (BE coalesce 0); first/last_viewed_at =
+// min/max viewed_at TRONG scope (nullable — luôn có ≥1 view nên thực tế non-null).
+export const smsProgramContactRowSchema = z.object({
+  contact_id: z.number().int(),
+  full_name: z.string(),
+  phone_masked: z.string(),
+  view_count: z.number().int(),
+  total_dwell_seconds: z.number().int(),
+  interest_score: z.number(),
+  first_viewed_at: z.string().nullable().optional(),
+  last_viewed_at: z.string().nullable().optional(),
+})
+export type SmsProgramContactRow = z.infer<typeof smsProgramContactRowSchema>
+
+export const smsProgramContactsResponseSchema = z.object({
+  major_program_id: z.number().int(),
+  total: z.number().int(),
+  items: z.array(smsProgramContactRowSchema).default([]),
+})
+export type SmsProgramContactsResponse = z.infer<
+  typeof smsProgramContactsResponseSchema
+>
+
 // --- P2-3/P2-4b consult officer (§16.7) ---
 export const smsConsultLinkResponseSchema = z.object({
   code: z.string(),
@@ -631,6 +655,23 @@ export const smsPreflightReportSchema = z.object({
   preview: z.array(z.string()),
 })
 export type SmsPreflightReport = z.infer<typeof smsPreflightReportSchema>
+
+// --- Measure/preview template (form soạn campaign, chưa recipient) ---
+// unknown_vars + has_internal_sentinel = điều kiện SẼ bị từ chối khi LƯU
+// (mirror gate `_validate_content`); warnings + optout_configured = cảnh báo mềm.
+export const smsMeasureResultSchema = z.object({
+  encoding: z.string(),
+  length: z.number().int(),
+  segments: z.number().int(),
+  is_over_limit: z.boolean(),
+  preview: z.string(),
+  has_link: z.boolean(),
+  unknown_vars: z.array(z.string()).default([]),
+  has_internal_sentinel: z.boolean(),
+  optout_configured: z.boolean(),
+  warnings: z.array(z.string()).default([]),
+})
+export type SmsMeasureResult = z.infer<typeof smsMeasureResultSchema>
 
 // =====================================================================
 // Admin — Attestation + Export lifecycle (PR-6e; mirror SmsAttestationCreate,


### PR DESCRIPTION
## Tóm tắt
Hoàn thiện các TODO tồn của module **SMS admin** sau PR #467 (landing redesign). Full-stack, **không migration**.

- **#1a** Xem "SĐT nào quan tâm ngành nào": section **"Quan tâm ngành"** ở dialog chi tiết contact (tái dùng cấu trúc list `LeadConsultSection`).
- **#1b** **Drill-down**: bấm 1 dòng ngành ở report "Quan tâm ngành" → **Sheet** liệt kê SĐT (đã mask) quan tâm ngành đó, kèm điểm quan tâm + xem-gần-nhất; số **khớp** dòng report.
- **#2** **Preview tin ghép + đếm ký tự/đoạn/encoding LIVE** trong form soạn campaign. Đo qua BE endpoint `measure` (dùng CHUNG `assemble_skeleton`/`measure_skeleton` với build → số khớp). Phân 2 tầng: lỗi-chặn-lưu (đỏ, biến lạ/sentinel — mirror gate `_validate_content`) vs cảnh báo mềm (vàng, optout/vượt đoạn).
- **#3** Config `SMS_LANDING_SCHOOL_NAME` default = "Cao đẳng Bách khoa Tây Nguyên".
- **#5** Unit test helper landing (`tuitionTier`/`groupPrograms`/`programLucideIcon`).
- **#6** UX: tooltip nút "Sửa" khi campaign rời draft; `/admin/sms` redirect → `/campaigns` (hết 404); empty-state report click giải thích cơ chế handed-off.

## Backend (2 endpoint read-only, require_admin)
- `POST /api/sms/campaigns/measure` — đo encoding/length/segments + preview tin cuối + cảnh báo biến lạ/sentinel.
- `GET /api/sms/reports/program-interest/{major_program_id}/contacts` — drill-down contact quan tâm 1 ngành. Build TRÊN `sms_program_view` (giữ contact chưa-heartbeat, số khớp report), group theo CONTACT, mask phone (§16.9), `interest_score` coalesce, `first/last_viewed_at` = scoped min/max viewed_at; cùng filter campaign/nhóm/ngày; order_by có tiebreaker `SmsContact.id` (offset/limit ổn định).

## Kiểm thử
- **BE 16/16** integration test pass (drill-down: group-by-contact vs 2-session-1-contact, bot loại, mask, filter/pagination, view-không-heartbeat; measure: GSM7/UCS2, unknown_vars, sentinel drift, auth).
- **FE** type-check + vitest 12 pass + lint 0 error (file SMS net-zero warning).
- **Chrome smoke 6/6** trên dữ liệu thật, console sạch (redirect, preview đỏ+vàng, contact interest, drill-down masked+score+viewed, landing school_name).
- **/code-review max**: 12 finding → fix 5 (tiebreaker phân trang, tách `_optout_violations` dùng chung build↔measure khử drift, hiển thị interest_score/last_viewed_at, đảo test free>70, bỏ `or 0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)