### PR TITLE
refactor(assignment): single-source reason token cho self-sourced (hardening #2)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -252,6 +252,8 @@ jobs:
           python -m pytest
           tests/api/test_admission_workflow_api.py
           tests/api/test_lead_assignment_api.py::test_lead_assignment_lifecycle_end_to_end
+          tests/services/test_assignment.py
+          tests/services/test_assignment_self_sourced.py
           tests/unit/test_admission_state_machine.py
           tests/unit/test_b2_1_admission_milestone_events.py
           tests/integration/test_delete_profile_revert.py

--- a/Backend_FastAPI/app/services/assignment_reason.py
+++ b/Backend_FastAPI/app/services/assignment_reason.py
@@ -1,0 +1,38 @@
+"""Single source of truth cho ``AssignmentLog.reason`` phục vụ phân loại
+self-sourced (officer tự tuyển).
+
+``assignment_service._self_sourced_subquery`` phân loại "officer TỰ TUYỂN" bằng
+cách match ``SELF_SOURCED_REASON_TOKEN`` trong ``reason``. ``reason`` được sinh bởi
+``build_assignment_reason()`` ở lead_service (create+direct-assign / assign tay).
+
+Gộp CẢ builder LẪN token ở MỘT nơi để producer (lead_service) và matcher
+(assignment_service) KHÔNG THỂ drift âm thầm — nếu drift, feature exclude-self-
+sourced sẽ no-op im lặng khi bật flag. Ghim bởi
+``test_self_sourced_reason_token_contract`` (assert builder-output-cho-officer
+CHỨA token). Refactor thuần: output byte-identical chuỗi reason cũ ⇒ dữ liệu prod
+hiện có vẫn khớp.
+"""
+from typing import TYPE_CHECKING
+
+from ..core.constants import UserRole
+
+if TYPE_CHECKING:
+    from .. import models
+
+# Substring CÓ MẶT trong reason khi người-gán là OFFICER (UserRole StrEnum ⇒
+# ``f"{UserRole.OFFICER}"`` = "officer" ⇒ token = "by officer "). Đây là thứ
+# ``_self_sourced_subquery`` match: ``reason ILIKE '%<token>%'``.
+SELF_SOURCED_REASON_TOKEN = f"by {UserRole.OFFICER} "
+
+
+def build_assignment_reason(prefix: str, actor: "models.User | None") -> str:
+    """Dựng ``AssignmentLog.reason`` dạng ``{prefix} by {role} {username}``
+    (``actor=None`` ⇒ ``{prefix} by system``).
+
+    Khi ``actor`` là OFFICER, kết quả CHỨA ``SELF_SOURCED_REASON_TOKEN`` ⇒
+    _self_sourced_subquery xếp là tự tuyển. Đổi shape ``... by <role> <name>``
+    (vd bỏ chữ "by", đảo thứ tự) BẮT BUỘC cập nhật ``SELF_SOURCED_REASON_TOKEN`` +
+    pattern subquery cùng lúc — nếu quên, test contract sẽ đỏ.
+    """
+    who = f"{actor.role} {actor.username}" if actor is not None else "system"
+    return f"{prefix} by {who}"

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -17,6 +17,7 @@ from ..core.constants import UserRole
 from ..core.events import SystemEvents
 from ..core.task_constants import AssignmentResult, AssignmentFailureReason
 from ..utils.exceptions import LockContentionError
+from .assignment_reason import SELF_SOURCED_REASON_TOKEN
 from .notification_dispatcher import dispatch
 from .notification_payloads import EventPayload
 from .status_helper import StatusHelper, AssignmentStatus
@@ -108,7 +109,9 @@ def _self_sourced_subquery():
     return (
         select(
             (al.method == "manual")
-            & al.reason.ilike("%by officer %")
+            # token single-source từ assignment_reason (= "by officer ") — khớp
+            # reason build_assignment_reason() sinh khi actor là OFFICER.
+            & al.reason.ilike(f"%{SELF_SOURCED_REASON_TOKEN}%")
         )
         .where(
             al.lead_id == models.Lead.id,

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -29,6 +29,7 @@ from ..core.status_mapping import (
 )
 from ..core.constants import UserRole
 from .status_helper import StatusHelper, AssignmentStatus
+from .assignment_reason import build_assignment_reason
 from ..repositories import LeadRepository  # ✅ PHASE 2: Repository Pattern
 from ..repositories.collaborator_repository import CollaboratorRepository
 from .lead_profile_sync import sync_profile_from_lead, detect_changed_personal_fields, SYNCABLE_FIELDS
@@ -1168,15 +1169,16 @@ async def create_lead(
             StatusHelper.set_assignment_status(db_lead, AssignmentStatus.ASSIGNED)
 
             # ✅ FIX: Create AssignmentLog for direct assignment during lead creation
-            # Without this, timeline has no record of the initial assignment
-            assigner_name = (
-                f"{created_by.role} {created_by.username}" if created_by else "system"
-            )
+            # Without this, timeline has no record of the initial assignment.
+            # reason qua build_assignment_reason: single-source token cho
+            # _self_sourced_subquery (xem assignment_reason.py). Output byte-identical.
             assignment_log_entry = models.AssignmentLog(
                 lead_id=db_lead.id,
                 officer_id=direct_assignment_officer_id,
                 method="manual",
-                reason=f"Assigned during lead creation by {assigner_name}",
+                reason=build_assignment_reason(
+                    "Assigned during lead creation", created_by
+                ),
                 timestamp=datetime.now(timezone.utc),
             )
             db.add(assignment_log_entry)
@@ -2347,7 +2349,7 @@ async def assign_lead_manually(
             log_reason = (
                 f"Reassigned from officer #{old_officer_id} to #{officer_id} by {assigner.role} {assigner.username}"
                 if is_reassignment
-                else f"Manually assigned by {assigner.role} {assigner.username}"
+                else build_assignment_reason("Manually assigned", assigner)
             )
             log_entry = models.AssignmentLog(
                 lead_id=lead_id,

--- a/Backend_FastAPI/tests/services/test_assignment.py
+++ b/Backend_FastAPI/tests/services/test_assignment.py
@@ -685,3 +685,42 @@ def test_assignment_source_methods_documented():
     )
     # sanity: scan thật sự bắt được các method lõi
     assert {"automatic", "manual", "officer_reject"} <= found
+
+
+def test_self_sourced_reason_token_contract():
+    """Ghim coupling producer↔matcher (#2): reason `build_assignment_reason()` sinh
+    cho OFFICER PHẢI chứa `SELF_SOURCED_REASON_TOKEN` mà `_self_sourced_subquery`
+    match; admin/manager/system thì KHÔNG. Đổi shape reason (bỏ 'by', đảo thứ tự)
+    hoặc đổi token mà quên bên kia ⇒ test ĐỎ (chống silent-no-op khi bật flag)."""
+    from types import SimpleNamespace
+
+    from app.core.constants import UserRole
+    from app.services.assignment_reason import (
+        SELF_SOURCED_REASON_TOKEN,
+        build_assignment_reason,
+    )
+
+    officer = SimpleNamespace(role=UserRole.OFFICER, username="hieu")
+    admin = SimpleNamespace(role=UserRole.ADMIN, username="boss")
+    manager = SimpleNamespace(role=UserRole.MANAGER, username="mgr")
+
+    # OFFICER actor ⇒ reason CHỨA token (cả 2 prefix producer thực dùng)
+    for prefix in ("Assigned during lead creation", "Manually assigned"):
+        assert SELF_SOURCED_REASON_TOKEN in build_assignment_reason(prefix, officer)
+    # admin / manager / system ⇒ KHÔNG chứa token (phân phối, không self-sourced)
+    assert SELF_SOURCED_REASON_TOKEN not in build_assignment_reason("X", admin)
+    assert SELF_SOURCED_REASON_TOKEN not in build_assignment_reason("X", manager)
+    assert SELF_SOURCED_REASON_TOKEN not in build_assignment_reason("X", None)
+
+    # Byte-identical hành vi cũ: token="by officer ", pattern subquery="%by officer %"
+    assert SELF_SOURCED_REASON_TOKEN == "by officer "
+    # Reason cụ thể byte-identical chuỗi cũ ⇒ dữ liệu prod hiện có vẫn khớp (CẢ 2
+    # prefix producer thực dùng — pin đầy đủ để bắt reword RIÊNG câu prefix).
+    assert (
+        build_assignment_reason("Assigned during lead creation", officer)
+        == "Assigned during lead creation by officer hieu"
+    )
+    assert (
+        build_assignment_reason("Manually assigned", officer)
+        == "Manually assigned by officer hieu"
+    )

--- a/Backend_FastAPI/tests/services/test_assignment_self_sourced.py
+++ b/Backend_FastAPI/tests/services/test_assignment_self_sourced.py
@@ -17,8 +17,8 @@ import pytest
 from sqlalchemy import func, select
 
 from app import models
-from app.core.constants import UserRole
 from app.security import get_password_hash
+from app.services.assignment_reason import build_assignment_reason
 from app.services.assignment_service import (
     _non_final_status_filter,
     _self_sourced_subquery,
@@ -26,16 +26,16 @@ from app.services.assignment_service import (
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
-# ⚠️ COUPLING: reason phải khớp cái lead_service.py sinh (create+direct-assign
-# ~1179 + assign_lead_to_officer ~2350) và pattern ILIKE '%by officer %' của
-# _self_sourced_subquery. Role token DERIVE từ UserRole.OFFICER (StrEnum→'officer')
-# ⇒ ĐỔI GIÁ TRỊ enum mà quên pattern subquery → reason không chứa 'by officer ' →
-# self_cnt=0 ≠ 2 → TEST ĐỎ (ghim role-value drift). ⚠️ Giới hạn: template prefix
-# "Assigned during lead creation by" hardcode ở đây → KHÔNG bắt nếu lead_service đổi
-# RIÊNG câu prefix (hướng no-op an toàn). Ghim đủ cần extract prefix ra hằng chung —
-# hoãn (out of scope flag-OFF).
-_REASON_SELF_CREATE = f"Assigned during lead creation by {UserRole.OFFICER} " + "{u}"
+# Seed reason officer-self qua CHÍNH build_assignment_reason (real producer, User
+# THẬT role=String 'officer') ⇒ integration exercise đúng path prod (User.role str
+# → token), KHÔNG hardcode shape. Admin negative case giữ literal (chỉ cần KHÔNG
+# chứa token). Coupling ghim thêm bởi test_self_sourced_reason_token_contract.
 _REASON_ADMIN_ASSIGN = "Manually assigned by admin {u}"
+
+
+def _self_reason(officer):
+    """reason officer tự tạo — qua CHÍNH builder production (User thật, role=str)."""
+    return build_assignment_reason("Assigned during lead creation", officer)
 
 
 async def _mk_officer(db, unit_id, tag):
@@ -122,7 +122,7 @@ async def test_self_sourced_subquery_classification(db, seeded_dependencies):
     # A: manual by officer (TỰ TUYỂN) ✓
     a = await _mk_lead(db, deps, officer, "0940000001")
     await _log(db, a, officer, "manual",
-               _REASON_SELF_CREATE.format(u=officer.username), t0)
+               _self_reason(officer), t0)
 
     # B: manual by admin (đã-chia — admin gán tay) ✗
     b = await _mk_lead(db, deps, officer, "0940000002")
@@ -140,12 +140,12 @@ async def test_self_sourced_subquery_classification(db, seeded_dependencies):
     e = await _mk_lead(db, deps, officer, "0940000005")
     await _log(db, e, officer, "automatic", "auto cũ", t0)
     await _log(db, e, officer, "manual",
-               _REASON_SELF_CREATE.format(u=officer.username), t0 + timedelta(days=1))
+               _self_reason(officer), t0 + timedelta(days=1))
 
     # F: manual by officer (cũ) → reassignment (mới) ⇒ latest = đã-chia ✗
     f = await _mk_lead(db, deps, officer, "0940000006")
     await _log(db, f, officer, "manual",
-               _REASON_SELF_CREATE.format(u=officer.username), t0)
+               _self_reason(officer), t0)
     await _log(
         db, f, officer, "manual_reassignment", "reassigned", t0 + timedelta(days=1)
     )
@@ -155,7 +155,7 @@ async def test_self_sourced_subquery_classification(db, seeded_dependencies):
     # officer ⇒ VẪN tự tuyển ✓ (khử P2: reject self-sourced lead không hoá đã-chia).
     g = await _mk_lead(db, deps, officer, "0940000007")
     await _log(db, g, officer, "manual",
-               _REASON_SELF_CREATE.format(u=officer.username), t0)
+               _self_reason(officer), t0)
     await _log(
         db, g, officer, "officer_reject", "Officer từ chối", t0 + timedelta(days=1)
     )
@@ -166,7 +166,7 @@ async def test_self_sourced_subquery_classification(db, seeded_dependencies):
     # case LUÔN load-bearing).
     h = await _mk_lead(db, deps, officer, "0940000008")
     await _log(db, h, officer, "manual",
-               _REASON_SELF_CREATE.format(u=officer.username), t0)
+               _self_reason(officer), t0)
     await _log(
         db, h, officer, "offering_change_unit_synced", "Đổi ngành",
         t0 + timedelta(days=1)
@@ -179,7 +179,7 @@ async def test_self_sourced_subquery_classification(db, seeded_dependencies):
     # officer_id không bị đếm nhầm sang officer khác).
     i_lead = await _mk_lead(db, deps, officer2, "0940000009")
     await _log(db, i_lead, officer, "manual",
-               _REASON_SELF_CREATE.format(u=officer.username), t0)
+               _self_reason(officer), t0)
     await _log(
         db, i_lead, officer2, "manual_reassignment", "reassign→officer2",
         t0 + timedelta(days=1)


### PR DESCRIPTION
## Mục tiêu
Hardening #2 **trước khi bật flag** `ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED` (feature loại-lead-tự-tuyển, đã ship ở #473, đang OFF). Đóng "coupling gap" cuối: việc phân loại "officer tự tuyển" **match chuỗi `reason`** (subquery `assignment_service`) trong khi `reason` được **sinh ở file khác** (`lead_service`) — nếu 2 nơi drift, feature **no-op im lặng** khi bật flag.

## Thay đổi
- **`app/services/assignment_reason.py`** (mới, leaf): gộp CẢ builder `build_assignment_reason()` LẪN `SELF_SOURCED_REASON_TOKEN` (="by officer ") vào **1 nơi**.
- `lead_service`: 2 chỗ build reason `method='manual'` (create+direct-assign, assign tay) → qua builder.
- `assignment_service`: subquery match token thay hardcode `"%by officer %"`.
- **`test_self_sourced_reason_token_contract`**: đổi shape reason/token mà quên bên kia → **test đỏ**.

## Refactor THUẦN — byte-identical
Chuỗi `reason` output **không đổi** ("by officer ") ⇒ **dữ liệu prod hiện có vẫn khớp**, phân loại **không đổi**. Verified char-for-char (officer/admin/None), `UserRole` là StrEnum → token = old pattern.

## Đã áp `/code-review max` (3 finder độc lập, byte-identical xác nhận 3 lần, **0 bug correctness**)
- **[test-gating]** Thêm `tests/services/test_assignment.py` + `test_assignment_self_sourced.py` vào **allowlist per-PR** (`backend-test.yml`) — trước đây chúng chỉ chạy nightly nên contract-test guard KHÔNG gate PR; nay **gate**.
- **[test-quality]** Integration seed qua `build_assignment_reason` + `models.User` THẬT (role=`String(50)` → 'officer') → exercise đúng path prod, hết hardcode shape.
- **[test-accuracy]** Contract test pin full-string CẢ 2 prefix (create + manual-assign).
- **[conventions]** isort: dời import `.assignment_reason` xuống nhóm `.`; type hint `actor: "models.User | None"` (TYPE_CHECKING).

Findings đã-chấp-nhận (không sửa): altitude — substring-match vẫn brittle (fix cấu trúc `method='self_claim'`/`actor_id` đã defer, documented); reassignment reason chưa qua builder (cosmetic, safe do subquery gate `method=='manual'`).

**22 test pass** (gồm contract + mode + integration), flake8 net-zero, imports sạch (no circular), YAML valid.

## ⚠️ Merge & rollout
- Cùng lô với #473; **KHÔNG thêm migration** → không đụng alembic head (`zbmonthlyseed20260706`). (Chỉ nhánh withdrawal `wpend20260710` cần `alembic merge` khi merge.)
- Sau khi merge+deploy PR này, bước cuối là **bật flag** (`recreate` env) + monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
