### PR TITLE
fix(infra): Redis limiter fail-open + DB pool < max_connections

### DIFF
--- a/Backend_FastAPI/app/core/rate_limits.py
+++ b/Backend_FastAPI/app/core/rate_limits.py
@@ -45,7 +45,19 @@ else:
 # get_client_ip also fixes SSR (server-rendered fetches bypass nginx but carry the
 # X-Real-IP forwarded by serverFetch; get_remote_address would key on the frontend
 # container IP). Every @limiter.limit inherits this default unless it passes key_func.
-limiter = Limiter(key_func=get_client_ip, storage_uri=STORAGE_URI)
+# in_memory_fallback_enabled: Redis là storage đếm rate-limit cho MỌI endpoint
+# (gồm public landing /r/, session, heartbeat). Mặc định slowapi fail-CLOSED —
+# Redis chết/đầy → lệnh storage raise → request 500 hàng loạt (SPOF). Bật fallback
+# → khi Redis lỗi, tự chuyển sang bộ đếm IN-MEMORY (per-process) với CÙNG limits:
+# landing không 500, và vẫn GIỮ enforcement (khác swallow_errors=tắt hẳn → hở
+# brute-force auth). Redis lành lại thì tự quay về Redis. circuit-breaker
+# redis_breaker (database.py) chỉ bọc safe_redis_*, KHÔNG bọc client nội bộ của
+# slowapi → fallback này là lớp bảo vệ riêng cho rate-limit.
+limiter = Limiter(
+    key_func=get_client_ip,
+    storage_uri=STORAGE_URI,
+    in_memory_fallback_enabled=True,
+)
 
 
 # ============================================================================

--- a/Backend_FastAPI/app/database.py
+++ b/Backend_FastAPI/app/database.py
@@ -27,8 +27,14 @@ else:
         settings.DATABASE_URL,
         pool_pre_ping=True,
         pool_recycle=3600,
-        pool_size=20,
-        max_overflow=40,
+        # Engine DÙNG CHUNG cho web workers + celery-worker + celery-beat (mỗi
+        # process 1 pool riêng). Cũ 20+40=60/process × ~4 process → burst tối đa
+        # ~240 » Postgres max_connections=100 → nguy cơ "too many connections".
+        # Giảm về 10+10=20/process → worst-case 4 process ≈ 80 < 100 (chừa ~20
+        # cho psql admin / alembic lúc deploy). ⚠️ Nếu nâng GUNICORN_WORKERS (>2)
+        # hoặc celery concurrency, phải tính lại hoặc nâng PG max_connections.
+        pool_size=10,
+        max_overflow=10,
         echo=False,
         connect_args={
             # ✅ Sét timeout ở mức độ command (phía client driver - asyncpg)


### PR DESCRIPTION
## Vấn đề
Từ **đánh giá khả năng chịu tải chiến dịch SMS**, 2 nợ hạ tầng **có sẵn** (không phải bug của PR nào) — chưa gây sự cố nhưng sẽ cắn khi tải tăng hoặc dịch vụ phụ trợ trục trặc.

### #1 🟠 Redis limiter fail-closed = SPOF
Rate-limit của **mọi** endpoint (gồm public landing `/r/`, session, heartbeat) đếm qua Redis. slowapi mặc định **fail-CLOSED**: Redis chết/đầy → lệnh storage raise → **500 hàng loạt**. Redis chỉ có 1 instance → là **điểm chết kéo sập cả trang landing** đúng lúc bắn campaign.

**Fix:** `in_memory_fallback_enabled=True` → Redis lỗi thì tự chuyển sang bộ đếm **in-memory** (per-process) với cùng limits → landing không 500, **vẫn giữ enforcement** (khác `swallow_errors` = tắt hẳn, hở brute-force auth). Redis lành lại tự quay về.

### #2 🟠 DB pool > max_connections
Engine dùng **chung** web workers + celery-worker + celery-beat. Cũ `pool_size=20 + max_overflow=40` = **60/process** × ~4 process → burst tới ~240 » Postgres `max_connections=100` → nguy cơ **"too many connections"** khi burst.

**Fix:** `10 + 10` = **20/process** → worst-case ~4 process ≈ **80 < 100** (chừa ~20 cho psql admin / alembic lúc deploy).

## Thay đổi
| File | Thay đổi |
|---|---|
| `app/core/rate_limits.py` | `Limiter(..., in_memory_fallback_enabled=True)` |
| `app/database.py` | `pool_size 20→10`, `max_overflow 40→10` |

- **Không migration.** Verify: import OK, `engine.pool.size()=10`, `_max_overflow=10`, limiter khởi tạo OK.
- ⚠️ Nếu sau này nâng `GUNICORN_WORKERS` (>2) hoặc celery concurrency → phải tính lại pool hoặc nâng PG `max_connections`.

## Bối cảnh
Follow-up nợ hạ tầng từ review tải (sau #468/#469). Món còn lại chưa làm (ưu tiên thấp, chỉ khi bắn >10k số/đợt): offload build loop + openpyxl streaming; dọn định kỳ recipient `invalidated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)