### PR TITLE
fix(sms): nâng rate-limit GET landing + opt-out (chống chặn oan CGNAT)

### DIFF
--- a/Backend_FastAPI/app/routers/sms_public.py
+++ b/Backend_FastAPI/app/routers/sms_public.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database
 from app.core.client_ip import get_client_ip
-from app.core.rate_limits import RateLimits, limiter
+from app.core.rate_limits import limiter
 from app.schemas import sms as sms_schemas
 from app.services.sms_engagement_service import SmsEngagementService
 from app.services.sms_landing_service import SmsLandingService
@@ -21,6 +21,12 @@ router = APIRouter(prefix="/api/public/sms", tags=["SMS Public"])
 # egress cho nhiều thuê bao → trần rộng + key theo get_client_ip (XFF-aware,
 # X-Real-IP nginx overwrite non-spoofable) chứ KHÔNG get_remote_address (=IP
 # nginx → khoá global). nginx limit_req là lớp chặn DoS thật.
+# GET landing là FIRST-TOUCH mọi khách (+ reload/back-forward/React-Query refetch)
+# → phải rộng như session/view, KHÔNG dùng PUBLIC_READ=100/giờ (mâu thuẫn với
+# chính lý do CGNAT ở trên: khách thứ 101 sau 1 IP nhà mạng nhận 429 ngay trên
+# trang landing). opt-out là QUYỀN từ chối — cũng không được chặn oan.
+_LANDING_LIMIT = "3000/hour"  # GET landing/{code} — first-touch, dưới CGNAT chung IP
+_OPTOUT_LIMIT = "600/hour"    # POST opt-out — quyền từ chối, chống chặn oan CGNAT
 _SESSION_LIMIT = "600/hour"   # ~1 phiên/lượt xem landing
 _VIEW_LIMIT = "2000/hour"     # khách mở nhiều trang ngành
 _HEARTBEAT_LIMIT = "6000/hour"  # heartbeat ~15s × nhiều phiên/IP
@@ -33,7 +39,7 @@ def _set_public_headers(response: Response) -> None:
 
 
 @router.get("/landing/{code}", response_model=sms_schemas.SmsLandingResponse)
-@limiter.limit(RateLimits.PUBLIC_READ, key_func=get_client_ip)
+@limiter.limit(_LANDING_LIMIT, key_func=get_client_ip)
 async def get_landing(
     request: Request,  # required by slowapi rate limiter
     response: Response,
@@ -48,7 +54,7 @@ async def get_landing(
 
 
 @router.post("/opt-out", response_model=sms_schemas.SmsPublicOptOutResponse)
-@limiter.limit(RateLimits.PUBLIC_READ, key_func=get_client_ip)
+@limiter.limit(_OPTOUT_LIMIT, key_func=get_client_ip)
 async def public_opt_out(
     request: Request,  # required by slowapi rate limiter
     response: Response,


### PR DESCRIPTION
## Vấn đề
Từ **đánh giá khả năng chịu tải chiến dịch SMS**, nút thắt thực tế **không phải phần cứng** mà là rate-limit landing:

`GET /api/public/sms/landing/{code}` và `POST /opt-out` đang dùng `RateLimits.PUBLIC_READ = 100/giờ/IP` — **mâu thuẫn với chính lý do CGNAT** đã nới rộng cho `session/view/heartbeat` (600/2000/6000) ngay bên trên trong cùng file.

**Kịch bản gãy (thực tế khi bắn hàng loạt):** landing GET là **first-touch** mọi khách. Nhiều số **cùng 1 nhà mạng** (CGNAT Viettel/Vina) hoặc **wifi trường** bấm short-link trong 1 giờ → dồn chung 1 bucket IP egress → **khách thứ 101 nhận 429 ngay trên trang landing (trang trắng)**, rất lâu trước khi CPU/DB nhúc nhích.

## Thay đổi
| Endpoint | Trước | Sau |
|---|---|---|
| `GET /landing/{code}` | `PUBLIC_READ` 100/h | `_LANDING_LIMIT` **3000/h** (rộng như view; first-touch + reload/refetch) |
| `POST /opt-out` | `PUBLIC_READ` 100/h | `_OPTOUT_LIMIT` **600/h** (quyền từ chối — không được chặn oan) |

- Key vẫn `get_client_ip` (X-Real-IP non-spoofable); `nginx limit_req` (50 r/s) vẫn là lớp chặn DoS thật.
- Bỏ import `RateLimits` không còn dùng trong file.
- **Không migration.** Chỉ đổi giá trị limit (trong test, `main.py` skip limiter → không ảnh hưởng test).

## Bối cảnh
Follow-up từ review tải của PR #468. Các điểm hạ tầng khác đã ghi nhận (chưa trong PR này): Redis limiter fail-closed (SPOF), DB pool 2×60 > `max_connections=100`, build engine block event loop khi N lớn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)