### PR TITLE
feat(admission): rút hồ sơ tự dọn tài chính + trạng thái withdrawal_pending

### DIFF
--- a/Backend_FastAPI/alembic/versions/refundsrc20260711_add_source_to_refund_request.py
+++ b/Backend_FastAPI/alembic/versions/refundsrc20260711_add_source_to_refund_request.py
@@ -1,0 +1,86 @@
+"""Add ``refund_request.source`` — distinguish withdrawal-auto-filed refunds.
+
+Issue 2 (PR-B follow-up). ``cancel_withdrawal``/rollback previously rejected
+EVERY open (pending/approved) refund on a profile via
+``reject_open_refunds_for_profile``, indiscriminately killing a pre-existing
+manual (finance-created) or overpayment refund that had nothing to do with the
+withdrawal. This adds a structured ``source`` so the rollback can target only
+``source='withdrawal'`` refunds.
+
+Additive column:
+* ``source VARCHAR(20) NOT NULL DEFAULT 'manual'`` + CHECK
+  (``withdrawal``|``manual``|``overpayment``) + index.
+
+Backfill: existing rows are reclassified best-effort from their ``reason`` text
+(the only prior discriminator) — the withdraw orchestrator wrote
+``"Rút hồ sơ #<id>"`` and overpayment refunds ``"Refund overpayment <id>"``.
+Everything else stays ``manual``. Terminal (rejected/refunded) rows are
+reclassified too for reporting consistency; it is harmless as the rollback only
+inspects pending/approved.
+
+Revision ID: refundsrc20260711
+Revises: wpend20260710
+Create Date: 2026-07-11
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "refundsrc20260711"
+down_revision: Union[str, None] = "wpend20260710"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE = "refund_request"
+COLUMN = "source"
+CHECK_NAME = "chk_refund_request_source_valid"
+INDEX_NAME = "ix_refund_request_source"
+
+
+def upgrade() -> None:
+    # 1. Add the column NOT NULL with a server default so existing rows fill in.
+    op.add_column(
+        TABLE,
+        sa.Column(
+            COLUMN,
+            sa.String(length=20),
+            nullable=False,
+            server_default="manual",
+            comment="Origin: withdrawal|manual|overpayment",
+        ),
+    )
+
+    # 2. Best-effort reclassification of historical rows from the reason text
+    #    (the only discriminator that existed before this column).
+    op.execute(
+        """
+        UPDATE refund_request
+        SET source = 'withdrawal'
+        WHERE reason LIKE 'Rút hồ sơ #%'
+        """
+    )
+    op.execute(
+        """
+        UPDATE refund_request
+        SET source = 'overpayment'
+        WHERE reason LIKE 'Refund overpayment %'
+        """
+    )
+
+    # 3. Guard rails: value CHECK + lookup index (rollback targets it by source).
+    op.create_check_constraint(
+        CHECK_NAME,
+        TABLE,
+        "source IN ('withdrawal', 'manual', 'overpayment')",
+    )
+    op.create_index(INDEX_NAME, TABLE, [COLUMN])
+
+
+def downgrade() -> None:
+    op.drop_index(INDEX_NAME, table_name=TABLE)
+    op.drop_constraint(CHECK_NAME, TABLE, type_="check")
+    op.drop_column(TABLE, COLUMN)

--- a/Backend_FastAPI/alembic/versions/refundsrc20260711_add_source_to_refund_request.py
+++ b/Backend_FastAPI/alembic/versions/refundsrc20260711_add_source_to_refund_request.py
@@ -70,6 +70,20 @@ def upgrade() -> None:
         WHERE reason LIKE 'Refund overpayment %'
         """
     )
+    # Authoritative overpayment reclassification: any refund an overpayment
+    # record points at IS an overpayment refund, regardless of its (possibly
+    # custom `notes`) reason text. Runs after the reason-based passes so it
+    # corrects rows a custom note left as 'manual'.
+    op.execute(
+        """
+        UPDATE refund_request
+        SET source = 'overpayment'
+        WHERE id IN (
+            SELECT refund_request_id FROM overpayment_record
+            WHERE refund_request_id IS NOT NULL
+        )
+        """
+    )
 
     # 3. Guard rails: value CHECK + lookup index (rollback targets it by source).
     op.create_check_constraint(

--- a/Backend_FastAPI/alembic/versions/wpend20260710_extend_status_check_withdrawal_pending.py
+++ b/Backend_FastAPI/alembic/versions/wpend20260710_extend_status_check_withdrawal_pending.py
@@ -33,7 +33,7 @@ Coupled deploy items (BE+FE atomic — Zod strict enum)
   ``withdrawal_pending`` BEFORE the BE writes it, or admission list parse fails.
 
 Revision ID: wpend20260710
-Revises: zbmonthlyseed20260706
+Revises: assignlogidx20260711
 Create Date: 2026-07-10
 """
 from typing import Sequence, Union
@@ -44,7 +44,10 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "wpend20260710"
-down_revision: Union[str, None] = "zbmonthlyseed20260706"
+# Rebased onto assignlogidx20260711 (#473, merged after this branch was cut) so
+# the two migrations chain linearly instead of forking two heads off
+# zbmonthlyseed20260706 → prevents "Multiple head revisions" at deploy.
+down_revision: Union[str, None] = "assignlogidx20260711"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/Backend_FastAPI/alembic/versions/wpend20260710_extend_status_check_withdrawal_pending.py
+++ b/Backend_FastAPI/alembic/versions/wpend20260710_extend_status_check_withdrawal_pending.py
@@ -1,0 +1,123 @@
+"""PR-B — extend ``admission_profile.status`` CHECK 14 → 15 state ⚠ ONE-WAY.
+
+Adds the intermediate ``withdrawal_pending`` ("Chờ hoàn để rút") state to the
+existing CHECK constraint (``ck_admission_profile_status``). It sits between an
+in-progress state and terminal ``withdrawn``, held while a refund is processed
+so the profile only settles to ``withdrawn`` once the money is actually returned.
+
+14 existing states are preserved verbatim — additive only:
+``draft / submitted / approved / rejected / confirmed / enrolled / resubmitted /
+overridden / revision_requested / withdrawn / reviewing / result_published /
+admitted / waitlisted``.
+
+ONE-WAY rationale + downgrade guard
+-----------------------------------
+
+Once this ships the app starts writing rows with ``withdrawal_pending`` via the
+withdraw orchestrator. Reverting the CHECK to 14 values would invalidate those
+rows — Postgres rejects ``ADD CHECK`` if any existing row violates the
+predicate, so the downgrade path defensively inspects current data:
+
+* 0 rows hold ``withdrawal_pending`` → safe rollback, recreate 14-state CHECK.
+* ≥1 row holds it → ``RuntimeError``; ops must restore from snapshot, not
+  downgrade (a pending withdrawal must be finalized or cancelled first).
+
+Coupled deploy items (BE+FE atomic — Zod strict enum)
+-----------------------------------------------------
+
+* ``app/models/admission.py`` ``CheckConstraint`` declaration → 15 states
+  (updated in this PR so test DB ``Base.metadata.create_all()`` matches prod).
+* ``app/services/admission_state_machine.py`` — ``WITHDRAWAL_PENDING`` enum
+  member + transitions.
+* FE ``lib/zod/admissions.ts`` strict ``z.enum`` → must include
+  ``withdrawal_pending`` BEFORE the BE writes it, or admission list parse fails.
+
+Revision ID: wpend20260710
+Revises: zbmonthlyseed20260706
+Create Date: 2026-07-10
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "wpend20260710"
+down_revision: Union[str, None] = "zbmonthlyseed20260706"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+CONSTRAINT_NAME = "ck_admission_profile_status"
+TABLE = "admission_profile"
+
+# Existing 14-state baseline (10 legacy + 4 Wave-3 milestone) — see
+# ``phase1_11_extend_profile_status_check_constraint.py``.
+OLD_STATES: tuple[str, ...] = (
+    "draft",
+    "submitted",
+    "approved",
+    "rejected",
+    "confirmed",
+    "enrolled",
+    "resubmitted",
+    "overridden",
+    "revision_requested",
+    "withdrawn",
+    "reviewing",
+    "result_published",
+    "admitted",
+    "waitlisted",
+)
+
+# PR-B intermediate refund-pending state.
+NEW_STATES: tuple[str, ...] = (
+    "withdrawal_pending",
+)
+
+ALL_STATES: tuple[str, ...] = OLD_STATES + NEW_STATES  # 15
+
+
+def _check_predicate(states: tuple[str, ...]) -> str:
+    """Build the SQL CHECK predicate from a state tuple.
+
+    Quoted with ``repr`` so a state name can never break out of the literal
+    (states come from this module's own constants, not user input)."""
+    return "status IN (" + ", ".join(repr(s) for s in states) + ")"
+
+
+def upgrade() -> None:
+    """Replace 14-state CHECK with 15-state CHECK. Pure additive — every row
+    that satisfied the old CHECK still satisfies the new one."""
+    op.drop_constraint(CONSTRAINT_NAME, TABLE, type_="check")
+    op.create_check_constraint(
+        CONSTRAINT_NAME,
+        TABLE,
+        _check_predicate(ALL_STATES),
+    )
+
+
+def downgrade() -> None:
+    """⚠ ONE-WAY guard — reject downgrade if any row holds
+    ``withdrawal_pending``. Otherwise recreate the 14-state CHECK."""
+    bind = op.get_bind()
+    new_state_count = bind.execute(
+        sa.text(
+            f"SELECT COUNT(*) FROM {TABLE} "
+            f"WHERE {_check_predicate(NEW_STATES)}"
+        )
+    ).scalar()
+    if new_state_count and new_state_count > 0:
+        raise RuntimeError(
+            f"Cannot downgrade wpend20260710: {new_state_count} row(s) in "
+            f"{TABLE} hold 'withdrawal_pending'. This is a ONE-WAY migration — "
+            f"finalize/cancel those pending withdrawals or restore from a "
+            f"snapshot instead of running `alembic downgrade`."
+        )
+    op.drop_constraint(CONSTRAINT_NAME, TABLE, type_="check")
+    op.create_check_constraint(
+        CONSTRAINT_NAME,
+        TABLE,
+        _check_predicate(OLD_STATES),
+    )

--- a/Backend_FastAPI/app/models/__init__.py
+++ b/Backend_FastAPI/app/models/__init__.py
@@ -135,6 +135,7 @@ from .finance import (
     PaymentStatusEnum,
     TransactionTypeEnum,
     RefundStatusEnum,
+    RefundSourceEnum,
     OverpaymentStatusEnum,
     ResolutionTypeEnum,
     # Models
@@ -280,6 +281,7 @@ __all__ = [
     "PaymentStatusEnum",
     "TransactionTypeEnum",
     "RefundStatusEnum",
+    "RefundSourceEnum",
     "OverpaymentStatusEnum",
     "ResolutionTypeEnum",
     # Models

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -53,14 +53,17 @@ class AdmissionProfile(Base):
         # keeping it in sync với migration prevents drift symptom per
         # memory ``test-db-schema-source``.
         UniqueConstraint('lead_id', 'academic_year', name='uq_admission_profile_lead_year'),
-        # Wave 3-A (M-1-11) extends 10-state CHECK to 14-state, adding the
+        # Wave 3-A (M-1-11) extended 10-state CHECK to 14-state, adding the
         # 4 choice-engine milestone states (reviewing / result_published /
-        # admitted / waitlisted). Migration owner:
-        # ``alembic/versions/phase1_11_extend_profile_status_check_constraint.py``.
+        # admitted / waitlisted). PR-B extends it to 15-state, adding the
+        # intermediate ``withdrawal_pending`` ("Chờ hoàn để rút") state.
+        # Migration owners:
+        # ``alembic/versions/phase1_11_extend_profile_status_check_constraint.py``
+        # (14-state) and ``alembic/versions/wpend20260710_*.py`` (15-state).
         # Test DB (``Base.metadata.create_all()``) reads this declaration —
         # keeping it in sync with the migration prevents test-vs-prod drift.
         CheckConstraint(
-            "status IN ('draft','submitted','approved','rejected','confirmed','enrolled','resubmitted','overridden','revision_requested','withdrawn','reviewing','result_published','admitted','waitlisted')",
+            "status IN ('draft','submitted','approved','rejected','confirmed','enrolled','resubmitted','overridden','revision_requested','withdrawn','reviewing','result_published','admitted','waitlisted','withdrawal_pending')",
             name="ck_admission_profile_status"
         ),
         CheckConstraint(

--- a/Backend_FastAPI/app/models/finance/__init__.py
+++ b/Backend_FastAPI/app/models/finance/__init__.py
@@ -35,7 +35,7 @@ from .invoice import (
 )
 from .payment_intent import PaymentIntent, PaymentIntentStatusEnum, GatewayStatusEnum
 from .payment import Payment, PaymentTransaction, PaymentStatusEnum, TransactionTypeEnum
-from .refund import RefundRequest, RefundStatusEnum
+from .refund import RefundRequest, RefundSourceEnum, RefundStatusEnum
 from .overpayment import OverpaymentRecord, OverpaymentStatusEnum, ResolutionTypeEnum
 from .payment_import import (
     PaymentImportBatch,
@@ -59,6 +59,7 @@ __all__ = [
     "TransactionTypeEnum",
     # Enums - Refund
     "RefundStatusEnum",
+    "RefundSourceEnum",
     # Enums - Overpayment
     "OverpaymentStatusEnum",
     "ResolutionTypeEnum",

--- a/Backend_FastAPI/app/models/finance/refund.py
+++ b/Backend_FastAPI/app/models/finance/refund.py
@@ -37,6 +37,20 @@ class RefundStatusEnum(str, enum.Enum):
     refunded = "refunded"    # Refund completed
 
 
+class RefundSourceEnum(str, enum.Enum):
+    """Origin of a refund request — distinguishes independently-managed refunds
+    from those the withdraw orchestrator auto-files.
+
+    Used by ``cancel_withdrawal``/rollback (``reject_open_refunds_for_profile``):
+    only ``withdrawal``-sourced refunds are auto-rejected when a pending
+    withdrawal is reverted. A pre-existing ``manual`` (finance-created) or
+    ``overpayment`` refund is left untouched — it is not part of the withdrawal.
+    """
+    withdrawal = "withdrawal"    # Auto-filed by the withdraw orchestrator
+    manual = "manual"            # Created by a finance user (POST /api/refunds)
+    overpayment = "overpayment"  # Filed to return a tracked overpayment
+
+
 class RefundRequest(Base):
     """
     Refund request record.
@@ -54,6 +68,10 @@ class RefundRequest(Base):
         CheckConstraint(
             "status IN ('pending', 'approved', 'rejected', 'refunded')",
             name='chk_refund_request_status_valid'
+        ),
+        CheckConstraint(
+            "source IN ('withdrawal', 'manual', 'overpayment')",
+            name='chk_refund_request_source_valid'
         ),
     )
 
@@ -87,6 +105,16 @@ class RefundRequest(Base):
         server_default="pending",
         index=True,
         comment="Status: pending|approved|rejected|refunded"
+    )
+
+    # Origin — drives whether cancel-withdrawal auto-rejects this refund.
+    source: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=RefundSourceEnum.manual.value,
+        server_default="manual",
+        index=True,
+        comment="Origin: withdrawal|manual|overpayment",
     )
 
     # Lifecycle timestamps

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -780,6 +780,12 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         )
         enrolled_count = status_counts.get("enrolled", 0)
         rejected_count = status_counts.get("rejected", 0)
+        # F6: surface the withdrawal states as their own buckets — before this
+        # they were counted in ``total`` but had no named bucket, so the returned
+        # counts did not sum to total_profiles and the withdrawal cohort was a
+        # silent orphan in any breakdown that trusts these fields.
+        withdrawn_count = status_counts.get("withdrawn", 0)
+        withdrawal_pending_count = status_counts.get("withdrawal_pending", 0)
         conversion_rate = round((enrolled_count / total) * 100, 1) if total > 0 else 0.0
 
         return {
@@ -789,6 +795,8 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             "approved_count": approved_count,
             "enrolled_count": enrolled_count,
             "rejected_count": rejected_count,
+            "withdrawn_count": withdrawn_count,
+            "withdrawal_pending_count": withdrawal_pending_count,
             "conversion_rate": conversion_rate,
             "avg_completion": 0.0,
         }

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -919,11 +919,15 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             )
             .where(ProfileDocument.graduation_proof_kind == "provisional_cert")
             # Review F3 — chỉ nhắc hồ sơ CÒN actionable: bỏ withdrawn (thí sinh
-            # rút) + dropped (is_dropped=True, status vẫn 'enrolled'). GIỮ
-            # enrolled-không-dropped (đúng use case: nhập học với giấy tạm thời,
-            # vẫn nợ bằng) + rejected (có thể resubmit; reject_document đã clear
-            # field khi reject ở tầng doc).
-            .where(models.AdmissionProfile.status != "withdrawn")
+            # rút) + withdrawal_pending (PR-B: đang rút, chờ hoàn tiền) + dropped
+            # (is_dropped=True, status vẫn 'enrolled'). GIỮ enrolled-không-dropped
+            # (đúng use case: nhập học với giấy tạm thời, vẫn nợ bằng) + rejected
+            # (có thể resubmit; reject_document đã clear field khi reject ở tầng doc).
+            .where(
+                models.AdmissionProfile.status.notin_(
+                    ("withdrawn", "withdrawal_pending")
+                )
+            )
             .where(models.AdmissionProfile.is_dropped.isnot(True))
             # Exclude profiles whose parent Lead is soft-deleted (don't remind
             # diploma debt for leads that have been removed).

--- a/Backend_FastAPI/app/repositories/fee_repository.py
+++ b/Backend_FastAPI/app/repositories/fee_repository.py
@@ -1013,6 +1013,13 @@ class InvoiceRepository(BaseRepository[Invoice]):
 
         def _scoped(query):
             query = query.join(Fee).join(models.AdmissionProfile).join(models.Lead)
+            # F4: exclude withdrawn / awaiting-refund profiles — they owe nothing,
+            # so their leftover invoices must not inflate outstanding / overdue.
+            query = query.where(
+                models.AdmissionProfile.status.notin_(
+                    ("withdrawn", "withdrawal_pending")
+                )
+            )
             if unit_id is not None:
                 query = query.where(models.Lead.unit_id == unit_id)
             return query

--- a/Backend_FastAPI/app/repositories/fee_repository.py
+++ b/Backend_FastAPI/app/repositories/fee_repository.py
@@ -160,6 +160,28 @@ class FeeRepository(BaseRepository[Fee]):
         )
         return Decimal(str(result.scalar() or 0))
 
+    async def sum_unrefunded_refundable_paid(self, profile_id: int) -> Decimal:
+        """Sum of ``paid_amount`` across REFUNDABLE fees still unrefunded.
+
+        Identical to ``sum_paid_amount_by_profile`` but EXCLUDES the
+        ``application`` fee (lệ phí xét tuyển) which is non-refundable and
+        therefore keeps ``paid_amount > 0`` forever. This is the amount that
+        determines whether a withdraw must wait in ``withdrawal_pending``
+        (PR-B): using the all-fees total instead would trap the profile in
+        ``withdrawal_pending`` permanently whenever an application fee was paid.
+
+        A processed refund DECREMENTS ``fee.paid_amount``, so this sum is exactly
+        the refundable money currently HELD (collected and NOT yet refunded).
+        Returns ``Decimal("0")`` when there is no unrefunded refundable balance.
+        """
+        result = await self.db.execute(
+            select(func.coalesce(func.sum(Fee.paid_amount), 0)).where(
+                Fee.admission_profile_id == profile_id,
+                Fee.fee_type != "application",
+            )
+        )
+        return Decimal(str(result.scalar() or 0))
+
     async def get_for_update(
         self,
         fee_id: int,

--- a/Backend_FastAPI/app/repositories/payment_repository.py
+++ b/Backend_FastAPI/app/repositories/payment_repository.py
@@ -138,6 +138,28 @@ class PaymentRepository(BaseRepository[Payment]):
         result = await self.db.execute(query)
         return result.scalars().first()
 
+    async def get_verified_by_profile(self, profile_id: int) -> List[Payment]:
+        """All VERIFIED payments on REFUNDABLE fees of an admission profile.
+
+        Joins Payment→Invoice→Fee, keeps only ``status='verified'`` payments and
+        EXCLUDES the non-refundable ``application`` fee (lệ phí xét tuyển). Used
+        by the withdraw orchestrator (PR-B) to auto-create a refund request per
+        collected tuition payment. No IDOR filter — the caller
+        (``withdraw_profile``) has already authorized access to the profile.
+        """
+        query = (
+            select(Payment)
+            .join(Invoice, Payment.invoice_id == Invoice.id)
+            .join(Fee, Invoice.fee_id == Fee.id)
+            .where(
+                Fee.admission_profile_id == profile_id,
+                Payment.status == PaymentStatusEnum.verified.value,
+                Fee.fee_type != "application",
+            )
+        )
+        result = await self.db.execute(query)
+        return list(result.scalars().all())
+
     async def get_by_invoice_id(
         self,
         invoice_id: int,

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -2303,6 +2303,47 @@ async def withdraw_admission(
 
 @limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
 @router.post(
+    "/{profile_id}/cancel-withdrawal",
+    response_model=schemas.AdmissionProfileResponse,
+    summary="Cancel a pending withdrawal (Admin only) — revert to draft",
+)
+async def cancel_withdrawal(
+    request: Request,
+    profile_id: int,
+    data: schemas.CancelWithdrawalRequest,
+    current_user: models.User = Depends(deps.require_admin),
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Admin reverts a ``withdrawal_pending`` profile back to ``draft`` when the
+    refund was rejected (the money stays with the school), so the profile is not
+    stuck awaiting a refund that will never complete.
+
+    **State transition:** withdrawal_pending → draft (edge exists).
+    **Security:** admin-only (``require_admin``); IDOR enforced in the service.
+    **Errors:** 400 (not in withdrawal_pending / missing reason), 404 (not found
+    or IDOR denial).
+    """
+    try:
+        result, callback = await admission_service.cancel_withdrawal(
+            db=db,
+            profile_id=profile_id,
+            actor=current_user,
+            reason=data.reason,
+        )
+        await db.commit()
+        await db.refresh(result)
+        if callback:
+            await callback()
+        return result
+
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except (BadRequest, BusinessRuleViolation) as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
+@router.post(
     "/{profile_id}/finalize",
     response_model=schemas.AdmissionProfileResponse,
     summary="Finalize to enrolled (Admin only)",

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -2301,12 +2301,12 @@ async def withdraw_admission(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 
 
-@limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
 @router.post(
     "/{profile_id}/cancel-withdrawal",
     response_model=schemas.AdmissionProfileResponse,
     summary="Cancel a pending withdrawal (Admin only) — revert to draft",
 )
+@limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
 async def cancel_withdrawal(
     request: Request,
     profile_id: int,

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -965,6 +965,11 @@ def _inv_status_value(inv):
     return inv.status.value if hasattr(inv.status, "value") else inv.status
 
 
+def _fee_status_value(fee):
+    """Normalize a fee status to its string value (Enum or str)."""
+    return fee.status.value if hasattr(fee.status, "value") else fee.status
+
+
 def _invoice_is_payable(inv) -> bool:
     """Hóa đơn còn THU ĐƯỢC: đã phát hành (issued/partial/overdue) và còn dư nợ
     (inv.remaining_amount = amount + penalty - paid > 0, GỒM penalty). Khớp
@@ -1000,7 +1005,18 @@ def _total_remaining_with_penalty(fees, invoices):
     Σ invoice.remaining (amount+penalty-paid) would OVER-state the header by
     the waived amount. Penalties live on the invoice (not the fee), so add the
     penalty of non-terminal invoices on top."""
-    principal = sum((f.remaining_amount for f in fees), Decimal("0"))
+    # Exclude CANCELLED fees: a cancelled fee (e.g. one auto-voided when a
+    # withdrawn profile's tuition was refunded) carries a non-zero
+    # remaining_amount (final − paid − waived) but is void — counting it would
+    # surface a phantom "Còn nợ" on a settled/withdrawn profile.
+    principal = sum(
+        (
+            f.remaining_amount
+            for f in fees
+            if _fee_status_value(f) != "cancelled"
+        ),
+        Decimal("0"),
+    )
     penalty = sum(
         (
             inv.penalty_amount

--- a/Backend_FastAPI/app/routers/finance_dashboard.py
+++ b/Backend_FastAPI/app/routers/finance_dashboard.py
@@ -166,7 +166,15 @@ async def get_dashboard_stats(
         )
         .join(models.AdmissionProfile)
         .join(models.Lead)
-        .where(Fee.status.in_(pending_fees_statuses))
+        .where(
+            Fee.status.in_(pending_fees_statuses),
+            # F4: a withdrawn / awaiting-refund profile owes nothing — its
+            # leftover 'invoiced'/'partial' fees (e.g. a refund-reopened invoice
+            # not yet cancelled) must NOT count as a receivable on the dashboard.
+            models.AdmissionProfile.status.notin_(
+                ("withdrawn", "withdrawal_pending")
+            ),
+        )
     )
     if unit_id is not None:
         pending_fees_query = pending_fees_query.where(models.Lead.unit_id == unit_id)
@@ -265,6 +273,39 @@ async def get_dashboard_stats(
         period_query = period_query.where(models.Lead.unit_id == unit_id)
     result = await db.execute(period_query)
     period_collections = Decimal(str(result.scalar() or 0))
+
+    # 5.9. F3 — net out PROCESSED refunds so "collections" match
+    # AccountingPeriod.net_revenue (a refunded payment is not revenue; the gross
+    # sums above still count it because process_approved_refund leaves
+    # payment.status='verified'). Refunds are matched by ``refunded_at`` within
+    # the SAME window as each collection metric. Net can go slightly negative in
+    # a window where refunds of prior-period payments exceed new collections —
+    # that is the correct net-outflow figure, left unclamped.
+    async def _refunds_processed(*conds) -> Decimal:
+        rq = (
+            select(func.coalesce(func.sum(RefundRequest.amount), 0))
+            .join(Payment, RefundRequest.payment_id == Payment.id)
+            .join(Invoice, Payment.invoice_id == Invoice.id)
+            .join(Fee, Invoice.fee_id == Fee.id)
+            .join(models.AdmissionProfile)
+            .join(models.Lead)
+            .where(RefundRequest.status == "refunded", *conds)
+        )
+        if unit_id is not None:
+            rq = rq.where(models.Lead.unit_id == unit_id)
+        return Decimal(str((await db.execute(rq)).scalar() or 0))
+
+    today_collections -= await _refunds_processed(
+        RefundRequest.refunded_at >= today_start,
+        RefundRequest.refunded_at <= today_end,
+    )
+    monthly_collections -= await _refunds_processed(
+        func.date(RefundRequest.refunded_at) >= month_start,
+    )
+    period_collections -= await _refunds_processed(
+        RefundRequest.refunded_at >= period_start_dt,
+        RefundRequest.refunded_at <= period_end_dt,
+    )
 
     # 6. Pending overpayments count
     overpayments_query = (

--- a/Backend_FastAPI/app/routers/refunds.py
+++ b/Backend_FastAPI/app/routers/refunds.py
@@ -251,6 +251,7 @@ def _build_refund_response(
         amount=refund.amount,
         reason=refund.reason,
         status=refund.status,
+        source=refund.source,
         requested_at=refund.requested_at,
         requested_by_id=refund.requested_by_id,
         approved_at=refund.approved_at,

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -208,6 +208,7 @@ from .admission import (
     ConfirmRequest,
     OverrideRequest,
     WithdrawRequest,
+    CancelWithdrawalRequest,
     FinalizeRequest,
     DropStudentRequest,
     MinorCorrectionRequest,

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -2355,6 +2355,8 @@ class AdmissionStats(BaseModel):
     enrolled_count: int = 0
     rejected_count: int = 0
     dropped_count: int = 0
+    withdrawn_count: int = 0
+    withdrawal_pending_count: int = 0
     conversion_rate: float = 0.0
     avg_completion: float = 0.0
 

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -2011,6 +2011,30 @@ class WithdrawRequest(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
 
+class CancelWithdrawalRequest(BaseModel):
+    """Schema for the admin "cancel withdrawal" action (PR-B).
+
+    Reverts a ``withdrawal_pending`` profile back to ``draft`` when the refund
+    was rejected, so the profile is not stuck awaiting a refund that will never
+    complete. Admin-only (router gate). No optimistic-lock version: this is a
+    rare recovery action on a profile that is, by definition, not being edited.
+    """
+    reason: str = Field(
+        ...,
+        min_length=5,
+        max_length=1000,
+        description="Reason for cancelling the withdrawal (required)",
+    )
+
+    @field_validator('reason')
+    @classmethod
+    def sanitize_reason(cls, v: str) -> str:
+        """XSS prevention: escape HTML entities."""
+        return html.escape(v.strip())
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+
 class OverrideRequest(BaseModel):
     """
     Schema for override action (Admin only).

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -27,6 +27,7 @@ from app.models.finance import (
     PaymentStatusEnum,
     PaymentIntentStatusEnum,
     RefundStatusEnum,
+    RefundSourceEnum,
     OverpaymentStatusEnum,
     ResolutionTypeEnum,
     TransactionTypeEnum,
@@ -754,6 +755,7 @@ class RefundRequestResponse(BaseModel):
     amount: Decimal
     reason: str
     status: RefundStatusEnum
+    source: RefundSourceEnum = RefundSourceEnum.manual
     requested_at: datetime
     requested_by_id: int
     approved_at: Optional[datetime]

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -1478,6 +1478,23 @@ async def admin_rollback_profile(
             None,
         )
 
+    # F1: if rolling back FROM withdrawal_pending, reject any pending refund the
+    # withdraw orchestrator auto-filed — else it could later be processed and
+    # return money on the re-activated profile (parity with cancel_withdrawal).
+    # Raises 400 if a refund is already approved + awaiting processing.
+    if rolled_back_from == "withdrawal_pending":
+        from .payment_service import RefundService
+        from .admission_service import _get_system_application_fee_user
+
+        _rej_id = getattr(actor, "id", None) or (
+            await _get_system_application_fee_user(db)
+        ).id
+        await RefundService(db).reject_open_refunds_for_profile(
+            profile.id,
+            reason=f"Hủy quy trình rút (admin rollback) hồ sơ #{profile.id}",
+            rejector_id=_rej_id,
+        )
+
     _, callback = await state_service.transition(
         db, profile, "draft",
         actor=actor,

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -10984,6 +10984,133 @@ async def delete_profile(
 # ==============================================================================
 
 
+async def _finalize_withdrawn(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    actor: Optional[models.User],
+    *,
+    from_status: str,
+    reason: str,
+) -> tuple[models.AdmissionProfile, Any]:
+    """Transition a (row-locked) profile to terminal ``withdrawn`` + build the
+    paired notification bundle. Shared by:
+
+    * the DIRECT-withdraw path — no refundable money collected, or an
+      ``admitted`` (seat-occupying) profile kept on the legacy direct path;
+    * the REFUND-FINALIZE path — ``payment_service.process_approved_refund``
+      once the last refundable payment on a ``withdrawal_pending`` profile is
+      returned.
+
+    ``from_status`` is the status BEFORE this finalize (original status on the
+    direct path, ``withdrawal_pending`` on the refund-finalize path); it drives
+    the audit ``from_status`` and the notification ``old_status``. The profile
+    is mutated in place AND returned (``state_transition`` may hand back a
+    different instance). Caller must hold the profile row lock.
+    """
+    _actor_id: Optional[int] = actor.id if actor else None
+    _actor_name: str = (
+        (actor.full_name or actor.username) if actor else "Ứng viên (magic-link)"
+    )
+
+    profile, transition_callback = await state_transition(
+        db,
+        profile,
+        "withdrawn",
+        actor=actor,
+        reason=reason,
+        source="api",
+        event_metadata={
+            "from_status": from_status,
+            "withdrawn_by_role": (actor.role if actor else "system"),
+            "reason": reason,
+        },
+    )
+
+    # PIPELINE SYNC: withdrawal milestone consultation
+    if profile.lead:
+        await _create_admission_milestone_consultation(
+            db=db,
+            lead=profile.lead,
+            event="profile_withdrawn",
+            actor=actor,
+            profile_id=profile.id,
+            reason=reason,
+        )
+
+    await db.flush()
+
+    # SYNC: lead consultation status → sts08 (withdrawn mapping)
+    from .lead_admission_sync import sync_lead_from_admission
+    await sync_lead_from_admission(
+        db=db,
+        profile=profile,
+        changed_by_user_id=_actor_id,
+        reason=f"Admission profile withdrawn: {reason[:50]}",
+    )
+
+    log.info(
+        "Admission profile withdrawn",
+        profile_id=profile.id,
+        actor_id=_actor_id,
+        old_status=from_status,
+    )
+
+    # Flag any still-unrefunded refundable money for the FE badge (refund stays
+    # manual via maker-checker). On the refund-finalize path this is 0 by
+    # construction (finalize only runs once the refundable balance hits 0).
+    await _populate_unrefunded_payment_flag(db, profile)
+
+    # Path C / Arch-3: atomic paired bundle (APPLICATION_STATUS_CHANGED +
+    # LEAD_STATUS_CHANGED). Withdraw has no commission check.
+    bundle_callback = None
+    if profile.lead_id:
+        intents = [
+            NotificationIntent(
+                event=SystemEvents.APPLICATION_STATUS_CHANGED,
+                payload={
+                    "application_id": profile.id,
+                    "lead_id": profile.lead_id,
+                    "old_status": from_status,
+                    "new_status": "withdrawn",
+                    "actor_id": _actor_id,
+                    "actor_name": _actor_name,
+                },
+                dedupe_key=f"admission_profile_withdrawn:{profile.id}",
+                rooms=rooms_for_admission(profile),
+            ),
+            NotificationIntent(
+                event=SystemEvents.LEAD_STATUS_CHANGED,
+                payload={
+                    "lead_id": profile.lead_id,
+                    "lead_name": f"Profile #{profile.id}",
+                    "old_status": from_status,
+                    "new_status": "sts08",
+                    "actor_id": _actor_id,
+                    "actor_name": _actor_name,
+                },
+                dedupe_key=f"lead_status_changed:{profile.lead_id}:sts08",
+                rooms=rooms_for_admission(profile),
+            ),
+        ]
+        bundle = await dispatch_bundle(
+            db, bundle_label="admission_withdraw", intents=intents,
+        )
+        bundle_callback = bundle.callback
+
+    async def _audit_log_callback():
+        log.info(
+            "Post-commit: Profile withdrawn notification",
+            profile_id=profile.id,
+        )
+
+    final_callback = compose_post_commit_callbacks(
+        label="admission_withdraw",
+        callbacks=[_audit_log_callback, bundle_callback, transition_callback],
+    )
+
+    return profile, final_callback
+
+
 async def withdraw_profile(
     db: AsyncSession,
     profile_id: int,
@@ -11031,16 +11158,10 @@ async def withdraw_profile(
     # IDOR bypass when actor=None (magic-link path verifies CCCD).
     _check_idor_access(profile, actor)
 
-    # Actor attribution capture (officer dashboard vs. magic-link
-    # self-service). All downstream audit/notification consumers
-    # already accept Optional ids; the human-readable label is used
-    # only in notification payloads.
+    # Actor attribution (officer dashboard vs. magic-link self-service).
+    # Downstream consumers accept Optional ids; the human-readable label is
+    # (re)computed inside ``_finalize_withdrawn`` where the bundle is built.
     _actor_id: Optional[int] = actor.id if actor else None
-    _actor_name: str = (
-        (actor.full_name or actor.username)
-        if actor
-        else "Ứng viên (magic-link)"
-    )
 
     from .admission_state_machine import validate_transition
 
@@ -11068,122 +11189,115 @@ async def withdraw_profile(
     # Caller still captures old_status for the legacy bundle below.
     _old_status_for_audit = profile.status
 
-    # Phase 1 hotfix-2 + magic-link FU: enrich payload với ``from_status``
-    # + ``withdrawn_by_role`` so the seeded ADMISSION_WITHDRAWN template's
-    # placeholders resolve at render time. ``actor=None`` (magic-link
-    # candidate self-service) maps to role "system" for the template.
+    # ---- PR-B orchestrator: auto-clean finances, then pick the target ----
+    # System user for the magic-link path (actor=None): cancel_fee /
+    # request_refund require a non-null user_id. Resolved lazily + cached.
+    _system_user_id: Optional[int] = None
+
+    async def _actor_or_system_id() -> int:
+        nonlocal _system_user_id
+        if _actor_id is not None:
+            return _actor_id
+        if _system_user_id is None:
+            _system_user_id = (await _get_system_application_fee_user(db)).id
+        return _system_user_id
+
+    # STEP 0 (v3): a seat-occupying (``admitted``) profile keeps the legacy
+    # DIRECT path — settle straight to ``withdrawn`` with NO auto-refund/cancel,
+    # so withdrawal never touches quota-seat accounting. (approved/confirmed/
+    # overridden/enrolled cannot reach here — they have no →withdrawn edge and
+    # are already blocked by validate_transition above.)
+    if _old_status_for_audit in QUOTA_OCCUPYING_STATUSES:
+        return await _finalize_withdrawn(
+            db, profile, actor,
+            from_status=_old_status_for_audit, reason=data["reason"],
+        )
+
+    from app.services.fee_calculation_service import FeeCalculationService
+    from app.services.payment_service import RefundService
+    from app.repositories.fee_repository import FeeRepository
+    from app.repositories.payment_repository import PaymentRepository
+
+    fee_repo = FeeRepository(db)
+    payment_repo = PaymentRepository(db)
+
+    # STEP 1 (refund-first): request a refund for every verified refundable
+    # payment. MUST run BEFORE cancel_fee — cancel_fee rejects a fee with
+    # paid_amount>0, so the payable surface is only removed after money is
+    # scheduled to be returned. Refund is per-payment (ceiling = amount −
+    # already-committed refunds) and stays 'pending' (maker-checker).
+    verified_payments = await payment_repo.get_verified_by_profile(profile_id)
+    if verified_payments:
+        refund_service = RefundService(db)
+        _uid = await _actor_or_system_id()
+        for pay in verified_payments:
+            committed = await payment_repo.get_total_refunds_for_payment(pay.id)
+            available = pay.amount - committed
+            if available <= 0:
+                continue
+            await refund_service.request_refund(
+                payment_id=pay.id,
+                amount=available,
+                reason=f"Rút hồ sơ #{profile_id}",
+                user_id=_uid,
+            )
+
+    # STEP 2: cancel every UNPAID fee (paid_amount==0) — cascades to its
+    # invoices. cancel_fee raises BusinessRuleViolation if a pending (unverified)
+    # payment exists; let it surface as 400 so the officer resolves that payment
+    # first (safer than silently proceeding).
+    fee_calc = FeeCalculationService(db)
+    for fee in await fee_repo.get_by_profile_id(profile_id):
+        if fee.paid_amount == 0 and fee.status != "cancelled":
+            _uid = await _actor_or_system_id()
+            await fee_calc.cancel_fee(
+                fee.id, reason=f"Rút hồ sơ #{profile_id}", user_id=_uid,
+            )
+
+    # STEP 3: pick the target. The refunds created above are still 'pending'
+    # (not processed), so paid_amount is unchanged — a profile with collected
+    # refundable tuition still has refundable_held>0 and must WAIT in
+    # ``withdrawal_pending`` until the refund is processed (finalize happens in
+    # ``process_approved_refund``). No refundable money → settle to ``withdrawn``
+    # now via the shared helper.
+    refundable_held = await fee_repo.sum_unrefunded_refundable_paid(profile_id)
+    if refundable_held <= 0:
+        return await _finalize_withdrawn(
+            db, profile, actor,
+            from_status=_old_status_for_audit, reason=data["reason"],
+        )
+
+    # → withdrawal_pending. Lead is HELD at its current status (no-op sync); the
+    # pipeline only moves to sts08 at finalize. No ADMISSION event is mapped for
+    # withdrawal_pending (v3) so the intermediate transition is silent — the
+    # ADMISSION_WITHDRAWN notification fires exactly once, at finalize.
     profile, transition_callback = await state_transition(
         db,
         profile,
-        "withdrawn",
+        "withdrawal_pending",
         actor=actor,
         reason=data["reason"],
         source="api",
         event_metadata={
             "from_status": _old_status_for_audit,
-            "withdrawn_by_role": (actor.role if actor else "system"),
             "reason": data["reason"],
         },
     )
-
-    # PIPELINE SYNC: Create system consultation for withdrawal milestone
-    if profile.lead:
-        await _create_admission_milestone_consultation(
-            db=db,
-            lead=profile.lead,
-            event="profile_withdrawn",
-            actor=actor,
-            profile_id=profile.id,
-            reason=data["reason"],
-        )
-
     await db.flush()
-
-    # SYNC: Update lead consultation status (withdrawn → sts08)
-    from .lead_admission_sync import sync_lead_from_admission
-    await sync_lead_from_admission(
-        db=db,
-        profile=profile,
-        changed_by_user_id=_actor_id,
-        reason=f"Admission profile withdrawn: {data['reason'][:50]}",
-    )
+    await _populate_unrefunded_payment_flag(db, profile)
 
     log.info(
-        "Admission profile withdrawn",
+        "Admission profile → withdrawal_pending (awaiting refund)",
         profile_id=profile.id,
         actor_id=_actor_id,
         old_status=_old_status_for_audit,
+        refundable_held=str(refundable_held),
     )
-
-    # TUITION_PREPAY_FASTTRACK finding #1 — flag + warn về học phí trả trước
-    # chưa hoàn khi rút hồ sơ. ``withdraw_profile`` không gọi
-    # ``_populate_response_fields`` (response tối giản theo thiết kế), nên set
-    # cờ trực tiếp qua helper nhẹ để mutation response có parity với GET. KHÔNG
-    # chặn rút — hoàn tiền vẫn thủ công qua maker-checker.
-    await _populate_unrefunded_payment_flag(db, profile)
-    if getattr(profile, "has_unrefunded_payment", False):
-        from app.repositories.fee_repository import FeeRepository
-
-        _total_paid = await FeeRepository(db).sum_paid_amount_by_profile(profile.id)
-        log.warning(
-            "Profile withdraw với khoản học phí chưa hoàn",
-            profile_id=profile.id,
-            total_paid=str(_total_paid),
-            status=profile.status,
-        )
-
-    # Path C / Arch-3: build atomic notification bundle for the paired
-    # transition (APPLICATION_STATUS_CHANGED + LEAD_STATUS_CHANGED).
-    # Withdraw is the one paired flow that does NOT have a commission
-    # check (withdrawn lead does not trigger commission); only the
-    # bundle callback is composed.
-    bundle_callback = None
-    if profile.lead_id:
-        intents = [
-            NotificationIntent(
-                event=SystemEvents.APPLICATION_STATUS_CHANGED,
-                payload={
-                    "application_id": profile_id,
-                    "lead_id": profile.lead_id,
-                    "old_status": _old_status_for_audit,
-                    "new_status": "withdrawn",
-                    "actor_id": _actor_id,
-                    "actor_name": _actor_name,
-                },
-                dedupe_key=f"admission_profile_withdrawn:{profile_id}",
-                rooms=rooms_for_admission(profile),
-            ),
-            NotificationIntent(
-                event=SystemEvents.LEAD_STATUS_CHANGED,
-                payload={
-                    "lead_id": profile.lead_id,
-                    "lead_name": f"Profile #{profile_id}",
-                    "old_status": _old_status_for_audit,
-                    "new_status": "sts08",
-                    "actor_id": _actor_id,
-                    "actor_name": _actor_name,
-                },
-                dedupe_key=f"lead_status_changed:{profile.lead_id}:sts08",
-                rooms=rooms_for_admission(profile),
-            ),
-        ]
-        bundle = await dispatch_bundle(
-            db, bundle_label="admission_withdraw", intents=intents,
-        )
-        bundle_callback = bundle.callback
-
-    async def _audit_log_callback():
-        """Existing post-commit log preserved for parity."""
-        log.info(
-            "Post-commit: Profile withdrawn notification",
-            profile_id=profile.id,
-        )
 
     final_callback = compose_post_commit_callbacks(
-        label="admission_withdraw",
-        callbacks=[_audit_log_callback, bundle_callback, transition_callback],
+        label="admission_withdrawal_pending",
+        callbacks=[transition_callback],
     )
-
     return profile, final_callback
 
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -11077,50 +11077,20 @@ async def _finalize_withdrawn(
     # (from_status == "withdrawal_pending"): each refundable payment was returned
     # via reverse_payment_balances, which zeroed the fee's paid_amount BUT
     # reopened its invoice to 'issued' (payable) — a phantom receivable ("còn
-    # nợ") on a profile that just settled to withdrawn. Cancel the now-unpaid
-    # non-application fees (cancel_fee cascades to their invoices) so no payable
-    # surface survives. The direct path (admitted / no-refundable-money) is
-    # EXCLUDED — its unpaid fees were already cancelled in withdraw STEP 2, and
-    # the admitted legacy path intentionally never touches finance.
-    #
-    # Runs after the lead is at sts08, so cancel_fee's HK1 sts14-revert is a
-    # guarded no-op; the application (lệ phí xét tuyển) fee is skipped (not
-    # refunded, stays collected). Each cancel is wrapped in a SAVEPOINT and is
-    # best-effort: a stale pending payment / active online intent on a sibling
-    # fee makes cancel_fee raise BusinessRuleViolation, which must NOT unwind the
-    # (already money-out) finalize — the phantom is money-safe via the payable
-    # guard, so we log and leave that one fee. Fees are locked in id order to
-    # keep a deterministic acquisition order under concurrency.
-    if from_status == "withdrawal_pending":
-        from app.services.fee_calculation_service import FeeCalculationService
-        from app.repositories.fee_repository import FeeRepository as _FeeRepo
-
-        _fee_calc = FeeCalculationService(db)
-        _fees = sorted(
-            await _FeeRepo(db).get_by_profile_id(profile.id), key=lambda f: f.id
-        )
-        for _f in _fees:
-            if (
-                _f.fee_type == "application"
-                or _f.paid_amount != 0
-                or _f.status == "cancelled"
-            ):
-                continue
-            try:
-                async with db.begin_nested():
-                    await _fee_calc.cancel_fee(
-                        _f.id,
-                        reason=f"Chốt rút hồ sơ #{profile.id} — huỷ phí đã hoàn",
-                        user_id=_actor_id,
-                    )
-            except Exception:
-                log.warning(
-                    "finalize_withdrawn: best-effort cancel of refunded fee "
-                    "failed (phantom invoice left; money-safe via payable guard)",
-                    profile_id=profile.id,
-                    fee_id=_f.id,
-                    exc_info=True,
-                )
+    # nợ") on a profile that just settled to withdrawn. Those now-unpaid
+    # non-application fees are cancelled POST-COMMIT in a fresh session
+    # (_cancel_phantom_fees_callback) — NOT in this transaction: cancel_fee can
+    # raise (stale pending payment / active online intent) and row-locks fees, so
+    # doing it here would either abort the already-money-out finalize or add a
+    # profile↔fee lock-order hazard, and its savepoint would expire the ORM
+    # objects this function still uses. The direct path (admitted /
+    # no-refundable-money) is EXCLUDED — its unpaid fees were already cancelled in
+    # withdraw STEP 2. Snapshot the ids now (the profile object must not be
+    # captured into the post-commit closure — the session is gone by then).
+    _cleanup_pid: Optional[int] = (
+        profile.id if from_status == "withdrawal_pending" else None
+    )
+    _cleanup_actor_id = _actor_id
 
     # Path C / Arch-3: atomic paired bundle (APPLICATION_STATUS_CHANGED +
     # LEAD_STATUS_CHANGED). Withdraw has no commission check.
@@ -11165,9 +11135,61 @@ async def _finalize_withdrawn(
             profile_id=profile.id,
         )
 
+    # Issue 1 cleanup — best-effort, POST-COMMIT, OWN session (see rationale
+    # above). Cancels the non-application fees the refund left at paid==0 (their
+    # invoices were reopened to 'issued') so no phantom payable survives on the
+    # withdrawn profile. Runs only on the refund-finalize path (_cleanup_pid set).
+    # A per-fee failure (pending payment / active intent) is money-safe via the
+    # payable guard — logged and skipped, never propagated. `compose_...` also
+    # swallows this callback's exceptions so it can never break notifications.
+    async def _cancel_phantom_fees_callback():
+        if _cleanup_pid is None:
+            return
+        from app.database import AsyncSessionLocal
+        from app.services.fee_calculation_service import FeeCalculationService
+        from app.repositories.fee_repository import FeeRepository as _FeeRepo
+
+        async with AsyncSessionLocal() as _sess:
+            _fee_calc = FeeCalculationService(_sess)
+            _fee_ids = [
+                f.id
+                for f in sorted(
+                    await _FeeRepo(_sess).get_by_profile_id(_cleanup_pid),
+                    key=lambda f: f.id,
+                )
+                if f.fee_type != "application"
+                and f.paid_amount == 0
+                and f.status != "cancelled"
+            ]
+            for _fid in _fee_ids:
+                try:
+                    await _fee_calc.cancel_fee(
+                        _fid,
+                        reason=(
+                            f"Chốt rút hồ sơ #{_cleanup_pid} — huỷ phí đã hoàn"
+                        ),
+                        user_id=_cleanup_actor_id,
+                    )
+                    await _sess.commit()
+                except Exception:
+                    await _sess.rollback()
+                    log.warning(
+                        "finalize_withdrawn post-commit: best-effort cancel of "
+                        "refunded fee failed (phantom invoice left; money-safe "
+                        "via payable guard)",
+                        profile_id=_cleanup_pid,
+                        fee_id=_fid,
+                        exc_info=True,
+                    )
+
     final_callback = compose_post_commit_callbacks(
         label="admission_withdraw",
-        callbacks=[_audit_log_callback, bundle_callback, transition_callback],
+        callbacks=[
+            _audit_log_callback,
+            _cancel_phantom_fees_callback,
+            bundle_callback,
+            transition_callback,
+        ],
     )
 
     return profile, final_callback

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -11076,6 +11076,11 @@ async def _finalize_withdrawn(
     # manual via maker-checker). On the refund-finalize path this is 0 by
     # construction (finalize only runs once the refundable balance hits 0).
     await _populate_unrefunded_payment_flag(db, profile)
+    # F12: Mutation Response Contract — populate computed fields so the direct
+    # withdraw response (STEP 0 admitted / refundable<=0 path) matches a GET.
+    # Harmless on the refund-finalize path (the RefundRequest is the response
+    # there); _populate_response_fields is a no-op when actor is None.
+    await _populate_response_fields(db, profile, actor)
 
     # Issue 1 (PR-B follow-up) — ONLY on the refund-finalize path
     # (from_status == "withdrawal_pending"): each refundable payment was returned
@@ -11426,6 +11431,9 @@ async def withdraw_profile(
     )
     await db.flush()
     await _populate_unrefunded_payment_flag(db, profile)
+    # F12: Mutation Response Contract — populate permissions/available_actions/
+    # eligibility/completion so the withdraw response matches a subsequent GET.
+    await _populate_response_fields(db, profile, actor)
 
     log.info(
         "Admission profile → withdrawal_pending (awaiting refund)",
@@ -11508,6 +11516,23 @@ async def cancel_withdrawal(
     )
     await db.flush()
     await _populate_unrefunded_payment_flag(db, profile)
+    # F12: Mutation Response Contract — populate computed fields so the
+    # cancel-withdrawal response matches a subsequent GET.
+    await _populate_response_fields(db, profile, actor)
+
+    # F7: the lead was HELD at its mid-admission consultation status throughout
+    # withdrawal_pending (the draft sync short-circuits). Now that the profile is
+    # back to draft, reset the lead to the draft mapping (sts06) so the pair is
+    # consistent — force=True bypasses the draft short-circuit + anti-regression
+    # floor, which is the intended behaviour for this admin reset only.
+    from .lead_admission_sync import sync_lead_from_admission
+    await sync_lead_from_admission(
+        db,
+        profile,
+        changed_by_user_id=(actor.id if actor else None),
+        reason=f"Hủy quy trình rút hồ sơ #{profile.id} — đưa lead về nháp",
+        force=True,
+    )
 
     log.info(
         "Withdrawal cancelled → draft",

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -11240,6 +11240,7 @@ async def withdraw_profile(
     from app.services.payment_service import RefundService
     from app.repositories.fee_repository import FeeRepository
     from app.repositories.payment_repository import PaymentRepository
+    from app.models.finance import RefundSourceEnum
 
     fee_repo = FeeRepository(db)
     payment_repo = PaymentRepository(db)
@@ -11270,6 +11271,7 @@ async def withdraw_profile(
                 amount=available,
                 reason=f"Rút hồ sơ #{profile_id}",
                 user_id=_uid,
+                source=RefundSourceEnum.withdrawal.value,
             )
 
     # STEP 2: cancel every UNPAID fee (paid_amount==0) — cascades to its

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -11073,6 +11073,55 @@ async def _finalize_withdrawn(
     # construction (finalize only runs once the refundable balance hits 0).
     await _populate_unrefunded_payment_flag(db, profile)
 
+    # Issue 1 (PR-B follow-up) — ONLY on the refund-finalize path
+    # (from_status == "withdrawal_pending"): each refundable payment was returned
+    # via reverse_payment_balances, which zeroed the fee's paid_amount BUT
+    # reopened its invoice to 'issued' (payable) — a phantom receivable ("còn
+    # nợ") on a profile that just settled to withdrawn. Cancel the now-unpaid
+    # non-application fees (cancel_fee cascades to their invoices) so no payable
+    # surface survives. The direct path (admitted / no-refundable-money) is
+    # EXCLUDED — its unpaid fees were already cancelled in withdraw STEP 2, and
+    # the admitted legacy path intentionally never touches finance.
+    #
+    # Runs after the lead is at sts08, so cancel_fee's HK1 sts14-revert is a
+    # guarded no-op; the application (lệ phí xét tuyển) fee is skipped (not
+    # refunded, stays collected). Each cancel is wrapped in a SAVEPOINT and is
+    # best-effort: a stale pending payment / active online intent on a sibling
+    # fee makes cancel_fee raise BusinessRuleViolation, which must NOT unwind the
+    # (already money-out) finalize — the phantom is money-safe via the payable
+    # guard, so we log and leave that one fee. Fees are locked in id order to
+    # keep a deterministic acquisition order under concurrency.
+    if from_status == "withdrawal_pending":
+        from app.services.fee_calculation_service import FeeCalculationService
+        from app.repositories.fee_repository import FeeRepository as _FeeRepo
+
+        _fee_calc = FeeCalculationService(db)
+        _fees = sorted(
+            await _FeeRepo(db).get_by_profile_id(profile.id), key=lambda f: f.id
+        )
+        for _f in _fees:
+            if (
+                _f.fee_type == "application"
+                or _f.paid_amount != 0
+                or _f.status == "cancelled"
+            ):
+                continue
+            try:
+                async with db.begin_nested():
+                    await _fee_calc.cancel_fee(
+                        _f.id,
+                        reason=f"Chốt rút hồ sơ #{profile.id} — huỷ phí đã hoàn",
+                        user_id=_actor_id,
+                    )
+            except Exception:
+                log.warning(
+                    "finalize_withdrawn: best-effort cancel of refunded fee "
+                    "failed (phantom invoice left; money-safe via payable guard)",
+                    profile_id=profile.id,
+                    fee_id=_f.id,
+                    exc_info=True,
+                )
+
     # Path C / Arch-3: atomic paired bundle (APPLICATION_STATUS_CHANGED +
     # LEAD_STATUS_CHANGED). Withdraw has no commission check.
     bundle_callback = None

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -8929,9 +8929,14 @@ async def reject_profile(
     if getattr(profile, "has_unrefunded_payment", False):
         from app.repositories.fee_repository import FeeRepository
 
-        _total_paid = await FeeRepository(db).sum_paid_amount_by_profile(profile.id)
+        # F8: mirror the flag's refundable-only basis (exclude the
+        # non-refundable application fee) so the logged amount == the amount
+        # actually to refund, not overstated by the 70k lệ phí xét tuyển.
+        _total_paid = await FeeRepository(db).sum_unrefunded_refundable_paid(
+            profile.id
+        )
         log.warning(
-            "Profile reject với khoản học phí chưa hoàn",
+            "Profile reject với khoản học phí chưa hoàn (refundable)",
             profile_id=profile.id,
             total_paid=str(_total_paid),
             status=profile.status,
@@ -11171,6 +11176,16 @@ async def withdraw_profile(
     # (re)computed inside ``_finalize_withdrawn`` where the bundle is built.
     _actor_id: Optional[int] = actor.id if actor else None
 
+    # F6: a profile already in withdrawal_pending must not be re-withdrawn — the
+    # withdrawal_pending→withdrawn edge would let it pass validate_transition,
+    # then STEP 3's state_transition(...,"withdrawal_pending") would 400 after
+    # STEP 1/2 already ran. Reject cleanly up front.
+    if profile.status == "withdrawal_pending":
+        raise BusinessRuleViolation(
+            "Hồ sơ đang ở 'Chờ hoàn để rút' — không thể rút lại. Hãy chờ hoàn "
+            "tất hoàn tiền, hoặc dùng 'Hủy quy trình rút' để đưa về nháp."
+        )
+
     from .admission_state_machine import validate_transition
 
     try:
@@ -11237,6 +11252,13 @@ async def withdraw_profile(
     verified_payments = await payment_repo.get_verified_by_profile(profile_id)
     if verified_payments:
         refund_service = RefundService(db)
+        # F3 (by design, not a system-user override): the refund's MAKER is the
+        # withdrawing actor (magic-link → system user). Maker-checker then
+        # requires a DIFFERENT approver — a manager who withdrew cannot approve
+        # their own auto-filed refund; an admin or second manager must. This is
+        # the intended finance control, not a bug. (Using the system user as
+        # requester was rejected: it needs the 'system' technical account seeded,
+        # which dev/test envs lack, and would weaken maker-checker.)
         _uid = await _actor_or_system_id()
         for pay in verified_payments:
             committed = await payment_repo.get_total_refunds_for_payment(pay.id)
@@ -11255,20 +11277,24 @@ async def withdraw_profile(
     # payment exists; let it surface as 400 so the officer resolves that payment
     # first (safer than silently proceeding).
     fee_calc = FeeCalculationService(db)
-    for fee in await fee_repo.get_by_profile_id(profile_id):
+    fees = await fee_repo.get_by_profile_id(profile_id)
+    for fee in fees:
         if fee.paid_amount == 0 and fee.status != "cancelled":
             _uid = await _actor_or_system_id()
             await fee_calc.cancel_fee(
                 fee.id, reason=f"Rút hồ sơ #{profile_id}", user_id=_uid,
             )
 
-    # STEP 3: pick the target. The refunds created above are still 'pending'
-    # (not processed), so paid_amount is unchanged — a profile with collected
-    # refundable tuition still has refundable_held>0 and must WAIT in
-    # ``withdrawal_pending`` until the refund is processed (finalize happens in
-    # ``process_approved_refund``). No refundable money → settle to ``withdrawn``
-    # now via the shared helper.
-    refundable_held = await fee_repo.sum_unrefunded_refundable_paid(profile_id)
+    # STEP 3: pick the target — computed IN-MEMORY from the STEP 2 fee list (F7,
+    # no extra query): the refunds above are still 'pending' so paid_amount is
+    # unchanged, and cancelled fees had paid_amount==0. Excludes the
+    # non-refundable ``application`` fee (mirrors sum_unrefunded_refundable_paid).
+    # refundable_held>0 → WAIT in ``withdrawal_pending`` until the refund is
+    # processed (finalize in ``process_approved_refund``); =0 → ``withdrawn`` now.
+    refundable_held = sum(
+        (f.paid_amount for f in fees if f.fee_type != "application"),
+        Decimal("0"),
+    )
     if refundable_held <= 0:
         return await _finalize_withdrawn(
             db, profile, actor,
@@ -11347,6 +11373,21 @@ async def cancel_withdrawal(
         )
     if not reason:
         raise BadRequest("Lý do hủy quy trình rút là bắt buộc")
+
+    # F1: reject any pending refund auto-filed by the withdraw orchestrator
+    # BEFORE reverting to draft — otherwise that refund could later be processed
+    # and return money on a re-activated (draft → … → enrolled) profile. Raises
+    # 400 if a refund is already APPROVED and awaiting processing (resolve first).
+    from app.services.payment_service import RefundService
+
+    _rejector_id = (
+        actor.id if actor else (await _get_system_application_fee_user(db)).id
+    )
+    await RefundService(db).reject_open_refunds_for_profile(
+        profile_id,
+        reason=f"Hủy quy trình rút hồ sơ #{profile_id}",
+        rejector_id=_rejector_id,
+    )
 
     _old_status = profile.status
     profile, transition_callback = await state_transition(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2194,6 +2194,9 @@ def _compute_frontend_fields(
             or is_manager
             or (is_officer and is_owner)
         ) and status not in ["draft", "withdrawn", "dropped", "withdrawal_pending"],
+        # PR-B: admin reverts a pending withdrawal back to draft when the refund
+        # was rejected (so the profile is not stuck awaiting a refund).
+        "cancel_withdrawal": is_admin and status == "withdrawal_pending",
         "drop": status == "enrolled" and not _is_dropped and (is_manager or is_admin),
         "claim": (status in ["submitted", "resubmitted"] and (is_manager or is_admin)
                   and not profile.assigned_reviewer_id),

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2168,15 +2168,20 @@ def _compute_frontend_fields(
         # Service-layer (priority_override_service) cũng có hard-deny officer
         # ngay đầu override_kv là defense-in-depth.
         "override_priority_kv": (
-            is_admin
-            or (
-                is_manager
-                and status in [
-                    "draft",
-                    "submitted",
-                    "reviewing",
-                    "revision_requested",
-                ]
+            # PR-B: never on a withdrawal_pending profile (on its way out) —
+            # gate the admin-unconditional branch too.
+            status != "withdrawal_pending"
+            and (
+                is_admin
+                or (
+                    is_manager
+                    and status in [
+                        "draft",
+                        "submitted",
+                        "reviewing",
+                        "revision_requested",
+                    ]
+                )
             )
         ),
         # Q9 #07 Phase E.3 — UT evidence verify/reject (officer write-path).
@@ -2188,7 +2193,7 @@ def _compute_frontend_fields(
             is_admin
             or is_manager
             or (is_officer and is_owner)
-        ) and status not in ["draft", "withdrawn", "dropped"],
+        ) and status not in ["draft", "withdrawn", "dropped", "withdrawal_pending"],
         "drop": status == "enrolled" and not _is_dropped and (is_manager or is_admin),
         "claim": (status in ["submitted", "resubmitted"] and (is_manager or is_admin)
                   and not profile.assigned_reviewer_id),
@@ -11296,6 +11301,72 @@ async def withdraw_profile(
 
     final_callback = compose_post_commit_callbacks(
         label="admission_withdrawal_pending",
+        callbacks=[transition_callback],
+    )
+    return profile, final_callback
+
+
+async def cancel_withdrawal(
+    db: AsyncSession,
+    profile_id: int,
+    actor: Optional[models.User],
+    reason: str,
+) -> tuple[models.AdmissionProfile, Any]:
+    """Admin cancels a pending withdrawal → back to DRAFT (PR-B).
+
+    Used when the refund tied to a ``withdrawal_pending`` profile is rejected:
+    the profile can't settle to ``withdrawn`` (the money stays with the school),
+    so an admin reverts it to ``draft`` — reusing the withdrawal_pending→draft
+    edge — instead of leaving it stuck. Admin-only (router gate); IDOR still
+    enforced. The lead is untouched: it was HELD at its pre-withdraw status
+    throughout ``withdrawal_pending`` and the ``draft`` sync short-circuits, so
+    there is no lead move to undo.
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    stmt = (
+        select(models.AdmissionProfile)
+        .where(models.AdmissionProfile.id == profile_id)
+        .options(selectinload(models.AdmissionProfile.lead))
+        .with_for_update()
+    )
+    profile = (await db.execute(stmt)).scalar_one_or_none()
+    if not profile:
+        raise ResourceNotFoundError(f"Admission profile {profile_id} not found")
+
+    _check_idor_access(profile, actor)
+
+    if profile.status != "withdrawal_pending":
+        raise BusinessRuleViolation(
+            "Chỉ có thể hủy quy trình rút khi hồ sơ đang ở trạng thái "
+            "'Chờ hoàn để rút'."
+        )
+    if not reason:
+        raise BadRequest("Lý do hủy quy trình rút là bắt buộc")
+
+    _old_status = profile.status
+    profile, transition_callback = await state_transition(
+        db,
+        profile,
+        "draft",
+        actor=actor,
+        reason=reason,
+        source="api",
+        event_metadata={"from_status": _old_status, "reason": reason},
+    )
+    await db.flush()
+    await _populate_unrefunded_payment_flag(db, profile)
+
+    log.info(
+        "Withdrawal cancelled → draft",
+        profile_id=profile.id,
+        actor_id=(actor.id if actor else None),
+        reason=reason[:50],
+    )
+
+    final_callback = compose_post_commit_callbacks(
+        label="admission_cancel_withdrawal",
         callbacks=[transition_callback],
     )
     return profile, final_callback

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -3413,23 +3413,29 @@ async def _populate_unrefunded_payment_flag(
     lets ops see "cần hoàn tiền" on the detail page (refund stays manual via
     the existing maker-checker flow).
 
-    ``SUM(fee.paid_amount)`` is the currently-HELD amount: a processed refund
-    decrements ``paid_amount`` (``payment_service.process_approved_refund``),
-    so the sum is exactly the unrefunded balance.
+    ``sum_unrefunded_refundable_paid`` is the currently-HELD REFUNDABLE amount:
+    a processed refund decrements ``paid_amount``
+    (``payment_service.process_approved_refund``), so the sum is exactly the
+    unrefunded refundable balance. It EXCLUDES the non-refundable ``application``
+    fee (PR-B) — otherwise a profile whose only paid fee is the lệ phí xét tuyển
+    (e.g. prod #251: 70k application, never refunded) would falsely show the
+    "cần hoàn tiền" badge forever.
 
-    Cost guard: ONLY queries when ``status in (rejected, withdrawn)``; every
-    other status short-circuits to ``False`` with no DB hit. Idempotent — safe
-    to call from both ``_populate_response_fields`` (mutations) and
-    ``get_profile`` (GET detail) for parity.
+    Cost guard: ONLY queries when ``status in (rejected, withdrawn,
+    withdrawal_pending)``; every other status short-circuits to ``False`` with
+    no DB hit. Idempotent — safe to call from both ``_populate_response_fields``
+    (mutations) and ``get_profile`` (GET detail) for parity.
     """
-    if profile.status not in ("rejected", "withdrawn"):
+    if profile.status not in ("rejected", "withdrawn", "withdrawal_pending"):
         profile.has_unrefunded_payment = False
         return
 
     from app.repositories.fee_repository import FeeRepository
 
-    total_paid = await FeeRepository(db).sum_paid_amount_by_profile(profile.id)
-    profile.has_unrefunded_payment = total_paid > 0
+    refundable_held = await FeeRepository(db).sum_unrefunded_refundable_paid(
+        profile.id
+    )
+    profile.has_unrefunded_payment = refundable_held > 0
 
 
 async def _load_priority_audit_log(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2168,9 +2168,13 @@ def _compute_frontend_fields(
         # Service-layer (priority_override_service) cũng có hard-deny officer
         # ngay đầu override_kv là defense-in-depth.
         "override_priority_kv": (
-            # PR-B: never on a withdrawal_pending profile (on its way out) —
-            # gate the admin-unconditional branch too.
-            status != "withdrawal_pending"
+            # PR-B: never on a profile on its way out / already out —
+            # withdrawal_pending (awaiting refund) OR terminal withdrawn — gate
+            # the admin-unconditional branch too (a KV override is meaningless
+            # once the profile is withdrawn). ``assign_officer`` below is NOT
+            # gated: it is a LEAD-level action (re-engagement) valid regardless
+            # of admission state.
+            status not in ("withdrawal_pending", "withdrawn")
             and (
                 is_admin
                 or (
@@ -11181,6 +11185,36 @@ async def _finalize_withdrawn(
                         fee_id=_fid,
                         exc_info=True,
                     )
+                    # A2: persist the failure to entity_audit_log so a left-behind
+                    # phantom fee is discoverable by ops (the log.warning above is
+                    # ephemeral stdout only). Own tiny commit; if even this fails
+                    # we swallow it — the phantom is money-safe regardless.
+                    try:
+                        from app.services import audit_service
+                        await audit_service.log_audit(
+                            _sess,
+                            entity_type="Fee",
+                            entity_id=_fid,
+                            action="phantom_cleanup_failed",
+                            actor_user_id=_cleanup_actor_id,
+                            new_value="phantom_invoice_left",
+                            reason=(
+                                "Post-commit huỷ phí đã hoàn THẤT BẠI khi chốt "
+                                f"rút hồ sơ #{_cleanup_pid} — hoá đơn payable còn "
+                                "sót (an toàn tiền qua payable guard)"
+                            ),
+                            source="system",
+                        )
+                        await _sess.commit()
+                    except Exception:
+                        await _sess.rollback()
+                        log.warning(
+                            "finalize_withdrawn post-commit: could not persist "
+                            "phantom-cleanup-failure audit",
+                            profile_id=_cleanup_pid,
+                            fee_id=_fid,
+                            exc_info=True,
+                        )
 
     final_callback = compose_post_commit_callbacks(
         label="admission_withdraw",

--- a/Backend_FastAPI/app/services/admission_state_machine.py
+++ b/Backend_FastAPI/app/services/admission_state_machine.py
@@ -67,6 +67,13 @@ class AdmissionStatus(str, Enum):
     ADMITTED = "admitted"
     WAITLISTED = "waitlisted"
 
+    # PR-B (DB CHECK extend 15-state) — intermediate "Chờ hoàn để rút" state
+    # between an in-progress state and terminal WITHDRAWN, held while a refund
+    # is being processed. NOT final: has edges → WITHDRAWN (refund done) and
+    # → DRAFT (refund rejected, admin cancels the withdrawal), so is_final_state
+    # derives False automatically.
+    WITHDRAWAL_PENDING = "withdrawal_pending"
+
 
 # Single source of truth for transitions — 14-state graph mixing legacy
 # single-NV edges + Phase 3 multi-NV edges. Engine writers
@@ -77,13 +84,20 @@ class AdmissionStatus(str, Enum):
 # service guards per plan v0.7 G7 add_choice precheck pattern).
 ALLOWED_TRANSITIONS: Dict[AdmissionStatus, Set[AdmissionStatus]] = {
     # Legacy 10-state lifecycle (preserved for uses_choice_engine=false)
-    AdmissionStatus.DRAFT: {AdmissionStatus.SUBMITTED, AdmissionStatus.WITHDRAWN},
+    AdmissionStatus.DRAFT: {
+        AdmissionStatus.SUBMITTED,
+        AdmissionStatus.WITHDRAWN,
+        # PR-B: withdraw with refundable money already paid → refund-pending
+        AdmissionStatus.WITHDRAWAL_PENDING,
+    },
     AdmissionStatus.SUBMITTED: {
         # Legacy: direct decision by manager (single-NV)
         AdmissionStatus.APPROVED,
         AdmissionStatus.REJECTED,
         AdmissionStatus.REVISION_REQUESTED,
         AdmissionStatus.WITHDRAWN,
+        # PR-B: withdraw with refundable money already paid → refund-pending
+        AdmissionStatus.WITHDRAWAL_PENDING,
         # Phase 3 T2: submitted → reviewing (manager review window)
         AdmissionStatus.REVIEWING,
         # Phase 3 PR-3C Sub-3.5 T17: admin rollback → draft
@@ -92,6 +106,8 @@ ALLOWED_TRANSITIONS: Dict[AdmissionStatus, Set[AdmissionStatus]] = {
     AdmissionStatus.REJECTED: {
         AdmissionStatus.RESUBMITTED,
         AdmissionStatus.WITHDRAWN,
+        # PR-B: withdraw with refundable money already paid → refund-pending
+        AdmissionStatus.WITHDRAWAL_PENDING,
         # Phase 3 PR-3C Sub-3.5 T17
         AdmissionStatus.DRAFT,
     },
@@ -99,6 +115,8 @@ ALLOWED_TRANSITIONS: Dict[AdmissionStatus, Set[AdmissionStatus]] = {
         AdmissionStatus.RESUBMITTED,
         AdmissionStatus.REJECTED,
         AdmissionStatus.WITHDRAWN,
+        # PR-B: withdraw with refundable money already paid → refund-pending
+        AdmissionStatus.WITHDRAWAL_PENDING,
         # Phase 3 T4: revision_requested → reviewing (after candidate fix)
         AdmissionStatus.REVIEWING,
         # Phase 3 PR-3C Sub-3.5 T17
@@ -109,6 +127,8 @@ ALLOWED_TRANSITIONS: Dict[AdmissionStatus, Set[AdmissionStatus]] = {
         AdmissionStatus.REJECTED,
         AdmissionStatus.REVISION_REQUESTED,
         AdmissionStatus.WITHDRAWN,
+        # PR-B: withdraw with refundable money already paid → refund-pending
+        AdmissionStatus.WITHDRAWAL_PENDING,
         # Phase 3: resubmitted → reviewing (uses_choice_engine path)
         AdmissionStatus.REVIEWING,
         # Phase 3 PR-3C Sub-3.5 T17
@@ -141,6 +161,8 @@ ALLOWED_TRANSITIONS: Dict[AdmissionStatus, Set[AdmissionStatus]] = {
         AdmissionStatus.RESULT_PUBLISHED,
         # Candidate withdraws during review window
         AdmissionStatus.WITHDRAWN,
+        # PR-B: withdraw with refundable money already paid → refund-pending
+        AdmissionStatus.WITHDRAWAL_PENDING,
         # Phase 3 PR-3C Sub-3.5 T17
         AdmissionStatus.DRAFT,
     },
@@ -169,7 +191,21 @@ ALLOWED_TRANSITIONS: Dict[AdmissionStatus, Set[AdmissionStatus]] = {
         AdmissionStatus.REJECTED,
         # Candidate withdraws while waitlisted
         AdmissionStatus.WITHDRAWN,
+        # PR-B: withdraw with refundable money already paid → refund-pending
+        AdmissionStatus.WITHDRAWAL_PENDING,
         # Phase 3 PR-3C Sub-3.5 T17
+        AdmissionStatus.DRAFT,
+    },
+
+    # PR-B: intermediate refund-pending state. Non-final (is_final_state derives
+    # False from this non-empty set).
+    #   → WITHDRAWN: refund fully processed (finalize in process_approved_refund)
+    #   → DRAFT: refund rejected → admin cancels the withdrawal (cancel_withdrawal)
+    # NOTE (v3): ADMITTED intentionally has NO → WITHDRAWAL_PENDING edge above;
+    # withdrawing a seat-occupying (admitted) profile keeps the legacy direct
+    # → WITHDRAWN path (no auto-refund) to avoid quota-seat churn.
+    AdmissionStatus.WITHDRAWAL_PENDING: {
+        AdmissionStatus.WITHDRAWN,
         AdmissionStatus.DRAFT,
     },
 }

--- a/Backend_FastAPI/app/services/admission_summary_export_service.py
+++ b/Backend_FastAPI/app/services/admission_summary_export_service.py
@@ -234,9 +234,18 @@ _LEAD_SQL = text(
            p.pstatus AS pstatus,
            COALESCE(p.has_doc_debt, false) AS has_doc_debt,
            COALESCE(p.has_app, false) AS has_app,
-           COALESCE(p.hk1_partial, false) AS hk1_partial,
-           COALESCE(p.hk1_settled, false) AS hk1_settled,
-           COALESCE(p.hk1_paid, 0) AS hk1_paid
+           -- F13: a withdrawn / awaiting-refund profile's HK1 tuition is
+           -- refunded (or being refunded), so it is NOT realized revenue —
+           -- zero the tuition flags/amount so it drops out of 'Doanh thu' and
+           -- the Học phí funnel, consistent with a finalized withdrawn profile
+           -- (whose cancelled fees already drop via the status<>'cancelled'
+           -- filter). Lệ phí xét tuyển (has_app) is non-refundable and stays.
+           CASE WHEN p.pstatus IN ('withdrawn', 'withdrawal_pending')
+                THEN false ELSE COALESCE(p.hk1_partial, false) END AS hk1_partial,
+           CASE WHEN p.pstatus IN ('withdrawn', 'withdrawal_pending')
+                THEN false ELSE COALESCE(p.hk1_settled, false) END AS hk1_settled,
+           CASE WHEN p.pstatus IN ('withdrawn', 'withdrawal_pending')
+                THEN 0 ELSE COALESCE(p.hk1_paid, 0) END AS hk1_paid
     FROM lead l
     LEFT JOIN program_offering po ON l.offering_id = po.id
     LEFT JOIN prof p ON p.lead_id = l.id

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -1308,9 +1308,17 @@ class FeeCalculationService:
         """
         fees = await self.fee_repo.get_by_profile_id(profile_id, unit_id)
 
-        total_fees = sum(f.final_amount for f in fees)
-        total_paid = sum(f.paid_amount for f in fees)
-        total_waived = sum(f.waived_amount for f in fees)
+        # Exclude CANCELLED fees from the money aggregates: a cancelled fee is
+        # void (final_amount>0, paid==0) so counting its remaining would surface
+        # a phantom "Còn nợ" on a settled/withdrawn profile. The ``fees`` list
+        # still returns every fee (incl cancelled) for display/history.
+        _active = [
+            f for f in fees
+            if f.status != FeeStatusEnum.cancelled.value
+        ]
+        total_fees = sum(f.final_amount for f in _active)
+        total_paid = sum(f.paid_amount for f in _active)
+        total_waived = sum(f.waived_amount for f in _active)
         total_remaining = total_fees - total_paid - total_waived
 
         return {

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -1195,6 +1195,9 @@ class FeeCalculationService:
                 )
 
         now = datetime.now(timezone.utc)
+        # Snapshot prior statuses BEFORE mutating — for the audit trail (A1).
+        _prev_fee_status = fee.status
+        _cancelled_invoices = [(inv.id, inv.status) for inv in active_invoices]
         # Cascade-cancel every non-cancelled invoice in the same transaction.
         for inv in active_invoices:
             inv.status = InvoiceStatusEnum.cancelled.value
@@ -1208,6 +1211,36 @@ class FeeCalculationService:
                     f"Cancelled by user {user_id}. Reason: {reason}"
 
         await self.db.flush()
+
+        # A1: persist the fee + invoice cancellation to entity_audit_log so a
+        # unified audit timeline shows the void (previously only on the invoice
+        # row's cancelled_* fields + fee.notes, invisible to an audit query).
+        from app.services import audit_service
+        await audit_service.log_audit(
+            self.db,
+            entity_type="Fee",
+            entity_id=fee.id,
+            action="status_changed",
+            actor_user_id=user_id,
+            field_name="status",
+            old_value=_prev_fee_status,
+            new_value=FeeStatusEnum.cancelled.value,
+            reason=reason,
+            source="api",
+        )
+        for _inv_id, _inv_prev in _cancelled_invoices:
+            await audit_service.log_audit(
+                self.db,
+                entity_type="Invoice",
+                entity_id=_inv_id,
+                action="status_changed",
+                actor_user_id=user_id,
+                field_name="status",
+                old_value=_inv_prev,
+                new_value=InvoiceStatusEnum.cancelled.value,
+                reason=reason,
+                source="api",
+            )
 
         # Lead projection reverse: ONLY HK1 tuition projects onto the lead, and
         # ONLY when NO OTHER non-cancelled HK1 tuition fee remains for the lead.

--- a/Backend_FastAPI/app/services/fee_compatibility_service.py
+++ b/Backend_FastAPI/app/services/fee_compatibility_service.py
@@ -298,6 +298,15 @@ class FeeCompatibilityService:
                 'remaining': remaining,
                 'status': fee.status,
             })
+            # F14: keep parity with FeeCalculationService.get_fee_summary —
+            # exclude CANCELLED fees from the money aggregates (a cancelled fee
+            # is void, final_amount>0/paid==0, so counting its remaining would
+            # surface a phantom "Còn nợ"). Still listed in ['fees'] for history.
+            _fee_status = (
+                fee.status.value if hasattr(fee.status, "value") else fee.status
+            )
+            if _fee_status == "cancelled":
+                continue
             summary['total_amount'] += fee.final_amount
             summary['total_paid'] += fee.paid_amount
             summary['total_remaining'] += remaining

--- a/Backend_FastAPI/app/services/lead_admission_sync.py
+++ b/Backend_FastAPI/app/services/lead_admission_sync.py
@@ -172,6 +172,7 @@ async def sync_lead_from_admission(
     profile: models.AdmissionProfile,
     changed_by_user_id: Optional[int] = None,
     reason: Optional[str] = None,
+    force: bool = False,
 ) -> bool:
     """
     Sync lead consultation status when admission profile status changes.
@@ -206,7 +207,11 @@ async def sync_lead_from_admission(
     # Skip draft — milestone consultation is the canonical sync for profile creation.
     # Avoids double LeadStatusHistory records when create_profile() calls both
     # sync_lead_from_admission() and _create_admission_milestone_consultation().
-    if profile.status == "draft":
+    # F7: ``force=True`` (admin cancel-withdrawal, wpend→draft) DELIBERATELY
+    # resets the held lead back to the draft mapping (sts06) so the reactivated
+    # draft profile and its lead are consistent — there is no milestone
+    # consultation on this path, so no double-history risk.
+    if profile.status == "draft" and not force:
         log.debug(
             "sync_lead_from_admission: Skipping draft, milestone consultation handles this",
             profile_id=profile.id,
@@ -256,7 +261,11 @@ async def sync_lead_from_admission(
     # must not regress a lead past sts07, and ``submitted`` / ``resubmitted``
     # must not erase a finance overlay (sts13/sts14/sts10/sts18 — SL1). See the
     # _should_apply_admission_floor docstring for the rationale.
-    if not _should_apply_admission_floor(profile.status, lead.consultation_status_id):
+    # F7: ``force`` bypasses the anti-regression floor — a cancel-withdrawal
+    # reset INTENDS to move the lead backward (sts07/sts14 → sts06 draft).
+    if not force and not _should_apply_admission_floor(
+        profile.status, lead.consultation_status_id
+    ):
         log.debug(
             "sync_lead_from_admission: Floor-only status, lead already past "
             "pre-application phase — preserving later state",

--- a/Backend_FastAPI/app/services/lead_admission_sync.py
+++ b/Backend_FastAPI/app/services/lead_admission_sync.py
@@ -120,6 +120,14 @@ SUBMIT_FLOOR_EVENTS: frozenset[str] = frozenset(
 # value at the call site.
 _RESULT_PUBLISHED_NO_OP: str = "result_published"
 
+# Sentinel for ``profile.status == "withdrawal_pending"`` (PR-B). While a
+# withdrawal waits for its refund to be processed, the lead KEEPS its current
+# consultation status (owner decision): sync is an explicit no-op here. The
+# pipeline only moves to sts08 when the withdrawal finalizes (status →
+# ``withdrawn``, handled by the withdrawn mapping), or stays put if the admin
+# cancels the withdrawal (status → ``draft``, handled by the draft short-circuit).
+_WITHDRAWAL_PENDING_NO_OP: str = "withdrawal_pending"
+
 
 def _should_apply_admission_floor(
     profile_status: str,
@@ -217,6 +225,18 @@ async def sync_lead_from_admission(
         log.debug(
             "sync_lead_from_admission: result_published is a future intermediate "
             "state / T6 broadcast marker — explicit no-op for lead sync",
+            profile_id=profile.id,
+        )
+        return False
+
+    # Explicit no-op for ``withdrawal_pending`` (PR-B). Holds the lead at its
+    # current consultation status until the refund finalizes (→ withdrawn → sts08)
+    # or is cancelled (→ draft, short-circuited above). Prevents an unmapped
+    # fall-through from logging a misleading "unknown status" warning.
+    if profile.status == _WITHDRAWAL_PENDING_NO_OP:
+        log.debug(
+            "sync_lead_from_admission: withdrawal_pending holds the lead status "
+            "until the refund finalizes — explicit no-op for lead sync",
             profile_id=profile.id,
         )
         return False

--- a/Backend_FastAPI/app/services/overpayment_service.py
+++ b/Backend_FastAPI/app/services/overpayment_service.py
@@ -18,6 +18,7 @@ from app.models.finance import (
     PAYABLE_INVOICE_STATUSES,
     PaymentTransaction,
     RefundRequest,
+    RefundSourceEnum,
     RefundStatusEnum,
     ResolutionTypeEnum,
     TransactionTypeEnum,
@@ -220,6 +221,7 @@ class OverpaymentService:
             reason=notes or f"Refund overpayment {overpayment.id}",
             user_id=user_id,
             unit_id=unit_id,
+            source=RefundSourceEnum.overpayment.value,
         )
 
         # F4: the overpayment liability stays *pending* and is only linked to the

--- a/Backend_FastAPI/app/services/overpayment_service.py
+++ b/Backend_FastAPI/app/services/overpayment_service.py
@@ -24,8 +24,7 @@ from app.models.finance import (
 )
 from app.repositories.fee_repository import FeeRepository, InvoiceRepository
 from app.repositories.payment_repository import OverpaymentRepository
-from app.services.payment_service import RefundService
-from app.utils.admission_status import NON_PAYABLE_PROFILE_STATUSES
+from app.services.payment_service import RefundService, assert_payable_target
 from app.utils.exceptions import (
     BadRequest,
     BusinessRuleViolation,
@@ -121,22 +120,22 @@ class OverpaymentService:
                 "Overpayment can only be applied to an invoice on the same profile"
             )
 
-        # P0: applying an overpayment writes money onto the target fee/invoice
-        # but does NOT pass through assert_payable_target — inline the profile
-        # guard so credit can't be applied to a withdrawn/rejected/refund-pending
-        # profile (its invoice can still be `issued` because withdraw does not
-        # cancel the fee).
-        target_profile_status = (
+        # P0: applying an overpayment writes money onto the target fee/invoice.
+        # Route through the shared money-write guard (target_fee + target_invoice
+        # already locked above) so credit can't land on a cancelled fee/invoice
+        # OR a withdrawn/rejected/refund-pending profile — one invariant. This
+        # also closes the pre-existing gap where a cancelled target_fee with an
+        # `issued` invoice slipped past the invoice-status check above.
+        target_profile = (
             await self.db.execute(
-                select(AdmissionProfile.status).where(
+                select(AdmissionProfile).where(
                     AdmissionProfile.id == target_fee.admission_profile_id
                 )
             )
         ).scalar_one_or_none()
-        if target_profile_status in NON_PAYABLE_PROFILE_STATUSES:
-            raise BusinessRuleViolation(
-                "Không thể áp khoản dư: hồ sơ đã rút/từ chối/đang chờ hoàn tiền."
-            )
+        assert_payable_target(
+            target_fee, target_invoice, target_profile, action="áp khoản dư"
+        )
 
         # Use `is not None` (not `or`): Decimal('0') is falsy, so `amount or ...`
         # would silently fall through to the full amount instead of being

--- a/Backend_FastAPI/app/services/overpayment_service.py
+++ b/Backend_FastAPI/app/services/overpayment_service.py
@@ -6,8 +6,10 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import List, Optional, Tuple
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models import AdmissionProfile
 from app.models.finance import (
     FeeStatusEnum,
     InvoiceStatusEnum,
@@ -23,6 +25,7 @@ from app.models.finance import (
 from app.repositories.fee_repository import FeeRepository, InvoiceRepository
 from app.repositories.payment_repository import OverpaymentRepository
 from app.services.payment_service import RefundService
+from app.utils.admission_status import NON_PAYABLE_PROFILE_STATUSES
 from app.utils.exceptions import (
     BadRequest,
     BusinessRuleViolation,
@@ -116,6 +119,23 @@ class OverpaymentService:
         if target_fee.admission_profile_id != overpayment.admission_profile_id:
             raise BusinessRuleViolation(
                 "Overpayment can only be applied to an invoice on the same profile"
+            )
+
+        # P0: applying an overpayment writes money onto the target fee/invoice
+        # but does NOT pass through assert_payable_target — inline the profile
+        # guard so credit can't be applied to a withdrawn/rejected/refund-pending
+        # profile (its invoice can still be `issued` because withdraw does not
+        # cancel the fee).
+        target_profile_status = (
+            await self.db.execute(
+                select(AdmissionProfile.status).where(
+                    AdmissionProfile.id == target_fee.admission_profile_id
+                )
+            )
+        ).scalar_one_or_none()
+        if target_profile_status in NON_PAYABLE_PROFILE_STATUSES:
+            raise BusinessRuleViolation(
+                "Không thể áp khoản dư: hồ sơ đã rút/từ chối/đang chờ hoàn tiền."
             )
 
         # Use `is not None` (not `or`): Decimal('0') is falsy, so `amount or ...`

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -54,6 +54,7 @@ from app.models.finance import (
     TransactionTypeEnum,
 )
 from app.repositories.fee_repository import FeeRepository, InvoiceRepository
+from app.utils.admission_status import NON_PAYABLE_PROFILE_STATUSES
 from app.utils.csv_helpers import sanitize_csv_row
 from app.utils.exceptions import (
     BadRequest,
@@ -1300,19 +1301,34 @@ async def commit_batch(
                 # Re-check lead chưa xóa mềm: preview lọc Lead.deleted_at IS NULL nhưng
                 # get_for_update KHÔNG lọc → chặn ghi tiền vào hồ sơ bị xóa mềm giữa
                 # preview→commit (mirror filter của _fetch_profiles).
-                lead_deleted = (
+                _pd_row = (
                     await db.execute(
-                        select(models.Lead.deleted_at)
+                        select(
+                            models.Lead.deleted_at,
+                            models.AdmissionProfile.status,
+                        )
                         .join(
                             models.AdmissionProfile,
                             models.AdmissionProfile.lead_id == models.Lead.id,
                         )
                         .where(models.AdmissionProfile.id == fee.admission_profile_id)
                     )
-                ).scalar_one_or_none()
+                ).one_or_none()
+                lead_deleted = _pd_row[0] if _pd_row else None
+                profile_status = _pd_row[1] if _pd_row else None
                 if lead_deleted is not None:
                     raise BusinessRuleViolation(
                         "hồ sơ đã bị xóa giữa preview→commit"
+                    )
+                # P0: bulk import does NOT pass through assert_payable_target, so
+                # inline the profile guard here (mirrors the fee cancelled/waived
+                # + lead-soft-deleted checks above). Refuse auto-verifying money
+                # onto a withdrawn/rejected/refund-pending profile — the invoice
+                # can still be `issued` because withdraw does not cancel the fee.
+                if profile_status in NON_PAYABLE_PROFILE_STATUSES:
+                    raise BusinessRuleViolation(
+                        f"hồ sơ đã {profile_status} — không thể thu tiền vào "
+                        f"hồ sơ đã rút/từ chối/đang chờ hoàn"
                     )
                 was_hk1 = is_hk1_settled_fee(fee)
 

--- a/Backend_FastAPI/app/services/payment_intent_service.py
+++ b/Backend_FastAPI/app/services/payment_intent_service.py
@@ -212,7 +212,20 @@ class PaymentIntentService:
         fee = await self.fee_repo.get_for_update(invoice.fee_id, unit_id)
         if fee is None:
             raise ResourceNotFoundError("Fee not found")
-        assert_payable_target(fee, invoice, action="tạo giao dịch thanh toán")
+        # Resolve the profile so the guard can also refuse creating an intent on
+        # a withdrawn/rejected/refund-pending profile (not just a cancelled fee).
+        _intent_profile = None
+        if fee.admission_profile_id:
+            _intent_profile = (
+                await self.db.execute(
+                    select(models.AdmissionProfile).where(
+                        models.AdmissionProfile.id == fee.admission_profile_id
+                    )
+                )
+            ).scalar_one_or_none()
+        assert_payable_target(
+            fee, invoice, _intent_profile, action="tạo giao dịch thanh toán"
+        )
 
         # Get payment method
         method = await self._get_payment_method(method_id)
@@ -598,12 +611,25 @@ class PaymentIntentService:
         if not fee:
             raise ResourceNotFoundError("Fee not found")
 
-        # Defense-in-depth (Nhóm B): never write money onto a cancelled fee or
-        # invoice. cancel_fee blocks while an active intent exists, so the normal
-        # path can't reach here; this also closes the manual cancel-invoice /
+        # Resolve admission profile (with lead eager-loaded) BEFORE the payable
+        # guard so a late gateway success is refused on a withdrawn/rejected/
+        # refund-pending profile too, not only a cancelled fee/invoice. Reused
+        # below for post-commit payload + HK1 lead sync.
+        profile: Optional[models.AdmissionProfile] = None
+        if fee.admission_profile_id:
+            result = await self.db.execute(
+                select(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == fee.admission_profile_id)
+                .options(selectinload(models.AdmissionProfile.lead))
+            )
+            profile = result.scalar_one_or_none()
+
+        # Defense-in-depth (Nhóm B): never write money onto a dead target.
+        # cancel_fee blocks while an active intent exists, so the normal path
+        # can't reach here; this also closes the manual cancel-invoice /
         # cancel-intent surface. A late gateway success on a dead target is
         # refused — the caller marks the intent failed; reconcile out-of-band.
-        assert_payable_target(fee, invoice, action="ghi nhận thanh toán")
+        assert_payable_target(fee, invoice, profile, action="ghi nhận thanh toán")
 
         # Capture balance before
         fee_balance_before = fee.final_amount - fee.paid_amount - fee.waived_amount
@@ -669,18 +695,6 @@ class PaymentIntentService:
 
         await self.db.flush()
         await self.db.refresh(payment)
-
-        # Resolve admission profile (with lead eager-loaded) for post-commit
-        # payload + lead sync. Mirrors payment_service._get_profile_for_fee
-        # pattern; inlined here to avoid cross-service dependency.
-        profile: Optional[models.AdmissionProfile] = None
-        if fee.admission_profile_id:
-            result = await self.db.execute(
-                select(models.AdmissionProfile)
-                .where(models.AdmissionProfile.id == fee.admission_profile_id)
-                .options(selectinload(models.AdmissionProfile.lead))
-            )
-            profile = result.scalar_one_or_none()
 
         # ADR-002 PR 5: Sync lead only on HK1 SETTLED-state transition
         # (remaining<=0). Partial online payment leaves lead at sts14.

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -138,10 +138,13 @@ def assert_payable_target(
     *,
     action: str,
 ) -> None:
-    """Refuse to write money onto a dead target — the SINGLE invariant every
-    money-touching entry runs right after locking the fee+invoice (manual
-    verify, online callback, intent creation). Centralising it means a future
-    entry point can't silently re-open the "ghi tiền vào target đã chết" hole.
+    """Refuse to write money onto a dead target — the shared invariant the
+    money-touching entries run right after locking the fee+invoice: manual
+    record, manual verify, online callback, intent creation, and overpayment
+    apply. The ONE exception is bulk import, which inlines an equivalent
+    per-row check (routing each row through here would force a per-row
+    ``selectinload``); keep the two in sync. Centralising it means a future
+    entry point can reuse one guard instead of re-deriving the checks.
     ``action`` customises the Vietnamese message.
 
     Two dead-target classes are refused:
@@ -252,16 +255,14 @@ class PaymentService:
         # P0: never even stage a pending payment on a withdrawn/rejected/
         # refund-pending profile. The invoice can still be `issued` on such a
         # profile (withdraw does not cancel fees), so the payable-status check
-        # above is not enough — resolve the profile and refuse up front.
-        _fee_for_guard = (
-            await self.db.get(Fee, invoice.fee_id) if invoice.fee_id else None
+        # above is not enough — resolve the fee/profile ONCE here, refuse up
+        # front, and reuse them for the notification payload below.
+        fee = await self.db.get(Fee, invoice.fee_id) if invoice.fee_id else None
+        profile = (
+            await self._get_profile_for_fee(fee) if fee is not None else None
         )
-        if _fee_for_guard is not None:
-            _profile_for_guard = await self._get_profile_for_fee(_fee_for_guard)
-            assert_payable_target(
-                _fee_for_guard, invoice, _profile_for_guard,
-                action="ghi nhận thanh toán",
-            )
+        if fee is not None:
+            assert_payable_target(fee, invoice, profile, action="ghi nhận thanh toán")
 
         # Validate amount doesn't exceed remaining
         remaining = invoice.remaining_amount
@@ -305,17 +306,14 @@ class PaymentService:
             created_by=user_id,
         )
 
-        # Resolve data for notification while session is active
-        fee = await self.db.get(Fee, invoice.fee_id) if invoice.fee_id else None
+        # Notification payload (fee/profile already resolved above for the guard)
         _profile_id = fee.admission_profile_id if fee else None
         _lead_id = None
         _officer_id = None
-        if fee:
-            profile = await self._get_profile_for_fee(fee)
-            if profile:
-                _lead_id = profile.lead_id
-                if hasattr(profile, 'lead') and profile.lead:
-                    _officer_id = profile.lead.assigned_officer_id
+        if profile:
+            _lead_id = profile.lead_id
+            if hasattr(profile, 'lead') and profile.lead:
+                _officer_id = profile.lead.assigned_officer_id
 
         _notify_payload = {
             "payment_id": payment.id,

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -1098,7 +1098,15 @@ class RefundService:
         profile = await self._get_profile_for_fee(fee)
 
         # ADR-002 PR 5 (D9): Only HK1 refund projects into admission pipeline.
-        if fee.fee_type == "tuition" and fee.semester_no == 1 and profile is not None:
+        # PR-B (blocker 1): while a withdrawal is pending, the lead is HELD — do
+        # NOT push it to sts18 here; the finalize below moves it to sts08 once
+        # the refund completes. Refunds OUTSIDE a withdrawal still project sts18.
+        if (
+            fee.fee_type == "tuition"
+            and fee.semester_no == 1
+            and profile is not None
+            and profile.status != "withdrawal_pending"
+        ):
             from app.services.lead_admission_sync import sync_lead_tuition_refunded
             await sync_lead_tuition_refunded(
                 db=self.db,
@@ -1107,6 +1115,32 @@ class RefundService:
                 changed_by_user_id=processor_id,
                 reason=f"Tuition fee refunded: {refund.amount:,.0f} VND. Reason: {refund.reason}",
             )
+
+        # PR-B: finalize the withdrawal once the LAST refundable payment is
+        # returned. reverse_payment_balances above already decremented this
+        # fee's paid_amount, so sum_unrefunded_refundable_paid reflects the
+        # post-refund balance. Gate on status==withdrawal_pending so ordinary
+        # refunds are untouched. NOTE: not row-locked — refunds are processed
+        # sequentially in practice; two concurrent last-refunds on one profile
+        # are vanishingly rare (plan §2.3).
+        withdraw_finalize_cb = None
+        if profile is not None and profile.status == "withdrawal_pending":
+            from app.repositories.fee_repository import FeeRepository
+            _remaining = await FeeRepository(
+                self.db
+            ).sum_unrefunded_refundable_paid(profile.id)
+            if _remaining <= 0:
+                import app.services.admission_service as admission_service
+                _processor = await self.db.get(models.User, processor_id)
+                profile, withdraw_finalize_cb = (
+                    await admission_service._finalize_withdrawn(
+                        self.db,
+                        profile,
+                        _processor,
+                        from_status="withdrawal_pending",
+                        reason=f"Hoàn tất hoàn tiền — chốt rút hồ sơ #{profile.id}",
+                    )
+                )
 
         log.info(
             "refund_processed",
@@ -1155,6 +1189,11 @@ class RefundService:
                 payload=_notify_payload,
                 rooms=_rooms,
             )
+            # PR-B: run the withdraw-finalize bundle (milestone + APPLICATION/
+            # LEAD status-changed) AFTER the refund notification, in the same
+            # post-commit frame.
+            if withdraw_finalize_cb is not None:
+                await withdraw_finalize_cb()
 
         return refund, post_commit
 

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -1225,38 +1225,8 @@ class RefundService:
                             ),
                         )
                     )
-                    # Issue 1 (PR-B follow-up): every refundable fee's
-                    # paid_amount is now 0, but reverse_payment_balances reopened
-                    # each invoice to 'issued' (payable) — a phantom receivable
-                    # ("còn nợ") on a profile that just settled to withdrawn.
-                    # Cancel the now-unpaid non-application fees (cancel_fee
-                    # cascades to their invoices) so no payable surface survives.
-                    # Runs AFTER _finalize_withdrawn: the lead is already at sts08
-                    # so cancel_fee's HK1 sts14-revert is a guarded no-op, and the
-                    # application (lệ phí xét tuyển) fee is skipped — it is not
-                    # refunded and must stay collected. cancel_fee returns no
-                    # callback, so nothing to compose.
-                    from app.services.fee_calculation_service import (
-                        FeeCalculationService,
-                    )
-                    _fee_calc = FeeCalculationService(self.db)
-                    _fees = await FeeRepository(self.db).get_by_profile_id(
-                        locked_profile.id
-                    )
-                    for _f in _fees:
-                        if (
-                            _f.fee_type != "application"
-                            and _f.paid_amount == 0
-                            and _f.status != FeeStatusEnum.cancelled.value
-                        ):
-                            await _fee_calc.cancel_fee(
-                                _f.id,
-                                reason=(
-                                    "Chốt rút hồ sơ "
-                                    f"#{locked_profile.id} — huỷ phí đã hoàn"
-                                ),
-                                user_id=processor_id,
-                            )
+                    # (Phantom-invoice cleanup lives INSIDE _finalize_withdrawn,
+                    # gated on from_status=='withdrawal_pending' — Issue 1/#7.)
 
         log.info(
             "refund_processed",

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -49,6 +49,7 @@ from app.utils.exceptions import (
     BusinessRuleViolation,
     ConflictError,
 )
+from app.utils.admission_status import NON_PAYABLE_PROFILE_STATUSES
 from app.config import settings
 
 log = structlog.get_logger(__name__)
@@ -131,13 +132,30 @@ def reverse_payment_balances(
 
 
 def assert_payable_target(
-    fee: Optional[Fee], invoice: Optional[Invoice], *, action: str
+    fee: Optional[Fee],
+    invoice: Optional[Invoice],
+    profile: Optional["models.AdmissionProfile"],
+    *,
+    action: str,
 ) -> None:
-    """Refuse to act on a cancelled fee/invoice — the SINGLE invariant every
+    """Refuse to write money onto a dead target — the SINGLE invariant every
     money-touching entry runs right after locking the fee+invoice (manual
     verify, online callback, intent creation). Centralising it means a future
-    fourth entry point can't silently re-open the "ghi tiền vào fee đã huỷ"
-    hole. ``action`` customises the Vietnamese message.
+    entry point can't silently re-open the "ghi tiền vào target đã chết" hole.
+    ``action`` customises the Vietnamese message.
+
+    Two dead-target classes are refused:
+      1. **Cancelled fee/invoice** — the fee or its invoice was cancelled
+         (``cancel_fee`` / cancel-invoice) after this operation started.
+      2. **Non-payable profile** — the admission profile was withdrawn /
+         rejected / is awaiting refund (``NON_PAYABLE_PROFILE_STATUSES``).
+         The invoice can still be ``issued`` on a withdrawn profile (withdraw
+         does not cancel fees today), so the invoice-status check alone would
+         let money land on a profile that is on its way out.
+
+    ``profile`` is REQUIRED (pass ``None`` explicitly when the fee has no
+    admission-profile linkage) so every caller consciously resolves it — a
+    silent default would re-open exactly the hole this guard closes.
     """
     if (fee is not None and fee.status == FeeStatusEnum.cancelled.value) or (
         invoice is not None
@@ -145,6 +163,10 @@ def assert_payable_target(
     ):
         raise BusinessRuleViolation(
             f"Không thể {action}: khoản phí/hoá đơn đã bị huỷ."
+        )
+    if profile is not None and profile.status in NON_PAYABLE_PROFILE_STATUSES:
+        raise BusinessRuleViolation(
+            f"Không thể {action}: hồ sơ đã rút/từ chối/đang chờ hoàn tiền."
         )
 
 
@@ -225,6 +247,20 @@ class PaymentService:
             raise BusinessRuleViolation(
                 f"Cannot record payment for invoice with status '{invoice.status}'. "
                 f"Allowed: {list(PAYABLE_INVOICE_STATUSES)}"
+            )
+
+        # P0: never even stage a pending payment on a withdrawn/rejected/
+        # refund-pending profile. The invoice can still be `issued` on such a
+        # profile (withdraw does not cancel fees), so the payable-status check
+        # above is not enough — resolve the profile and refuse up front.
+        _fee_for_guard = (
+            await self.db.get(Fee, invoice.fee_id) if invoice.fee_id else None
+        )
+        if _fee_for_guard is not None:
+            _profile_for_guard = await self._get_profile_for_fee(_fee_for_guard)
+            assert_payable_target(
+                _fee_for_guard, invoice, _profile_for_guard,
+                action="ghi nhận thanh toán",
             )
 
         # Validate amount doesn't exceed remaining
@@ -381,11 +417,14 @@ class PaymentService:
             raise ResourceNotFoundError("Fee not found")
 
         # Defense-in-depth: the fee/invoice may have been cancelled (cancel_fee)
-        # AFTER this pending payment was recorded but BEFORE verification. Refuse
-        # to write money onto a cancelled target — the pending payment is left
-        # for rejection. cancel_fee blocks while a pending payment exists, so
-        # this only fires for the narrow record-during-cancel race window.
-        assert_payable_target(fee, invoice, action="xác minh thanh toán")
+        # AFTER this pending payment was recorded but BEFORE verification, or the
+        # profile may have been withdrawn/rejected in the meantime. Refuse to
+        # write money onto a dead target — the pending payment is left for
+        # rejection. cancel_fee blocks while a pending payment exists, so the
+        # cancelled-target case only fires for the narrow record-during-cancel
+        # race; the profile check closes the withdrawn-but-fee-still-issued hole.
+        profile = await self._get_profile_for_fee(fee)
+        assert_payable_target(fee, invoice, profile, action="xác minh thanh toán")
 
         # Capture settled state BEFORE mutation (PR 5 transition detection)
         from app.services.fee_calculation_service import is_hk1_settled_fee
@@ -1153,7 +1192,13 @@ class RefundService:
         self,
         fee: Fee,
     ) -> Optional[models.AdmissionProfile]:
-        """Get admission profile for fee with Lead relationship loaded."""
+        """Get admission profile for fee with Lead relationship loaded.
+
+        RefundService's own copy — ``process_approved_refund`` resolves the
+        profile via ``self``. Deliberately NOT shared with
+        ``PaymentService._get_profile_for_fee``: they are the same body on two
+        separate service classes, not a duplicate to dedupe.
+        """
         query = (
             select(models.AdmissionProfile)
             .options(selectinload(models.AdmissionProfile.lead))

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -952,6 +952,8 @@ class RefundService:
         reason: str,
         rejector_id: int,
         unit_id: Optional[int] = None,
+        *,
+        allow_withdrawal_pending: bool = False,
     ) -> Tuple["RefundRequest", Optional[Callable]]:
         """
         Reject a refund request.
@@ -961,6 +963,11 @@ class RefundService:
             reason: Rejection reason
             rejector_id: User rejecting refund
             unit_id: Unit ID for IDOR protection
+            allow_withdrawal_pending: bypass the F1 guard below — set ONLY by
+                ``reject_open_refunds_for_profile`` (cancel-withdrawal), which
+                rejects ALL withdrawal refunds atomically and reverts the profile
+                to draft, so the strand-in-``withdrawal_pending`` risk cannot
+                occur there.
 
         Returns:
             Tuple of (RefundRequest, post_commit_callback)
@@ -978,6 +985,32 @@ class RefundService:
 
         if not reason or not reason.strip():
             raise BadRequest("Rejection reason is required")
+
+        # F1: a withdrawal-sourced refund on a profile still in
+        # 'withdrawal_pending' must NOT be rejected individually — rejecting one
+        # of several strands the profile forever (the finalize gate
+        # sum_unrefunded_refundable_paid never reaches 0, money stays held). The
+        # admin must use cancel-withdrawal, which rejects ALL withdrawal refunds
+        # atomically and reverts the profile to draft.
+        if (
+            not allow_withdrawal_pending
+            and refund.source == RefundSourceEnum.withdrawal.value
+        ):
+            _prof_status = (
+                await self.db.execute(
+                    select(models.AdmissionProfile.status)
+                    .join(Fee, Fee.admission_profile_id == models.AdmissionProfile.id)
+                    .join(Invoice, Invoice.fee_id == Fee.id)
+                    .join(Payment, Payment.invoice_id == Invoice.id)
+                    .where(Payment.id == refund.payment_id)
+                )
+            ).scalar_one_or_none()
+            if _prof_status == "withdrawal_pending":
+                raise BusinessRuleViolation(
+                    "Không thể từ chối lẻ yêu cầu hoàn của hồ sơ đang rút "
+                    "(sẽ kẹt hồ sơ ở trạng thái chờ hoàn). Dùng 'Hủy quy trình "
+                    "rút' để hủy toàn bộ và đưa hồ sơ về nháp."
+                )
 
         # Update refund status
         refund.status = RefundStatusEnum.rejected.value
@@ -1052,6 +1085,7 @@ class RefundService:
         for r in open_refunds:
             await self.reject_refund(
                 r.id, reason=reason, rejector_id=rejector_id,
+                allow_withdrawal_pending=True,  # F1: this IS the safe bulk path
             )
             count += 1
         return count
@@ -1112,12 +1146,24 @@ class RefundService:
         refund.refunded_at = datetime.now(timezone.utc)
         refund.refund_reference = refund_reference
 
+        # F2: snapshot BEFORE reverse — reverse_payment_balances recomputes
+        # fee.status from paid_amount and reopens the invoice to 'issued'. If the
+        # fee was already CANCELLED (e.g. a prior withdrawal finalize voided it),
+        # processing this (overpayment/manual) refund would un-cancel it and
+        # resurrect a phantom receivable on a withdrawn profile — re-void below.
+        _fee_was_cancelled = fee.status == FeeStatusEnum.cancelled.value
+
         # Rút tiền khỏi invoice + fee — 1 NGUỒN SỰ THẬT chung với void lô import
         # (reverse_payment_balances). paid về 0 → invoice 'issued' (mở lại để thu),
         # fee recompute status + bump version.
         fee_balance_before, fee_balance_after = reverse_payment_balances(
             invoice=invoice, fee=fee, amount=refund.amount
         )
+        if _fee_was_cancelled:
+            # F2: keep the void — money still returned, but the fee/invoice stay
+            # cancelled so no payable surface / "Còn nợ" reappears.
+            fee.status = FeeStatusEnum.cancelled.value
+            invoice.status = InvoiceStatusEnum.cancelled.value
 
         # Create audit transaction
         transaction = PaymentTransaction(

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -34,7 +34,7 @@ from app import models
 from app.models.finance import (
     Fee, Invoice, Payment, PaymentTransaction, PaymentMethod,
     PaymentStatusEnum, InvoiceStatusEnum, FeeStatusEnum,
-    RefundRequest, RefundStatusEnum, TransactionTypeEnum,
+    RefundRequest, RefundStatusEnum, RefundSourceEnum, TransactionTypeEnum,
     OverpaymentRecord, OverpaymentStatusEnum, ResolutionTypeEnum,
     PAYABLE_INVOICE_STATUSES,
 )
@@ -819,6 +819,7 @@ class RefundService:
         reason: str,
         user_id: int,
         unit_id: Optional[int] = None,
+        source: str = RefundSourceEnum.manual.value,
     ) -> Tuple["RefundRequest", Optional[Callable]]:
         """
         Request a refund for a verified payment.
@@ -829,6 +830,10 @@ class RefundService:
             reason: Refund reason (required)
             user_id: User requesting refund
             unit_id: Unit ID for IDOR protection
+            source: Origin of the request (``manual`` by default). The withdraw
+                orchestrator passes ``withdrawal`` and overpayment refunds pass
+                ``overpayment`` so ``reject_open_refunds_for_profile`` can target
+                only auto-filed withdrawal refunds.
 
         Returns:
             Tuple of (RefundRequest, post_commit_callback)
@@ -874,6 +879,7 @@ class RefundService:
             amount=amount,
             reason=reason,
             status=RefundStatusEnum.pending.value,
+            source=source,
             requested_by_id=user_id,
             requested_at=datetime.now(timezone.utc),
         )
@@ -997,13 +1003,15 @@ class RefundService:
         reason: str,
         rejector_id: int,
     ) -> int:
-        """Reject every PENDING refund of a profile (PR-B F1).
+        """Reject every open WITHDRAWAL-sourced refund of a profile (PR-B F1).
 
         Used when a withdrawal is cancelled/rolled back (``withdrawal_pending →
         draft``): the withdraw orchestrator auto-files refund requests, and if
         those are left open they could later be processed — returning money on a
         profile that has since been re-activated (draft → … → enrolled). This
-        rejects the pending ones so they can never be processed.
+        rejects the pending ones so they can never be processed. Only
+        ``source='withdrawal'`` refunds are touched — a manual or overpayment
+        refund is independently managed and left as-is.
 
         Raises ``BusinessRuleViolation`` if any refund is already APPROVED
         (awaiting processing): that cannot be silently cancelled here — the
@@ -1018,6 +1026,12 @@ class RefundService:
             .join(Fee, Invoice.fee_id == Fee.id)
             .where(
                 Fee.admission_profile_id == profile_id,
+                # Only the refunds THIS withdraw orchestrator auto-filed. A
+                # pre-existing manual (finance-created) or overpayment refund is
+                # independently managed and must survive the withdrawal rollback
+                # — rejecting it here would silently kill an unrelated refund and
+                # (for overpayment) re-open a liability that was being settled.
+                RefundRequest.source == RefundSourceEnum.withdrawal.value,
                 RefundRequest.status.in_([
                     RefundStatusEnum.pending.value,
                     RefundStatusEnum.approved.value,
@@ -1211,6 +1225,38 @@ class RefundService:
                             ),
                         )
                     )
+                    # Issue 1 (PR-B follow-up): every refundable fee's
+                    # paid_amount is now 0, but reverse_payment_balances reopened
+                    # each invoice to 'issued' (payable) — a phantom receivable
+                    # ("còn nợ") on a profile that just settled to withdrawn.
+                    # Cancel the now-unpaid non-application fees (cancel_fee
+                    # cascades to their invoices) so no payable surface survives.
+                    # Runs AFTER _finalize_withdrawn: the lead is already at sts08
+                    # so cancel_fee's HK1 sts14-revert is a guarded no-op, and the
+                    # application (lệ phí xét tuyển) fee is skipped — it is not
+                    # refunded and must stay collected. cancel_fee returns no
+                    # callback, so nothing to compose.
+                    from app.services.fee_calculation_service import (
+                        FeeCalculationService,
+                    )
+                    _fee_calc = FeeCalculationService(self.db)
+                    _fees = await FeeRepository(self.db).get_by_profile_id(
+                        locked_profile.id
+                    )
+                    for _f in _fees:
+                        if (
+                            _f.fee_type != "application"
+                            and _f.paid_amount == 0
+                            and _f.status != FeeStatusEnum.cancelled.value
+                        ):
+                            await _fee_calc.cancel_fee(
+                                _f.id,
+                                reason=(
+                                    "Chốt rút hồ sơ "
+                                    f"#{locked_profile.id} — huỷ phí đã hoàn"
+                                ),
+                                user_id=processor_id,
+                            )
 
         log.info(
             "refund_processed",

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -990,6 +990,58 @@ class RefundService:
 
         return refund, None
 
+    async def reject_open_refunds_for_profile(
+        self,
+        profile_id: int,
+        *,
+        reason: str,
+        rejector_id: int,
+    ) -> int:
+        """Reject every PENDING refund of a profile (PR-B F1).
+
+        Used when a withdrawal is cancelled/rolled back (``withdrawal_pending →
+        draft``): the withdraw orchestrator auto-files refund requests, and if
+        those are left open they could later be processed — returning money on a
+        profile that has since been re-activated (draft → … → enrolled). This
+        rejects the pending ones so they can never be processed.
+
+        Raises ``BusinessRuleViolation`` if any refund is already APPROVED
+        (awaiting processing): that cannot be silently cancelled here — the
+        operator must process or reject it first — so the caller (cancel/rollback)
+        surfaces a 400 instead of orphaning an in-flight refund. Returns the
+        number of refunds rejected.
+        """
+        stmt = (
+            select(RefundRequest)
+            .join(Payment, RefundRequest.payment_id == Payment.id)
+            .join(Invoice, Payment.invoice_id == Invoice.id)
+            .join(Fee, Invoice.fee_id == Fee.id)
+            .where(
+                Fee.admission_profile_id == profile_id,
+                RefundRequest.status.in_([
+                    RefundStatusEnum.pending.value,
+                    RefundStatusEnum.approved.value,
+                ]),
+            )
+        )
+        open_refunds = list((await self.db.execute(stmt)).scalars().all())
+
+        if any(
+            r.status == RefundStatusEnum.approved.value for r in open_refunds
+        ):
+            raise BusinessRuleViolation(
+                "Không thể hủy quy trình rút: còn yêu cầu hoàn tiền ĐÃ DUYỆT "
+                "đang chờ xử lý. Hãy xử lý (hoặc từ chối) yêu cầu hoàn đó trước."
+            )
+
+        count = 0
+        for r in open_refunds:
+            await self.reject_refund(
+                r.id, reason=reason, rejector_id=rejector_id,
+            )
+            count += 1
+        return count
+
     async def process_approved_refund(
         self,
         refund_id: int,
@@ -1120,27 +1172,45 @@ class RefundService:
         # returned. reverse_payment_balances above already decremented this
         # fee's paid_amount, so sum_unrefunded_refundable_paid reflects the
         # post-refund balance. Gate on status==withdrawal_pending so ordinary
-        # refunds are untouched. NOTE: not row-locked — refunds are processed
-        # sequentially in practice; two concurrent last-refunds on one profile
-        # are vanishingly rare (plan §2.3).
+        # refunds are untouched.
         withdraw_finalize_cb = None
         if profile is not None and profile.status == "withdrawal_pending":
-            from app.repositories.fee_repository import FeeRepository
-            _remaining = await FeeRepository(
-                self.db
-            ).sum_unrefunded_refundable_paid(profile.id)
-            if _remaining <= 0:
-                import app.services.admission_service as admission_service
-                _processor = await self.db.get(models.User, processor_id)
-                profile, withdraw_finalize_cb = (
-                    await admission_service._finalize_withdrawn(
-                        self.db,
-                        profile,
-                        _processor,
-                        from_status="withdrawal_pending",
-                        reason=f"Hoàn tất hoàn tiền — chốt rút hồ sơ #{profile.id}",
-                    )
+            # F5: LOCK the profile row so two concurrent last-refunds serialize.
+            # Without the lock each reads the other's not-yet-committed balance as
+            # >0 → NEITHER finalizes → the profile is stranded in
+            # withdrawal_pending with money fully refunded. Re-read status under
+            # the lock (an admin cancel-withdrawal may have moved it to draft).
+            locked_profile = (
+                await self.db.execute(
+                    select(models.AdmissionProfile)
+                    .where(models.AdmissionProfile.id == profile.id)
+                    .options(selectinload(models.AdmissionProfile.lead))
+                    .with_for_update()
                 )
+            ).scalar_one_or_none()
+            if (
+                locked_profile is not None
+                and locked_profile.status == "withdrawal_pending"
+            ):
+                from app.repositories.fee_repository import FeeRepository
+                _remaining = await FeeRepository(
+                    self.db
+                ).sum_unrefunded_refundable_paid(locked_profile.id)
+                if _remaining <= 0:
+                    import app.services.admission_service as admission_service
+                    _processor = await self.db.get(models.User, processor_id)
+                    profile, withdraw_finalize_cb = (
+                        await admission_service._finalize_withdrawn(
+                            self.db,
+                            locked_profile,
+                            _processor,
+                            from_status="withdrawal_pending",
+                            reason=(
+                                "Hoàn tất hoàn tiền — chốt rút hồ sơ "
+                                f"#{locked_profile.id}"
+                            ),
+                        )
+                    )
 
         log.info(
             "refund_processed",

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -117,6 +117,7 @@ _HARD_DENIED_STATUS: frozenset[str] = frozenset({
     "withdrawn",
     "dropped",
     "rejected",
+    "withdrawal_pending",  # PR-B: profile is on its way out (awaiting refund)
 })
 
 _MIN_REASON_LEN = 20
@@ -174,6 +175,7 @@ _EVIDENCE_HARD_DENIED_STATUS: frozenset[str] = frozenset({
     "withdrawn",
     "dropped",
     "rejected",
+    "withdrawal_pending",  # PR-B: profile is on its way out (awaiting refund)
 })
 
 # Legacy alias retained — referenced by external callers; matches the

--- a/Backend_FastAPI/app/services/quota_matrix_service.py
+++ b/Backend_FastAPI/app/services/quota_matrix_service.py
@@ -203,7 +203,11 @@ class QuotaMatrixService:
             select(
                 AdmissionProfileChoice.admission_path_id.label("path_id"),
                 func.count(distinct(AdmissionProfileChoice.admission_profile_id))
-                .filter(AdmissionProfile.status.not_in(("draft", "withdrawn")))
+                .filter(
+                    AdmissionProfile.status.not_in(
+                        ("draft", "withdrawn", "withdrawal_pending")
+                    )
+                )
                 .label("submitted_cnt"),
                 func.count(distinct(AdmissionProfileChoice.admission_profile_id))
                 .filter(
@@ -249,7 +253,11 @@ class QuotaMatrixService:
             select(
                 path_id_text.label("path_id_text"),
                 func.count(AdmissionProfile.id)
-                .filter(AdmissionProfile.status.not_in(("draft", "withdrawn")))
+                .filter(
+                    AdmissionProfile.status.not_in(
+                        ("draft", "withdrawn", "withdrawal_pending")
+                    )
+                )
                 .label("submitted_cnt"),
                 func.count(AdmissionProfile.id)
                 .filter(AdmissionProfile.status.in_(QUOTA_OCCUPYING_STATUSES))

--- a/Backend_FastAPI/app/utils/admission_status.py
+++ b/Backend_FastAPI/app/utils/admission_status.py
@@ -85,6 +85,23 @@ CONFIRMATION_ELIGIBLE_STATUSES: frozenset[str] = frozenset(
 )
 
 
+# Profile statuses on which NO money may be recorded — the shared money-write
+# gate for the whole finance surface. A profile that has been withdrawn /
+# rejected / is awaiting-refund (``withdrawal_pending``) must never accept a new
+# payment through ANY entry point: manual verify, online-gateway callback,
+# intent creation, bulk import, or overpayment application. Centralised here (a
+# pure, side-effect-free module) so every money-touching service checks the
+# SAME set and a future entry point cannot silently re-open the hole.
+#
+# ``withdrawal_pending`` is pre-seeded here BEFORE the state itself lands (it
+# arrives with the refund-cleanup PR-B). It is a harmless, never-matched string
+# until the CHECK constraint / state machine widen to allow it, and pre-seeding
+# means PR-B need not re-touch every guard site.
+NON_PAYABLE_PROFILE_STATUSES: frozenset[str] = frozenset(
+    {"withdrawn", "rejected", "withdrawal_pending"}
+)
+
+
 def is_admitted_like(profile: "AdmissionProfile") -> bool:
     """True iff ``profile.status`` is in the admitted-equivalent set.
 

--- a/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
+++ b/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
@@ -963,3 +963,119 @@ class TestUnrefundedPaymentFlag:
         assert ok.status_code == 200, ok.text
         assert ok.json()["status"] == "approved", ok.json()
         assert ok.json()["has_unrefunded_payment"] is False, ok.json()
+
+
+# ===========================================================================
+# PR-B §2.10 — withdrawal_pending finalize + cancel-withdrawal
+# ===========================================================================
+
+
+class TestWithdrawalPendingFlow:
+    """Withdraw with collected refundable tuition → withdrawal_pending, then
+    either finalize (refund processed → withdrawn) or cancel (admin → draft)."""
+
+    async def test_finalize_on_last_refund(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """Scenario (e): withdraw parks the profile in withdrawal_pending and
+        auto-files a refund; processing that refund self-settles the profile to
+        ``withdrawn`` (finalize hook) + lead → sts08."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+        await _ensure_consultation_status(
+            "sts08", "Tu choi tu van", "stg07", "#CC0000"
+        )
+
+        pid = await _submit_and_prepay(
+            client, officer, manager, accountant, unit_id, officer_user_in_db["id"]
+        )
+
+        # Withdraw → withdrawal_pending (BE auto-files a refund request whose
+        # requester is the withdrawing actor). Withdraw as the OFFICER so the
+        # auto-filed refund's maker (officer) differs from its approver
+        # (manager) — otherwise the approve step self-approves and 400s.
+        body = await _get(client, officer, pid)
+        res = await client.post(
+            f"{ADMISSIONS}/{pid}/withdraw",
+            headers=officer,
+            json={"reason": "Học sinh rút hồ sơ", "version": body["version"]},
+        )
+        assert res.status_code == 200, res.text
+        assert res.json()["status"] == "withdrawal_pending", res.json()
+
+        # Find the auto-filed pending refund, then approve + process it.
+        refunds = await client.get(
+            "/api/refunds", params={"status": "pending"}, headers=manager
+        )
+        assert refunds.status_code == 200, refunds.text
+        items = refunds.json()["items"]
+        assert len(items) >= 1, items
+        refund_id = items[0]["id"]
+
+        appr = await client.post(
+            f"/api/refunds/{refund_id}/approve", headers=manager
+        )
+        assert appr.status_code == 200, appr.text
+        proc = await client.post(
+            f"/api/refunds/{refund_id}/process",
+            json={"refund_id": refund_id, "refund_reference": "BANK-REF-FIN"},
+            headers=accountant,
+        )
+        assert proc.status_code == 200, proc.text
+
+        # Finalize hook fired: profile self-settled to withdrawn.
+        after = await _get(client, manager, pid)
+        assert after["status"] == "withdrawn", after
+        assert after["has_unrefunded_payment"] is False, after
+
+    async def test_admin_cancel_withdrawal_back_to_draft(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """§2.4: admin cancels a pending withdrawal → draft; a non-admin
+        (manager) is blocked by ``require_admin`` (403)."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+        admin = await _auth(client, admin_user_in_db)
+
+        pid = await _submit_and_prepay(
+            client, officer, manager, accountant, unit_id, officer_user_in_db["id"]
+        )
+        body = await _get(client, manager, pid)
+        res = await client.post(
+            f"{ADMISSIONS}/{pid}/withdraw",
+            headers=manager,
+            json={"reason": "Rút hồ sơ chờ hoàn", "version": body["version"]},
+        )
+        assert res.status_code == 200 and res.json()["status"] == "withdrawal_pending"
+
+        # Non-admin (manager) cannot cancel → 403.
+        forbidden = await client.post(
+            f"{ADMISSIONS}/{pid}/cancel-withdrawal",
+            headers=manager,
+            json={"reason": "Manager thử hủy — phải bị chặn"},
+        )
+        assert forbidden.status_code == 403, forbidden.text
+
+        # Admin cancels → draft.
+        cancel = await client.post(
+            f"{ADMISSIONS}/{pid}/cancel-withdrawal",
+            headers=admin,
+            json={"reason": "Hoàn tiền bị từ chối — đưa hồ sơ về nháp"},
+        )
+        assert cancel.status_code == 200, cancel.text
+        assert cancel.json()["status"] == "draft", cancel.json()

--- a/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
+++ b/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
@@ -816,6 +816,20 @@ async def _submit_and_prepay(
     return pid
 
 
+async def _lead_status_of(profile_id: int) -> str | None:
+    """Consultation status of the lead behind a profile (lead-sync asserts)."""
+    async with AsyncSessionLocal() as session:
+        row = await session.execute(
+            select(models.Lead.consultation_status_id)
+            .join(
+                models.AdmissionProfile,
+                models.AdmissionProfile.lead_id == models.Lead.id,
+            )
+            .where(models.AdmissionProfile.id == profile_id)
+        )
+        return row.scalar_one_or_none()
+
+
 class TestUnrefundedPaymentFlag:
     async def test_reject_with_prepay_sets_flag_and_warns(
         self,
@@ -1010,14 +1024,21 @@ class TestWithdrawalPendingFlow:
         assert res.status_code == 200, res.text
         assert res.json()["status"] == "withdrawal_pending", res.json()
 
-        # Find the auto-filed pending refund, then approve + process it.
+        # Find the auto-filed pending refund for THIS profile by reason (NOT
+        # items[0] — the pending list is unit-wide and other tests leave pending
+        # refunds behind). Assert exactly one, for the collected tuition amount.
         refunds = await client.get(
             "/api/refunds", params={"status": "pending"}, headers=manager
         )
         assert refunds.status_code == 200, refunds.text
-        items = refunds.json()["items"]
-        assert len(items) >= 1, items
-        refund_id = items[0]["id"]
+        mine = [
+            r for r in refunds.json()["items"]
+            if f"#{pid}" in (r.get("reason") or "")
+        ]
+        assert len(mine) == 1, mine
+        refund = mine[0]
+        refund_id = refund["id"]
+        assert Decimal(refund["amount"]) == PREPAY, refund
 
         appr = await client.post(
             f"/api/refunds/{refund_id}/approve", headers=manager
@@ -1030,10 +1051,11 @@ class TestWithdrawalPendingFlow:
         )
         assert proc.status_code == 200, proc.text
 
-        # Finalize hook fired: profile self-settled to withdrawn.
+        # Finalize hook fired: profile self-settled to withdrawn + lead → sts08.
         after = await _get(client, manager, pid)
         assert after["status"] == "withdrawn", after
         assert after["has_unrefunded_payment"] is False, after
+        assert await _lead_status_of(pid) == "sts08"
 
     async def test_admin_cancel_withdrawal_back_to_draft(
         self,
@@ -1079,3 +1101,48 @@ class TestWithdrawalPendingFlow:
         )
         assert cancel.status_code == 200, cancel.text
         assert cancel.json()["status"] == "draft", cancel.json()
+
+        # F1: the refund the withdraw auto-filed must now be REJECTED — so it can
+        # never be processed and return money on this re-activated profile.
+        rejected = await client.get(
+            "/api/refunds", params={"status": "rejected"}, headers=admin
+        )
+        assert rejected.status_code == 200, rejected.text
+        assert any(
+            f"#{pid}" in (r.get("reason") or "")
+            for r in rejected.json()["items"]
+        ), rejected.json()
+
+    async def test_cannot_rewithdraw_pending(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """F6: a profile already in withdrawal_pending rejects a second withdraw
+        cleanly (400) instead of running STEP 1/2 then dying at STEP 3."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+
+        pid = await _submit_and_prepay(
+            client, officer, manager, accountant, unit_id, officer_user_in_db["id"]
+        )
+        body = await _get(client, manager, pid)
+        r1 = await client.post(
+            f"{ADMISSIONS}/{pid}/withdraw",
+            headers=manager,
+            json={"reason": "Rút lần một", "version": body["version"]},
+        )
+        assert r1.status_code == 200 and r1.json()["status"] == "withdrawal_pending"
+
+        body2 = await _get(client, manager, pid)
+        r2 = await client.post(
+            f"{ADMISSIONS}/{pid}/withdraw",
+            headers=manager,
+            json={"reason": "Rút lần hai", "version": body2["version"]},
+        )
+        assert r2.status_code == 400, r2.text

--- a/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
+++ b/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
@@ -857,6 +857,19 @@ async def _refund_by_id(refund_id: int) -> models.RefundRequest | None:
         return await session.get(models.RefundRequest, refund_id)
 
 
+async def _audit_actions(entity_type: str, entity_id: int) -> list[str]:
+    """Actions logged to entity_audit_log for one entity (A1 assertions)."""
+    async with AsyncSessionLocal() as session:
+        rows = await session.execute(
+            select(models.EntityAuditLog.action)
+            .where(
+                models.EntityAuditLog.entity_type == entity_type,
+                models.EntityAuditLog.entity_id == entity_id,
+            )
+        )
+        return list(rows.scalars().all())
+
+
 async def _seed_unpaid_dormitory_fee(profile_id: int) -> int:
     """Attach an UNPAID (paid_amount=0) non-tuition fee to a profile so the
     withdraw orchestrator's STEP 2 (cancel every unpaid fee) has something to
@@ -1123,6 +1136,14 @@ class TestWithdrawalPendingFlow:
             if s in ("issued", "partial", "overdue")
         ]
         assert not payable, f"payable invoice left on withdrawn profile: {payable}"
+
+        # A1: the fee cancellation is persisted to entity_audit_log (unified
+        # audit timeline), not only on the fee.notes / invoice.cancelled_* row
+        # fields — even though it runs in the post-commit cleanup session.
+        tuition = next(f for f in fees if f.fee_type == "tuition")
+        assert "status_changed" in await _audit_actions("Fee", tuition.id), (
+            "fee cancellation must be written to entity_audit_log"
+        )
 
     async def test_admin_cancel_withdrawal_back_to_draft(
         self,

--- a/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
+++ b/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
@@ -883,8 +883,12 @@ class TestUnrefundedPaymentFlag:
         accountant_user_in_db: dict,
         seed_lead_dependencies: dict,
     ):
-        """(c) Withdraw a profile that holds a verified prepay → flag True on
-        the mutation response AND a subsequent GET."""
+        """(c) PR-B: withdraw a profile holding a verified TUITION prepay →
+        the orchestrator AUTO-FILES a refund request and parks the profile in
+        ``withdrawal_pending`` (NOT ``withdrawn``); it settles to ``withdrawn``
+        only once the refund is processed. The refundable money is still held
+        (refund is 'pending'), so ``has_unrefunded_payment`` is True on both the
+        mutation response and a subsequent GET."""
         unit_id = seed_lead_dependencies["unit_id"]
         officer = await _auth(client, officer_user_in_db)
         manager = await _auth(client, manager_user_in_db)
@@ -894,15 +898,25 @@ class TestUnrefundedPaymentFlag:
             client, officer, manager, accountant, unit_id, officer_user_in_db["id"]
         )
 
-        # withdraw lead-sync advances the lead to sts08 (not in the conftest
-        # seed list) — seed it so the sync resolves.
+        # withdraw finalize lead-sync advances the lead to sts08 (not in the
+        # conftest seed list) — seed it so the sync resolves.
         await _ensure_consultation_status(
             "sts08", "Tu choi tu van", "stg07", "#CC0000"
         )
 
-        withdrawn = await _withdraw(client, manager, pid, "Học sinh đổi nguyện vọng")
+        # Withdraw with collected refundable tuition → withdrawal_pending.
+        body = await _get(client, manager, pid)
+        res = await client.post(
+            f"{ADMISSIONS}/{pid}/withdraw",
+            headers=manager,
+            json={"reason": "Học sinh đổi nguyện vọng", "version": body["version"]},
+        )
+        assert res.status_code == 200, res.text
+        withdrawn = res.json()
+        assert withdrawn["status"] == "withdrawal_pending", withdrawn
         assert withdrawn["has_unrefunded_payment"] is True, withdrawn
         after = await _get(client, manager, pid)
+        assert after["status"] == "withdrawal_pending", after
         assert after["has_unrefunded_payment"] is True, after
 
     async def test_nonterminal_statuses_flag_false(

--- a/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
+++ b/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
@@ -830,6 +830,55 @@ async def _lead_status_of(profile_id: int) -> str | None:
         return row.scalar_one_or_none()
 
 
+async def _fees_of(profile_id: int) -> list[models.Fee]:
+    """All fees of a profile (finance-state asserts)."""
+    async with AsyncSessionLocal() as session:
+        rows = await session.execute(
+            select(models.Fee).where(
+                models.Fee.admission_profile_id == profile_id
+            )
+        )
+        return list(rows.scalars().all())
+
+
+async def _invoice_statuses_of(profile_id: int) -> list[str]:
+    """Statuses of every invoice hanging off a profile's fees."""
+    async with AsyncSessionLocal() as session:
+        rows = await session.execute(
+            select(models.Invoice.status)
+            .join(models.Fee, models.Fee.id == models.Invoice.fee_id)
+            .where(models.Fee.admission_profile_id == profile_id)
+        )
+        return list(rows.scalars().all())
+
+
+async def _refund_by_id(refund_id: int) -> models.RefundRequest | None:
+    async with AsyncSessionLocal() as session:
+        return await session.get(models.RefundRequest, refund_id)
+
+
+async def _seed_unpaid_dormitory_fee(profile_id: int) -> int:
+    """Attach an UNPAID (paid_amount=0) non-tuition fee to a profile so the
+    withdraw orchestrator's STEP 2 (cancel every unpaid fee) has something to
+    cancel. Non-tuition → semester_no must be NULL. Returns the fee id."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            fee = models.Fee(
+                admission_profile_id=profile_id,
+                fee_type="dormitory",
+                academic_year=2026,
+                semester_no=None,
+                base_amount=Decimal("1000000"),
+                final_amount=Decimal("1000000"),
+                paid_amount=Decimal("0"),
+                status="invoiced",
+                version=1,
+            )
+            session.add(fee)
+            await session.flush()
+            return fee.id
+
+
 class TestUnrefundedPaymentFlag:
     async def test_reject_with_prepay_sets_flag_and_warns(
         self,
@@ -1057,6 +1106,24 @@ class TestWithdrawalPendingFlow:
         assert after["has_unrefunded_payment"] is False, after
         assert await _lead_status_of(pid) == "sts08"
 
+        # Issue 1: reverse_payment_balances reopened the tuition invoice to
+        # 'issued' (payable). Finalize must cancel the now-unpaid non-application
+        # fee + cascade its invoice — no phantom receivable ("còn nợ") may survive
+        # on the withdrawn profile.
+        fees = await _fees_of(pid)
+        leftover = [
+            (f.id, f.fee_type, f.status)
+            for f in fees
+            if f.fee_type != "application" and f.status != "cancelled"
+        ]
+        assert not leftover, f"non-application fee left payable: {leftover}"
+        payable = [
+            s
+            for s in await _invoice_statuses_of(pid)
+            if s in ("issued", "partial", "overdue")
+        ]
+        assert not payable, f"payable invoice left on withdrawn profile: {payable}"
+
     async def test_admin_cancel_withdrawal_back_to_draft(
         self,
         client: AsyncClient,
@@ -1112,6 +1179,148 @@ class TestWithdrawalPendingFlow:
             f"#{pid}" in (r.get("reason") or "")
             for r in rejected.json()["items"]
         ), rejected.json()
+
+    async def test_cancel_withdrawal_preserves_manual_refund(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """Issue 2: cancel-withdrawal rejects ONLY the withdraw-auto-filed
+        (``source=withdrawal``) refund. A pre-existing manual refund on the same
+        profile is independently managed and must survive the rollback."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+        admin = await _auth(client, admin_user_in_db)
+
+        # Submitted profile with a tuition fee paid by TWO verified payments — so
+        # a manual refund can sit on one while withdraw auto-files on the other.
+        _doc_id, doc_code = await _create_doc_type("hocba")
+        lead_id = await _create_lead(unit_id, officer_user_in_db["id"])
+        pid, _oac = await _build_draft_profile(lead_id, mandatory_docs=[doc_code])
+        await _submit_with_debt(client, officer, pid, "giữ chỗ")
+        fee_detail = await _calculate_tuition(client, officer, pid)
+        invoice_id = fee_detail["invoices"][0]["id"]
+        await _record_and_verify_payment(
+            client, accountant, manager, invoice_id, Decimal("3000000")
+        )
+        pay2 = await _record_and_verify_payment(
+            client, accountant, manager, invoice_id, Decimal("3000000")
+        )
+
+        # Finance user manually files a refund on pay2 (source defaults 'manual',
+        # fully committing pay2) — unrelated to any withdrawal.
+        man = await client.post(
+            "/api/refunds",
+            json={
+                "payment_id": pay2["id"],
+                "amount": "3000000",
+                "reason": "Hoàn thủ công — thu thừa tay",
+            },
+            headers=accountant,
+        )
+        assert man.status_code == 201, man.text
+        manual_refund_id = man.json()["id"]
+        assert man.json()["source"] == "manual", man.json()
+
+        # Withdraw (officer) → withdrawal_pending; STEP 1 files a refund only on
+        # pay1 (pay2 has 0 available after the manual refund commitment).
+        body = await _get(client, officer, pid)
+        wd = await client.post(
+            f"{ADMISSIONS}/{pid}/withdraw",
+            headers=officer,
+            json={"reason": "Rút hồ sơ", "version": body["version"]},
+        )
+        assert wd.status_code == 200, wd.text
+        assert wd.json()["status"] == "withdrawal_pending", wd.json()
+
+        pend = await client.get(
+            "/api/refunds", params={"status": "pending"}, headers=manager
+        )
+        auto = [
+            r
+            for r in pend.json()["items"]
+            if r["source"] == "withdrawal"
+            and f"#{pid}" in (r.get("reason") or "")
+        ]
+        assert len(auto) == 1, auto
+        withdrawal_refund_id = auto[0]["id"]
+
+        # Admin cancels the withdrawal → draft.
+        cancel = await client.post(
+            f"{ADMISSIONS}/{pid}/cancel-withdrawal",
+            headers=admin,
+            json={"reason": "Hoàn tiền bị từ chối — về nháp"},
+        )
+        assert cancel.status_code == 200, cancel.text
+        assert cancel.json()["status"] == "draft", cancel.json()
+
+        # Withdrawal-sourced refund rejected; manual one untouched.
+        wr = await _refund_by_id(withdrawal_refund_id)
+        mr = await _refund_by_id(manual_refund_id)
+        assert wr is not None and wr.status == "rejected", wr
+        assert mr is not None and mr.status == "pending", mr
+        assert mr.source == "manual", mr
+
+    async def test_cancel_withdrawal_leaves_unpaid_fee_cancelled(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """Issue 3: withdraw STEP 2 cancels every UNPAID fee. When admin later
+        cancels the withdrawal (→ draft) those fees are NOT auto-restored — the
+        officer recalculates them. Pins that documented behavior for the
+        'paid refundable fee + unpaid fee' combo (previously untested)."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+        admin = await _auth(client, admin_user_in_db)
+
+        # Paid refundable tuition (→ withdrawal_pending) + a SECOND unpaid fee
+        # that STEP 2 will cancel.
+        pid = await _submit_and_prepay(
+            client, officer, manager, accountant, unit_id, officer_user_in_db["id"]
+        )
+        dorm_fee_id = await _seed_unpaid_dormitory_fee(pid)
+
+        body = await _get(client, officer, pid)
+        wd = await client.post(
+            f"{ADMISSIONS}/{pid}/withdraw",
+            headers=officer,
+            json={"reason": "Rút hồ sơ", "version": body["version"]},
+        )
+        assert wd.status_code == 200, wd.text
+        assert wd.json()["status"] == "withdrawal_pending", wd.json()
+
+        # Unpaid dormitory fee cancelled by withdraw STEP 2.
+        fees = {f.id: f for f in await _fees_of(pid)}
+        assert fees[dorm_fee_id].status == "cancelled", fees[dorm_fee_id].status
+
+        # Admin cancels the withdrawal → draft.
+        cancel = await client.post(
+            f"{ADMISSIONS}/{pid}/cancel-withdrawal",
+            headers=admin,
+            json={"reason": "Hoàn tiền bị từ chối — về nháp"},
+        )
+        assert cancel.status_code == 200, cancel.text
+        assert cancel.json()["status"] == "draft", cancel.json()
+
+        # Documented behavior: the cancelled fee is NOT restored on rollback.
+        fees2 = {f.id: f for f in await _fees_of(pid)}
+        assert fees2[dorm_fee_id].status == "cancelled", (
+            "cancel-withdrawal must NOT auto-restore the fee withdraw cancelled "
+            f"(got {fees2[dorm_fee_id].status})"
+        )
 
     async def test_cannot_rewithdraw_pending(
         self,

--- a/Backend_FastAPI/tests/services/test_admission_withdraw.py
+++ b/Backend_FastAPI/tests/services/test_admission_withdraw.py
@@ -260,6 +260,47 @@ class TestWithdrawService:
                     data={"reason": "Stale client version", "version": 999},
                 )
 
+    async def test_admitted_profile_withdraws_directly(
+        self,
+        admin_user_in_db: dict,
+        seed_sts08: dict,
+    ):
+        """PR-B v3 scenario (f): an ``admitted`` (seat-occupying) profile is
+        withdrawn STRAIGHT to ``withdrawn`` — the orchestrator's STEP 0 keeps the
+        legacy direct path (no auto-refund/cancel, no ``withdrawal_pending``) so
+        withdrawal never churns quota-seat accounting."""
+        from app.services import admission_service
+
+        unit_id = seed_sts08["unit_id"]
+        officer_id = admin_user_in_db["id"]
+
+        lead_id = await _create_lead(unit_id, officer_id)
+        profile = await _create_profile(lead_id, status="admitted")
+
+        actor = models.User(
+            id=officer_id,
+            username=admin_user_in_db["username"],
+            email="admitted@test.com",
+            password_hash="x",
+            role="admin",
+            status="active",
+        )
+
+        async with AsyncSessionLocal() as session:
+            result, callback = await admission_service.withdraw_profile(
+                db=session,
+                profile_id=profile.id,
+                actor=actor,
+                data={"reason": "Trúng tuyển nhưng đổi ý", "version": 1},
+            )
+            await session.commit()
+            if callback:
+                await callback()
+
+        reloaded = await _reload_profile(profile.id)
+        assert reloaded.status == "withdrawn"
+        assert await _get_lead_status(lead_id) == "sts08"
+
 
 # ==============================================================================
 # HTTP-LEVEL TESTS

--- a/Backend_FastAPI/tests/services/test_payment_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_service.py
@@ -225,10 +225,36 @@ class TestRecordPayment:
 
         assert "not active" in str(exc_info.value).lower()
 
+    @pytest.mark.parametrize("terminal_status", ["withdrawn", "rejected"])
+    async def test_record_payment_blocked_when_profile_terminal(
+        self, db, payment_fixtures, terminal_status
+    ):
+        """P0: cannot even stage a pending payment on a withdrawn/rejected
+        profile — its invoice can still be `issued` because withdraw does not
+        cancel the fee. (``withdrawal_pending`` arrives with PR-B; the CHECK
+        constraint rejects it today, so it is covered by the pure-logic unit
+        test ``test_assert_payable_target``.)"""
+        service = PaymentService(db)
+        pf = payment_fixtures
+
+        pf["profile"].status = terminal_status
+        await db.commit()
+
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await service.record_manual_payment(
+                invoice_id=pf["invoice"].id,
+                method_id=pf["cash_method"].id,
+                amount=Decimal("100000"),
+                user_id=pf["maker"].id,
+                unit_id=pf["unit_id"],
+            )
+        assert "hồ sơ" in str(exc.value).lower()
+
 
 # =============================================================================
 # PAYMENT VERIFICATION TESTS
 # =============================================================================
+
 
 class TestVerifyPayment:
     """Tests for payment verification (maker-checker)."""
@@ -407,10 +433,44 @@ class TestVerifyPayment:
         assert pf["fee"].status == FeeStatusEnum.paid.value
         assert pf["fee"].paid_amount == Decimal("1000000")
 
+    @pytest.mark.parametrize("terminal_status", ["withdrawn", "rejected"])
+    async def test_verify_payment_blocked_when_profile_terminal(
+        self, db, payment_fixtures, terminal_status
+    ):
+        """P0 race guard: a pending payment recorded while the profile was live,
+        then the profile is withdrawn/rejected → verify refuses to write money
+        (fee.paid_amount stays 0). Mirrors the cancelled-fee race guard."""
+        service = PaymentService(db)
+        pf = payment_fixtures
+
+        payment, _ = await service.record_manual_payment(
+            invoice_id=pf["invoice"].id,
+            method_id=pf["cash_method"].id,
+            amount=Decimal("500000"),
+            user_id=pf["maker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        pf["profile"].status = terminal_status
+        await db.commit()
+
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await service.verify_payment(
+                payment_id=payment.id,
+                verifier_id=pf["checker"].id,
+                unit_id=pf["unit_id"],
+            )
+        assert "hồ sơ" in str(exc.value).lower()
+
+        await db.refresh(pf["fee"])
+        assert pf["fee"].paid_amount == Decimal("0")
+
 
 # =============================================================================
 # PAYMENT REJECTION TESTS
 # =============================================================================
+
 
 class TestRejectPayment:
     """Tests for payment rejection."""
@@ -782,10 +842,49 @@ class TestOverpaymentService:
             )
         assert "status" in str(exc.value).lower()
 
+    @pytest.mark.parametrize("terminal_status", ["withdrawn", "rejected"])
+    async def test_apply_overpayment_blocked_when_profile_terminal(
+        self, db, payment_fixtures, terminal_status
+    ):
+        """P0: overpayment credit must not be applied onto a withdrawn/rejected
+        profile's invoice. The overpayment-apply path writes money but does NOT
+        run through ``assert_payable_target``, so it carries its own inline
+        profile guard."""
+        pf = payment_fixtures
+        overpayment = await self._create_pending_overpayment(db, pf)
+
+        target_invoice = Invoice(
+            fee_id=pf["fee"].id,
+            invoice_number="INV-TEST-TERMGUARD-0001",
+            installment_no=2,
+            amount=Decimal("500000"),
+            paid_amount=Decimal("0"),
+            penalty_amount=Decimal("0"),
+            status=InvoiceStatusEnum.issued.value,
+            due_date=date.today() + timedelta(days=30),
+        )
+        db.add(target_invoice)
+        await db.flush()
+        await db.refresh(target_invoice)
+
+        pf["profile"].status = terminal_status
+        await db.commit()
+
+        service = OverpaymentService(db)
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await service.apply_to_invoice(
+                overpayment_id=overpayment.id,
+                target_invoice_id=target_invoice.id,
+                user_id=pf["checker"].id,
+                unit_id=pf["unit_id"],
+            )
+        assert "hồ sơ" in str(exc.value).lower()
+
 
 # =============================================================================
 # REFUND SERVICE TESTS
 # =============================================================================
+
 
 class TestRefundService:
     """Tests for refund request lifecycle."""

--- a/Backend_FastAPI/tests/services/test_payment_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_service.py
@@ -39,6 +39,14 @@ from app.utils.exceptions import (
 pytestmark = pytest.mark.asyncio
 
 
+# Non-payable statuses the P0 guard blocks that are ALSO valid in the DB CHECK
+# constraint today, so they can be exercised end-to-end here.
+# ⚠️ PR-B widens the constraint to allow "withdrawal_pending" — add it to this
+# list then (the pure-logic path is already covered by
+# tests/unit/test_assert_payable_target.py).
+_DB_VALID_NON_PAYABLE = ["withdrawn", "rejected"]
+
+
 # =============================================================================
 # FIXTURES
 # =============================================================================
@@ -225,7 +233,7 @@ class TestRecordPayment:
 
         assert "not active" in str(exc_info.value).lower()
 
-    @pytest.mark.parametrize("terminal_status", ["withdrawn", "rejected"])
+    @pytest.mark.parametrize("terminal_status", _DB_VALID_NON_PAYABLE)
     async def test_record_payment_blocked_when_profile_terminal(
         self, db, payment_fixtures, terminal_status
     ):
@@ -248,7 +256,7 @@ class TestRecordPayment:
                 user_id=pf["maker"].id,
                 unit_id=pf["unit_id"],
             )
-        assert "hồ sơ" in str(exc.value).lower()
+        assert "rút/từ chối" in str(exc.value).lower()
 
 
 # =============================================================================
@@ -433,7 +441,7 @@ class TestVerifyPayment:
         assert pf["fee"].status == FeeStatusEnum.paid.value
         assert pf["fee"].paid_amount == Decimal("1000000")
 
-    @pytest.mark.parametrize("terminal_status", ["withdrawn", "rejected"])
+    @pytest.mark.parametrize("terminal_status", _DB_VALID_NON_PAYABLE)
     async def test_verify_payment_blocked_when_profile_terminal(
         self, db, payment_fixtures, terminal_status
     ):
@@ -461,7 +469,7 @@ class TestVerifyPayment:
                 verifier_id=pf["checker"].id,
                 unit_id=pf["unit_id"],
             )
-        assert "hồ sơ" in str(exc.value).lower()
+        assert "rút/từ chối" in str(exc.value).lower()
 
         await db.refresh(pf["fee"])
         assert pf["fee"].paid_amount == Decimal("0")
@@ -842,7 +850,7 @@ class TestOverpaymentService:
             )
         assert "status" in str(exc.value).lower()
 
-    @pytest.mark.parametrize("terminal_status", ["withdrawn", "rejected"])
+    @pytest.mark.parametrize("terminal_status", _DB_VALID_NON_PAYABLE)
     async def test_apply_overpayment_blocked_when_profile_terminal(
         self, db, payment_fixtures, terminal_status
     ):
@@ -878,7 +886,7 @@ class TestOverpaymentService:
                 user_id=pf["checker"].id,
                 unit_id=pf["unit_id"],
             )
-        assert "hồ sơ" in str(exc.value).lower()
+        assert "rút/từ chối" in str(exc.value).lower()
 
 
 # =============================================================================

--- a/Backend_FastAPI/tests/unit/test_admission_state_machine.py
+++ b/Backend_FastAPI/tests/unit/test_admission_state_machine.py
@@ -25,8 +25,8 @@ class TestAdmissionStatusEnum:
     """Test AdmissionStatus enum values."""
 
     def test_all_statuses_defined(self):
-        """Verify all 14 statuses defined — 10 legacy + 4 Phase 3 multi-NV
-        (phase1_11 DB CHECK extend, plan v0.7 PR-3B).
+        """Verify all 15 statuses defined — 10 legacy + 4 Phase 3 multi-NV
+        (phase1_11 DB CHECK extend) + 1 PR-B refund-pending state.
         """
         expected_statuses = {
             # Legacy 10-state
@@ -45,6 +45,8 @@ class TestAdmissionStatusEnum:
             "result_published",
             "admitted",
             "waitlisted",
+            # PR-B intermediate refund-pending state
+            "withdrawal_pending",
         }
         actual_statuses = {status.value for status in AdmissionStatus}
         assert actual_statuses == expected_statuses
@@ -60,48 +62,53 @@ class TestAllowedTransitions:
     """Test ALLOWED_TRANSITIONS state machine map."""
 
     def test_draft_transitions(self):
-        """DRAFT can transition to SUBMITTED or WITHDRAWN."""
+        """DRAFT can transition to SUBMITTED, WITHDRAWN or WITHDRAWAL_PENDING."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.DRAFT] == {
             AdmissionStatus.SUBMITTED,
             AdmissionStatus.WITHDRAWN,
+            AdmissionStatus.WITHDRAWAL_PENDING,  # PR-B
         }
 
     def test_submitted_transitions(self):
-        """SUBMITTED: legacy 4 + REVIEWING (Phase 3 T2) + DRAFT (T17 PR-3C)."""
+        """SUBMITTED: legacy 4 + REVIEWING (T2) + DRAFT (T17) + WITHDRAWAL_PENDING."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.SUBMITTED] == {
             AdmissionStatus.APPROVED,
             AdmissionStatus.REJECTED,
             AdmissionStatus.REVISION_REQUESTED,
             AdmissionStatus.WITHDRAWN,
+            AdmissionStatus.WITHDRAWAL_PENDING,  # PR-B
             AdmissionStatus.REVIEWING,
             AdmissionStatus.DRAFT,  # T17 PR-3C Sub-3.5
         }
 
     def test_rejected_transitions(self):
-        """REJECTED: legacy 2 + DRAFT (T17 PR-3C Sub-3.5)."""
+        """REJECTED: legacy 2 + DRAFT (T17) + WITHDRAWAL_PENDING (PR-B)."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.REJECTED] == {
             AdmissionStatus.RESUBMITTED,
             AdmissionStatus.WITHDRAWN,
+            AdmissionStatus.WITHDRAWAL_PENDING,  # PR-B
             AdmissionStatus.DRAFT,
         }
 
     def test_resubmitted_transitions(self):
-        """RESUBMITTED: legacy 4 + REVIEWING + DRAFT (T17)."""
+        """RESUBMITTED: legacy 4 + REVIEWING + DRAFT (T17) + WITHDRAWAL_PENDING."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.RESUBMITTED] == {
             AdmissionStatus.APPROVED,
             AdmissionStatus.REJECTED,
             AdmissionStatus.REVISION_REQUESTED,
             AdmissionStatus.WITHDRAWN,
+            AdmissionStatus.WITHDRAWAL_PENDING,  # PR-B
             AdmissionStatus.REVIEWING,
             AdmissionStatus.DRAFT,
         }
 
     def test_revision_requested_transitions(self):
-        """REVISION_REQUESTED: legacy 3 + REVIEWING (T4) + DRAFT (T17)."""
+        """REVISION_REQUESTED: legacy 3 + REVIEWING (T4) + DRAFT (T17) + WITHDRAWAL_PENDING."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.REVISION_REQUESTED] == {
             AdmissionStatus.RESUBMITTED,
             AdmissionStatus.REJECTED,
             AdmissionStatus.WITHDRAWN,
+            AdmissionStatus.WITHDRAWAL_PENDING,  # PR-B
             AdmissionStatus.REVIEWING,
             AdmissionStatus.DRAFT,
         }
@@ -135,6 +142,26 @@ class TestAllowedTransitions:
     def test_withdrawn_transitions(self):
         """WITHDRAWN is final state - no transitions allowed."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.WITHDRAWN] == set()
+
+    def test_withdrawal_pending_transitions(self):
+        """WITHDRAWAL_PENDING (PR-B): → WITHDRAWN (refund done) or DRAFT
+        (refund rejected → admin cancels the withdrawal). Non-final."""
+        assert ALLOWED_TRANSITIONS[AdmissionStatus.WITHDRAWAL_PENDING] == {
+            AdmissionStatus.WITHDRAWN,
+            AdmissionStatus.DRAFT,
+        }
+
+    def test_admitted_has_no_withdrawal_pending_edge(self):
+        """v3: a seat-occupying ``admitted`` profile keeps the legacy DIRECT
+        → WITHDRAWN path; it must NOT gain a → WITHDRAWAL_PENDING edge."""
+        assert (
+            AdmissionStatus.WITHDRAWAL_PENDING
+            not in ALLOWED_TRANSITIONS[AdmissionStatus.ADMITTED]
+        )
+        assert (
+            AdmissionStatus.WITHDRAWN
+            in ALLOWED_TRANSITIONS[AdmissionStatus.ADMITTED]
+        )
 
     def test_all_statuses_have_transitions_defined(self):
         """Verify every status has a transition rule (even if empty)."""
@@ -219,34 +246,36 @@ class TestGetAllowedTransitions:
     """Test get_allowed_transitions() helper function."""
 
     def test_draft_allowed_transitions(self):
-        """DRAFT can go to SUBMITTED or WITHDRAWN."""
-        assert get_allowed_transitions("draft") == {"submitted", "withdrawn"}
+        """DRAFT can go to SUBMITTED, WITHDRAWN or WITHDRAWAL_PENDING (PR-B)."""
+        assert get_allowed_transitions("draft") == {
+            "submitted", "withdrawn", "withdrawal_pending",
+        }
 
     def test_submitted_allowed_transitions(self):
-        """SUBMITTED: legacy 4 + Phase 3 reviewing (T2) + draft (T17)."""
+        """SUBMITTED: legacy 4 + reviewing (T2) + draft (T17) + withdrawal_pending."""
         assert get_allowed_transitions("submitted") == {
             "approved", "rejected", "revision_requested", "withdrawn",
-            "reviewing", "draft",
+            "withdrawal_pending", "reviewing", "draft",
         }
 
     def test_rejected_allowed_transitions(self):
-        """REJECTED: legacy 2 + draft (T17 PR-3C Sub-3.5)."""
+        """REJECTED: legacy 2 + draft (T17) + withdrawal_pending (PR-B)."""
         assert get_allowed_transitions("rejected") == {
-            "resubmitted", "withdrawn", "draft",
+            "resubmitted", "withdrawn", "withdrawal_pending", "draft",
         }
 
     def test_revision_requested_allowed_transitions(self):
-        """REVISION_REQUESTED: legacy 3 + Phase 3 reviewing (T4) + draft (T17)."""
+        """REVISION_REQUESTED: legacy 3 + reviewing (T4) + draft (T17) + withdrawal_pending."""
         assert get_allowed_transitions("revision_requested") == {
             "resubmitted", "rejected", "withdrawn",
-            "reviewing", "draft",
+            "withdrawal_pending", "reviewing", "draft",
         }
 
     def test_resubmitted_allowed_transitions(self):
-        """RESUBMITTED: legacy 4 + Phase 3 reviewing + draft (T17)."""
+        """RESUBMITTED: legacy 4 + reviewing + draft (T17) + withdrawal_pending."""
         assert get_allowed_transitions("resubmitted") == {
             "approved", "rejected", "revision_requested", "withdrawn",
-            "reviewing", "draft",
+            "withdrawal_pending", "reviewing", "draft",
         }
 
     def test_approved_allowed_transitions(self):
@@ -298,6 +327,7 @@ class TestIsFinalState:
             "resubmitted",
             "confirmed",
             "overridden",
+            "withdrawal_pending",  # PR-B: intermediate, not final
         ],
     )
     def test_non_final_states(self, status):

--- a/Backend_FastAPI/tests/unit/test_assert_payable_target.py
+++ b/Backend_FastAPI/tests/unit/test_assert_payable_target.py
@@ -1,0 +1,95 @@
+"""Unit tests for ``assert_payable_target`` — the shared money-write guard.
+
+PR-A (P0): every money-touching entry that flows through the choke point
+(manual verify, online-gateway callback, intent creation, manual record) must
+refuse a cancelled fee/invoice AND a non-payable profile
+(``withdrawn`` / ``rejected`` / ``withdrawal_pending``).
+
+Pure-logic test — no DB — so it can exercise ``withdrawal_pending`` even though
+the CHECK constraint / state machine that make it a valid column value only
+land in PR-B. The service-level tests (``test_payment_service.py``) cover the
+two DB-valid statuses (``withdrawn`` / ``rejected``) end-to-end.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.models.finance import FeeStatusEnum, InvoiceStatusEnum
+from app.services.payment_service import assert_payable_target
+from app.utils.admission_status import NON_PAYABLE_PROFILE_STATUSES
+from app.utils.exceptions import BusinessRuleViolation
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+
+def _fee(status: str = "invoiced") -> SimpleNamespace:
+    return SimpleNamespace(status=status)
+
+
+def _invoice(status: str = "issued") -> SimpleNamespace:
+    return SimpleNamespace(status=status)
+
+
+def _profile(status: str = "submitted") -> SimpleNamespace:
+    return SimpleNamespace(status=status)
+
+
+class TestAssertPayableTarget:
+    """The single invariant every money-touching entry point runs."""
+
+    def test_healthy_target_passes(self):
+        """invoiced fee + issued invoice + submitted profile → no raise."""
+        assert_payable_target(_fee(), _invoice(), _profile(), action="thu tiền")
+
+    def test_all_none_passes(self):
+        """Nothing to check (no fee/invoice/profile) → no raise."""
+        assert_payable_target(None, None, None, action="thu tiền")
+
+    def test_profile_none_skips_profile_check(self):
+        """Fee not linked to a profile → profile guard is skipped, healthy passes."""
+        assert_payable_target(_fee(), _invoice(), None, action="thu tiền")
+
+    def test_cancelled_fee_blocked(self):
+        with pytest.raises(BusinessRuleViolation) as exc:
+            assert_payable_target(
+                _fee(FeeStatusEnum.cancelled.value), _invoice(), _profile(),
+                action="thu tiền",
+            )
+        assert "đã bị huỷ" in str(exc.value)
+
+    def test_cancelled_invoice_blocked(self):
+        with pytest.raises(BusinessRuleViolation) as exc:
+            assert_payable_target(
+                _fee(), _invoice(InvoiceStatusEnum.cancelled.value), _profile(),
+                action="thu tiền",
+            )
+        assert "đã bị huỷ" in str(exc.value)
+
+    @pytest.mark.parametrize(
+        "status", ["withdrawn", "rejected", "withdrawal_pending"]
+    )
+    def test_non_payable_profile_blocked(self, status):
+        """The core P0 hole: money must not land on a profile on its way out,
+        even when its invoice is still `issued` (withdraw does not cancel fees)."""
+        with pytest.raises(BusinessRuleViolation) as exc:
+            assert_payable_target(
+                _fee(), _invoice(), _profile(status), action="thu tiền"
+            )
+        assert "hồ sơ" in str(exc.value).lower()
+
+    def test_cancelled_target_message_takes_priority(self):
+        """Cancelled fee is checked first, so its message wins over the profile
+        one when both conditions hold — deterministic, not a correctness issue."""
+        with pytest.raises(BusinessRuleViolation) as exc:
+            assert_payable_target(
+                _fee(FeeStatusEnum.cancelled.value), _invoice(),
+                _profile("withdrawn"), action="thu tiền",
+            )
+        assert "đã bị huỷ" in str(exc.value)
+
+    def test_seed_set_is_exactly_the_three_terminal_statuses(self):
+        """Drift guard: the shared set must stay the withdrawn/rejected/pending
+        trio (withdrawal_pending pre-seeded ahead of PR-B)."""
+        assert NON_PAYABLE_PROFILE_STATUSES == frozenset(
+            {"withdrawn", "rejected", "withdrawal_pending"}
+        )

--- a/Backend_FastAPI/tests/unit/test_assert_payable_target.py
+++ b/Backend_FastAPI/tests/unit/test_assert_payable_target.py
@@ -75,7 +75,7 @@ class TestAssertPayableTarget:
             assert_payable_target(
                 _fee(), _invoice(), _profile(status), action="thu tiền"
             )
-        assert "hồ sơ" in str(exc.value).lower()
+        assert "rút/từ chối" in str(exc.value).lower()
 
     def test_cancelled_target_message_takes_priority(self):
         """Cancelled fee is checked first, so its message wins over the profile

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
@@ -25,6 +25,7 @@ import { canDecide } from "@/lib/utils/admission-permissions"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 import { SendConfirmationButton } from "./SendConfirmationButton"
 import { SendMagicLinkButton } from "./SendMagicLinkButton"
+import { WithdrawActionButton } from "./WithdrawActionButton"
 
 interface AdmissionActionsProps {
   profile: AdmissionProfileResponse
@@ -109,8 +110,21 @@ export function AdmissionActions({
           {can('send_resubmit_link') && (
             <SendMagicLinkButton profileId={profile.id} action="resubmit" />
           )}
+          {/* PR-B: officer withdraws on the spot (candidate at school) —
+              replaces the magic-link for withdraw; submit/resubmit still use it. */}
           {can('send_withdraw_link') && (
-            <SendMagicLinkButton profileId={profile.id} action="withdraw" />
+            <WithdrawActionButton
+              profileId={profile.id}
+              version={profile.version ?? 0}
+              mode="withdraw"
+            />
+          )}
+          {can('cancel_withdrawal') && (
+            <WithdrawActionButton
+              profileId={profile.id}
+              version={profile.version ?? 0}
+              mode="cancel"
+            />
           )}
         </div>
       </div>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
@@ -549,25 +549,40 @@ export function AdmissionDetailClient({
           </div>
         )}
 
-        {/* Tuition prepay fast-track finding #1: a rejected/withdrawn profile
-            that still holds collected (unrefunded) tuition. BE flag combines
-            status ∈ {rejected, withdrawn} + SUM(fee.paid_amount) > 0, so FE
-            just renders. Refund stays manual via the existing maker-checker
-            flow (this is only a reminder, not an action). */}
+        {/* Unrefunded-tuition banner. BE flag = status ∈ {rejected, withdrawn,
+            withdrawal_pending} + refundable paid > 0. withdrawal_pending (PR-B)
+            is a DISTINCT, in-progress state — the withdraw auto-filed a refund,
+            so it gets an amber "waiting" banner, NOT the red "đã từ chối" one. */}
         {profile.has_unrefunded_payment && (
-          <div
-            role="alert"
-            className="mb-4 rounded-lg border-2 border-error-300 bg-error-50 p-4 text-error-900"
-          >
-            <p className="font-semibold mb-1">
-              ⚠️ Hồ sơ đã hủy/từ chối nhưng còn khoản học phí đã thu chưa hoàn
-            </p>
-            <p className="text-sm">
-              Hồ sơ đã <strong>{profile.status === "withdrawn" ? "rút" : "từ chối"}</strong>{" "}
-              nhưng vẫn còn khoản học phí đã thu (trả trước/giữ chỗ) chưa được hoàn.
-              Vui lòng xử lý <strong>hoàn tiền</strong> ở tab Học phí (quy trình hoàn tiền thủ công).
-            </p>
-          </div>
+          profile.status === "withdrawal_pending" ? (
+            <div
+              role="alert"
+              className="mb-4 rounded-lg border-2 border-amber-300 bg-amber-50 p-4 text-amber-900"
+            >
+              <p className="font-semibold mb-1">
+                ⏳ Đang chờ hoàn học phí để rút hồ sơ
+              </p>
+              <p className="text-sm">
+                Hồ sơ đã được yêu cầu rút và còn học phí đã thu. Hệ thống đã tạo{" "}
+                <strong>yêu cầu hoàn tiền</strong> — hãy duyệt và xử lý ở tab Học phí.
+                Hồ sơ chỉ chuyển sang <strong>Đã rút</strong> khi hoàn tất hoàn tiền.
+              </p>
+            </div>
+          ) : (
+            <div
+              role="alert"
+              className="mb-4 rounded-lg border-2 border-error-300 bg-error-50 p-4 text-error-900"
+            >
+              <p className="font-semibold mb-1">
+                ⚠️ Hồ sơ đã hủy/từ chối nhưng còn khoản học phí đã thu chưa hoàn
+              </p>
+              <p className="text-sm">
+                Hồ sơ đã <strong>{profile.status === "withdrawn" ? "rút" : "từ chối"}</strong>{" "}
+                nhưng vẫn còn khoản học phí đã thu (trả trước/giữ chỗ) chưa được hoàn.
+                Vui lòng xử lý <strong>hoàn tiền</strong> ở tab Học phí (quy trình hoàn tiền thủ công).
+              </p>
+            </div>
+          )
         )}
 
         {/* TAB CONTENT — no wrapper card: each tab renders its own Card(s), so an

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/WithdrawActionButton.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/WithdrawActionButton.tsx
@@ -1,0 +1,141 @@
+// src/app/(dashboard)/admissions/[id]/_components/WithdrawActionButton.tsx
+"use client"
+
+import { useState } from "react"
+import { Loader2, LogOut, RotateCcw } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import {
+  useWithdrawAdmission,
+  useCancelWithdrawal,
+} from "@/hooks/admissions/useAdmissions"
+
+/**
+ * PR-B — direct withdraw / cancel-withdrawal actions.
+ *
+ * Owner-chosen flow: the candidate comes to the school and the officer withdraws
+ * the profile ON THE SPOT (no magic-link). ``mode="withdraw"`` opens a reason
+ * dialog → POST /withdraw (officer/manager/admin, gated by ``send_withdraw_link``
+ * upstream). ``mode="cancel"`` reverts a ``withdrawal_pending`` profile back to
+ * draft → POST /cancel-withdrawal (admin only, gated by ``cancel_withdrawal``).
+ *
+ * Thin-client: the parent gates visibility via BE permission flags before
+ * mounting this — the component itself does not check roles.
+ */
+interface Props {
+  profileId: number
+  version: number
+  mode: "withdraw" | "cancel"
+}
+
+const MIN_REASON = 5
+
+export function WithdrawActionButton({ profileId, version, mode }: Props) {
+  const [open, setOpen] = useState(false)
+  const [reason, setReason] = useState("")
+
+  const withdraw = useWithdrawAdmission(profileId)
+  const cancel = useCancelWithdrawal(profileId)
+
+  const isWithdraw = mode === "withdraw"
+  const isPending = isWithdraw ? withdraw.isPending : cancel.isPending
+  const tooShort = reason.trim().length < MIN_REASON
+
+  const reset = () => {
+    setOpen(false)
+    setReason("")
+  }
+
+  const handleSubmit = () => {
+    if (tooShort) return
+    const trimmed = reason.trim()
+    if (isWithdraw) {
+      withdraw.mutate(
+        { reason: trimmed, version },
+        { onSuccess: reset },
+      )
+    } else {
+      cancel.mutate({ reason: trimmed }, { onSuccess: reset })
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant={isWithdraw ? "outline" : "secondary"}
+        onClick={() => setOpen(true)}
+        className="gap-2"
+      >
+        {isWithdraw ? (
+          <LogOut className="h-4 w-4" />
+        ) : (
+          <RotateCcw className="h-4 w-4" />
+        )}
+        {isWithdraw ? "Rút hồ sơ" : "Hủy quy trình rút"}
+      </Button>
+
+      <Dialog open={open} onOpenChange={(o) => (o ? setOpen(true) : reset())}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {isWithdraw ? "Rút hồ sơ tuyển sinh" : "Hủy quy trình rút"}
+            </DialogTitle>
+            <DialogDescription>
+              {isWithdraw
+                ? "Xác nhận rút hồ sơ tại chỗ (thí sinh đến trường)."
+                : "Đưa hồ sơ đang chờ hoàn trở về nháp — dùng khi hoàn tiền bị từ chối, để hồ sơ không kẹt."}
+            </DialogDescription>
+          </DialogHeader>
+
+          {isWithdraw ? (
+            <Alert>
+              <AlertDescription>
+                Nếu hồ sơ đã đóng học phí, hệ thống sẽ tự tạo yêu cầu hoàn tiền;
+                hồ sơ chỉ rút xong khi hoàn tất hoàn tiền.
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          <div className="space-y-2">
+            <Label htmlFor="withdraw-reason">Lý do</Label>
+            <Textarea
+              id="withdraw-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Nhập lý do (tối thiểu 5 ký tự)"
+              rows={3}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="secondary" onClick={reset}>
+              Đóng
+            </Button>
+            <Button
+              type="button"
+              variant={isWithdraw ? "destructive" : "default"}
+              onClick={handleSubmit}
+              disabled={isPending || tooShort}
+            >
+              {isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              {isWithdraw ? "Xác nhận rút" : "Xác nhận hủy rút"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.status-tabs.test.ts
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.status-tabs.test.ts
@@ -31,8 +31,10 @@ describe("ADMISSION_STATUS_TABS — grouping", () => {
     )
   })
 
-  it("'rejected' bundles rejected/withdrawn", () => {
-    expect(byKey.get("rejected")).toEqual(new Set(["rejected", "withdrawn"]))
+  it("'rejected' bundles rejected/withdrawn/withdrawal_pending", () => {
+    expect(byKey.get("rejected")).toEqual(
+      new Set(["rejected", "withdrawn", "withdrawal_pending"]),
+    )
   })
 
   it("'all' tab = empty (no filter)", () => {
@@ -63,6 +65,7 @@ describe("ADMISSION_STATUS_TABS — 14-state coverage", () => {
     "overridden",
     "enrolled",
     "withdrawn",
+    "withdrawal_pending", // PR-B: grouped in the "Từ chối" tab with withdrawn
   ] as const
 
   it("every workflow-target status appears in at least one specific tab", () => {

--- a/frontend/src/components/common/status/StatusBadge.tsx
+++ b/frontend/src/components/common/status/StatusBadge.tsx
@@ -130,6 +130,7 @@ export const ADMISSION_STATUS_MAP: Record<string, StatusConfig> = {
   overridden: { label: "Đã override", variant: "primary" },
   enrolled: { label: "Đã nhập học", variant: "admission-enrolled" },
   withdrawn: { label: "Đã rút hồ sơ", variant: "neutral" },
+  withdrawal_pending: { label: "Chờ hoàn để rút", variant: "warning" },
 };
 
 export const SCORE_LEVEL_MAP: Record<string, StatusConfig> = {

--- a/frontend/src/components/layouts/SocketHandler.tsx
+++ b/frontend/src/components/layouts/SocketHandler.tsx
@@ -678,7 +678,9 @@ export function SocketHandler() {
       queryClient.invalidateQueries({ queryKey: financeDashboardKeys.all });
       if (data.lead_stage_changed) {
         queryClient.invalidateQueries({ queryKey: leadsKeys.lists() });
-        queryClient.invalidateQueries({ queryKey: pipelineKeys.fullPipeline() });
+        // pipelineKeys.all — fullPipeline() would be a no-op invalidation
+        // (trailing undefined fails React Query's partial match).
+        queryClient.invalidateQueries({ queryKey: pipelineKeys.all });
       }
     };
 

--- a/frontend/src/components/layouts/SocketHandler.tsx
+++ b/frontend/src/components/layouts/SocketHandler.tsx
@@ -13,6 +13,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { leadsKeys } from "@/hooks/useLeads";
 import { admissionsKeys } from "@/hooks/admissions/useAdmissions";
 import { feesKeys } from "@/hooks/finance/useFees";
+import { invoicesKeys } from "@/hooks/finance/useInvoices";
+import { refundsKeys } from "@/hooks/finance/useRefunds";
 import { financeDashboardKeys } from "@/hooks/finance/useFinanceDashboard";
 import { pipelineKeys } from "@/hooks/usePipeline";
 import { isSafeUrl } from "@/lib/utils";
@@ -647,6 +649,18 @@ export function SocketHandler() {
       // detail gets a targeted refresh too so the open page updates instantly.
       queryClient.invalidateQueries({ queryKey: admissionsKeys.all });
       queryClient.invalidateQueries({ queryKey: admissionsKeys.detail(data.application_id) });
+      // Cross-tab finance sync: the withdrawal-finalize transition
+      // (→ 'withdrawn') reverses/cancels fees, reopens-then-cancels invoices and
+      // settles refunds server-side. Without this, another user's open finance
+      // views (fees / invoices / refunds / dashboard + the admission Tuition tab)
+      // stay stale. Gated on 'withdrawn' so ordinary status changes don't trigger
+      // a finance refetch storm.
+      if (data.new_status === "withdrawn") {
+        queryClient.invalidateQueries({ queryKey: feesKeys.all });
+        queryClient.invalidateQueries({ queryKey: invoicesKeys.all });
+        queryClient.invalidateQueries({ queryKey: refundsKeys.lists() });
+        queryClient.invalidateQueries({ queryKey: financeDashboardKeys.all });
+      }
       // ✅ NO TOAST - Per-user notification will show toast via "new_notification" event
     };
 

--- a/frontend/src/hooks/admissions/filterDefaults.ts
+++ b/frontend/src/hooks/admissions/filterDefaults.ts
@@ -33,7 +33,7 @@ export const ADMISSION_STATUS_TABS: ReadonlyArray<{
   { key: "waitlisted", label: "Chờ ghế", statuses: ["waitlisted"] },
   { key: "confirmed", label: "Đã xác nhận", statuses: ["confirmed"] },
   { key: "enrolled", label: "Đã nhập học", statuses: ["enrolled"] },
-  { key: "rejected", label: "Từ chối", statuses: ["rejected", "withdrawn"] },
+  { key: "rejected", label: "Từ chối", statuses: ["rejected", "withdrawn", "withdrawal_pending"] },
 ]
 
 export const ADMISSIONS_DEFAULT_PAGE_SIZE = 20

--- a/frontend/src/hooks/admissions/types.ts
+++ b/frontend/src/hooks/admissions/types.ts
@@ -50,6 +50,7 @@ export type AdmissionStatus =
   | "confirmed"
   | "enrolled"
   | "overridden"
+  | "withdrawal_pending" // PR-B: "Chờ hoàn để rút"
   | "withdrawn"
 
 // ============================================================================

--- a/frontend/src/hooks/admissions/useAdmissionViewModel.ts
+++ b/frontend/src/hooks/admissions/useAdmissionViewModel.ts
@@ -33,6 +33,7 @@ const STATUS_LABELS: Record<string, string> = {
   overridden: "Đã override",
   revision_requested: "Yêu cầu bổ sung",
   withdrawn: "Đã rút hồ sơ",
+  withdrawal_pending: "Chờ hoàn để rút",
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -46,6 +47,7 @@ const STATUS_COLORS: Record<string, string> = {
   overridden: "purple",
   revision_requested: "orange",
   withdrawn: "gray",
+  withdrawal_pending: "amber",
 }
 
 // ============================================================================

--- a/frontend/src/hooks/admissions/useAdmissions.ts
+++ b/frontend/src/hooks/admissions/useAdmissions.ts
@@ -13,6 +13,7 @@ import { useRouter } from "next/navigation"
 
 import { admissionsApi } from "@/lib/api/admissions"
 import { feesKeys } from "@/hooks/finance/useFees"
+import { invoicesKeys } from "@/hooks/finance/useInvoices"
 import { refundsKeys } from "@/hooks/finance/useRefunds"
 import { leadsKeys } from "@/hooks/useLeads"
 import { pipelineKeys } from "@/hooks/usePipeline"
@@ -349,7 +350,14 @@ export function useWithdrawAdmission(id: number) {
         toast.success("Đã rút hồ sơ")
       }
       queryClient.invalidateQueries({ queryKey: admissionsKeys.all })
+      // Withdraw STEP 2 cancels every unpaid fee → cascades to its invoices.
+      // Refresh the fee views the admission UI actually reads (profileSummary
+      // drives the Tuition tab + "Còn nợ" badge; byProfile has no consumer but
+      // kept for parity) + the fees/invoices workspaces.
       queryClient.invalidateQueries({ queryKey: feesKeys.byProfile(id) })
+      queryClient.invalidateQueries({ queryKey: feesKeys.profileSummary(id) })
+      queryClient.invalidateQueries({ queryKey: feesKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: invoicesKeys.all })
       // BE auto-files pending refund requests for every verified refundable
       // payment (admission_service.withdraw STEP 1). Refresh the finance refunds
       // list + dashboard so an already-open finance page shows the new requests
@@ -391,6 +399,7 @@ export function useCancelWithdrawal(id: number) {
       toast.success("Đã hủy quy trình rút — hồ sơ trở về nháp")
       queryClient.invalidateQueries({ queryKey: admissionsKeys.all })
       queryClient.invalidateQueries({ queryKey: feesKeys.byProfile(id) })
+      queryClient.invalidateQueries({ queryKey: feesKeys.profileSummary(id) })
       // BE rejects every open (pending) refund auto-filed by the withdraw
       // orchestrator before reverting to draft (admission_service.cancel_withdrawal
       // F1 → reject_open_refunds_for_profile). Refresh the finance refunds list +

--- a/frontend/src/hooks/admissions/useAdmissions.ts
+++ b/frontend/src/hooks/admissions/useAdmissions.ts
@@ -14,6 +14,8 @@ import { useRouter } from "next/navigation"
 import { admissionsApi } from "@/lib/api/admissions"
 import { feesKeys } from "@/hooks/finance/useFees"
 import { refundsKeys } from "@/hooks/finance/useRefunds"
+import { leadsKeys } from "@/hooks/useLeads"
+import { pipelineKeys } from "@/hooks/usePipeline"
 import type {
   AdmissionProfileResponse,
   AdmissionProfileUpdate,
@@ -354,6 +356,14 @@ export function useWithdrawAdmission(id: number) {
       // (mirrors useCreateRefund).
       queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
       queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
+      // Direct-withdraw (no refundable money) finalizes immediately and projects
+      // the lead to sts08 (withdrawn), so refresh the lead list + pipeline board.
+      // The withdrawal_pending path HOLDS the lead (no move) → only the withdrawn
+      // path needs this; its eventual finalize refreshes via useProcessRefund.
+      if (data.status === "withdrawn") {
+        queryClient.invalidateQueries({ queryKey: leadsKeys.lists() })
+        queryClient.invalidateQueries({ queryKey: pipelineKeys.all })
+      }
     },
     onError: (error: AxiosError<ApiErrorResponse>) => {
       handleApiError(error, {

--- a/frontend/src/hooks/admissions/useAdmissions.ts
+++ b/frontend/src/hooks/admissions/useAdmissions.ts
@@ -323,6 +323,68 @@ export function useResubmitAdmission(id: number) {
 }
 
 /**
+ * Withdraw admission profile (Officer/Manager/Admin).
+ *
+ * POSTs reason + version to ``/admissions/{id}/withdraw``. Response status is
+ * ``withdrawn`` (settled immediately) OR ``withdrawal_pending`` (refundable
+ * tuition was collected → BE auto-files refund requests; settles to withdrawn
+ * once the refund is processed). Invalidates admissions + finance-by-profile
+ * (a refund request may have been created).
+ */
+export function useWithdrawAdmission(id: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: { reason: string; version: number }) =>
+      admissionsApi.withdrawAdmission(id, data),
+    onSuccess: (data) => {
+      if (data.status === "withdrawal_pending") {
+        toast.info("Đã ghi nhận rút hồ sơ — đang chờ hoàn học phí", {
+          description: "Hồ sơ chỉ rút xong khi hoàn tiền hoàn tất.",
+        })
+      } else {
+        toast.success("Đã rút hồ sơ")
+      }
+      queryClient.invalidateQueries({ queryKey: admissionsKeys.all })
+      queryClient.invalidateQueries({ queryKey: feesKeys.byProfile(id) })
+    },
+    onError: (error: AxiosError<ApiErrorResponse>) => {
+      handleApiError(error, {
+        queryClient,
+        invalidateKeys: [[...admissionsKeys.detail(id)]],
+        context: "rút hồ sơ",
+      })
+    },
+  })
+}
+
+/**
+ * Cancel a pending withdrawal (Admin) — revert ``withdrawal_pending`` → draft.
+ *
+ * Used when the refund tied to a pending withdrawal was rejected, so the
+ * profile is not stuck awaiting a refund that will never complete.
+ */
+export function useCancelWithdrawal(id: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: { reason: string }) =>
+      admissionsApi.cancelWithdrawal(id, data),
+    onSuccess: () => {
+      toast.success("Đã hủy quy trình rút — hồ sơ trở về nháp")
+      queryClient.invalidateQueries({ queryKey: admissionsKeys.all })
+    },
+    onError: (error: AxiosError<ApiErrorResponse>) => {
+      handleApiError(error, {
+        queryClient,
+        invalidateKeys: [[...admissionsKeys.detail(id)]],
+        context: "hủy quy trình rút",
+      })
+    },
+  })
+}
+
+/**
  * Apply post-approval minor correction (Officer/Manager/Admin).
  *
  * Submits the diffed `changes` payload + reason + version to

--- a/frontend/src/hooks/admissions/useAdmissions.ts
+++ b/frontend/src/hooks/admissions/useAdmissions.ts
@@ -13,6 +13,7 @@ import { useRouter } from "next/navigation"
 
 import { admissionsApi } from "@/lib/api/admissions"
 import { feesKeys } from "@/hooks/finance/useFees"
+import { refundsKeys } from "@/hooks/finance/useRefunds"
 import type {
   AdmissionProfileResponse,
   AdmissionProfileUpdate,
@@ -347,6 +348,12 @@ export function useWithdrawAdmission(id: number) {
       }
       queryClient.invalidateQueries({ queryKey: admissionsKeys.all })
       queryClient.invalidateQueries({ queryKey: feesKeys.byProfile(id) })
+      // BE auto-files pending refund requests for every verified refundable
+      // payment (admission_service.withdraw STEP 1). Refresh the finance refunds
+      // list + dashboard so an already-open finance page shows the new requests
+      // (mirrors useCreateRefund).
+      queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
     },
     onError: (error: AxiosError<ApiErrorResponse>) => {
       handleApiError(error, {
@@ -373,6 +380,13 @@ export function useCancelWithdrawal(id: number) {
     onSuccess: () => {
       toast.success("Đã hủy quy trình rút — hồ sơ trở về nháp")
       queryClient.invalidateQueries({ queryKey: admissionsKeys.all })
+      queryClient.invalidateQueries({ queryKey: feesKeys.byProfile(id) })
+      // BE rejects every open (pending) refund auto-filed by the withdraw
+      // orchestrator before reverting to draft (admission_service.cancel_withdrawal
+      // F1 → reject_open_refunds_for_profile). Refresh the finance refunds list +
+      // dashboard so an already-open finance page drops the now-rejected requests.
+      queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
     },
     onError: (error: AxiosError<ApiErrorResponse>) => {
       handleApiError(error, {

--- a/frontend/src/hooks/finance/useRefunds.ts
+++ b/frontend/src/hooks/finance/useRefunds.ts
@@ -2,6 +2,9 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { AxiosError } from "axios"
 import { toast } from "sonner"
 import { refundsApi, type RefundPaginatedResponse, type RefundRejectRequest } from "@/lib/api/refunds"
+import { admissionsKeys } from "@/hooks/admissions/useAdmissions"
+import { leadsKeys } from "@/hooks/useLeads"
+import { pipelineKeys } from "@/hooks/usePipeline"
 import type { ApiErrorResponse } from "@/types/api.types"
 import type {
   RefundCreateRequest,
@@ -88,6 +91,10 @@ export function useRejectRefund() {
       toast.success("Đã từ chối hoàn phí")
       queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
       queryClient.invalidateQueries({ queryKey: refundsKeys.detail(refund.id) })
+      // Rejecting a pending refund drops it from the "chờ hoàn" totals, so the
+      // dashboard stat must refresh too (parity with useCreateRefund, which
+      // increments the same counter on the way in).
+      queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
     },
     onError: (error) => {
       toast.error(getErrorMessage(error, "Không thể từ chối hoàn phí"))
@@ -111,6 +118,16 @@ export function useProcessRefund() {
       // Processing a refund can auto-close a linked overpayment (F4), so refresh
       // the overpayments cache too.
       queryClient.invalidateQueries({ queryKey: ["overpayments"] })
+      // Processing the LAST refundable payment finalizes a pending withdrawal
+      // (admission_service.process_approved_refund → _finalize_withdrawn):
+      // admission status withdrawal_pending → withdrawn AND the lead advances to
+      // sts08. An ordinary HK1-tuition refund likewise projects the lead to
+      // sts18 (sync_lead_tuition_refunded). Neither is reflected in the response
+      // (a bare RefundRequest), so refresh the admission + lead + pipeline caches
+      // to keep those views in sync.
+      queryClient.invalidateQueries({ queryKey: admissionsKeys.all })
+      queryClient.invalidateQueries({ queryKey: leadsKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: pipelineKeys.fullPipeline() })
     },
     onError: (error) => {
       toast.error(getErrorMessage(error, "Không thể xử lý hoàn phí"))

--- a/frontend/src/hooks/finance/useRefunds.ts
+++ b/frontend/src/hooks/finance/useRefunds.ts
@@ -127,7 +127,10 @@ export function useProcessRefund() {
       // to keep those views in sync.
       queryClient.invalidateQueries({ queryKey: admissionsKeys.all })
       queryClient.invalidateQueries({ queryKey: leadsKeys.lists() })
-      queryClient.invalidateQueries({ queryKey: pipelineKeys.fullPipeline() })
+      // pipelineKeys.all — NOT fullPipeline(): the board mounts with concrete
+      // params, so fullPipeline()'s trailing `undefined` fails React Query's
+      // partial match and the invalidation would be a silent no-op.
+      queryClient.invalidateQueries({ queryKey: pipelineKeys.all })
     },
     onError: (error) => {
       toast.error(getErrorMessage(error, "Không thể xử lý hoàn phí"))

--- a/frontend/src/hooks/finance/useRefunds.ts
+++ b/frontend/src/hooks/finance/useRefunds.ts
@@ -3,6 +3,8 @@ import { AxiosError } from "axios"
 import { toast } from "sonner"
 import { refundsApi, type RefundPaginatedResponse, type RefundRejectRequest } from "@/lib/api/refunds"
 import { admissionsKeys } from "@/hooks/admissions/useAdmissions"
+import { feesKeys } from "@/hooks/finance/useFees"
+import { invoicesKeys } from "@/hooks/finance/useInvoices"
 import { leadsKeys } from "@/hooks/useLeads"
 import { pipelineKeys } from "@/hooks/usePipeline"
 import type { ApiErrorResponse } from "@/types/api.types"
@@ -131,6 +133,14 @@ export function useProcessRefund() {
       // params, so fullPipeline()'s trailing `undefined` fails React Query's
       // partial match and the invalidation would be a silent no-op.
       queryClient.invalidateQueries({ queryKey: pipelineKeys.all })
+      // Processing a refund reverses fee.paid_amount (reverse_payment_balances)
+      // and, on the withdrawal-finalize path, cancels the reopened fees/invoices.
+      // The RefundRequest response carries only payment_id (no profile/fee id),
+      // so invalidate the fee + invoice roots — the admission Tuition tab /
+      // "Còn nợ" badge (feesKeys.profileSummary) and /finance/invoices otherwise
+      // keep showing the money as still collected / the invoice as payable.
+      queryClient.invalidateQueries({ queryKey: feesKeys.all })
+      queryClient.invalidateQueries({ queryKey: invoicesKeys.all })
     },
     onError: (error) => {
       toast.error(getErrorMessage(error, "Không thể xử lý hoàn phí"))

--- a/frontend/src/hooks/usePipeline.ts
+++ b/frontend/src/hooks/usePipeline.ts
@@ -28,6 +28,11 @@ import type { LossReason } from "@/lib/loss-reasons";
 export const pipelineKeys = {
   all: ["pipeline"] as const,
   stages: () => [...pipelineKeys.all, "stages"] as const,
+  // NOTE: use `fullPipeline(params)` ONLY as a useQuery key. As an
+  // invalidateQueries target the no-arg `fullPipeline()` builds
+  // ["pipeline","full",undefined], whose trailing `undefined` fails React
+  // Query's partial match against the board's ["pipeline","full",{params}] →
+  // a silent no-op. Invalidate `pipelineKeys.all` instead.
   fullPipeline: (params?: PipelineQueryParams) => [...pipelineKeys.all, "full", params] as const,
   stageLeads: (stageId: string) => [...pipelineKeys.all, "stageLeads", stageId] as const,
   consultationStatuses: () => [...pipelineKeys.all, "consultationStatuses"] as const,
@@ -280,7 +285,7 @@ export function useCreatePipelineStage() {
       });
 
       queryClient.invalidateQueries({ queryKey: pipelineKeys.stages(), refetchType: 'active' });
-      queryClient.invalidateQueries({ queryKey: pipelineKeys.fullPipeline(), refetchType: 'active' });
+      queryClient.invalidateQueries({ queryKey: pipelineKeys.all, refetchType: 'active' });
     },
 
     onError: (error) => {
@@ -327,7 +332,7 @@ export function useUpdatePipelineStage() {
       });
 
       queryClient.invalidateQueries({ queryKey: pipelineKeys.stages(), refetchType: 'active' });
-      queryClient.invalidateQueries({ queryKey: pipelineKeys.fullPipeline(), refetchType: 'active' });
+      queryClient.invalidateQueries({ queryKey: pipelineKeys.all, refetchType: 'active' });
     },
 
     onError: (error) => {
@@ -364,7 +369,7 @@ export function useDeletePipelineStage() {
       toast.success("Pipeline stage deleted!");
 
       queryClient.invalidateQueries({ queryKey: pipelineKeys.stages(), refetchType: 'active' });
-      queryClient.invalidateQueries({ queryKey: pipelineKeys.fullPipeline(), refetchType: 'active' });
+      queryClient.invalidateQueries({ queryKey: pipelineKeys.all, refetchType: 'active' });
     },
 
     onError: (error) => {
@@ -412,7 +417,7 @@ export function useCreateConsultationStatus() {
       });
 
       queryClient.invalidateQueries({ queryKey: pipelineKeys.consultationStatuses(), refetchType: 'active' });
-      queryClient.invalidateQueries({ queryKey: pipelineKeys.fullPipeline(), refetchType: 'active' });
+      queryClient.invalidateQueries({ queryKey: pipelineKeys.all, refetchType: 'active' });
     },
 
     onError: (error) => {
@@ -459,7 +464,7 @@ export function useUpdateConsultationStatus() {
       });
 
       queryClient.invalidateQueries({ queryKey: pipelineKeys.consultationStatuses(), refetchType: 'active' });
-      queryClient.invalidateQueries({ queryKey: pipelineKeys.fullPipeline(), refetchType: 'active' });
+      queryClient.invalidateQueries({ queryKey: pipelineKeys.all, refetchType: 'active' });
     },
 
     onError: (error) => {
@@ -496,7 +501,7 @@ export function useDeleteConsultationStatus() {
       toast.success("Consultation status deleted!");
 
       queryClient.invalidateQueries({ queryKey: pipelineKeys.consultationStatuses(), refetchType: 'active' });
-      queryClient.invalidateQueries({ queryKey: pipelineKeys.fullPipeline(), refetchType: 'active' });
+      queryClient.invalidateQueries({ queryKey: pipelineKeys.all, refetchType: 'active' });
     },
 
     onError: (error) => {

--- a/frontend/src/lib/api/admissions.ts
+++ b/frontend/src/lib/api/admissions.ts
@@ -288,6 +288,45 @@ export async function dropStudent(
 }
 
 /**
+ * Withdraw admission profile (Officer/Manager/Admin action)
+ * POST /api/admissions/{id}/withdraw
+ *
+ * Transitions to ``withdrawn`` — OR, if refundable tuition was already
+ * collected, to ``withdrawal_pending`` (BE auto-files refund requests and the
+ * profile settles to ``withdrawn`` once the refund is processed). Requires
+ * reason (min 5) + version for optimistic locking.
+ */
+export async function withdrawAdmission(
+  id: number,
+  data: { reason: string; version: number }
+): Promise<AdmissionProfileResponse> {
+  const response = await api.post<AdmissionProfileResponse>(
+    `/api/admissions/${id}/withdraw`,
+    data
+  )
+  return response.data
+}
+
+/**
+ * Cancel a pending withdrawal (Admin action) — revert withdrawal_pending → draft
+ * POST /api/admissions/{id}/cancel-withdrawal
+ *
+ * Used when the refund tied to a ``withdrawal_pending`` profile was rejected,
+ * so the profile is not stuck awaiting a refund that will never complete.
+ * Admin-only. Requires reason (min 5); no version (rare recovery action).
+ */
+export async function cancelWithdrawal(
+  id: number,
+  data: { reason: string }
+): Promise<AdmissionProfileResponse> {
+  const response = await api.post<AdmissionProfileResponse>(
+    `/api/admissions/${id}/cancel-withdrawal`,
+    data
+  )
+  return response.data
+}
+
+/**
  * Upload admission document
  */
 export async function uploadAdmissionDocument(
@@ -616,6 +655,8 @@ export const admissionsApi = {
   rejectAdmission,
   minorCorrection,
   dropStudent,
+  withdrawAdmission,
+  cancelWithdrawal,
   enrollStudent,
   deleteAdmission,
   uploadAdmissionDocument,

--- a/frontend/src/lib/status-config.ts
+++ b/frontend/src/lib/status-config.ts
@@ -121,6 +121,17 @@ export const ADMISSION_STATUS_CONFIG: Record<string, StatusUIConfig> = {
     bannerMessage: 'Hồ sơ đã được rút lại.',
     allowedActions: [],
   },
+  // PR-B: intermediate "Chờ hoàn để rút" — a refund is being processed; the
+  // profile settles to withdrawn only once the money is returned.
+  withdrawal_pending: {
+    label: 'Chờ hoàn để rút',
+    badgeVariant: 'outline',
+    badgeColor: 'bg-amber-50 text-amber-700',
+    showBanner: true,
+    bannerType: 'warning',
+    bannerMessage: 'Hồ sơ có học phí đã thu — đang chờ hoàn tiền trước khi rút. Chỉ rút xong khi hoàn tất.',
+    allowedActions: [],
+  },
   // Phase 3 PR-3D-A Sub-3: 4 NEW multi-NV states (Phase 1 #11 DB CHECK
   // extension, choice-engine workflow). Status badge config trong
   // `status-badge.config.ts` đã có entries từ Phase 1 — đây là
@@ -184,6 +195,7 @@ export const ADMISSION_STATUS_DOT_COLOR: Record<string, string> = {
   enrolled: 'bg-blue-500',
   rejected: 'bg-error-500',
   withdrawn: 'bg-gray-400',
+  withdrawal_pending: 'bg-amber-500',
   result_published: 'bg-sky-500',
 }
 

--- a/frontend/src/lib/ui-config/status-badge-coverage.test.ts
+++ b/frontend/src/lib/ui-config/status-badge-coverage.test.ts
@@ -28,7 +28,7 @@ import { ADMISSION_STATUS_MAP } from "@/components/common/status/StatusBadge"
 // (admitted / waitlisted / result_published) plus the 11 legacy
 // states. Adding a new status = update this list, the
 // ``AdmissionStatus`` type union, and both badge maps in lockstep.
-const ALL_14_STATES: ReadonlyArray<AdmissionStatus> = [
+const ALL_STATES: ReadonlyArray<AdmissionStatus> = [
   "draft",
   "submitted",
   "resubmitted",
@@ -43,6 +43,7 @@ const ALL_14_STATES: ReadonlyArray<AdmissionStatus> = [
   "overridden",
   "enrolled",
   "withdrawn",
+  "withdrawal_pending", // PR-B: "Chờ hoàn để rút"
 ]
 
 
@@ -52,8 +53,8 @@ const ALL_14_STATES: ReadonlyArray<AdmissionStatus> = [
 
 
 describe("ADMISSION_BADGE_CONFIG", () => {
-  it("has a config entry for every one of the 14 admission status", () => {
-    for (const status of ALL_14_STATES) {
+  it("has a config entry for every one of the 15 admission status", () => {
+    for (const status of ALL_STATES) {
       expect(
         ADMISSION_BADGE_CONFIG[status],
         `missing badge config for ${status}`,
@@ -62,7 +63,7 @@ describe("ADMISSION_BADGE_CONFIG", () => {
   })
 
   it("every entry has label + shortLabel + className + variant + order", () => {
-    for (const status of ALL_14_STATES) {
+    for (const status of ALL_STATES) {
       const config = ADMISSION_BADGE_CONFIG[status]
       expect(config.label, `${status}.label`).toBeTruthy()
       expect(config.shortLabel, `${status}.shortLabel`).toBeTruthy()
@@ -72,10 +73,10 @@ describe("ADMISSION_BADGE_CONFIG", () => {
     }
   })
 
-  it("has exactly 14 entries (no leftover legacy keys, no orphan future keys)", () => {
+  it("has exactly 15 entries (no leftover legacy keys, no orphan future keys)", () => {
     const keys = Object.keys(ADMISSION_BADGE_CONFIG)
-    expect(keys).toHaveLength(14)
-    expect(new Set(keys)).toEqual(new Set(ALL_14_STATES))
+    expect(keys).toHaveLength(15)
+    expect(new Set(keys)).toEqual(new Set(ALL_STATES))
   })
 
   it("3 new phase1_11 states have distinct order between approved (5) and rejected (6)", () => {
@@ -101,8 +102,8 @@ describe("ADMISSION_BADGE_CONFIG", () => {
 
 
 describe("ADMISSION_STATUS_MAP", () => {
-  it("has a label for every one of the 14 admission status", () => {
-    for (const status of ALL_14_STATES) {
+  it("has a label for every one of the 15 admission status", () => {
+    for (const status of ALL_STATES) {
       expect(
         ADMISSION_STATUS_MAP[status],
         `missing ADMISSION_STATUS_MAP entry for ${status}`,

--- a/frontend/src/lib/ui-config/status-badge.config.ts
+++ b/frontend/src/lib/ui-config/status-badge.config.ts
@@ -58,6 +58,7 @@ export type AdmissionStatus =
   | "confirmed"
   | "overridden"
   | "enrolled"
+  | "withdrawal_pending" // PR-B: "Chờ hoàn để rút"
   | "withdrawn";
 
 export type LeadStatus =
@@ -232,6 +233,18 @@ export const ADMISSION_BADGE_CONFIG: Record<AdmissionStatus, StatusBadgeConfig> 
     variant: "default",
     description: "Thí sinh đã hoàn tất nhập học",
     order: 10,
+  },
+  // PR-B: intermediate "Chờ hoàn để rút" — a refund is being processed; the
+  // profile only settles to ``withdrawn`` once the money is returned. Amber
+  // (pending-but-not-done), ordered just before withdrawn.
+  withdrawal_pending: {
+    label: "Chờ hoàn để rút",
+    shortLabel: "Chờ rút",
+    icon: Clock,
+    className: "bg-amber-50 text-amber-700 border-amber-200",
+    variant: "outline",
+    description: "Đang chờ hoàn tiền trước khi rút hồ sơ",
+    order: 10.5,
   },
   withdrawn: {
     label: "Đã rút hồ sơ",

--- a/frontend/src/lib/zod/admissions.eligibility.test.ts
+++ b/frontend/src/lib/zod/admissions.eligibility.test.ts
@@ -169,11 +169,11 @@ describe("admissionProfileResponseSchema — strict 14-state status parse (Stage
     }
   })
 
-  it("locks the strict enum to exactly 14 entries (drift guard)", () => {
+  it("locks the strict enum to exactly 15 entries (drift guard)", () => {
     // Anchor non-tautological — count any enum drift on this schema.
     // If a 15th state is added to BE without this test updating, CI
     // fails here, forcing the coordinated FE bump.
-    const expected14 = [
+    const expected15 = [
       "draft",
       "submitted",
       "resubmitted",
@@ -188,16 +188,17 @@ describe("admissionProfileResponseSchema — strict 14-state status parse (Stage
       "result_published",
       "admitted",
       "waitlisted",
+      "withdrawal_pending", // PR-B
     ]
 
-    for (const status of expected14) {
+    for (const status of expected15) {
       const result = admissionProfileResponseSchema.safeParse({
         ..._baselineProfile(),
         status,
       })
       expect(result.success, `expected state ${status} not accepted`).toBe(true)
     }
-    expect(expected14.length).toBe(14)
+    expect(expected15.length).toBe(15)
   })
 })
 

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -910,6 +910,7 @@ export const admissionProfileResponseSchema = z.object({
     "draft", "submitted", "resubmitted", "approved", "rejected",
     "revision_requested", "confirmed", "overridden", "enrolled", "withdrawn",
     "reviewing", "result_published", "admitted", "waitlisted",
+    "withdrawal_pending", // PR-B: "Chờ hoàn để rút" (intermediate refund-pending)
   ]),
   version: z.number().int().optional(), // Optimistic locking
   academic_year: z.number().int().optional(), // Academic year
@@ -1435,6 +1436,7 @@ const STATUS_COLORS: Record<string, string> = {
   enrolled: "bg-info-100 text-info-800",
   overridden: "bg-purple-100 text-purple-800",
   withdrawn: "bg-muted text-muted-foreground",
+  withdrawal_pending: "bg-amber-100 text-amber-800",
 }
 
 /**
@@ -1460,6 +1462,7 @@ const STATUS_LABELS: Record<string, string> = {
   enrolled: "Đã nhập học",
   overridden: "Đã override",
   withdrawn: "Đã rút hồ sơ",
+  withdrawal_pending: "Chờ hoàn để rút",
 }
 
 /**

--- a/frontend/src/lib/zod/finance.ts
+++ b/frontend/src/lib/zod/finance.ts
@@ -76,6 +76,14 @@ export const refundStatusSchema = z.enum([
   "refunded",
 ])
 
+// Origin of a refund — mirrors backend RefundSourceEnum. Only `withdrawal`
+// refunds are auto-rejected when a pending withdrawal is cancelled.
+export const refundSourceSchema = z.enum([
+  "withdrawal",
+  "manual",
+  "overpayment",
+])
+
 export const transactionTypeSchema = z.enum([
   "payment",
   "refund",
@@ -383,6 +391,7 @@ export const refundRequestSchema = z.object({
   amount: z.string(),
   reason: z.string(),
   status: refundStatusSchema,
+  source: refundSourceSchema,
   requested_at: z.string(),
   requested_by_id: z.number().int().positive(),
   approved_at: z.string().nullable(),

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -18,6 +18,9 @@ export type PaymentStatus = "pending" | "verified" | "rejected" | "refunded"
 export type PaymentIntentStatus = "created" | "pending" | "completed" | "failed" | "expired" | "cancelled"
 export type OverpaymentStatus = "pending" | "applied" | "refunded" | "cancelled"
 export type RefundStatus = "pending" | "approved" | "rejected" | "refunded"
+// Mirrors backend RefundSourceEnum. Only `withdrawal` refunds are auto-rejected
+// when a pending withdrawal is cancelled.
+export type RefundSource = "withdrawal" | "manual" | "overpayment"
 export type TransactionType = "payment" | "refund" | "adjustment" | "waive" | "penalty" | "reversal"
 export type ResolutionType = "apply_to_next" | "refund" | "write_off"
 
@@ -397,6 +400,7 @@ export interface RefundRequest {
   amount: string
   reason: string
   status: RefundStatus
+  source: RefundSource
   requested_at: string
   requested_by_id: number
   approved_at: string | null


### PR DESCRIPTION
## Tóm tắt

Rút hồ sơ tuyển sinh **tự dọn tài chính** và **xác nhận hoàn học phí xong** trước khi chốt rút, kèm bịt lỗ hổng thu tiền vào hồ sơ đã rút/từ chối. Gộp 2 phần (18 commit, stacked):

- **PR-A (P0 bảo mật tài chính)** — chặn ghi tiền vào hồ sơ `withdrawn`/`rejected`/`withdrawal_pending` ở **đủ 5 đường ghi tiền** (`record_manual_payment`, `verify_payment`, payment intent/callback, bulk-import, overpayment apply).
- **PR-B (rút hồ sơ tự dọn)** — thêm trạng thái trung gian `withdrawal_pending`, orchestrator tự hoàn phí + huỷ phí phantom, finalize khi hoàn xong, huỷ quy trình rút, FE plumbing + nút thao tác.

## Nghiệp vụ

- **Rút hồ sơ** ⟺ mọi thủ tục hoàn **học phí** đã xong. Còn học phí đã thu → `withdrawal_pending` (Chờ hoàn để rút) + auto tạo refund; hết → `withdrawn` ngay. Lệ phí xét tuyển (`application`) **không** hoàn, không chặn rút.
- **Finalize**: khi refund cuối `refunded` xong → chốt `withdrawn` + lead sang trạng thái phù hợp; huỷ nốt phí phantom (`paid==0`) **post-commit session riêng** (không abort finalize, không mất tiền — payable guard chặn thu).
- **Huỷ quy trình rút** (admin): `withdrawal_pending` → `draft`, reject mọi refund `source='withdrawal'` đang mở, reset lead.

## Thay đổi chính

- **Migration**: mở rộng CHECK `ck_admission_profile_status` (+`withdrawal_pending`) + cột `refund_request.source` (`withdrawal|manual|overpayment`, backfill-by-reason).
- **State machine**: 7 nguồn → `withdrawal_pending`; `admitted` giữ đi thẳng `withdrawn`.
- **Finance**: `request_refund(source=)`, `reject_open_refunds_for_profile` chỉ đụng refund withdrawal, aggregate công nợ/summary loại fee `cancelled` + hồ sơ withdrawn/wpend.
- **Report/KPI**: loại withdrawn/wpend khỏi cụm hồ sơ; dashboard collections trừ refund trong window (khớp net); export zero-flag học phí HK1.
- **FE**: Zod strict enum + badge + tab filter + nút "Rút hồ sơ"/"Huỷ quy trình rút" + đồng bộ cache react-query (lead·admission·finance·pipeline).
- **Audit**: ghi `entity_audit_log` cho Fee/Invoice cancelled + `phantom_cleanup_failed`.

## Kiểm thử

- Backend: **338 test pass** (state-machine, withdraw, prepay_flow, payment_service, dashboard_correctness, summary_export, lead_admission_sync); flake8 net-zero.
- FE: **type-check + lint 0-error** (chạy với src host mount).
- **Chrome MCP E2E smoke 4 scenario** (local, app thật): rút hồ sơ học-phí=0 → withdrawn thẳng; rút đã-đóng → wpend + refund; huỷ rút → draft + refund rejected; approve+process refund → withdrawn + fee/invoice cancelled + lead sync. Verify DB từng bước.
- 2 vòng `/code-review max` (F1 rò rỉ tiền + 13 finding khác đã áp/defer có chủ đích).

## Lưu ý triển khai

- **Deploy atomic BE↔FE bắt buộc**: FE Zod `z.enum` strict — thiếu `withdrawal_pending` phía FE khi BE đã có sẽ crash UI runtime.
- Backlog defer có chủ đích (đã xác nhận **phạm vi prod = 0**): **F5** `submission_count` không nhả slot — chỉ latent, prod có `round_quota` = NULL toàn bộ (0/111 path); **C2** re-apply cùng năm sau rút; **F16** workload wpend (by-design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
