### PR TITLE
feat(assignment): loại lead officer tự tuyển khỏi cơ sở cân bằng chia lead

### DIFF
--- a/Backend_FastAPI/alembic/versions/assignlogidx20260711_add_composite_index.py
+++ b/Backend_FastAPI/alembic/versions/assignlogidx20260711_add_composite_index.py
@@ -1,0 +1,42 @@
+"""add composite index assignment_log(lead_id, officer_id, timestamp DESC)
+
+Hỗ trợ ``_self_sourced_subquery`` (khi ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED +
+member/fairness): ``ORDER BY timestamp DESC LIMIT 1`` lọc theo (lead_id,
+officer_id) — chạy 1 lần / lead-row của đơn vị. Index rời sẵn có (lead_id /
+officer_id) KHÔNG phục vụ được ORDER BY timestamp → Postgres phải sort. Composite
+(lead_id, officer_id, timestamp DESC) cho index-scan lấy bản ghi mới nhất của cặp.
+Additive + reversible, KHÔNG đổi dữ liệu.
+
+``assignment_log`` là bảng log nhỏ (1 dòng / sự kiện phân công, ~vài nghìn dòng)
+nên ``CREATE INDEX`` thường (trong transaction) build mili-giây — KHÔNG cần
+CONCURRENTLY (đơn giản + rollback an toàn). Nếu về sau bảng phình rất lớn, cân
+nhắc rebuild CONCURRENTLY thủ công. Đồng bộ với model AssignmentLog.__table_args__.
+
+Revision ID: assignlogidx20260711
+Revises: zbmonthlyseed20260706
+Create Date: 2026-07-11
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "assignlogidx20260711"
+down_revision = "zbmonthlyseed20260706"
+branch_labels = None
+depends_on = None
+
+_INDEX = "ix_assignment_log_lead_officer_ts"
+_TABLE = "assignment_log"
+
+
+def upgrade():
+    op.create_index(
+        _INDEX,
+        _TABLE,
+        ["lead_id", "officer_id", sa.text("timestamp DESC")],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(_INDEX, table_name=_TABLE)

--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -576,6 +576,16 @@ class Settings(BaseSettings):
     # proportionally more leads. INDEPENDENT of ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT
     # (either, both, or neither may be on). Default False ⇒ no behavior change until
     # flipped. The safety gate (real_util >= SAFETY_THRESHOLD) is never bent by weight.
+    ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED: bool = Field(
+        default=False,
+        validation_alias="ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED",
+    )  # Khi ON: khóa SẮP XẾP auto-assign (real_util/eff_util) tính trên
+    # dist_load = workload − (lead officer TỰ TUYỂN, xem _self_sourced_subquery),
+    # KHÔNG trên tổng workload. Mục tiêu: lead tự tuyển không làm giảm suất nhận
+    # lead-chia. Cổng an toàn `overloaded`, gate `workload < capacity`, và
+    # is_officer_at_threshold (referral fast-path) VẪN dùng TỔNG workload —
+    # self-tuyển không phá trần quá tải thật. Default False ⇒ 0 đổi hành vi + 0
+    # query phụ cho tới khi bật.
 
     # -- Lead Lifecycle SLA: auto-close stale rejected consultations --
     # A lead in sts04 (CONSULT_REJECTED, is_final=false for re-engagement) that

--- a/Backend_FastAPI/app/models/lead.py
+++ b/Backend_FastAPI/app/models/lead.py
@@ -448,6 +448,18 @@ class AssignmentLog(Base):
 
     __tablename__ = "assignment_log"
 
+    # Composite index cho _self_sourced_subquery (assignment_service): latest log
+    # của cặp (lead_id, officer_id) qua ORDER BY timestamp DESC LIMIT 1. Đồng bộ
+    # với migration assignlogidx20260711 (tránh autogenerate drift → spurious DROP).
+    __table_args__ = (
+        Index(
+            "ix_assignment_log_lead_officer_ts",
+            "lead_id",
+            "officer_id",
+            text("timestamp DESC"),
+        ),
+    )
+
     id = Column(Integer, primary_key=True)
     lead_id = Column(Integer, ForeignKey("lead.id"), nullable=False, index=True)  # ✅ FIX: Added index
     method = Column(String(50))

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -51,18 +51,25 @@ def _self_sourced_subquery():
     Tự tuyển = latest method='manual' VÀ ``reason`` do một OFFICER khởi tạo. Mọi
     thứ khác — 'automatic', reassign, manual do admin/manager chỉ định (phân
     phối), hay không có log — đều KHÔNG phải tự tuyển ⇒ tính vào tải đã-chia. Dùng
-    ở BƯỚC 3b (chỉ khi ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED) để loại lead tự
-    tuyển khỏi CƠ SỞ SẮP XẾP (real_util/eff_util), KHÔNG khỏi tổng workload.
+    khi ``exclude_active`` để loại lead tự tuyển khỏi CƠ SỞ SẮP XẾP (real_util/
+    eff_util), KHÔNG khỏi tổng workload.
 
-    Fail-safe: subquery trả NULL (không log) ⇒ ``NULL`` trong WHERE ⇒ KHÔNG tính
-    là tự tuyển (an toàn: không tự dưng cấp thêm suất). reason không khớp mẫu cũng
-    rơi về đã-chia.
+    ⚠️ NGỮ NGHĨA (latent): pattern chỉ kiểm VAI TRÒ người-gán = officer, KHÔNG kiểm
+    assigner == assigned_officer_id. Hôm nay AN TOÀN vì officer-create ép
+    direct_assignment = created_by (lead_service.py:~837) và ``/assign`` chỉ
+    manager/admin (Casbin OFFICER_TEMPLATE không cấp). NẾU RBAC sau cho officer gán
+    cho ĐỒNG NGHIỆP → lead đã-chia của B bị tính B tự tuyển → over-grant (UNSAFE,
+    ngược ý đồ). Khi đó ghi ý định ở write-time (method='self_claim' / actor_id)
+    thay vì match chuỗi reason.
 
-    ⚠️ COUPLING: khớp chuỗi ``reason`` sinh ở lead_service.py (create+direct-assign
-    ~1179 và assign_lead_to_officer ~2350). Đổi chữ "by officer" ở đó sẽ âm thầm
-    xếp lead tự tuyển thành đã-chia — nhưng theo HƯỚNG AN TOÀN (không cấp thêm
-    suất). Ghim bởi test_assignment_self_sourced.py. Audit prod unit 14
-    (2026-07-10): 467/537 manual = 'by officer', 70 = admin gán.
+    Fail-safe: NULL (không log) hoặc reason không khớp ⇒ KHÔNG phải tự tuyển (an
+    toàn: không cấp thêm suất).
+
+    ⚠️ COUPLING: khớp ``reason`` sinh ở lead_service.py (create+direct-assign
+    ~1179 + assign_lead_to_officer ~2350); ghim bởi test_assignment_self_sourced.py.
+    ⚠️ INDEX: ORDER BY ... LIMIT 1 dựa ``ix_assignment_log_lead_officer_ts``
+    (lead_id, officer_id, timestamp DESC) — thiếu → seq-scan mỗi lead-row. Audit
+    prod unit 14 (2026-07-10): 467/537 manual = 'by officer', 70 = admin gán.
     """
     al = models.AssignmentLog
     return (
@@ -74,7 +81,10 @@ def _self_sourced_subquery():
             al.lead_id == models.Lead.id,
             al.officer_id == models.Lead.assigned_officer_id,
         )
-        .order_by(al.timestamp.desc())
+        # tie-breaker id DESC: timestamp=datetime.now() có thể trùng microsecond
+        # trên 2 log cùng (lead, officer) ⇒ LIMIT 1 non-deterministic; id DESC làm
+        # sort toàn phần.
+        .order_by(al.timestamp.desc(), al.id.desc())
         .limit(1)
         .correlate(models.Lead)
         .scalar_subquery()
@@ -305,14 +315,36 @@ async def automatically_assign_lead(
                     f"[Lead ID: {lead_id}] Found {len(available_officers)} available officers for unit {lead_unit_id}."
                 )
 
-                # === BƯỚC 3: TÍNH TOÁN WORKLOAD (Chỉ cho các officer lấy được) ===
-                # ✅ REFACTORED: Sử dụng JOIN với ConsultationStatus thay vì danh sách hard-coded
+                # === BƯỚC 3: TÍNH TOÁN WORKLOAD (+ tải TỰ TUYỂN nếu exclude_active) ===
+                # `exclude_active` = flag loại-self CHỈ có tác dụng ở chế độ member/
+                # fairness (legacy sắp xếp thuần last_assigned → dist_load vô nghĩa;
+                # gate ở đây tránh query thừa + không bẩn legacy snapshot). Khi active
+                # thêm 1 aggregate self_cnt = COUNT(...) FILTER(tự tuyển) NGAY trên
+                # workload_stmt ⇒ 1 round-trip, và bất biến self_cnt ≤ workload là CẤU
+                # TRÚC (subset của FILTER trên cùng tập dòng) ⇒ balance_load ≥ 0 khỏi
+                # cần max(0). Flags đọc 1 lần ở đây, tái dùng ở BƯỚC 5.
+                from ..config import settings
+
+                member_on = settings.ENABLE_MEMBER_WEIGHTED_ASSIGNMENT
+                fairness_on = settings.ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT
+                exclude_active = (
+                    settings.ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED
+                    and (member_on or fairness_on)
+                )
+
                 officer_ids = [o.id for o in available_officers]
-                workload_stmt = (
-                    select(
-                        models.Lead.assigned_officer_id,
-                        func.count(models.Lead.id).label("workload"),
+                _wl_cols = [
+                    models.Lead.assigned_officer_id,
+                    func.count(models.Lead.id).label("workload"),
+                ]
+                if exclude_active:
+                    _wl_cols.append(
+                        func.count(models.Lead.id)
+                        .filter(_self_sourced_subquery())
+                        .label("self_cnt")
                     )
+                workload_stmt = (
+                    select(*_wl_cols)
                     .join(
                         models.ConsultationStatus,
                         models.Lead.consultation_status_id == models.ConsultationStatus.id,
@@ -327,51 +359,15 @@ async def automatically_assign_lead(
                     )
                     .group_by(models.Lead.assigned_officer_id)
                 )
-                workload_results = await db.execute(workload_stmt)
-                workload_map = {
-                    row.assigned_officer_id: row.workload for row in workload_results
-                }
-                log.debug(
-                    f"[Lead ID: {lead_id}] Calculated workloads (non-final leads only) for available officers: {workload_map}"
-                )
-
-                # BƯỚC 3b: tải TỰ TUYỂN (self_map) — CHỈ query khi flag ON (OFF ⇒
-                # 0 chi phí). Đếm mỗi officer số lead non-final mà bản ghi
-                # assignment_log mới nhất (cho chính officer đó) là do officer tự
-                # tuyển (xem _self_sourced_subquery). Cùng base-filter với
-                # workload_stmt + thêm 1 điều kiện ⇒ self_cnt LUÔN là tập con ⇒
-                # balance_load = workload − self_cnt ≥ 0.
-                from ..config import settings
-
+                workload_map: dict = {}
                 self_map: dict = {}
-                if settings.ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED:
-                    self_stmt = (
-                        select(
-                            models.Lead.assigned_officer_id,
-                            func.count(models.Lead.id).label("self_cnt"),
-                        )
-                        .join(
-                            models.ConsultationStatus,
-                            models.Lead.consultation_status_id
-                            == models.ConsultationStatus.id,
-                            isouter=True,
-                        )
-                        .where(
-                            models.Lead.assigned_officer_id.in_(officer_ids),
-                            models.Lead.deleted_at.is_(None),
-                            _non_final_status_filter(),
-                            # latest-log của officer này là tự tuyển (bool subquery)
-                            _self_sourced_subquery(),
-                        )
-                        .group_by(models.Lead.assigned_officer_id)
-                    )
-                    self_results = await db.execute(self_stmt)
-                    self_map = {
-                        row.assigned_officer_id: row.self_cnt for row in self_results
-                    }
-                    log.debug(
-                        f"[Lead ID: {lead_id}] Self-sourced per officer: {self_map}"
-                    )
+                for row in await db.execute(workload_stmt):
+                    workload_map[row.assigned_officer_id] = row.workload
+                    if exclude_active:
+                        self_map[row.assigned_officer_id] = row.self_cnt
+                log.debug(
+                    f"[Lead ID: {lead_id}] Workloads={workload_map} self-sourced={self_map}"
+                )
 
                 # === BƯỚC 4: Xây dựng Danh sách Officer Hợp lệ (còn capacity) ===
                 officer_loads = []
@@ -385,15 +381,14 @@ async def automatically_assign_lead(
                     # self-tuyển/weight KHÔNG BAO GIỜ nới trần này.
                     if workload < capacity:
                         weight = _safe_weight(officer)
-                        # balance_load = CƠ SỞ SẮP XẾP. Khi flag ON, loại phần
-                        # officer tự tuyển (self_cnt) ⇒ lead tự tuyển không làm
-                        # giảm suất nhận lead-chia. max(0, …) phòng drift nếu filter
-                        # self_stmt/workload_stmt lệch nhau (bất biến: self_cnt ≤
-                        # workload).
-                        self_cnt = self_map.get(officer.id, 0)
+                        # balance_load = CƠ SỞ SẮP XẾP. Khi exclude_active, trừ phần
+                        # officer tự tuyển ⇒ lead tự tuyển không làm giảm suất nhận
+                        # lead-chia. self_cnt = COUNT FILTER trên cùng tập dòng ⇒
+                        # self_cnt ≤ workload (bất biến CẤU TRÚC) ⇒ balance_load ≥ 0,
+                        # KHÔNG cần max(0).
                         balance_load = (
-                            max(0, workload - self_cnt)
-                            if settings.ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED
+                            workload - self_map.get(officer.id, 0)
+                            if exclude_active
                             else workload
                         )
                         # real_util/eff_util tính trên balance_load (đầu vào SẮP
@@ -411,7 +406,7 @@ async def automatically_assign_lead(
                                 "eff_util": eff_util,
                                 "weight": weight,
                                 # ⚠️ Cổng an toàn theo TỔNG tải (workload/capacity),
-                                # TÁCH khỏi real_util (nay dist-based khi flag ON).
+                                # TÁCH khỏi real_util (dist-based khi exclude_active).
                                 # weight/self-tuyển KHÔNG phá trần. Đặt sẵn ở đây.
                                 "overloaded": (workload / capacity) >= SAFETY_THRESHOLD,
                                 # score = giá trị dùng để SẮP XẾP; mặc định real_util,
@@ -476,9 +471,7 @@ async def automatically_assign_lead(
                 # order_util = eff_util nếu member ON, ngược lại real_util (=== hôm nay).
                 # overloaded = (workload/capacity) >= SAFETY_THRESHOLD — LUÔN theo
                 # TỔNG tải; weight/self-tuyển KHÔNG BAO GIỜ phá cổng an toàn (không
-                # dồn quá tải thật). (settings import ở BƯỚC 3b — cùng scope hàm.)
-                member_on = settings.ENABLE_MEMBER_WEIGHTED_ASSIGNMENT
-                fairness_on = settings.ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT
+                # dồn quá tải thật). (member_on/fairness_on/settings đã đọc ở BƯỚC 3.)
 
                 # `overloaded` (cổng an toàn theo tải THẬT) đã đặt sẵn ở BƯỚC 4 —
                 # SAFETY_THRESHOLD là hằng module (chia sẻ với referral fast-path qua
@@ -537,17 +530,19 @@ async def automatically_assign_lead(
                     assign_reason = "member_fairness_weighted"
                     log.info(f"[Lead ID: {lead_id}] Member+fairness weighted (pool_hist={eligible_hist_total})")
                 elif scoring == "fairness":
+                    # ⚠️ Khi exclude_active, real_util là DIST-based ⇒ score fairness
+                    # KHÁC P2-2 gốc (officer thắng có thể lật). Chủ đích (spec §5).
                     for e in officer_loads:
                         share = hist_counts.get(e["officer"].id, 0) / total_hist
-                        e["score"] = 0.6 * e["real_util"] + 0.4 * share  # Y HỆT P2-2 cũ
+                        e["score"] = 0.6 * e["real_util"] + 0.4 * share
                     assign_reason = "fairness_weighted"
                     log.info(f"[Lead ID: {lead_id}] Using fairness-weighted scoring (history={total_hist})")
                 elif scoring == "member":
                     # Tie-break đầu là eff_util (weight cao ⇒ eff_util thấp ⇒ ưu tiên),
-                    # rồi last_assigned. ⚠️ Weight ĐỒNG ĐỀU (đều =1) ⇒ eff_util == real_util
-                    # ⇒ order theo TẢI THẬT (workload-proportional), KHÔNG phải round-robin
-                    # thuần như legacy — đây là chủ đích của member mode, KHÁC legacy dù
-                    # chưa phân hoá weight (xem test_matrix_member_on_uniform_weight...).
+                    # rồi last_assigned. Weight ĐỒNG ĐỀU (đều =1) ⇒ eff_util == real_util
+                    # ⇒ order theo TẢI (proportional), KHÁC round-robin thuần legacy —
+                    # chủ đích member mode. ⚠️ Khi exclude_active, "TẢI" ở đây là
+                    # DIST-based (đã trừ tự tuyển), KHÔNG phải tổng workload.
                     for e in officer_loads:
                         e["score"] = e["eff_util"]
                     assign_reason = "member_weighted"
@@ -568,8 +563,8 @@ async def automatically_assign_lead(
                 chosen_workload = chosen_officer_data["workload"]
                 log.info(
                     f"[Lead ID: {lead_id}] Selected officer {chosen_one.id} ({chosen_one.username}). "
-                    f"Current Workload: {chosen_workload}, Max Capacity: {chosen_one.max_capacity}, "
-                    f"Utilization: {chosen_officer_data['real_util']:.2f}, "
+                    f"Current Workload (TỔNG): {chosen_workload}, Max Capacity: {chosen_one.max_capacity}, "
+                    f"Util(cơ sở sắp xếp, dist khi exclude_active): {chosen_officer_data['real_util']:.2f}, "
                     f"Last Assigned: {chosen_officer_data['last_assigned']}"
                 )
 
@@ -600,10 +595,11 @@ async def automatically_assign_lead(
                 # fairness_weighted / member_weighted / member_fairness_weighted).
                 # scores_snapshot (thuần audit — KHÔNG consumer runtime nào đọc;
                 # fairness_service chỉ đọc capacity_snapshot):
-                #  - Chế độ weighted → dict {real_util, eff_util, weight, score}
-                #    (`score` là thành phần SẮP XẾP; đọc kèm `reason`).
+                #  - Chế độ weighted → dict {workload, dist_load, real_util, eff_util,
+                #    weight, score} (workload=TỔNG; dist_load=cơ sở sắp xếp = tổng khi
+                #    KHÔNG exclude_active; `score` = thành phần SẮP XẾP, đọc kèm reason).
                 #  - Legacy/round-robin → gọn: chỉ real_util (eff_util==real_util,
-                #    weight==1, score==real_util nên 3 field kia thừa; sort chỉ theo
+                #    weight==1, score==real_util nên các field kia thừa; sort chỉ theo
                 #    overloaded + last_assigned).
                 await _log_assignment_decision(
                     db, lead_id=lead_id, assigned_officer_id=chosen_one.id,

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -43,16 +43,32 @@ def _non_final_status_filter():
     )
 
 
+# Các method = SỰ KIỆN (RE-)PHÂN CÔNG (cách officer CÓ lead). PHÂN BIỆT với hành
+# động STATUS giữ nguyên officer: officer_reject (từ chối, giữ officer + non-final
+# sts04) và offering_change_unit_synced (keep-sync đổi ngành) — hai cái này KHÔNG
+# đổi "nguồn sở hữu" nên KHÔNG được reset phân loại tự-tuyển. officer_reassign nulls
+# officer nên không bao giờ match (assigned_officer_id đã NULL).
+_ASSIGNMENT_SOURCE_METHODS = (
+    "automatic",
+    "manual",
+    "manual_reassignment",
+    "system_auto_reassign",
+)
+
+
 def _self_sourced_subquery():
     """Correlated boolean scalar subquery — True nếu lead do CHÍNH officer đang
-    được gán TỰ TUYỂN (tự tạo + tự nhận), theo bản ghi ``assignment_log`` MỚI NHẤT
-    của cặp (lead, officer hiện tại).
+    được gán TỰ TUYỂN (tự tạo + tự nhận), theo bản ghi (RE-)PHÂN CÔNG MỚI NHẤT của
+    cặp (lead, officer hiện tại) — CHỈ xét ``_ASSIGNMENT_SOURCE_METHODS``, bỏ qua
+    hành động status (officer_reject) / keep-sync.
 
-    Tự tuyển = latest method='manual' VÀ ``reason`` do một OFFICER khởi tạo. Mọi
-    thứ khác — 'automatic', reassign, manual do admin/manager chỉ định (phân
-    phối), hay không có log — đều KHÔNG phải tự tuyển ⇒ tính vào tải đã-chia. Dùng
-    khi ``exclude_active`` để loại lead tự tuyển khỏi CƠ SỞ SẮP XẾP (real_util/
-    eff_util), KHÔNG khỏi tổng workload.
+    Tự tuyển = latest (assignment-source) method='manual' VÀ ``reason`` do một
+    OFFICER khởi tạo. Mọi thứ khác — 'automatic', reassign, manual do admin/manager
+    chỉ định (phân phối), hay không có log — đều KHÔNG phải tự tuyển ⇒ tính vào tải
+    đã-chia. ⚠️ officer_reject/offering_change_unit_synced KHÔNG reset (nếu xét MỌI
+    log, self-sourced lead bị officer reject sẽ hoá đã-chia OAN → giảm suất officer,
+    ngược ý đồ). Dùng khi ``exclude_active`` để loại lead tự tuyển khỏi CƠ SỞ SẮP
+    XẾP (real_util/eff_util), KHÔNG khỏi tổng workload.
 
     ⚠️ NGỮ NGHĨA (latent): pattern chỉ kiểm VAI TRÒ người-gán = officer, KHÔNG kiểm
     assigner == assigned_officer_id. Hôm nay AN TOÀN vì officer-create ép
@@ -80,6 +96,10 @@ def _self_sourced_subquery():
         .where(
             al.lead_id == models.Lead.id,
             al.officer_id == models.Lead.assigned_officer_id,
+            # CHỈ xét sự kiện (re-)phân công — bỏ qua status-action (officer_reject)
+            # + keep-sync (offering_change_unit_synced) để chúng KHÔNG reset phân
+            # loại tự-tuyển của lead.
+            al.method.in_(_ASSIGNMENT_SOURCE_METHODS),
         )
         # tie-breaker id DESC: timestamp=datetime.now() có thể trùng microsecond
         # trên 2 log cùng (lead, officer) ⇒ LIMIT 1 non-deterministic; id DESC làm

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -43,6 +43,44 @@ def _non_final_status_filter():
     )
 
 
+def _self_sourced_subquery():
+    """Correlated boolean scalar subquery — True nếu lead do CHÍNH officer đang
+    được gán TỰ TUYỂN (tự tạo + tự nhận), theo bản ghi ``assignment_log`` MỚI NHẤT
+    của cặp (lead, officer hiện tại).
+
+    Tự tuyển = latest method='manual' VÀ ``reason`` do một OFFICER khởi tạo. Mọi
+    thứ khác — 'automatic', reassign, manual do admin/manager chỉ định (phân
+    phối), hay không có log — đều KHÔNG phải tự tuyển ⇒ tính vào tải đã-chia. Dùng
+    ở BƯỚC 3b (chỉ khi ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED) để loại lead tự
+    tuyển khỏi CƠ SỞ SẮP XẾP (real_util/eff_util), KHÔNG khỏi tổng workload.
+
+    Fail-safe: subquery trả NULL (không log) ⇒ ``NULL`` trong WHERE ⇒ KHÔNG tính
+    là tự tuyển (an toàn: không tự dưng cấp thêm suất). reason không khớp mẫu cũng
+    rơi về đã-chia.
+
+    ⚠️ COUPLING: khớp chuỗi ``reason`` sinh ở lead_service.py (create+direct-assign
+    ~1179 và assign_lead_to_officer ~2350). Đổi chữ "by officer" ở đó sẽ âm thầm
+    xếp lead tự tuyển thành đã-chia — nhưng theo HƯỚNG AN TOÀN (không cấp thêm
+    suất). Ghim bởi test_assignment_self_sourced.py. Audit prod unit 14
+    (2026-07-10): 467/537 manual = 'by officer', 70 = admin gán.
+    """
+    al = models.AssignmentLog
+    return (
+        select(
+            (al.method == "manual")
+            & al.reason.ilike("%by officer %")
+        )
+        .where(
+            al.lead_id == models.Lead.id,
+            al.officer_id == models.Lead.assigned_officer_id,
+        )
+        .order_by(al.timestamp.desc())
+        .limit(1)
+        .correlate(models.Lead)
+        .scalar_subquery()
+    )
+
+
 def _safe_positive_int(value: int | None, default: int) -> int:
     """Coerce to a usable positive int: None → ``default``, any value <= 0 → 1.
     Single backbone for _safe_capacity / _safe_weight."""
@@ -297,6 +335,44 @@ async def automatically_assign_lead(
                     f"[Lead ID: {lead_id}] Calculated workloads (non-final leads only) for available officers: {workload_map}"
                 )
 
+                # BƯỚC 3b: tải TỰ TUYỂN (self_map) — CHỈ query khi flag ON (OFF ⇒
+                # 0 chi phí). Đếm mỗi officer số lead non-final mà bản ghi
+                # assignment_log mới nhất (cho chính officer đó) là do officer tự
+                # tuyển (xem _self_sourced_subquery). Cùng base-filter với
+                # workload_stmt + thêm 1 điều kiện ⇒ self_cnt LUÔN là tập con ⇒
+                # balance_load = workload − self_cnt ≥ 0.
+                from ..config import settings
+
+                self_map: dict = {}
+                if settings.ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED:
+                    self_stmt = (
+                        select(
+                            models.Lead.assigned_officer_id,
+                            func.count(models.Lead.id).label("self_cnt"),
+                        )
+                        .join(
+                            models.ConsultationStatus,
+                            models.Lead.consultation_status_id
+                            == models.ConsultationStatus.id,
+                            isouter=True,
+                        )
+                        .where(
+                            models.Lead.assigned_officer_id.in_(officer_ids),
+                            models.Lead.deleted_at.is_(None),
+                            _non_final_status_filter(),
+                            # latest-log của officer này là tự tuyển (bool subquery)
+                            _self_sourced_subquery(),
+                        )
+                        .group_by(models.Lead.assigned_officer_id)
+                    )
+                    self_results = await db.execute(self_stmt)
+                    self_map = {
+                        row.assigned_officer_id: row.self_cnt for row in self_results
+                    }
+                    log.debug(
+                        f"[Lead ID: {lead_id}] Self-sourced per officer: {self_map}"
+                    )
+
                 # === BƯỚC 4: Xây dựng Danh sách Officer Hợp lệ (còn capacity) ===
                 officer_loads = []
                 for officer in available_officers:
@@ -305,24 +381,39 @@ async def automatically_assign_lead(
                     # cùng helper với is_officer_at_threshold.
                     capacity = _safe_capacity(officer)
 
+                    # Gate còn-capacity LUÔN theo TỔNG workload (trần cứng) —
+                    # self-tuyển/weight KHÔNG BAO GIỜ nới trần này.
                     if workload < capacity:
-                        # real_util = tải THẬT (workload/capacity), KHÔNG nhân weight —
-                        # cổng an toàn `overloaded` LUÔN đọc con số này. eff_util = tải
-                        # hiệu dụng có nhân weight: weight cao ⇒ eff_util thấp ⇒ officer
-                        # "được coi là vơi hơn" ⇒ nhận nhiều lead hơn (khi member ON).
-                        real_util = workload / capacity
                         weight = _safe_weight(officer)
-                        eff_util = workload / (capacity * weight)
+                        # balance_load = CƠ SỞ SẮP XẾP. Khi flag ON, loại phần
+                        # officer tự tuyển (self_cnt) ⇒ lead tự tuyển không làm
+                        # giảm suất nhận lead-chia. max(0, …) phòng drift nếu filter
+                        # self_stmt/workload_stmt lệch nhau (bất biến: self_cnt ≤
+                        # workload).
+                        self_cnt = self_map.get(officer.id, 0)
+                        balance_load = (
+                            max(0, workload - self_cnt)
+                            if settings.ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED
+                            else workload
+                        )
+                        # real_util/eff_util tính trên balance_load (đầu vào SẮP
+                        # XẾP ở BƯỚC 5). eff_util có nhân weight: weight cao ⇒
+                        # eff_util thấp ⇒ officer "được coi là vơi hơn" ⇒ nhận
+                        # nhiều lead hơn (member ON).
+                        real_util = balance_load / capacity
+                        eff_util = balance_load / (capacity * weight)
                         officer_loads.append(
                             {
                                 "officer": officer,
-                                "workload": workload,
+                                "workload": workload,  # TỔNG tải (audit + gate)
+                                "dist_load": balance_load,  # cơ sở SẮP XẾP
                                 "real_util": real_util,
                                 "eff_util": eff_util,
                                 "weight": weight,
-                                # Cổng an toàn theo tải THẬT — đặt sẵn ở đây, khỏi cần
-                                # vòng lặp phụ ở BƯỚC 5 (weight không bao giờ phá trần).
-                                "overloaded": real_util >= SAFETY_THRESHOLD,
+                                # ⚠️ Cổng an toàn theo TỔNG tải (workload/capacity),
+                                # TÁCH khỏi real_util (nay dist-based khi flag ON).
+                                # weight/self-tuyển KHÔNG phá trần. Đặt sẵn ở đây.
+                                "overloaded": (workload / capacity) >= SAFETY_THRESHOLD,
                                 # score = giá trị dùng để SẮP XẾP; mặc định real_util,
                                 # các nhánh weighted ở BƯỚC 5 ghi đè. Ở nhánh legacy/
                                 # fallback score GIỮ real_util nhưng KHÔNG quyết định thứ
@@ -383,10 +474,9 @@ async def automatically_assign_lead(
                 #   ENABLE_MEMBER_WEIGHTED_ASSIGNMENT   → order theo eff_util (nhân weight)
                 #   ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT → thêm thành phần fairness share
                 # order_util = eff_util nếu member ON, ngược lại real_util (=== hôm nay).
-                # overloaded = real_util >= SAFETY_THRESHOLD — LUÔN tải thật; weight
-                # KHÔNG BAO GIỜ phá cổng an toàn (không dồn quá tải thật).
-                from ..config import settings
-
+                # overloaded = (workload/capacity) >= SAFETY_THRESHOLD — LUÔN theo
+                # TỔNG tải; weight/self-tuyển KHÔNG BAO GIỜ phá cổng an toàn (không
+                # dồn quá tải thật). (settings import ở BƯỚC 3b — cùng scope hàm.)
                 member_on = settings.ENABLE_MEMBER_WEIGHTED_ASSIGNMENT
                 fairness_on = settings.ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT
 
@@ -527,6 +617,8 @@ async def automatically_assign_lead(
                         if scoring == "legacy"
                         else {
                             str(ol["officer"].id): {
+                                "workload": ol["workload"],  # TỔNG (cổng an toàn)
+                                "dist_load": ol["dist_load"],  # =tổng khi flag OFF
                                 "real_util": round(ol["real_util"], 4),
                                 "eff_util": round(ol["eff_util"], 4),
                                 "weight": ol["weight"],

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -43,11 +43,27 @@ def _non_final_status_filter():
     )
 
 
-# Các method = SỰ KIỆN (RE-)PHÂN CÔNG (cách officer CÓ lead). PHÂN BIỆT với hành
-# động STATUS giữ nguyên officer: officer_reject (từ chối, giữ officer + non-final
-# sts04) và offering_change_unit_synced (keep-sync đổi ngành) — hai cái này KHÔNG
-# đổi "nguồn sở hữu" nên KHÔNG được reset phân loại tự-tuyển. officer_reassign nulls
-# officer nên không bao giờ match (assigned_officer_id đã NULL).
+# _ASSIGNMENT_SOURCE_METHODS = method của SỰ KIỆN (RE-)PHÂN CÔNG (cách officer CÓ
+# lead). _self_sourced_subquery chỉ xét bản ghi có method này cho "latest", BỎ QUA
+# status-action / keep-sync giữ nguyên officer (chúng KHÔNG đổi "nguồn sở hữu").
+#
+# ⚠️ AUDIT 7 write-site models.AssignmentLog(method=...) (11-07):
+#  SOURCE (whitelist): 'automatic' · 'manual' · 'manual_reassignment' · (defensive)
+#    'system_auto_reassign'.
+#  NON-SOURCE (loại đúng — KHÔNG reset phân loại):
+#   - 'offering_change_unit_synced' (keep-sync đổi ngành, GIỮ officer + non-final):
+#     case LUÔN load-bearing.
+#   - 'officer_reject' (process_officer_action reject, GIỮ officer): thành non-final
+#     qua get_rejected_status()→None→fallback consultation_status_id=None (prod: 0
+#     status legacy='rejected'+is_final=true → luôn None), hoặc FINAL nếu env có
+#     status đó (khi đó lead rớt khỏi workload, việc loại thành no-op). Prod scope
+#     officer_reject-as-latest hiện = 0 lead.
+#  DEAD-nhưng-defensive: 'officer_reassign' + 'system_auto_reassign' đều NULL/đổi
+#    assigned_officer_id nên KHÔNG BAO GIỜ correlate (al.officer_id==assigned) — vô
+#    hại, giữ để rõ ý "source".
+# ⚠️ THÊM method mới (re-)assign lead cho officer + giữ non-final ⇒ PHẢI thêm vào
+#    đây; quên → lead phân phối bị coi self-sourced → OVER-GRANT (UNSAFE). Ghim bởi
+#    test_assignment_source_methods_documented.
 _ASSIGNMENT_SOURCE_METHODS = (
     "automatic",
     "manual",
@@ -65,10 +81,11 @@ def _self_sourced_subquery():
     Tự tuyển = latest (assignment-source) method='manual' VÀ ``reason`` do một
     OFFICER khởi tạo. Mọi thứ khác — 'automatic', reassign, manual do admin/manager
     chỉ định (phân phối), hay không có log — đều KHÔNG phải tự tuyển ⇒ tính vào tải
-    đã-chia. ⚠️ officer_reject/offering_change_unit_synced KHÔNG reset (nếu xét MỌI
-    log, self-sourced lead bị officer reject sẽ hoá đã-chia OAN → giảm suất officer,
-    ngược ý đồ). Dùng khi ``exclude_active`` để loại lead tự tuyển khỏi CƠ SỞ SẮP
-    XẾP (real_util/eff_util), KHÔNG khỏi tổng workload.
+    đã-chia. ⚠️ offering_change_unit_synced (keep-sync, LUÔN giữ officer + non-final)
+    và officer_reject KHÔNG reset phân loại (nếu xét MỌI log, self-sourced lead sau
+    các action đó hoá đã-chia OAN → giảm suất officer, ngược ý đồ) — xem
+    ``_ASSIGNMENT_SOURCE_METHODS``. Dùng khi ``exclude_active`` để loại lead tự tuyển
+    khỏi CƠ SỞ SẮP XẾP (real_util/eff_util), KHÔNG khỏi tổng workload.
 
     ⚠️ NGỮ NGHĨA (latent): pattern chỉ kiểm VAI TRÒ người-gán = officer, KHÔNG kiểm
     assigner == assigned_officer_id. Hôm nay AN TOÀN vì officer-create ép

--- a/Backend_FastAPI/tests/services/conftest.py
+++ b/Backend_FastAPI/tests/services/conftest.py
@@ -617,11 +617,14 @@ async def deleted_lead_with_phone(
 
 
 class MockWorkloadRow:
-    """Row shape returned by the BƯỚC 3 workload GROUP BY query."""
+    """Row shape returned by the BƯỚC 3 workload GROUP BY query. ``self_cnt`` chỉ
+    có mặt khi exclude_active (COUNT FILTER tự-tuyển gộp vào cùng query); default 0
+    để test không dùng exclude giữ nguyên."""
 
-    def __init__(self, assigned_officer_id, workload):
+    def __init__(self, assigned_officer_id, workload, self_cnt=0):
         self.assigned_officer_id = assigned_officer_id
         self.workload = workload
+        self.self_cnt = self_cnt
 
 
 @pytest.fixture

--- a/Backend_FastAPI/tests/services/test_assignment.py
+++ b/Backend_FastAPI/tests/services/test_assignment.py
@@ -24,6 +24,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from app import models
 from app.config import settings
+from app.core.task_constants import AssignmentFailureReason
 from app.services import assignment_service
 from app.services.status_helper import AssignmentStatus
 
@@ -326,7 +327,8 @@ async def test_matrix_member_on_weight_gets_more(
     """member ON, fairness OFF. Hai officer CÙNG workload dương bằng nhau (4/10 —
     không dùng 0 vì eff_util đều 0 thì weight vô nghĩa). officer_2 weight=2 ⇒
     eff_util = 4/(10*2)=0.2 < officer_1 eff_util 0.4 ⇒ officer_2 được chọn.
-    Cũng kiểm audit contract: scores_snapshot là dict {real_util,eff_util,weight,score}.
+    Cũng kiểm audit contract: scores_snapshot là dict
+    {workload,dist_load,real_util,eff_util,weight,score}.
     """
     monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
     monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
@@ -348,11 +350,16 @@ async def test_matrix_member_on_weight_gets_more(
     snap = decision.scores_snapshot
     assert set(snap.keys()) == {"101", "102"}
     for v in snap.values():
-        assert set(v.keys()) == {"real_util", "eff_util", "weight", "score"}
+        assert set(v.keys()) == {
+            "workload", "dist_load", "real_util", "eff_util", "weight", "score",
+        }
     # real_util KHÔNG nhân weight (bằng nhau); eff_util có nhân weight.
     assert snap["101"]["real_util"] == snap["102"]["real_util"] == 0.4
     assert snap["102"]["eff_util"] < snap["101"]["eff_util"]
     assert snap["102"]["weight"] == 2
+    # flag EXCLUDE_SELF_SOURCED OFF (mặc định) ⇒ dist_load == workload.
+    assert snap["101"]["dist_load"] == snap["101"]["workload"] == 4
+    assert snap["102"]["dist_load"] == snap["102"]["workload"] == 4
 
 
 @pytest.mark.asyncio
@@ -455,3 +462,136 @@ async def test_matrix_fairness_and_member_insufficient_history_falls_back(
 
     assert lead_new.assigned_officer_id == officer_2.id
     assert _decision_log(mock_db_session).reason == "member_weighted"
+
+
+# =====================================================================
+# Self-sourced exclusion (ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED)
+# =====================================================================
+# BƯỚC 3b query self_map chạy khi flag ON ⇒ side_effect THÊM 1 phần tử
+# (_self_result) so với khi OFF. real_util/eff_util (khóa SẮP XẾP) đổi sang
+# dist_load = workload − self_cnt; cổng `overloaded` + gate `workload <
+# capacity` VẪN theo TỔNG workload. (Subquery tương quan thật kiểm ở
+# test_assignment_self_sourced.py — mock ở đây inject self_map trực tiếp.)
+
+
+class MockSelfRow:
+    """Row shape của self_stmt GROUP BY (BƯỚC 3b). GROUP BY BỎ officer self_cnt=0
+    (không có row) ⇒ chỉ liệt kê officer CÓ lead tự tuyển."""
+
+    def __init__(self, assigned_officer_id, self_cnt):
+        self.assigned_officer_id = assigned_officer_id
+        self.self_cnt = self_cnt
+
+
+def _self_result(rows):
+    # BƯỚC 3b iterates the result directly (`for row in self_results`).
+    return list(rows)
+
+
+@pytest.mark.asyncio
+async def test_self_sourced_flag_off_is_regression_safe(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """Flag OFF (mặc định) ⇒ self_stmt KHÔNG chạy: side_effect chỉ 3 phần tử
+    vẫn đủ (service cố query self_map sẽ HẾT side_effect → lỗi). Kết quả y hệt
+    member mode hôm nay: officer_2 (tải 2) thắng officer_1 (tải 5)."""
+    monkeypatch.setattr(settings, "ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED", False)
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    officer_1.assignment_weight = 1
+    officer_2.assignment_weight = 1
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([MockWorkloadRow(101, 5), MockWorkloadRow(102, 2)]),
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    assert lead_new.assigned_officer_id == officer_2.id
+
+
+@pytest.mark.asyncio
+async def test_self_sourced_flips_winner_to_high_selftuyen_officer(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """member + flag ON. officer_1 tải TỔNG cao hơn (7) nhưng phần lớn tự tuyển
+    (self=5 ⇒ dist=2); officer_2 tải 4 toàn đã-chia (self=0 ⇒ dist=4). Khóa SẮP
+    XẾP theo dist ⇒ officer_1 (eff dist 0.2) THẮNG officer_2 (0.4) — NGƯỢC với
+    khi không loại tự tuyển (eff TỔNG 0.7 vs 0.4 ⇒ officer_2 thắng). Cả hai CHƯA
+    overloaded (0.7/0.4 < 0.8). Audit: snapshot có dist_load + workload=TỔNG."""
+    monkeypatch.setattr(settings, "ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED", True)
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    officer_1.assignment_weight = 1
+    officer_2.assignment_weight = 1
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([MockWorkloadRow(101, 7), MockWorkloadRow(102, 4)]),
+        _self_result([MockSelfRow(101, 5)]),  # officer_2 self=0 ⇒ KHÔNG có row
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    assert lead_new.assigned_officer_id == officer_1.id
+    decision = _decision_log(mock_db_session)
+    assert decision.reason == "member_weighted"
+    snap = decision.scores_snapshot
+    # dist_load vào snapshot (audit §3.5); workload GIỮ = TỔNG
+    assert snap["101"]["dist_load"] == 2 and snap["101"]["workload"] == 7
+    assert snap["102"]["dist_load"] == 4 and snap["102"]["workload"] == 4
+    assert snap["101"]["eff_util"] < snap["102"]["eff_util"]
+
+
+@pytest.mark.asyncio
+async def test_self_sourced_safety_gate_still_uses_total(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """flag ON. officer_1 tự tuyển GẦN HẾT: tổng 9 (self=9 ⇒ dist=0 ⇒ eff thấp
+    nhất) NHƯNG tổng 9/10=0.9 ≥ 0.8 ⇒ overloaded (theo TỔNG) ⇒ bị đẩy sau.
+    officer_2 tải 4, dist 4, không overloaded ⇒ THẮNG dù eff dist cao hơn. Chứng
+    minh cổng an toàn đọc TỔNG chứ không đọc dist_load."""
+    monkeypatch.setattr(settings, "ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED", True)
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    officer_1.assignment_weight = 1
+    officer_2.assignment_weight = 1
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([MockWorkloadRow(101, 9), MockWorkloadRow(102, 4)]),
+        _self_result([MockSelfRow(101, 9)]),
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    assert lead_new.assigned_officer_id == officer_2.id
+
+
+@pytest.mark.asyncio
+async def test_self_sourced_capacity_gate_still_uses_total(
+    monkeypatch, mock_db_session, lead_new, officer_1
+):
+    """flag ON. Officer DUY NHẤT có tổng == capacity (10/10) dù TOÀN tự tuyển
+    (self=10 ⇒ dist=0). Gate còn-capacity đọc dist (0<10) thì officer được nhận;
+    nhưng gate đọc TỔNG (10<10 sai) ⇒ bị loại ⇒ FAILED/AT_CAPACITY."""
+    monkeypatch.setattr(settings, "ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED", True)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1]),
+        _workload_result([MockWorkloadRow(101, 10)]),
+        _self_result([MockSelfRow(101, 10)]),
+    ]
+
+    result, _ = await assignment_service.automatically_assign_lead(
+        lead_new.id, mock_db_session
+    )
+
+    assert lead_new.assignment_status == AssignmentStatus.FAILED
+    assert result["reason"] == AssignmentFailureReason.AT_CAPACITY

--- a/Backend_FastAPI/tests/services/test_assignment.py
+++ b/Backend_FastAPI/tests/services/test_assignment.py
@@ -585,3 +585,103 @@ async def test_self_sourced_capacity_gate_still_uses_total(
 
     assert lead_new.assignment_status == AssignmentStatus.FAILED
     assert result["reason"] == AssignmentFailureReason.AT_CAPACITY
+
+
+@pytest.mark.asyncio
+async def test_self_sourced_fairness_mode_uses_dist(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """fairness ON + member OFF + exclude ON ⇒ exclude_active True ⇒ real_util
+    DIST-based ⇒ score=0.6*real_util+0.4*share. officer_1 tổng 7 nhưng tự tuyển 5
+    (dist=2 ⇒ real_util 0.2) THẮNG officer_2 (dist=4 ⇒ 0.4) — NGƯỢC nếu real_util
+    theo tổng (0.7 vs 0.4 ⇒ officer_2). share cân (5/5, hist=10≥10 ⇒ fairness không
+    fallback legacy). Ghim mode 'winner có thể lật'."""
+    monkeypatch.setattr(settings, "ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED", True)
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", True)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", False)
+    officer_1.assignment_weight = 1
+    officer_2.assignment_weight = 1
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result(
+            [MockWorkloadRow(101, 7, self_cnt=5), MockWorkloadRow(102, 4, self_cnt=0)]
+        ),
+        _hist_result([MockHistRow(101, 5), MockHistRow(102, 5)]),  # total=10
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    assert lead_new.assigned_officer_id == officer_1.id
+    assert _decision_log(mock_db_session).reason == "fairness_weighted"
+
+
+@pytest.mark.asyncio
+async def test_self_sourced_member_fairness_mode_uses_dist(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """member+fairness ON + exclude ON, đủ pool-history ⇒ member_fairness:
+    score=0.6*eff_util+0.4*(actual_share−target_share), eff_util DIST-based.
+    officer_1 dist=2 (eff 0.2) THẮNG officer_2 dist=4 (0.4); share cân (6/6, pool
+    hist 12≥10, pressure≈0). Ghim mode phức tạp nhất + dist-based eff_util."""
+    monkeypatch.setattr(settings, "ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED", True)
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", True)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    officer_1.assignment_weight = 1
+    officer_2.assignment_weight = 1
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result(
+            [MockWorkloadRow(101, 7, self_cnt=5), MockWorkloadRow(102, 4, self_cnt=0)]
+        ),
+        _hist_result([MockHistRow(101, 6), MockHistRow(102, 6)]),  # pool=12≥10
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    assert lead_new.assigned_officer_id == officer_1.id
+    assert _decision_log(mock_db_session).reason == "member_fairness_weighted"
+
+
+def test_assignment_source_methods_documented():
+    """Ghim taxonomy `_ASSIGNMENT_SOURCE_METHODS` + QUÉT write-site: mọi method
+    literal ghi vào AssignmentLog (assignment_service + lead_service) PHẢI được phân
+    loại (source hoặc known-non-source). Thêm method mới (re-)assign giữ-officer ⇒
+    thêm whitelist + đây; quên → lead phân phối bị coi self-sourced → OVER-GRANT
+    (UNSAFE, finding F3-1)."""
+    import re
+    from pathlib import Path
+
+    import app.services.assignment_service as asvc
+    import app.services.lead_service as lsvc
+    from app.services.assignment_service import _ASSIGNMENT_SOURCE_METHODS
+
+    assert set(_ASSIGNMENT_SOURCE_METHODS) == {
+        "automatic", "manual", "manual_reassignment", "system_auto_reassign",
+    }
+    known_non_source = {
+        "officer_reject",               # status-action, giữ officer
+        "offering_change_unit_synced",  # keep-sync đổi ngành, giữ officer
+        "officer_reassign",             # nulls officer
+    }
+    assert not (set(_ASSIGNMENT_SOURCE_METHODS) & known_non_source)
+
+    all_known = set(_ASSIGNMENT_SOURCE_METHODS) | known_non_source
+    found: set = set()
+    for mod in (asvc, lsvc):
+        lines = Path(mod.__file__).read_text(encoding="utf-8").splitlines()
+        for idx, ln in enumerate(lines):
+            if "AssignmentLog(" in ln:  # KHÔNG match AssignmentDecisionLog(
+                block = "\n".join(lines[idx:idx + 8])
+                found |= set(re.findall(r'method\s*=\s*"([a-z_]+)"', block))
+        found |= set(re.findall(r'log_method\s*=\s*"([a-z_]+)"', "\n".join(lines)))
+    unknown = found - all_known
+    assert not unknown, (
+        "Method AssignmentLog chưa phân loại (thêm vào _ASSIGNMENT_SOURCE_METHODS "
+        f"nếu là (re-)assign giữ-officer, hoặc known_non_source): {unknown}"
+    )
+    # sanity: scan thật sự bắt được các method lõi
+    assert {"automatic", "manual", "officer_reject"} <= found

--- a/Backend_FastAPI/tests/services/test_assignment.py
+++ b/Backend_FastAPI/tests/services/test_assignment.py
@@ -467,34 +467,22 @@ async def test_matrix_fairness_and_member_insufficient_history_falls_back(
 # =====================================================================
 # Self-sourced exclusion (ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED)
 # =====================================================================
-# BƯỚC 3b query self_map chạy khi flag ON ⇒ side_effect THÊM 1 phần tử
-# (_self_result) so với khi OFF. real_util/eff_util (khóa SẮP XẾP) đổi sang
-# dist_load = workload − self_cnt; cổng `overloaded` + gate `workload <
-# capacity` VẪN theo TỔNG workload. (Subquery tương quan thật kiểm ở
-# test_assignment_self_sourced.py — mock ở đây inject self_map trực tiếp.)
-
-
-class MockSelfRow:
-    """Row shape của self_stmt GROUP BY (BƯỚC 3b). GROUP BY BỎ officer self_cnt=0
-    (không có row) ⇒ chỉ liệt kê officer CÓ lead tự tuyển."""
-
-    def __init__(self, assigned_officer_id, self_cnt):
-        self.assigned_officer_id = assigned_officer_id
-        self.self_cnt = self_cnt
-
-
-def _self_result(rows):
-    # BƯỚC 3b iterates the result directly (`for row in self_results`).
-    return list(rows)
+# self_cnt GỘP vào workload query (COUNT FILTER) khi exclude_active = flag ON +
+# (member hoặc fairness) ⇒ side_effect KHÔNG thêm phần tử; workload row mang thêm
+# self_cnt (MockWorkloadRow(..., self_cnt=N)). real_util/eff_util (khóa SẮP XẾP)
+# đổi sang dist_load = workload − self_cnt; cổng `overloaded` + gate `workload <
+# capacity` VẪN theo TỔNG workload. Cả 2 weighted flag OFF (legacy) ⇒
+# exclude_active=False ⇒ self_cnt bỏ qua (feature no-op ở legacy). Subquery +
+# query gộp FILTER kiểm trên DB THẬT ở test_assignment_self_sourced.py.
 
 
 @pytest.mark.asyncio
 async def test_self_sourced_flag_off_is_regression_safe(
     monkeypatch, mock_db_session, lead_new, officer_1, officer_2
 ):
-    """Flag OFF (mặc định) ⇒ self_stmt KHÔNG chạy: side_effect chỉ 3 phần tử
-    vẫn đủ (service cố query self_map sẽ HẾT side_effect → lỗi). Kết quả y hệt
-    member mode hôm nay: officer_2 (tải 2) thắng officer_1 (tải 5)."""
+    """Flag OFF (mặc định) ⇒ exclude_active False ⇒ workload query KHÔNG có cột
+    self_cnt: side_effect 3 phần tử vẫn đủ. Kết quả y hệt member mode hôm nay:
+    officer_2 (tải 2) thắng officer_1 (tải 5)."""
     monkeypatch.setattr(settings, "ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED", False)
     monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
     monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
@@ -530,8 +518,9 @@ async def test_self_sourced_flips_winner_to_high_selftuyen_officer(
     mock_db_session.execute.side_effect = [
         _lead_result(lead_new),
         _officers_result([officer_1, officer_2]),
-        _workload_result([MockWorkloadRow(101, 7), MockWorkloadRow(102, 4)]),
-        _self_result([MockSelfRow(101, 5)]),  # officer_2 self=0 ⇒ KHÔNG có row
+        _workload_result(
+            [MockWorkloadRow(101, 7, self_cnt=5), MockWorkloadRow(102, 4, self_cnt=0)]
+        ),
     ]
 
     await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
@@ -563,8 +552,9 @@ async def test_self_sourced_safety_gate_still_uses_total(
     mock_db_session.execute.side_effect = [
         _lead_result(lead_new),
         _officers_result([officer_1, officer_2]),
-        _workload_result([MockWorkloadRow(101, 9), MockWorkloadRow(102, 4)]),
-        _self_result([MockSelfRow(101, 9)]),
+        _workload_result(
+            [MockWorkloadRow(101, 9, self_cnt=9), MockWorkloadRow(102, 4, self_cnt=0)]
+        ),
     ]
 
     await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
@@ -581,12 +571,12 @@ async def test_self_sourced_capacity_gate_still_uses_total(
     nhưng gate đọc TỔNG (10<10 sai) ⇒ bị loại ⇒ FAILED/AT_CAPACITY."""
     monkeypatch.setattr(settings, "ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED", True)
     monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    officer_1.max_capacity = 10  # tường minh: gate workload(10) < capacity(10) = False
 
     mock_db_session.execute.side_effect = [
         _lead_result(lead_new),
         _officers_result([officer_1]),
-        _workload_result([MockWorkloadRow(101, 10)]),
-        _self_result([MockSelfRow(101, 10)]),
+        _workload_result([MockWorkloadRow(101, 10, self_cnt=10)]),
     ]
 
     result, _ = await assignment_service.automatically_assign_lead(

--- a/Backend_FastAPI/tests/services/test_assignment_self_sourced.py
+++ b/Backend_FastAPI/tests/services/test_assignment_self_sourced.py
@@ -110,11 +110,13 @@ def _count_stmt(officer_ids, *extra_where):
 
 
 async def test_self_sourced_subquery_classification(db, seeded_dependencies):
-    """7 lead non-final gán cho 1 officer, đủ 7 tình huống latest-log. Đếm tự-tuyển
-    = A + E + G (latest-ASSIGNMENT là manual 'by officer') = 3; self_cnt ≤ workload
-    (bất biến ⇒ balance_load ≥ 0). Kiểm CẢ subquery-WHERE LẪN COUNT-FILTER gộp."""
+    """officer1: 8 lead non-final, 8 tình huống latest-log ⇒ tự-tuyển = A+E+G+H
+    (latest-ASSIGNMENT là manual 'by officer') = 4. officer2: 1 lead (I) chứng minh
+    correlation officer_id — log 'by officer' của officer1 KHÔNG lọt sang officer2.
+    self_cnt ≤ workload. Kiểm CẢ subquery-WHERE LẪN COUNT-FILTER gộp."""
     deps = seeded_dependencies
     officer = await _mk_officer(db, deps["unit_id"], "clf")
+    officer2 = await _mk_officer(db, deps["unit_id"], "clf2")
     t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
     # A: manual by officer (TỰ TUYỂN) ✓
@@ -158,15 +160,37 @@ async def test_self_sourced_subquery_classification(db, seeded_dependencies):
         db, g, officer, "officer_reject", "Officer từ chối", t0 + timedelta(days=1)
     )
 
-    # (1) subquery làm WHERE — đếm số dòng tự tuyển
-    workload = {
-        r[0]: r[1] for r in (await db.execute(_count_stmt([officer.id]))).all()
-    }
+    # H: manual by officer (cũ) → offering_change_unit_synced (mới, keep-sync đổi
+    # ngành, GIỮ officer + non-final) ⇒ KHÔNG phải assignment-source ⇒ latest-
+    # assignment = manual by officer ⇒ VẪN tự tuyển ✓ (nửa còn lại của fix P2 —
+    # case LUÔN load-bearing).
+    h = await _mk_lead(db, deps, officer, "0940000008")
+    await _log(db, h, officer, "manual",
+               _REASON_SELF_CREATE.format(u=officer.username), t0)
+    await _log(
+        db, h, officer, "offering_change_unit_synced", "Đổi ngành",
+        t0 + timedelta(days=1)
+    )
+
+    # I (CROSS-OFFICER): lead nay gán OFFICER2 nhưng có log 'by officer' của
+    # OFFICER1 (t0) rồi manual_reassignment sang officer2 (t1). Subquery của officer2
+    # (correlate al.officer_id==assigned=officer2) chỉ thấy log officer2 = reassign ⇒
+    # KHÔNG tự tuyển; log 'by officer' của officer1 KHÔNG lọt (chứng minh correlation
+    # officer_id không bị đếm nhầm sang officer khác).
+    i_lead = await _mk_lead(db, deps, officer2, "0940000009")
+    await _log(db, i_lead, officer, "manual",
+               _REASON_SELF_CREATE.format(u=officer.username), t0)
+    await _log(
+        db, i_lead, officer2, "manual_reassignment", "reassign→officer2",
+        t0 + timedelta(days=1)
+    )
+
+    ids = [officer.id, officer2.id]
+    # (1) subquery làm WHERE — đếm số dòng tự tuyển, theo officer
+    workload = {r[0]: r[1] for r in (await db.execute(_count_stmt(ids))).all()}
     self_where = {
         r[0]: r[1]
-        for r in (
-            await db.execute(_count_stmt([officer.id], _self_sourced_subquery()))
-        ).all()
+        for r in (await db.execute(_count_stmt(ids, _self_sourced_subquery()))).all()
     }
     # (2) PRODUCTION path: COUNT(id) FILTER(_self_sourced_subquery()) GỘP 1 query
     filter_stmt = (
@@ -183,15 +207,22 @@ async def test_self_sourced_subquery_classification(db, seeded_dependencies):
             isouter=True,
         )
         .where(
-            models.Lead.assigned_officer_id == officer.id,
+            models.Lead.assigned_officer_id.in_(ids),
             models.Lead.deleted_at.is_(None),
             _non_final_status_filter(),
         )
         .group_by(models.Lead.assigned_officer_id)
     )
-    frow = (await db.execute(filter_stmt)).one()
+    frows = {r.assigned_officer_id: r for r in (await db.execute(filter_stmt)).all()}
 
-    assert workload[officer.id] == 7                   # tất cả 7 lead non-final
-    assert self_where.get(officer.id, 0) == 3          # subquery-WHERE: A + E + G
-    assert frow.workload == 7 and frow.self_cnt == 3   # FILTER gộp khớp
-    assert frow.self_cnt <= frow.workload              # bất biến subset (cấu trúc)
+    # officer1: 8 lead, tự tuyển A+E+G+H = 4 (officer_reject + offering-sync ko reset)
+    assert workload[officer.id] == 8
+    assert self_where.get(officer.id, 0) == 4
+    assert frows[officer.id].workload == 8 and frows[officer.id].self_cnt == 4
+    # officer2: 1 lead (I) — correlation officer_id ⇒ log 'by officer' của officer1
+    # KHÔNG lọt sang officer2 ⇒ self_cnt = 0
+    assert workload[officer2.id] == 1
+    assert self_where.get(officer2.id, 0) == 0
+    assert frows[officer2.id].workload == 1 and frows[officer2.id].self_cnt == 0
+    # bất biến subset cấu trúc
+    assert all(fr.self_cnt <= fr.workload for fr in frows.values())

--- a/Backend_FastAPI/tests/services/test_assignment_self_sourced.py
+++ b/Backend_FastAPI/tests/services/test_assignment_self_sourced.py
@@ -1,13 +1,13 @@
 # tests/services/test_assignment_self_sourced.py
 # -*- coding: utf-8 -*-
-"""Real-DB test cho ``_self_sourced_subquery`` (BƯỚC 3b của auto-assign).
+"""Real-DB test cho ``_self_sourced_subquery`` + query GỘP COUNT-FILTER (BƯỚC 3).
 
-Mock-suite (test_assignment.py) inject ``self_map`` trực tiếp nên KHÔNG chạy
-subquery tương quan thật. File này seed lead + assignment_log THẬT rồi execute
-đúng ``self_stmt`` để chốt: chỉ lead 'manual' + reason 'by officer' (bản ghi mới
-nhất của officer hiện tại) mới bị loại; admin-manual / automatic / không-log /
-reassign-mới-nhất đều tính đã-chia. Ghim coupling định dạng ``reason`` ở
-lead_service.py (create+direct-assign).
+Mock-suite (test_assignment.py) inject self_cnt trực tiếp nên KHÔNG chạy subquery
+tương quan / FILTER thật. File này seed lead + assignment_log THẬT rồi execute cả
+subquery (làm WHERE) LẪN production path ``COUNT(id) FILTER(_self_sourced_subquery)``
+để chốt: chỉ lead 'manual' + reason 'by officer' (bản ghi MỚI NHẤT của officer
+hiện tại) mới bị loại; admin-manual / automatic / không-log / reassign-mới-nhất
+đều tính đã-chia.
 
 Chạy one-off container (CLAUDE.md) — seed DB thật.
 """
@@ -17,6 +17,7 @@ import pytest
 from sqlalchemy import func, select
 
 from app import models
+from app.core.constants import UserRole
 from app.security import get_password_hash
 from app.services.assignment_service import (
     _non_final_status_filter,
@@ -25,10 +26,15 @@ from app.services.assignment_service import (
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
-# ⚠️ PHẢI khớp reason sinh ở lead_service.py (create+direct-assign ~1179 và
-# assign_lead_to_officer ~2350) — _self_sourced_subquery lọc ILIKE '%by officer %'.
-# Đổi chữ "by officer" ở lead_service mà quên chỗ này ⇒ test đỏ.
-_REASON_SELF_CREATE = "Assigned during lead creation by officer {u}"
+# ⚠️ COUPLING: reason phải khớp cái lead_service.py sinh (create+direct-assign
+# ~1179 + assign_lead_to_officer ~2350) và pattern ILIKE '%by officer %' của
+# _self_sourced_subquery. Role token DERIVE từ UserRole.OFFICER (StrEnum→'officer')
+# ⇒ ĐỔI GIÁ TRỊ enum mà quên pattern subquery → reason không chứa 'by officer ' →
+# self_cnt=0 ≠ 2 → TEST ĐỎ (ghim role-value drift). ⚠️ Giới hạn: template prefix
+# "Assigned during lead creation by" hardcode ở đây → KHÔNG bắt nếu lead_service đổi
+# RIÊNG câu prefix (hướng no-op an toàn). Ghim đủ cần extract prefix ra hằng chung —
+# hoãn (out of scope flag-OFF).
+_REASON_SELF_CREATE = f"Assigned during lead creation by {UserRole.OFFICER} " + "{u}"
 _REASON_ADMIN_ASSIGN = "Manually assigned by admin {u}"
 
 
@@ -104,9 +110,9 @@ def _count_stmt(officer_ids, *extra_where):
 
 
 async def test_self_sourced_subquery_classification(db, seeded_dependencies):
-    """6 lead non-final gán cho 1 officer, đủ 6 tình huống latest-log. self_stmt
-    chỉ đếm A + E (manual 'by officer' là bản ghi mới nhất) = 2; self_cnt ≤
-    workload (bất biến ⇒ balance_load ≥ 0)."""
+    """6 lead non-final gán cho 1 officer, đủ 6 tình huống latest-log. Đếm tự-tuyển
+    = A + E (manual 'by officer' là bản ghi mới nhất) = 2; self_cnt ≤ workload (bất
+    biến ⇒ balance_load ≥ 0). Kiểm CẢ subquery-làm-WHERE LẪN COUNT-FILTER gộp."""
     deps = seeded_dependencies
     officer = await _mk_officer(db, deps["unit_id"], "clf")
     t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
@@ -142,16 +148,40 @@ async def test_self_sourced_subquery_classification(db, seeded_dependencies):
         db, f, officer, "manual_reassignment", "reassigned", t0 + timedelta(days=1)
     )
 
+    # (1) subquery làm WHERE — đếm số dòng tự tuyển
     workload = {
         r[0]: r[1] for r in (await db.execute(_count_stmt([officer.id]))).all()
     }
-    self_map = {
+    self_where = {
         r[0]: r[1]
         for r in (
             await db.execute(_count_stmt([officer.id], _self_sourced_subquery()))
         ).all()
     }
+    # (2) PRODUCTION path: COUNT(id) FILTER(_self_sourced_subquery()) GỘP 1 query
+    filter_stmt = (
+        select(
+            models.Lead.assigned_officer_id,
+            func.count(models.Lead.id).label("workload"),
+            func.count(models.Lead.id)
+            .filter(_self_sourced_subquery())
+            .label("self_cnt"),
+        )
+        .join(
+            models.ConsultationStatus,
+            models.Lead.consultation_status_id == models.ConsultationStatus.id,
+            isouter=True,
+        )
+        .where(
+            models.Lead.assigned_officer_id == officer.id,
+            models.Lead.deleted_at.is_(None),
+            _non_final_status_filter(),
+        )
+        .group_by(models.Lead.assigned_officer_id)
+    )
+    frow = (await db.execute(filter_stmt)).one()
 
-    assert workload[officer.id] == 6           # tất cả 6 lead non-final
-    assert self_map.get(officer.id, 0) == 2    # chỉ A + E
-    assert self_map.get(officer.id, 0) <= workload[officer.id]  # bất biến subset
+    assert workload[officer.id] == 6                   # tất cả 6 lead non-final
+    assert self_where.get(officer.id, 0) == 2          # subquery-WHERE: chỉ A + E
+    assert frow.workload == 6 and frow.self_cnt == 2   # FILTER gộp khớp
+    assert frow.self_cnt <= frow.workload              # bất biến subset (cấu trúc)

--- a/Backend_FastAPI/tests/services/test_assignment_self_sourced.py
+++ b/Backend_FastAPI/tests/services/test_assignment_self_sourced.py
@@ -1,0 +1,157 @@
+# tests/services/test_assignment_self_sourced.py
+# -*- coding: utf-8 -*-
+"""Real-DB test cho ``_self_sourced_subquery`` (BƯỚC 3b của auto-assign).
+
+Mock-suite (test_assignment.py) inject ``self_map`` trực tiếp nên KHÔNG chạy
+subquery tương quan thật. File này seed lead + assignment_log THẬT rồi execute
+đúng ``self_stmt`` để chốt: chỉ lead 'manual' + reason 'by officer' (bản ghi mới
+nhất của officer hiện tại) mới bị loại; admin-manual / automatic / không-log /
+reassign-mới-nhất đều tính đã-chia. Ghim coupling định dạng ``reason`` ở
+lead_service.py (create+direct-assign).
+
+Chạy one-off container (CLAUDE.md) — seed DB thật.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import func, select
+
+from app import models
+from app.security import get_password_hash
+from app.services.assignment_service import (
+    _non_final_status_filter,
+    _self_sourced_subquery,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+# ⚠️ PHẢI khớp reason sinh ở lead_service.py (create+direct-assign ~1179 và
+# assign_lead_to_officer ~2350) — _self_sourced_subquery lọc ILIKE '%by officer %'.
+# Đổi chữ "by officer" ở lead_service mà quên chỗ này ⇒ test đỏ.
+_REASON_SELF_CREATE = "Assigned during lead creation by officer {u}"
+_REASON_ADMIN_ASSIGN = "Manually assigned by admin {u}"
+
+
+async def _mk_officer(db, unit_id, tag):
+    u = models.User(
+        username=f"ss_{tag}",
+        email=f"ss_{tag}@test.com",
+        password_hash=get_password_hash("OfficerPass123!"),
+        role="officer",
+        status="active",
+        availability_status="available",
+        full_name=f"SelfSourced Officer {tag}",
+        unit_id=unit_id,
+        max_capacity=100,
+    )
+    db.add(u)
+    await db.flush()
+    await db.refresh(u)
+    return u
+
+
+async def _mk_lead(db, deps, officer, phone):
+    lead = models.Lead(
+        full_name="SS Lead",
+        phone=phone,
+        source="website",
+        unit_id=deps["unit_id"],
+        status=deps["initial_status_id"],
+        consultation_status_id=deps["initial_status_id"],  # non-final
+        pipeline_stage_id=deps["stage_id"],
+        assigned_officer_id=officer.id,
+        assigned_at=datetime.now(timezone.utc),
+    )
+    db.add(lead)
+    await db.flush()
+    await db.refresh(lead)
+    return lead
+
+
+async def _log(db, lead, officer, method, reason, ts):
+    db.add(
+        models.AssignmentLog(
+            lead_id=lead.id,
+            officer_id=officer.id,
+            method=method,
+            reason=reason,
+            timestamp=ts,
+        )
+    )
+    await db.flush()
+
+
+def _count_stmt(officer_ids, *extra_where):
+    stmt = (
+        select(
+            models.Lead.assigned_officer_id,
+            func.count(models.Lead.id),
+        )
+        .join(
+            models.ConsultationStatus,
+            models.Lead.consultation_status_id == models.ConsultationStatus.id,
+            isouter=True,
+        )
+        .where(
+            models.Lead.assigned_officer_id.in_(officer_ids),
+            models.Lead.deleted_at.is_(None),
+            _non_final_status_filter(),
+            *extra_where,
+        )
+        .group_by(models.Lead.assigned_officer_id)
+    )
+    return stmt
+
+
+async def test_self_sourced_subquery_classification(db, seeded_dependencies):
+    """6 lead non-final gán cho 1 officer, đủ 6 tình huống latest-log. self_stmt
+    chỉ đếm A + E (manual 'by officer' là bản ghi mới nhất) = 2; self_cnt ≤
+    workload (bất biến ⇒ balance_load ≥ 0)."""
+    deps = seeded_dependencies
+    officer = await _mk_officer(db, deps["unit_id"], "clf")
+    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    # A: manual by officer (TỰ TUYỂN) ✓
+    a = await _mk_lead(db, deps, officer, "0940000001")
+    await _log(db, a, officer, "manual",
+               _REASON_SELF_CREATE.format(u=officer.username), t0)
+
+    # B: manual by admin (đã-chia — admin gán tay) ✗
+    b = await _mk_lead(db, deps, officer, "0940000002")
+    await _log(db, b, officer, "manual",
+               _REASON_ADMIN_ASSIGN.format(u="admin1"), t0)
+
+    # C: automatic (đã-chia) ✗
+    c = await _mk_lead(db, deps, officer, "0940000003")
+    await _log(db, c, officer, "automatic", "Hệ thống phân công tự động", t0)
+
+    # D: KHÔNG có log (đã-chia — subquery NULL, fail-safe) ✗
+    await _mk_lead(db, deps, officer, "0940000004")
+
+    # E: automatic (cũ) → manual by officer (mới) ⇒ LATEST = self ✓
+    e = await _mk_lead(db, deps, officer, "0940000005")
+    await _log(db, e, officer, "automatic", "auto cũ", t0)
+    await _log(db, e, officer, "manual",
+               _REASON_SELF_CREATE.format(u=officer.username), t0 + timedelta(days=1))
+
+    # F: manual by officer (cũ) → reassignment (mới) ⇒ latest = đã-chia ✗
+    f = await _mk_lead(db, deps, officer, "0940000006")
+    await _log(db, f, officer, "manual",
+               _REASON_SELF_CREATE.format(u=officer.username), t0)
+    await _log(
+        db, f, officer, "manual_reassignment", "reassigned", t0 + timedelta(days=1)
+    )
+
+    workload = {
+        r[0]: r[1] for r in (await db.execute(_count_stmt([officer.id]))).all()
+    }
+    self_map = {
+        r[0]: r[1]
+        for r in (
+            await db.execute(_count_stmt([officer.id], _self_sourced_subquery()))
+        ).all()
+    }
+
+    assert workload[officer.id] == 6           # tất cả 6 lead non-final
+    assert self_map.get(officer.id, 0) == 2    # chỉ A + E
+    assert self_map.get(officer.id, 0) <= workload[officer.id]  # bất biến subset

--- a/Backend_FastAPI/tests/services/test_assignment_self_sourced.py
+++ b/Backend_FastAPI/tests/services/test_assignment_self_sourced.py
@@ -110,9 +110,9 @@ def _count_stmt(officer_ids, *extra_where):
 
 
 async def test_self_sourced_subquery_classification(db, seeded_dependencies):
-    """6 lead non-final gán cho 1 officer, đủ 6 tình huống latest-log. Đếm tự-tuyển
-    = A + E (manual 'by officer' là bản ghi mới nhất) = 2; self_cnt ≤ workload (bất
-    biến ⇒ balance_load ≥ 0). Kiểm CẢ subquery-làm-WHERE LẪN COUNT-FILTER gộp."""
+    """7 lead non-final gán cho 1 officer, đủ 7 tình huống latest-log. Đếm tự-tuyển
+    = A + E + G (latest-ASSIGNMENT là manual 'by officer') = 3; self_cnt ≤ workload
+    (bất biến ⇒ balance_load ≥ 0). Kiểm CẢ subquery-WHERE LẪN COUNT-FILTER gộp."""
     deps = seeded_dependencies
     officer = await _mk_officer(db, deps["unit_id"], "clf")
     t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
@@ -148,6 +148,16 @@ async def test_self_sourced_subquery_classification(db, seeded_dependencies):
         db, f, officer, "manual_reassignment", "reassigned", t0 + timedelta(days=1)
     )
 
+    # G: manual by officer (cũ) → officer_reject (mới, GIỮ officer + non-final) ⇒
+    # officer_reject KHÔNG phải assignment-source ⇒ latest-assignment = manual by
+    # officer ⇒ VẪN tự tuyển ✓ (khử P2: reject self-sourced lead không hoá đã-chia).
+    g = await _mk_lead(db, deps, officer, "0940000007")
+    await _log(db, g, officer, "manual",
+               _REASON_SELF_CREATE.format(u=officer.username), t0)
+    await _log(
+        db, g, officer, "officer_reject", "Officer từ chối", t0 + timedelta(days=1)
+    )
+
     # (1) subquery làm WHERE — đếm số dòng tự tuyển
     workload = {
         r[0]: r[1] for r in (await db.execute(_count_stmt([officer.id]))).all()
@@ -181,7 +191,7 @@ async def test_self_sourced_subquery_classification(db, seeded_dependencies):
     )
     frow = (await db.execute(filter_stmt)).one()
 
-    assert workload[officer.id] == 6                   # tất cả 6 lead non-final
-    assert self_where.get(officer.id, 0) == 2          # subquery-WHERE: chỉ A + E
-    assert frow.workload == 6 and frow.self_cnt == 2   # FILTER gộp khớp
+    assert workload[officer.id] == 7                   # tất cả 7 lead non-final
+    assert self_where.get(officer.id, 0) == 3          # subquery-WHERE: A + E + G
+    assert frow.workload == 7 and frow.self_cnt == 3   # FILTER gộp khớp
     assert frow.self_cnt <= frow.workload              # bất biến subset (cấu trúc)


### PR DESCRIPTION
## Mục tiêu
Auto-assign cân bằng chỉ dựa trên lead **đã-chia**; lead officer **TỰ TUYỂN** (tự tạo + tự nhận) không làm giảm suất nhận lead-chia. Giữ trần an toàn TỔNG để không quá tải thật. Backend-only, flag `ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED` **default OFF** ⇒ deploy = no-op cho tới khi bật.

## Cơ chế
- `dist_load = workload − self_cnt`. `real_util`/`eff_util` (khóa SẮP XẾP) tính trên `dist_load`; cổng `overloaded`, gate `workload < capacity`, và `is_officer_at_threshold` (referral fast-path) VẪN dùng TỔNG `workload` — self-tuyển/weight không phá trần.
- Phân loại "tự tuyển" = **SHARP**: bản ghi `assignment_log` (RE-)PHÂN CÔNG mới nhất của cặp (lead, officer) có `method='manual' AND reason 'by officer'`. Chỉ xét `_ASSIGNMENT_SOURCE_METHODS` (bỏ qua status-action `officer_reject` / keep-sync `offering_change_unit_synced` — chúng KHÔNG đổi nguồn sở hữu).
- Gộp `self_cnt` vào `workload_stmt` qua `COUNT(id) FILTER(...)` (1 round-trip; bất biến self_cnt≤workload = cấu trúc). Gate `exclude_active = flag AND (member OR fairness)` (no-op ở legacy).
- Migration + model index `ix_assignment_log_lead_officer_ts (lead_id, officer_id, timestamp DESC)` cho ORDER BY..LIMIT 1 của subquery.

Audit prod unit 14: 467/537 lead `manual` là officer tự tuyển, 70 là admin gán → Sharp loại đúng (naive loại oan 70).

## Chất lượng
- ✅ **2 vòng /code-review + 1 đánh giá mở rộng** (6 finder × verify × prod-check). **KHÔNG bug correctness cứng** — SQL verified end-to-end trên dữ liệu prod thật (self_cnt≤workload 213≤298; correlation khớp).
- Side-effect (dispatch notification / emit socket / sync consultation+assignment status / post-commit callback) **không bị ảnh hưởng** — refactor chỉ đổi cách TÍNH tải/xếp hạng + snapshot audit.
- Test: mock (regression flag-off · member/fairness/member_fairness+exclude · safety+capacity gate=TỔNG · whitelist-completeness quét write-site) + integration DB-thật (8 tình huống latest-log + cross-officer correlation). **21 test pass**, flake8 net-zero, migration roundtrip up/down/up verified.

### Findings đã chấp nhận (không sửa — flag OFF / pre-existing / audit-only)
real_util đổi-nghĩa dist-based khi flag ON (audit trap) · exclude_active vs legacy-fallback (comment) · member_fairness scale/weight-2-lần (pre-existing) · dead entry `system_auto_reassign` · CTV-referral judgment · id-index tie-break nit · reason-prefix coupling (chỉ ghim role-value; nên extract prefix ra hằng chung khi chuẩn bị BẬT flag prod).

## ⚠️ Merge-collision (deploy)
Migration `assignlogidx20260711` và nhánh in-flight `feat/admission-withdrawal-pending` (`wpend20260710`) **cùng `down_revision='zbmonthlyseed20260706'`** → khi CẢ HAI vào main = 2 alembic head → `alembic upgrade head` lúc deploy FAIL. **PR này merge ĐỘC LẬP thì OK** (main head vẫn zbmonthlyseed); khi merge nhánh thứ hai phải viết 1 `alembic merge` reconcile.

## Rollout
Deploy flag OFF = 0 thay đổi. Bật: env `ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED=true` cần **recreate** container (không phải restart). Rollback = tắt flag (không schema / không revert code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
