### PR TITLE
feat(leads): đại tu UI card/menu/panel + datetime mobile bottom-sheet + BE permission flags

### DIFF
--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -349,16 +349,8 @@ async def get_all_leads(
         no_consultation=no_consultation,
         is_hot=is_hot,
         consultation_status_id=consultation_status_id,
+        current_user=current_user,  # → service gắn cờ hành động thin-client per-lead
     )
-
-    # Thin-client: gắn cờ hành động query-free cho từng lead (can_transfer_lead /
-    # can_request_reassign) để menu card mobile + hàng bảng desktop khớp menu panel
-    # mà KHỎI fetch chi tiết từng dòng. Không truy vấn DB thêm — chỉ đọc role +
-    # assigned_officer_id đã có sẵn. Single source: compute_lead_action_permissions().
-    for _lead in leads:
-        _lead.permissions = lead_service.compute_lead_action_permissions(
-            _lead, current_user
-        )
 
     # Scope-only counts for the "Giai đoạn" filter tree (static navigation map).
     # Reuses the SAME LeadListFilter scope as the list → no RBAC leak; ignores

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -351,6 +351,15 @@ async def get_all_leads(
         consultation_status_id=consultation_status_id,
     )
 
+    # Thin-client: gắn cờ hành động query-free cho từng lead (can_transfer_lead /
+    # can_request_reassign) để menu card mobile + hàng bảng desktop khớp menu panel
+    # mà KHỎI fetch chi tiết từng dòng. Không truy vấn DB thêm — chỉ đọc role +
+    # assigned_officer_id đã có sẵn. Single source: compute_lead_action_permissions().
+    for _lead in leads:
+        _lead.permissions = lead_service.compute_lead_action_permissions(
+            _lead, current_user
+        )
+
     # Scope-only counts for the "Giai đoạn" filter tree (static navigation map).
     # Reuses the SAME LeadListFilter scope as the list → no RBAC leak; ignores
     # secondary filters on purpose. See LEAD_STAGE_TREE_FILTER_PLAN.md §2.

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -129,6 +129,7 @@ from .lead import (
     LeadBase,
     LeadCreate,
     LeadDetail,
+    LeadListItem,  # ✅ list item = Lead + query-free action flags (permissions)
     ReopenReasonBody,  # ✅ Reopen: body {reason} (Phase A reopen + Phase B request)
     ReopenReviewBody,  # ✅ Reopen Phase B: body approve/reject
     LeadReopenRequestOut,  # ✅ Reopen Phase B: response 1 yêu cầu

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -450,22 +450,42 @@ class Lead(LeadBase):
     model_config = ConfigDict(from_attributes=True)
 
 
-class LeadDetail(Lead):
+class LeadListItem(Lead):
+    """Lead as returned in the paginated list (GET /leads).
+
+    Extends plain ``Lead`` with query-free action permission flags so the
+    mobile card / desktop row menu can gate "Chuyển giao lead" /
+    "Yêu cầu đổi người phụ trách" WITHOUT a per-row detail fetch and WITHOUT
+    the FE reading ``user.role`` (thin-client rule). Populated per item in the
+    GET /leads router via ``lead_service.compute_lead_action_permissions()``.
+
+    Only ``can_transfer_lead`` / ``can_request_reassign`` are carried here; the
+    fuller ``create_admission`` / reopen flags stay on ``LeadDetail`` (they need
+    eligibility/config lookups that would be too costly per list row).
+    """
+    permissions: Dict[str, bool] = Field(
+        default_factory=dict,
+        description=(
+            "Query-free per-user action flags "
+            "(can_transfer_lead, can_request_reassign)."
+        ),
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LeadDetail(LeadListItem):
     """Lead response for GET /leads/{id} with thin-client gate flags.
 
     Populated by lead_service._populate_lead_detail_fields() based on
-    admission_service.check_lead_level_admission_eligibility(). Other lead
-    endpoints (list/create/update) continue returning plain ``Lead`` and
-    do not carry these fields.
+    admission_service.check_lead_level_admission_eligibility(). Inherits the
+    query-free ``permissions`` flags from ``LeadListItem`` and augments the dict
+    with detail-only flags (create_admission, can_reopen, ...).
 
     Blocker codes emitted for ``create_admission``:
       forbidden, already_has_profile, invalid_lead_status, missing_offering,
       no_consultation, consultation_missing_status, consultation_universal_status.
     """
-    permissions: Dict[str, bool] = Field(
-        default_factory=dict,
-        description="Permission flags computed per-user (e.g. create_admission).",
-    )
     available_actions: List[str] = Field(
         default_factory=list,
         description="Actions currently allowed (subset of permissions keys where value=True).",
@@ -546,7 +566,7 @@ class EffectiveScope(BaseModel):
 
 class LeadsPage(BaseModel):
     total_count: int
-    leads: List[Lead]
+    leads: List[LeadListItem]
     summary: Optional[LeadsSummary] = None
     effective_scope: Optional[EffectiveScope] = None
     # Scope-only counts per consultation_status_id for the "Giai đoạn" filter

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -4776,6 +4776,23 @@ async def restore_lead(
 # Thin-client gate fields for LeadDetail response (GET /leads/{id})
 # =============================================================================
 
+def _lead_role_context(
+    lead: models.Lead,
+    current_user: models.User,
+) -> tuple[bool, bool, bool]:
+    """(is_manager_admin, is_officer_assigned, lead_assigned) — nguồn DUY NHẤT cho
+    predicate role/ownership, dùng chung bởi compute_lead_action_permissions() và
+    các gate reopen trong _populate_lead_detail_fields (khỏi định nghĩa 2 nơi rồi
+    lệch nhau khi đổi luật)."""
+    is_manager_admin = current_user.role in (UserRole.MANAGER, UserRole.ADMIN)
+    is_officer_assigned = (
+        current_user.role == UserRole.OFFICER
+        and lead.assigned_officer_id == current_user.id
+    )
+    lead_assigned = lead.assigned_officer_id is not None
+    return is_manager_admin, is_officer_assigned, lead_assigned
+
+
 def compute_lead_action_permissions(
     lead: models.Lead,
     current_user: Optional[models.User],
@@ -4791,12 +4808,9 @@ def compute_lead_action_permissions(
     """
     if current_user is None:
         return {}
-    is_manager_admin = current_user.role in (UserRole.MANAGER, UserRole.ADMIN)
-    is_officer_assigned = (
-        current_user.role == UserRole.OFFICER
-        and lead.assigned_officer_id == current_user.id
+    is_manager_admin, is_officer_assigned, lead_assigned = _lead_role_context(
+        lead, current_user
     )
-    lead_assigned = lead.assigned_officer_id is not None
     return {
         # manager/admin gán lead CHƯA có người phụ trách (endpoint /assign =
         # "Admin/Manager only") → thin-client gate nút "Gán cho cán bộ".
@@ -4852,7 +4866,8 @@ async def _populate_lead_detail_fields(
     # FE hiện nút "Mở lại tư vấn" THUẦN theo cờ này (KHÔNG đọc user.role ở FE). Backend
     # là nơi role-gate. Blocker: not_terminal (lead chưa ở trạng thái cuối tư vấn) /
     # forbidden (đúng trạng thái nhưng user không phải manager/admin).
-    is_manager_admin = current_user.role in (UserRole.MANAGER, UserRole.ADMIN)
+    # Single source role/ownership (reopen + compute_lead_action_permissions).
+    is_manager_admin, is_officer_assigned, _ = _lead_role_context(lead, current_user)
     cs_terminal = False
     if lead.consultation_status_id:
         _cs = await db.get(models.ConsultationStatus, lead.consultation_status_id)
@@ -4864,10 +4879,7 @@ async def _populate_lead_detail_fields(
 
     # Phase B: officer assigned XIN mở lại (chờ manager/admin duyệt). Manager/admin
     # dùng can_reopen (mở trực tiếp), nên can_request_reopen chỉ bật cho officer.
-    is_officer_assigned = (
-        current_user.role == UserRole.OFFICER
-        and lead.assigned_officer_id == current_user.id
-    )
+    # is_officer_assigned lấy từ _lead_role_context ở trên (single source).
     can_request_reopen = is_officer_assigned and cs_terminal
     pending_exists = False
     if can_request_reopen:

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -4852,6 +4852,15 @@ async def _populate_lead_detail_fields(
             else ("not_terminal" if not cs_terminal else "forbidden")
         )
 
+    # ✅ Reassign/Transfer (P0 thin-client): FE gate nút "Chuyển giao lead"
+    # (manager/admin — đổi trực tiếp) vs "Yêu cầu đổi người phụ trách" (officer
+    # ĐƯỢC GIAO lead — xin đổi) THUẦN theo cờ này thay vì đọc user.role ở FE.
+    # Backend là nơi role-gate duy nhất. Chỉ áp khi lead đã có người phụ trách;
+    # lead chưa gán dùng luồng "Gán cho cán bộ" riêng.
+    lead_assigned = lead.assigned_officer_id is not None
+    permissions["can_transfer_lead"] = is_manager_admin and lead_assigned
+    permissions["can_request_reassign"] = is_officer_assigned  # officer được giao
+
     lead.permissions = permissions
     lead.available_actions = [k for k, v in permissions.items() if v]
     lead.action_blockers = blockers

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -720,6 +720,7 @@ async def get_leads(
     is_hot: Optional[bool] = None,
     consultation_status_id: Optional[str] = None,
     include_summary: bool = True,
+    current_user: Optional[models.User] = None,
 ) -> Tuple[int, List[models.Lead], Optional[dict]]:
     """
     Lấy danh sách Leads (List View) + optional summary stats.
@@ -759,6 +760,14 @@ async def get_leads(
         order=order,
         **filter_kwargs,
     )
+
+    # Thin-client: gắn cờ hành động query-free cho từng lead (can_assign_lead /
+    # can_transfer_lead / can_request_reassign) để menu card/hàng khớp panel mà
+    # KHỎI fetch chi tiết từng dòng. Chỉ khi có current_user — caller export
+    # truyền None nên bỏ qua. Không truy vấn DB thêm (đọc role + assigned_officer_id).
+    if current_user is not None:
+        for _lead in leads:
+            _lead.permissions = compute_lead_action_permissions(_lead, current_user)
 
     return total_count, leads, summary
 
@@ -4789,6 +4798,9 @@ def compute_lead_action_permissions(
     )
     lead_assigned = lead.assigned_officer_id is not None
     return {
+        # manager/admin gán lead CHƯA có người phụ trách (endpoint /assign =
+        # "Admin/Manager only") → thin-client gate nút "Gán cho cán bộ".
+        "can_assign_lead": is_manager_admin,
         # manager/admin đổi trực tiếp; chỉ khi lead đã có người phụ trách
         "can_transfer_lead": is_manager_admin and lead_assigned,
         # officer ĐƯỢC GIAO lead → xin đổi

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -4767,6 +4767,35 @@ async def restore_lead(
 # Thin-client gate fields for LeadDetail response (GET /leads/{id})
 # =============================================================================
 
+def compute_lead_action_permissions(
+    lead: models.Lead,
+    current_user: Optional[models.User],
+) -> dict[str, bool]:
+    """Query-free lead action flags (transfer / reassign) from role + assignment
+    state only.
+
+    Shared by the ``LeadDetail`` populate path (GET /leads/{id}) AND the paginated
+    list serializer (GET /leads) so the mobile card / desktop row menu can gate
+    "Chuyển giao lead" / "Yêu cầu đổi người phụ trách" WITHOUT a per-row detail
+    fetch — and WITHOUT the FE reading ``user.role`` (thin-client rule). No DB
+    access → safe to call per list item. Returns ``{}`` for system contexts.
+    """
+    if current_user is None:
+        return {}
+    is_manager_admin = current_user.role in (UserRole.MANAGER, UserRole.ADMIN)
+    is_officer_assigned = (
+        current_user.role == UserRole.OFFICER
+        and lead.assigned_officer_id == current_user.id
+    )
+    lead_assigned = lead.assigned_officer_id is not None
+    return {
+        # manager/admin đổi trực tiếp; chỉ khi lead đã có người phụ trách
+        "can_transfer_lead": is_manager_admin and lead_assigned,
+        # officer ĐƯỢC GIAO lead → xin đổi
+        "can_request_reassign": is_officer_assigned,
+    }
+
+
 async def _populate_lead_detail_fields(
     db: AsyncSession,
     lead: models.Lead,
@@ -4856,10 +4885,9 @@ async def _populate_lead_detail_fields(
     # (manager/admin — đổi trực tiếp) vs "Yêu cầu đổi người phụ trách" (officer
     # ĐƯỢC GIAO lead — xin đổi) THUẦN theo cờ này thay vì đọc user.role ở FE.
     # Backend là nơi role-gate duy nhất. Chỉ áp khi lead đã có người phụ trách;
-    # lead chưa gán dùng luồng "Gán cho cán bộ" riêng.
-    lead_assigned = lead.assigned_officer_id is not None
-    permissions["can_transfer_lead"] = is_manager_admin and lead_assigned
-    permissions["can_request_reassign"] = is_officer_assigned  # officer được giao
+    # lead chưa gán dùng luồng "Gán cho cán bộ" riêng. Cùng nguồn với list
+    # serializer qua compute_lead_action_permissions() (single source of truth).
+    permissions.update(compute_lead_action_permissions(lead, current_user))
 
     lead.permissions = permissions
     lead.available_actions = [k for k, v in permissions.items() if v]

--- a/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
+++ b/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
@@ -1580,6 +1580,42 @@ async def test_can_request_reopen_flag(db: AsyncSession):
     assert lead.action_blockers["can_request_reopen"] == "pending_exists"
 
 
+async def test_can_transfer_and_request_reassign_flags(db: AsyncSession):
+    """P0 thin-client: can_transfer_lead=True cho manager/admin trên lead ĐÃ GÁN;
+    can_request_reassign=True cho officer ĐƯỢC GIAO; officer khác / lead chưa gán → False.
+    FE gate nút "Chuyển giao" vs "Yêu cầu đổi" theo cờ này thay vì đọc user.role."""
+    from app.services.lead_service import _populate_lead_detail_fields
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    manager = await _make_manager(db, unit.id)
+    officer = await _make_officer(db, unit.id, cap=10)
+    other = await _make_officer(db, unit.id, cap=10)
+    assigned_lead = await _make_lead(db, unit.id, officer_id=officer.id)
+    unassigned_lead = await _make_lead(db, unit.id, status="new")
+
+    # Manager trên lead đã gán → chuyển giao trực tiếp, không "xin đổi".
+    await _populate_lead_detail_fields(db, assigned_lead, manager)
+    assert assigned_lead.permissions["can_transfer_lead"] is True
+    assert assigned_lead.permissions["can_request_reassign"] is False
+    assert "can_transfer_lead" in assigned_lead.available_actions
+
+    # Officer được giao → xin đổi, không chuyển giao trực tiếp.
+    await _populate_lead_detail_fields(db, assigned_lead, officer)
+    assert assigned_lead.permissions["can_transfer_lead"] is False
+    assert assigned_lead.permissions["can_request_reassign"] is True
+
+    # Officer KHÔNG được giao → cả hai False (không thao tác lead người khác).
+    await _populate_lead_detail_fields(db, assigned_lead, other)
+    assert assigned_lead.permissions["can_transfer_lead"] is False
+    assert assigned_lead.permissions["can_request_reassign"] is False
+
+    # Lead CHƯA gán → manager không "chuyển giao" (dùng luồng "Gán cho cán bộ").
+    await _populate_lead_detail_fields(db, unassigned_lead, manager)
+    assert unassigned_lead.permissions["can_transfer_lead"] is False
+    assert unassigned_lead.permissions["can_request_reassign"] is False
+
+
 async def test_reopen_lead_auto_resolves_pending_request(db: AsyncSession):
     """#1: lead mở lại TRỰC TIẾP (Phase A reopen_lead) khi đang có pending request →
     request được AUTO-approved (không mồ côi 'Chờ duyệt' mãi)."""

--- a/Backend_FastAPI/tests/unit/test_lead_action_permissions.py
+++ b/Backend_FastAPI/tests/unit/test_lead_action_permissions.py
@@ -27,16 +27,19 @@ def test_manager_assigned_can_transfer_not_reassign():
     p = compute_lead_action_permissions(_lead(assigned_officer_id=5), _user(UserRole.MANAGER))
     assert p["can_transfer_lead"] is True
     assert p["can_request_reassign"] is False
+    assert p["can_assign_lead"] is True  # manager luôn được gán (endpoint admin/manager-only)
 
 
 def test_admin_assigned_can_transfer():
     p = compute_lead_action_permissions(_lead(assigned_officer_id=5), _user(UserRole.ADMIN))
     assert p["can_transfer_lead"] is True
+    assert p["can_assign_lead"] is True
 
 
-def test_manager_unassigned_cannot_transfer():
-    # lead chưa có người phụ trách → dùng luồng "Gán cho cán bộ", không transfer
+def test_manager_unassigned_can_assign_not_transfer():
+    # lead chưa có người phụ trách → hiện "Gán cho cán bộ" (can_assign), không transfer
     p = compute_lead_action_permissions(_lead(assigned_officer_id=None), _user(UserRole.MANAGER))
+    assert p["can_assign_lead"] is True
     assert p["can_transfer_lead"] is False
     assert p["can_request_reassign"] is False
 
@@ -47,6 +50,7 @@ def test_officer_assigned_to_self_can_request_reassign():
     )
     assert p["can_request_reassign"] is True
     assert p["can_transfer_lead"] is False
+    assert p["can_assign_lead"] is False  # officer KHÔNG được gán (thin-client ẩn nút)
 
 
 def test_officer_not_assigned_no_flags():
@@ -56,6 +60,7 @@ def test_officer_not_assigned_no_flags():
     )
     assert p["can_request_reassign"] is False
     assert p["can_transfer_lead"] is False
+    assert p["can_assign_lead"] is False
 
 
 def test_system_context_none_user_returns_empty():

--- a/Backend_FastAPI/tests/unit/test_lead_action_permissions.py
+++ b/Backend_FastAPI/tests/unit/test_lead_action_permissions.py
@@ -1,0 +1,62 @@
+"""Unit tests for lead_service.compute_lead_action_permissions().
+
+Pure function (no DB): verifies the query-free transfer/reassign action flags
+shared by the LeadDetail populate path and the paginated list serializer. These
+flags gate "Chuyển giao lead" (manager/admin) vs "Yêu cầu đổi người phụ trách"
+(officer được giao) in the row/card menu without the FE reading user.role.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.constants import UserRole
+from app.services.lead_service import compute_lead_action_permissions
+
+pytestmark = pytest.mark.unit
+
+
+def _lead(assigned_officer_id=None):
+    return SimpleNamespace(assigned_officer_id=assigned_officer_id)
+
+
+def _user(role, uid=1):
+    return SimpleNamespace(role=role, id=uid)
+
+
+def test_manager_assigned_can_transfer_not_reassign():
+    p = compute_lead_action_permissions(_lead(assigned_officer_id=5), _user(UserRole.MANAGER))
+    assert p["can_transfer_lead"] is True
+    assert p["can_request_reassign"] is False
+
+
+def test_admin_assigned_can_transfer():
+    p = compute_lead_action_permissions(_lead(assigned_officer_id=5), _user(UserRole.ADMIN))
+    assert p["can_transfer_lead"] is True
+
+
+def test_manager_unassigned_cannot_transfer():
+    # lead chưa có người phụ trách → dùng luồng "Gán cho cán bộ", không transfer
+    p = compute_lead_action_permissions(_lead(assigned_officer_id=None), _user(UserRole.MANAGER))
+    assert p["can_transfer_lead"] is False
+    assert p["can_request_reassign"] is False
+
+
+def test_officer_assigned_to_self_can_request_reassign():
+    p = compute_lead_action_permissions(
+        _lead(assigned_officer_id=7), _user(UserRole.OFFICER, uid=7)
+    )
+    assert p["can_request_reassign"] is True
+    assert p["can_transfer_lead"] is False
+
+
+def test_officer_not_assigned_no_flags():
+    # officer nhìn lead của người khác → không có cờ hành động nào
+    p = compute_lead_action_permissions(
+        _lead(assigned_officer_id=99), _user(UserRole.OFFICER, uid=7)
+    )
+    assert p["can_request_reassign"] is False
+    assert p["can_transfer_lead"] is False
+
+
+def test_system_context_none_user_returns_empty():
+    assert compute_lead_action_permissions(_lead(assigned_officer_id=5), None) == {}

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -36,22 +36,11 @@ const nextConfig: NextConfig = {
   cacheComponents: true,
 
   // Allow cross-origin requests from devices on local network during development
-  // This enables testing from mobile devices when dev server runs on desktop
-  // Note: Next.js requires both with/without port for proper matching
+  // (test từ điện thoại khi dev server chạy trên desktop). Next.js so khớp theo
+  // HOSTNAME — KHÔNG kèm protocol/port; khai full-URL sẽ không match → dev-server
+  // chặn /_next/* (403) → RSC/hydrate vỡ trên thiết bị LAN.
   allowedDevOrigins: isDev
-    ? [
-        // Common mobile device testing IPs
-        "http://192.168.88.125", // Without port
-        "http://192.168.88.125:80", // With port 80 (nginx/proxy)
-        "http://192.168.88.125:3000", // With port 3000
-        "http://192.168.88.125:3001", // With port 3001
-
-        // Additional device IP from previous setup
-        "http://192.168.0.120",
-        "http://192.168.0.120:80",
-        "http://192.168.0.120:3000",
-        "http://192.168.0.120:3001",
-      ]
+    ? ["192.168.88.125", "192.168.0.120"]
     : [],
 
   // ✅ Security Headers

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/SendConfirmationButton.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/SendConfirmationButton.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from "react"
 import { toast } from "sonner"
+import { copyToClipboard } from "@/lib/clipboard"
 import { Copy, Mail, Loader2, Send, Check } from "lucide-react"
 import type { AxiosError } from "axios"
 
@@ -69,12 +70,11 @@ export function SendConfirmationButton({ profileId }: Props) {
 
   const handleCopy = async () => {
     if (!result?.confirm_url) return
-    try {
-      await navigator.clipboard.writeText(result.confirm_url)
+    if (await copyToClipboard(result.confirm_url)) {
       setCopied(true)
       toast.success("Đã sao chép liên kết")
       setTimeout(() => setCopied(false), 2000)
-    } catch {
+    } else {
       toast.error("Không sao chép được. Vui lòng sao thủ công.")
     }
   }

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/SendMagicLinkButton.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/SendMagicLinkButton.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from "react"
 import { toast } from "sonner"
+import { copyToClipboard } from "@/lib/clipboard"
 import { Copy, Loader2, Send, Check } from "lucide-react"
 import type { AxiosError } from "axios"
 
@@ -107,12 +108,11 @@ export function SendMagicLinkButton({ profileId, action }: Props) {
 
   const handleCopy = async () => {
     if (!result?.magic_link_url) return
-    try {
-      await navigator.clipboard.writeText(result.magic_link_url)
+    if (await copyToClipboard(result.magic_link_url)) {
       setCopied(true)
       toast.success("Đã sao chép liên kết")
       setTimeout(() => setCopied(false), 2000)
-    } catch {
+    } else {
       toast.error("Không sao chép được. Vui lòng sao thủ công.")
     }
   }

--- a/frontend/src/app/(dashboard)/guideline/page.tsx
+++ b/frontend/src/app/(dashboard)/guideline/page.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { copyToClipboard } from "@/lib/clipboard";
 import {
   BookOpen,
   Users,
@@ -108,10 +109,11 @@ function InfoBox({
 function CodeBlock({ code, language = "tsx" }: { code: string; language?: string }) {
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const handleCopy = async () => {
+    if (await copyToClipboard(code)) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
   };
 
   return (

--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
@@ -70,6 +70,7 @@ import { LeadInfoTabs } from "./LeadInfoTabs";
 import { LeadConsultSection } from "@/components/leads/LeadConsultSection";
 import { WorkflowBreadcrumb } from "@/components/common";
 import { cn, sanitizeColorCode } from "@/lib/utils";
+import { copyToClipboard } from "@/lib/clipboard";
 import { getLeadScoreLabel, getLeadScoreTextColor } from "@/constants";
 import type { LeadDetail, TimelineItem, LeadInsights } from "@/types/lead.types";
 
@@ -105,14 +106,11 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [phoneCopied, setPhoneCopied] = useState(false);
 
-  // Copy phone number to clipboard
+  // Copy phone number to clipboard (fallback execCommand khi HTTP/insecure)
   const handleCopyPhone = async (phone: string) => {
-    try {
-      await navigator.clipboard.writeText(phone);
+    if (await copyToClipboard(phone)) {
       setPhoneCopied(true);
       setTimeout(() => setPhoneCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy phone:", err);
     }
   };
 

--- a/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
@@ -491,6 +491,7 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
                   onSelectLead={handleLeadSelect}
                   onEditLead={handleEdit}
                   onDeleteLead={handleDelete}
+                  onAssignLead={handleAssign}
                   page={filterState.page}
                   pageSize={filterState.pageSize}
                   totalCount={leadsPage?.total_count || 0}
@@ -560,6 +561,7 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
               onSelectLead={handleLeadSelect}
               onEditLead={handleEdit}
               onDeleteLead={handleDelete}
+              onAssignLead={handleAssign}
               page={filterState.page}
               pageSize={filterState.pageSize}
               totalCount={leadsPage?.total_count || 0}

--- a/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
@@ -585,7 +585,9 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
           <SheetHeader className="sr-only">
             <SheetTitle>Chi tiết Lead</SheetTitle>
           </SheetHeader>
-          <div className="h-full overflow-y-auto">
+          {/* Chỉ 1 tầng cuộn: LeadDetailPanel tự có ScrollArea (như desktop).
+              Wrapper KHÔNG overflow-y-auto để tránh cuộn lồng gây giật. */}
+          <div className="h-full">
             <LeadDetailPanel
               leadId={selectedLeadId}
               onEdit={(lead) => {

--- a/frontend/src/app/(dashboard)/settings/mfa/_components/MfaSettingsClient.tsx
+++ b/frontend/src/app/(dashboard)/settings/mfa/_components/MfaSettingsClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { toast } from "sonner";
+import { copyToClipboard } from "@/lib/clipboard";
 import { ShieldCheck, ShieldOff, Copy, RefreshCw } from "lucide-react";
 
 import { api } from "@/lib/api/client";
@@ -150,9 +151,12 @@ export function MfaSettingsClient() {
     },
   });
 
-  function copyBackupCodes() {
-    navigator.clipboard.writeText(backupCodes.join("\n"));
-    toast.success("Đã sao chép mã dự phòng.");
+  async function copyBackupCodes() {
+    if (await copyToClipboard(backupCodes.join("\n"))) {
+      toast.success("Đã sao chép mã dự phòng.");
+    } else {
+      toast.error("Không sao chép được.");
+    }
   }
 
   if (isStatusLoading) {

--- a/frontend/src/app/(dashboard)/settings/notifications/_components/NotificationSettingsClient.tsx
+++ b/frontend/src/app/(dashboard)/settings/notifications/_components/NotificationSettingsClient.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { copyToClipboard } from "@/lib/clipboard";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -188,11 +189,10 @@ export function NotificationSettingsClient({
   };
 
   const handleCopyCode = async (code: string) => {
-    try {
-      await navigator.clipboard.writeText(code);
+    if (await copyToClipboard(code)) {
       toast.success("Đã sao chép mã.");
-    } catch {
-      // Clipboard may be denied (insecure context, browser policy).
+    } else {
+      // Copy bị chặn (insecure/policy) → hiện mã để copy tay.
       toast.info(`Mã: ${code}`);
     }
   };

--- a/frontend/src/components/common/CopyableCell.tsx
+++ b/frontend/src/components/common/CopyableCell.tsx
@@ -20,6 +20,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { copyToClipboard } from "@/lib/clipboard";
 import { toast } from "sonner";
 
 // =============================================================================
@@ -64,18 +65,17 @@ export function CopyableCell({
       
       if (!value) return;
 
-      try {
-        await navigator.clipboard.writeText(value);
+      // copyToClipboard tự fallback execCommand khi HTTP/insecure (LAN/phone).
+      const ok = await copyToClipboard(value);
+      if (ok) {
         setCopied(true);
         toast.success(`Đã sao chép ${label}`, {
           description: value,
           duration: 2000,
         });
-        
         // Reset copied state after animation
         setTimeout(() => setCopied(false), 2000);
-      } catch (err) {
-        console.error("Failed to copy:", err);
+      } else {
         toast.error("Không thể sao chép");
       }
     },

--- a/frontend/src/components/common/MobileActionSheet.tsx
+++ b/frontend/src/components/common/MobileActionSheet.tsx
@@ -68,6 +68,10 @@ interface ActionItemProps {
   disabled?: boolean;
   /** Variant */
   variant?: "default" | "destructive";
+  /** Render as a real anchor (tel:/mailto:/https) instead of a button. */
+  href?: string;
+  /** Anchor target (e.g. "_blank" for external links). Only with href. */
+  target?: string;
   /** Additional class name */
   className?: string;
 }
@@ -142,32 +146,31 @@ function ActionItem({
   onClick,
   disabled,
   variant = "default",
+  href,
+  target,
   className,
 }: ActionItemProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        // Base styles
-        "w-full flex items-center gap-3 px-4 py-3 rounded-lg",
-        "text-left text-sm font-medium",
-        "transition-colors",
-        // Touch target
-        "min-h-[48px]",
-        // States
-        "hover:bg-accent active:bg-accent/80",
-        "disabled:opacity-50 disabled:cursor-not-allowed",
-        // Variants
-        variant === "destructive" && [
-          "text-destructive",
-          "hover:bg-destructive/10",
-          "active:bg-destructive/20",
-        ],
-        className
-      )}
-    >
+  const itemClass = cn(
+    // Base styles
+    "w-full flex items-center gap-3 px-4 py-3 rounded-lg",
+    "text-left text-sm font-medium",
+    "transition-colors",
+    // Touch target
+    "min-h-[48px]",
+    // States
+    "hover:bg-accent active:bg-accent/80",
+    "disabled:opacity-50 disabled:cursor-not-allowed",
+    // Variants
+    variant === "destructive" && [
+      "text-destructive",
+      "hover:bg-destructive/10",
+      "active:bg-destructive/20",
+    ],
+    className
+  );
+
+  const inner = (
+    <>
       {Icon && (
         <Icon
           className={cn(
@@ -177,6 +180,29 @@ function ActionItem({
         />
       )}
       <span className="flex-1">{children}</span>
+    </>
+  );
+
+  // href → anchor thật (tel:/mailto:/https) theo link semantics, tránh
+  // window.open('tel:', '_blank') mở tab trắng trên mobile. onClick vẫn chạy
+  // (đóng sheet) trước khi trình duyệt xử lý href.
+  if (href) {
+    return (
+      <a
+        href={href}
+        target={target}
+        rel={target === "_blank" ? "noopener noreferrer" : undefined}
+        onClick={onClick}
+        className={itemClass}
+      >
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <button type="button" onClick={onClick} disabled={disabled} className={itemClass}>
+      {inner}
     </button>
   );
 }

--- a/frontend/src/components/common/SwipeToCall.test.tsx
+++ b/frontend/src/components/common/SwipeToCall.test.tsx
@@ -112,6 +112,27 @@ describe("SwipeToCall — bấm giữ rồi kéo phải để gọi", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it("bấm-giữ trên control [data-swipe-ignore] (menu ⋮ / checkbox) → KHÔNG arm, click con vẫn chạy", () => {
+    // Regression: trước đây long-press ≥400ms trên nút con vẫn arm gesture rồi
+    // onClickCapture nuốt tap → menu không mở / checkbox không tick.
+    const onCall = vi.fn();
+    const onChild = vi.fn();
+    const utils = render(
+      <SwipeToCall phone="0900000000" onCall={onCall}>
+        <button data-swipe-ignore onClick={onChild}>
+          menu
+        </button>
+      </SwipeToCall>
+    );
+    const child = utils.getByText("menu");
+    down(child, 0, 0);
+    vi.advanceTimersByTime(400); // vượt ARM_MS mà KHÔNG được khoá chế độ kéo
+    up(child);
+    fireEvent.click(child);
+    expect(onCall).not.toHaveBeenCalled();
+    expect(onChild).toHaveBeenCalledTimes(1);
+  });
+
   it("không có SĐT → render children, bỏ qua cử chỉ", () => {
     const onCall = vi.fn();
     const { getByText, root } = (() => {

--- a/frontend/src/components/common/SwipeToCall.test.tsx
+++ b/frontend/src/components/common/SwipeToCall.test.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { SwipeToCall } from "./SwipeToCall";
+
+// jsdom: PointerEvent gốc không giữ clientX/Y ổn định qua fireEvent → thay bằng
+// lớp gốc MouseEvent (chắc chắn mang toạ độ). setPointerCapture cũng chưa có.
+class TestPointerEvent extends MouseEvent {
+  pointerId: number;
+  pointerType: string;
+  constructor(type: string, params: PointerEventInit = {}) {
+    super(type, params);
+    this.pointerId = params.pointerId ?? 1;
+    this.pointerType = params.pointerType ?? "touch";
+  }
+}
+(globalThis as unknown as { PointerEvent: unknown }).PointerEvent = TestPointerEvent;
+if (!Element.prototype.setPointerCapture) Element.prototype.setPointerCapture = () => {};
+if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+
+// jsdom: offsetWidth=0 → SwipeToCall fallback 320 → ngưỡng = 320*0.45 = 144px.
+
+function renderSwipe(
+  overrides: Partial<React.ComponentProps<typeof SwipeToCall>> = {}
+) {
+  const onCall = vi.fn();
+  const onClick = vi.fn();
+  const utils = render(
+    <SwipeToCall phone="0900000000" label="Nguyễn Văn A" onCall={onCall} {...overrides}>
+      <button onClick={onClick}>card</button>
+    </SwipeToCall>
+  );
+  const root = utils.container.firstChild as HTMLElement;
+  return { ...utils, root, onCall, onClick };
+}
+
+const down = (el: HTMLElement, x = 0, y = 0) =>
+  fireEvent.pointerDown(el, { clientX: x, clientY: y, pointerId: 1, button: 0, pointerType: "touch" });
+const move = (el: HTMLElement, x: number, y = 0) =>
+  fireEvent.pointerMove(el, { clientX: x, clientY: y, pointerId: 1, pointerType: "touch" });
+const up = (el: HTMLElement) =>
+  fireEvent.pointerUp(el, { pointerId: 1, pointerType: "touch" });
+
+describe("SwipeToCall — bấm giữ rồi kéo phải để gọi", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("long-press 400ms → kéo qua ngưỡng → thả = gọi", () => {
+    const { root, onCall } = renderSwipe();
+    down(root, 0, 0);
+    vi.advanceTimersByTime(400); // ARM
+    move(root, 200, 0); // kéo phải > 144px
+    up(root);
+    expect(onCall).toHaveBeenCalledWith("0900000000");
+  });
+
+  it("đã arm nhưng kéo CHƯA qua ngưỡng → KHÔNG gọi", () => {
+    const { root, onCall } = renderSwipe();
+    down(root, 0, 0);
+    vi.advanceTimersByTime(400);
+    move(root, 50, 0); // < 144px
+    up(root);
+    expect(onCall).not.toHaveBeenCalled();
+  });
+
+  it("tap nhanh (chưa đủ 400ms) → KHÔNG gọi, click mở chi tiết vẫn chạy", () => {
+    const { root, onCall, onClick, getByText } = renderSwipe();
+    down(root, 0, 0);
+    vi.advanceTimersByTime(150);
+    up(root); // nhả trước khi arm
+    fireEvent.click(getByText("card"));
+    expect(onCall).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("di chuyển sớm (cuộn dọc) trước khi arm → KHÔNG arm, KHÔNG gọi", () => {
+    const { root, onCall } = renderSwipe();
+    down(root, 0, 0);
+    move(root, 0, 40); // cuộn dọc 40px → huỷ arm-timer
+    vi.advanceTimersByTime(400);
+    move(root, 200, 40);
+    up(root);
+    expect(onCall).not.toHaveBeenCalled();
+  });
+
+  it("sau long-press+kéo, click kế tiếp bị chặn (không mở chi tiết oan)", () => {
+    const { root, onCall, onClick, getByText } = renderSwipe();
+    down(root, 0, 0);
+    vi.advanceTimersByTime(400);
+    move(root, 200, 0);
+    up(root);
+    fireEvent.click(getByText("card")); // trình duyệt có thể phát click sau drag
+    expect(onCall).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("gesture bị huỷ giữa chừng (pointercancel) → KHÔNG nuốt oan tap kế tiếp", () => {
+    const { root, onCall, onClick, getByText } = renderSwipe();
+    // Gesture 1: long-press (arm) rồi huỷ.
+    down(root, 0, 0);
+    vi.advanceTimersByTime(400);
+    fireEvent.pointerCancel(root, { pointerId: 1, pointerType: "touch" });
+    // Gesture 2: tap nhanh → phải mở chi tiết (click không bị chặn oan).
+    down(root, 0, 0);
+    vi.advanceTimersByTime(120);
+    up(root);
+    fireEvent.click(getByText("card"));
+    expect(onCall).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("không có SĐT → render children, bỏ qua cử chỉ", () => {
+    const onCall = vi.fn();
+    const { getByText, root } = (() => {
+      const utils = render(
+        <SwipeToCall phone={null} onCall={onCall}>
+          <button>no-phone</button>
+        </SwipeToCall>
+      );
+      return { ...utils, root: utils.container.firstChild as HTMLElement };
+    })();
+    expect(getByText("no-phone")).toBeInTheDocument();
+    down(root, 0, 0);
+    vi.advanceTimersByTime(400);
+    move(root, 200, 0);
+    up(root);
+    expect(onCall).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/common/SwipeToCall.tsx
+++ b/frontend/src/components/common/SwipeToCall.tsx
@@ -190,7 +190,9 @@ export function SwipeToCall({
   return (
     <div
       ref={containerRef}
-      className={cn("relative overflow-hidden rounded-lg", className)}
+      // rounded-xl khớp bán kính card con (MobileLeadCard) — lệch (card rounded-xl
+      // > container rounded-lg) làm nền "Gọi" xanh ló ở 4 góc mọi card.
+      className={cn("relative overflow-hidden rounded-xl", className)}
       // pan-y: browser vẫn cuộn dọc; ngang do JS xử lý.
       style={{ touchAction: "pan-y" }}
       onPointerDown={onPointerDown}
@@ -217,7 +219,7 @@ export function SwipeToCall({
       <motion.div
         style={{ x }}
         className={cn(
-          "relative z-10 rounded-lg",
+          "relative z-10 rounded-xl",
           armed && "shadow-lg ring-2 ring-success-400"
         )}
       >

--- a/frontend/src/components/common/SwipeToCall.tsx
+++ b/frontend/src/components/common/SwipeToCall.tsx
@@ -82,13 +82,17 @@ export function SwipeToCall({
     }
   }, []);
 
-  const dims = React.useCallback(() => {
-    // offsetWidth=0 (jsdom / chưa layout) → fallback 320 để logic test được.
-    const w = containerRef.current?.offsetWidth || 320;
-    return { max: w * REVEAL_RATIO, threshold: w * THRESHOLD_RATIO };
-  }, []);
+  // Kích thước kéo chốt 1 LẦN lúc arm (bề rộng card cố định suốt cử chỉ) → khỏi
+  // đọc offsetWidth (layout read) mỗi pointermove trên hot path.
+  // offsetWidth=0 (jsdom / chưa layout) → fallback 320 để logic test được.
+  const dimsRef = React.useRef({
+    max: 320 * REVEAL_RATIO,
+    threshold: 320 * THRESHOLD_RATIO,
+  });
 
-  const reset = React.useCallback(() => {
+  // Hàm thường (không useCallback): chỉ được gọi bởi các inline pointer-handler tạo
+  // mới mỗi render, không phải dep của consumer memo hoá nào — wrap chỉ tốn bookkeeping.
+  const reset = () => {
     clearTimer();
     armedRef.current = false;
     draggingRef.current = false;
@@ -97,17 +101,21 @@ export function SwipeToCall({
     setPast(false);
     if (prefersReduced) x.set(0);
     else animate(x, 0, { type: "spring", stiffness: 500, damping: 40 });
-  }, [clearTimer, prefersReduced, x]);
+  };
 
-  const triggerCall = React.useCallback(() => {
+  const triggerCall = () => {
     if (!phone) return;
     if (onCall) onCall(phone);
     else if (typeof window !== "undefined") window.location.href = `tel:${phone}`;
-  }, [phone, onCall]);
+  };
 
   const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!canSwipe) return;
     if (e.pointerType === "mouse" && e.button !== 0) return; // bỏ chuột phải/giữa
+    // Bấm vào control con TỰ-XỬ-LÝ (menu ⋮, checkbox…): pointerdown của chúng bubble
+    // lên đây; nếu vẫn arm gesture thì onClickCapture sẽ nuốt luôn tap mở menu / tick
+    // chọn (giữ ≥400ms). Bỏ qua mọi subtree đánh dấu [data-swipe-ignore].
+    if ((e.target as HTMLElement).closest?.("[data-swipe-ignore]")) return;
     startRef.current = { x: e.clientX, y: e.clientY };
     // Xoá cờ chặn-click còn sót từ gesture trước bị huỷ (tránh nuốt oan tap mới).
     suppressClickRef.current = false;
@@ -120,6 +128,9 @@ export function SwipeToCall({
     clearTimer();
     timerRef.current = setTimeout(() => {
       // Đủ ARM_MS mà chưa huỷ (không cuộn/tap) → khoá chế độ kéo.
+      // Chốt kích thước kéo 1 lần (bề rộng card cố định từ đây tới hết cử chỉ).
+      const w = containerRef.current?.offsetWidth || 320;
+      dimsRef.current = { max: w * REVEAL_RATIO, threshold: w * THRESHOLD_RATIO };
       armedRef.current = true;
       suppressClickRef.current = true; // chặn mở-chi-tiết sau long-press
       setArmed(true);
@@ -145,7 +156,7 @@ export function SwipeToCall({
     }
     // Đã armed → kéo phải, kẹp trong [0, max].
     draggingRef.current = true;
-    const { max, threshold } = dims();
+    const { max, threshold } = dimsRef.current;
     const nx = Math.max(0, Math.min(dx, max));
     x.set(nx);
     const p = nx >= threshold;
@@ -168,7 +179,7 @@ export function SwipeToCall({
     }
     pointerIdRef.current = null;
     if (armedRef.current && draggingRef.current) {
-      const { threshold } = dims();
+      const { threshold } = dimsRef.current;
       if (x.get() >= threshold) triggerCall();
     }
     reset();

--- a/frontend/src/components/common/SwipeToCall.tsx
+++ b/frontend/src/components/common/SwipeToCall.tsx
@@ -1,0 +1,230 @@
+// src/components/common/SwipeToCall.tsx
+/**
+ * SwipeToCall — cử chỉ "bấm giữ rồi kéo phải để gọi điện" cho card mobile.
+ *
+ * Mô hình (chốt với owner): long-press ~400ms để "khoá" chế độ kéo (chống gọi
+ * nhầm khi cuộn), sau đó kéo card sang phải; thả khi qua ngưỡng → quay số tel:.
+ *
+ *   IDLE ─pointerdown→ PRESSING(timer 400ms)
+ *     ├ di chuyển >10px sớm  → huỷ (nhường cuộn dọc / tap mở chi tiết)
+ *     ├ nhả <400ms & <10px   → TAP (onClick của card chạy bình thường)
+ *     └ đủ 400ms & <10px     → ARMED (rung + lộ nền "Gọi") ─kéo→ DRAGGING
+ *          └ thả: offset ≥ ngưỡng → gọi ; < ngưỡng → bật về chỗ cũ
+ *
+ * Tăng cường, KHÔNG thay thế: tap→chi tiết và menu ⋮ vẫn là đường tiếp cận
+ * (a11y). Reduced-motion: tắt animation kéo, GIỮ hành động gọi.
+ */
+"use client";
+
+import * as React from "react";
+import { motion, useMotionValue, animate, useReducedMotion } from "framer-motion";
+import { Phone } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface SwipeToCallProps {
+  /** Số điện thoại để gọi. Rỗng/thiếu → tắt cử chỉ. */
+  phone: string | null | undefined;
+  /** Tên hiển thị trong vùng gọi: "Gọi {label}". */
+  label?: string;
+  children: React.ReactNode;
+  /** Tắt cử chỉ thủ công. */
+  disabled?: boolean;
+  /** Ghi đè hành động gọi (mặc định điều hướng `tel:`). Dùng cho test/analytics. */
+  onCall?: (phone: string) => void;
+  className?: string;
+}
+
+const ARM_MS = 400; // bấm giữ để khoá chế độ kéo
+const MOVE_CANCEL_PX = 10; // di chuyển quá mức này trước khi arm → huỷ
+const REVEAL_RATIO = 0.55; // kéo tối đa (theo bề rộng card)
+const THRESHOLD_RATIO = 0.45; // qua đây thả là gọi
+
+function vibrate(ms: number) {
+  try {
+    if (typeof navigator !== "undefined" && "vibrate" in navigator) {
+      navigator.vibrate(ms);
+    }
+  } catch {
+    /* một số trình duyệt chặn — bỏ qua */
+  }
+}
+
+export function SwipeToCall({
+  phone,
+  label,
+  children,
+  disabled,
+  onCall,
+  className,
+}: SwipeToCallProps) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const x = useMotionValue(0);
+  const prefersReduced = useReducedMotion();
+
+  const [armed, setArmed] = React.useState(false);
+  const [past, setPast] = React.useState(false);
+
+  // Refs đọc/ghi đồng bộ trong pointer handlers (state async không kịp).
+  const armedRef = React.useRef(false);
+  const draggingRef = React.useRef(false);
+  const pastRef = React.useRef(false);
+  const suppressClickRef = React.useRef(false);
+  const startRef = React.useRef({ x: 0, y: 0 });
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pointerIdRef = React.useRef<number | null>(null);
+
+  const canSwipe = !disabled && !!phone;
+
+  const clearTimer = React.useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const dims = React.useCallback(() => {
+    // offsetWidth=0 (jsdom / chưa layout) → fallback 320 để logic test được.
+    const w = containerRef.current?.offsetWidth || 320;
+    return { max: w * REVEAL_RATIO, threshold: w * THRESHOLD_RATIO };
+  }, []);
+
+  const reset = React.useCallback(() => {
+    clearTimer();
+    armedRef.current = false;
+    draggingRef.current = false;
+    pastRef.current = false;
+    setArmed(false);
+    setPast(false);
+    if (prefersReduced) x.set(0);
+    else animate(x, 0, { type: "spring", stiffness: 500, damping: 40 });
+  }, [clearTimer, prefersReduced, x]);
+
+  const triggerCall = React.useCallback(() => {
+    if (!phone) return;
+    if (onCall) onCall(phone);
+    else if (typeof window !== "undefined") window.location.href = `tel:${phone}`;
+  }, [phone, onCall]);
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!canSwipe) return;
+    if (e.pointerType === "mouse" && e.button !== 0) return; // bỏ chuột phải/giữa
+    startRef.current = { x: e.clientX, y: e.clientY };
+    // Xoá cờ chặn-click còn sót từ gesture trước bị huỷ (tránh nuốt oan tap mới).
+    suppressClickRef.current = false;
+    armedRef.current = false;
+    draggingRef.current = false;
+    pastRef.current = false;
+    setArmed(false);
+    setPast(false);
+    pointerIdRef.current = e.pointerId;
+    clearTimer();
+    timerRef.current = setTimeout(() => {
+      // Đủ ARM_MS mà chưa huỷ (không cuộn/tap) → khoá chế độ kéo.
+      armedRef.current = true;
+      suppressClickRef.current = true; // chặn mở-chi-tiết sau long-press
+      setArmed(true);
+      vibrate(10);
+      try {
+        containerRef.current?.setPointerCapture(e.pointerId);
+      } catch {
+        /* jsdom / trình duyệt cũ */
+      }
+    }, ARM_MS);
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!canSwipe) return;
+    const dx = e.clientX - startRef.current.x;
+    const dy = e.clientY - startRef.current.y;
+    if (!armedRef.current) {
+      // Trước khi arm: di chuyển sớm = cuộn/tap-trượt → huỷ, nhường browser.
+      if (Math.abs(dx) > MOVE_CANCEL_PX || Math.abs(dy) > MOVE_CANCEL_PX) {
+        clearTimer();
+      }
+      return;
+    }
+    // Đã armed → kéo phải, kẹp trong [0, max].
+    draggingRef.current = true;
+    const { max, threshold } = dims();
+    const nx = Math.max(0, Math.min(dx, max));
+    x.set(nx);
+    const p = nx >= threshold;
+    if (p !== pastRef.current) {
+      pastRef.current = p;
+      setPast(p);
+      if (p) vibrate(20);
+    }
+  };
+
+  const onPointerUp = () => {
+    if (!canSwipe) return;
+    clearTimer();
+    try {
+      if (pointerIdRef.current != null) {
+        containerRef.current?.releasePointerCapture(pointerIdRef.current);
+      }
+    } catch {
+      /* no-op */
+    }
+    pointerIdRef.current = null;
+    if (armedRef.current && draggingRef.current) {
+      const { threshold } = dims();
+      if (x.get() >= threshold) triggerCall();
+    }
+    reset();
+    // suppressClickRef giữ true nếu đã armed → onClickCapture nuốt click kế tiếp.
+  };
+
+  const onClickCapture = (e: React.MouseEvent) => {
+    if (suppressClickRef.current) {
+      e.stopPropagation();
+      e.preventDefault();
+      suppressClickRef.current = false;
+    }
+  };
+
+  React.useEffect(() => () => clearTimer(), [clearTimer]);
+
+  if (!canSwipe) return <>{children}</>;
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("relative overflow-hidden rounded-lg", className)}
+      // pan-y: browser vẫn cuộn dọc; ngang do JS xử lý.
+      style={{ touchAction: "pan-y" }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={reset}
+      onClickCapture={onClickCapture}
+    >
+      {/* Nền hành động "Gọi", lộ dần khi kéo phải */}
+      <div
+        aria-hidden
+        className={cn(
+          "absolute inset-0 z-0 flex items-center gap-2 pl-4 pr-3 text-white transition-colors",
+          past ? "bg-success-600" : "bg-success-500"
+        )}
+      >
+        <Phone className={cn("h-5 w-5 shrink-0 transition-transform", past && "scale-110")} />
+        <span className="whitespace-nowrap text-sm font-semibold">
+          {past ? "Thả để gọi" : label ? `Gọi ${label}` : "Gọi"}
+        </span>
+      </div>
+
+      {/* Card kéo được (đục, che nền xanh cho tới khi kéo) */}
+      <motion.div
+        style={{ x }}
+        className={cn(
+          "relative z-10 rounded-lg",
+          armed && "shadow-lg ring-2 ring-success-400"
+        )}
+      >
+        {children}
+      </motion.div>
+    </div>
+  );
+}
+
+export default SwipeToCall;

--- a/frontend/src/components/common/form/DateTimePicker.tsx
+++ b/frontend/src/components/common/form/DateTimePicker.tsx
@@ -386,7 +386,11 @@ export function DateTimePicker({
             )}
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="start">
+        <PopoverContent
+          className="w-auto max-w-[calc(100vw-1rem)] overflow-auto p-0"
+          align="start"
+          collisionPadding={8}
+        >
           {/* Input display */}
           <div className="p-3 border-b">
             <Input
@@ -397,9 +401,11 @@ export function DateTimePicker({
             />
           </div>
 
-          <div className="flex">
+          {/* Xếp DỌC trên mobile (calendar trên, giờ dưới) để không tràn màn ~390px;
+              NGANG (side-by-side) từ sm trở lên. */}
+          <div className="flex flex-col sm:flex-row">
             {/* Calendar */}
-            <div className="border-r">
+            <div className="border-b sm:border-b-0 sm:border-r">
               <Calendar
                 mode="single"
                 selected={value || undefined}
@@ -428,8 +434,9 @@ export function DateTimePicker({
               </div>
             </div>
 
-            {/* Time picker columns */}
-            <div className="flex divide-x">
+            {/* Time picker columns — trên mobile mỗi cột flex-1 trải đều bằng bề
+                rộng calendar cho cân đối; desktop giữ bề rộng tự nhiên. */}
+            <div className="flex divide-x [&>div]:flex-1 sm:[&>div]:flex-none">
               {use12Hour ? (
                 <>
                   {/* Hour (12-hour) */}

--- a/frontend/src/components/common/form/DateTimePicker.tsx
+++ b/frontend/src/components/common/form/DateTimePicker.tsx
@@ -14,7 +14,17 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Sheet,
+  SheetContent,
+  SheetTrigger,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+  SheetClose,
+} from "@/components/ui/sheet";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import { cn } from "@/lib/utils";
 
 // =============================================================================
@@ -123,7 +133,7 @@ function TimeColumn({ values, selectedValue, onChange, formatFn, label }: TimeCo
       <div className="text-xs font-medium text-center py-1 text-muted-foreground border-b">
         {label}
       </div>
-      <ScrollArea className="h-[200px]">
+      <ScrollArea className="h-[168px] sm:h-[200px]">
         <div className="flex flex-col p-1">
           {values.map((value) => {
             const isSelected = value === selectedValue;
@@ -178,6 +188,10 @@ export function DateTimePicker({
 }: DateTimePickerProps) {
   const [internalOpen, setInternalOpen] = React.useState(false);
   const triggerId = React.useId();
+  // Mobile (≤767px): render picker trong bottom Sheet thay vì Popover neo-trigger.
+  // Popover bị giới hạn chiều cao theo vị trí trigger → lịch+giờ (~660px) không đủ
+  // chỗ, khối giờ tụt dưới mép cuộn. Bottom Sheet cao ~92vh chứa đủ cả hai.
+  const isMobile = useIsMobile();
 
   // Use controlled state if provided, otherwise use internal state
   const isControlled = controlledOpen !== undefined;
@@ -340,6 +354,136 @@ export function DateTimePicker({
     [minDate, maxDate]
   );
 
+  // Nút trigger (dùng chung Popover desktop & Sheet mobile). Khi hideTrigger →
+  // sr-only, open điều khiển từ ngoài (vd QuickConsultationSectionV2).
+  const triggerButton = (
+    <Button
+      id={triggerId}
+      variant="outline"
+      role="combobox"
+      aria-expanded={open}
+      disabled={disabled}
+      className={cn(
+        "w-full justify-start text-left font-normal",
+        !value && "text-muted-foreground",
+        hasError && "border-destructive focus-visible:ring-destructive",
+        hideTrigger && "sr-only",
+        className
+      )}
+    >
+      <CalendarIcon className="mr-2 h-4 w-4" />
+      {displayValue || placeholder}
+
+      {/* Clear button */}
+      {clearable && value && !disabled && (
+        <span
+          className="ml-auto"
+          onClick={handleClear}
+          role="button"
+          aria-label="Xóa"
+        >
+          <X className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+        </span>
+      )}
+    </Button>
+  );
+
+  // Thân picker (lịch + giờ) — dùng chung cho Popover & Sheet.
+  const pickerBody = (
+    <>
+      {/* Input display */}
+      <div className="p-3 border-b">
+        <Input
+          value={displayValue}
+          readOnly
+          className="text-center font-medium"
+          placeholder={placeholder}
+        />
+      </div>
+
+      {/* Xếp DỌC trên mobile (calendar trên, giờ dưới) để không tràn màn ~390px;
+          NGANG (side-by-side) từ sm trở lên. */}
+      <div className="flex flex-col sm:flex-row">
+        {/* Calendar */}
+        <div className="border-b sm:border-b-0 sm:border-r">
+          <Calendar
+            mode="single"
+            selected={value || undefined}
+            onSelect={handleDateSelect}
+            disabled={disabledDatesFn}
+            locale={vi}
+            initialFocus
+          />
+          {/* Today & Clear buttons */}
+          <div className="flex justify-between px-3 pb-3 gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleClear}
+              className="text-destructive hover:text-destructive"
+            >
+              Xóa
+            </Button>
+            <Button variant="ghost" size="sm" onClick={handleToday}>
+              Hôm nay
+            </Button>
+          </div>
+        </div>
+
+        {/* Time picker columns — trên mobile mỗi cột flex-1 trải đều bằng bề
+            rộng calendar cho cân đối; desktop giữ bề rộng tự nhiên. */}
+        <div className="flex divide-x [&>div]:flex-1 sm:[&>div]:flex-none">
+          {use12Hour ? (
+            <>
+              {/* Hour (12-hour) */}
+              <TimeColumn
+                values={HOURS_12}
+                selectedValue={hour12}
+                onChange={handleHour12Change}
+                formatFn={(v) => formatTwoDigits(v as number)}
+                label="Giờ"
+              />
+              {/* Minute */}
+              <TimeColumn
+                values={MINUTES}
+                selectedValue={minute}
+                onChange={handleMinuteChange}
+                formatFn={(v) => formatTwoDigits(v as number)}
+                label="Phút"
+              />
+              {/* Period (SA/CH) */}
+              <TimeColumn
+                values={[...PERIODS]}
+                selectedValue={period}
+                onChange={handlePeriodChange}
+                label=""
+              />
+            </>
+          ) : (
+            <>
+              {/* Hour (24-hour) */}
+              <TimeColumn
+                values={HOURS_24}
+                selectedValue={hour24}
+                onChange={handleHour24Change}
+                formatFn={(v) => formatTwoDigits(v as number)}
+                label="Giờ"
+              />
+              {/* Minute */}
+              <TimeColumn
+                values={MINUTES}
+                selectedValue={minute}
+                onChange={handleMinuteChange}
+                formatFn={(v) => formatTwoDigits(v as number)}
+                label="Phút"
+              />
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <div className={cn("space-y-2", containerClassName)}>
       {/* Label */}
@@ -353,140 +497,44 @@ export function DateTimePicker({
         </Label>
       )}
 
-      {/* DateTime picker */}
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            id={triggerId}
-            variant="outline"
-            role="combobox"
-            aria-expanded={open}
-            disabled={disabled}
-            className={cn(
-              "w-full justify-start text-left font-normal",
-              !value && "text-muted-foreground",
-              hasError && "border-destructive focus-visible:ring-destructive",
-              hideTrigger && "sr-only",
-              className
-            )}
+      {/* MOBILE: bottom Sheet — chiều cao kiểm soát được, hiển thị đủ lịch+giờ. */}
+      {isMobile ? (
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>{triggerButton}</SheetTrigger>
+          <SheetContent
+            side="bottom"
+            aria-describedby={undefined}
+            className="flex max-h-[92vh] flex-col gap-0 overflow-y-auto p-0"
           >
-            <CalendarIcon className="mr-2 h-4 w-4" />
-            {displayValue || placeholder}
-
-            {/* Clear button */}
-            {clearable && value && !disabled && (
-              <span
-                className="ml-auto"
-                onClick={handleClear}
-                role="button"
-                aria-label="Xóa"
-              >
-                <X className="h-4 w-4 text-muted-foreground hover:text-foreground" />
-              </span>
-            )}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent
-          className="w-auto max-w-[calc(100vw-1rem)] overflow-auto p-0"
-          align="start"
-          collisionPadding={8}
-        >
-          {/* Input display */}
-          <div className="p-3 border-b">
-            <Input
-              value={displayValue}
-              readOnly
-              className="text-center font-medium"
-              placeholder={placeholder}
-            />
-          </div>
-
-          {/* Xếp DỌC trên mobile (calendar trên, giờ dưới) để không tràn màn ~390px;
-              NGANG (side-by-side) từ sm trở lên. */}
-          <div className="flex flex-col sm:flex-row">
-            {/* Calendar */}
-            <div className="border-b sm:border-b-0 sm:border-r">
-              <Calendar
-                mode="single"
-                selected={value || undefined}
-                onSelect={handleDateSelect}
-                disabled={disabledDatesFn}
-                locale={vi}
-                initialFocus
-              />
-              {/* Today & Clear buttons */}
-              <div className="flex justify-between px-3 pb-3 gap-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleClear}
-                  className="text-destructive hover:text-destructive"
-                >
-                  Xóa
+            <SheetHeader className="border-b px-4 py-3 pr-14 text-left">
+              <SheetTitle className="text-base">
+                {label || "Chọn ngày giờ"}
+              </SheetTitle>
+            </SheetHeader>
+            {pickerBody}
+            <SheetFooter className="border-t p-3">
+              <SheetClose asChild>
+                <Button type="button" className="w-full">
+                  Xong
                 </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleToday}
-                >
-                  Hôm nay
-                </Button>
-              </div>
-            </div>
-
-            {/* Time picker columns — trên mobile mỗi cột flex-1 trải đều bằng bề
-                rộng calendar cho cân đối; desktop giữ bề rộng tự nhiên. */}
-            <div className="flex divide-x [&>div]:flex-1 sm:[&>div]:flex-none">
-              {use12Hour ? (
-                <>
-                  {/* Hour (12-hour) */}
-                  <TimeColumn
-                    values={HOURS_12}
-                    selectedValue={hour12}
-                    onChange={handleHour12Change}
-                    formatFn={(v) => formatTwoDigits(v as number)}
-                    label="Giờ"
-                  />
-                  {/* Minute */}
-                  <TimeColumn
-                    values={MINUTES}
-                    selectedValue={minute}
-                    onChange={handleMinuteChange}
-                    formatFn={(v) => formatTwoDigits(v as number)}
-                    label="Phút"
-                  />
-                  {/* Period (SA/CH) */}
-                  <TimeColumn
-                    values={[...PERIODS]}
-                    selectedValue={period}
-                    onChange={handlePeriodChange}
-                    label=""
-                  />
-                </>
-              ) : (
-                <>
-                  {/* Hour (24-hour) */}
-                  <TimeColumn
-                    values={HOURS_24}
-                    selectedValue={hour24}
-                    onChange={handleHour24Change}
-                    formatFn={(v) => formatTwoDigits(v as number)}
-                    label="Giờ"
-                  />
-                  {/* Minute */}
-                  <TimeColumn
-                    values={MINUTES}
-                    selectedValue={minute}
-                    onChange={handleMinuteChange}
-                    formatFn={(v) => formatTwoDigits(v as number)}
-                    label="Phút"
-                  />
-                </>
-              )}
-            </div>
-          </div>
-        </PopoverContent>
-      </Popover>
+              </SheetClose>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
+      ) : (
+        /* DESKTOP: Popover neo trigger. */
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
+          <PopoverContent
+            // max-h theo không gian còn lại của viewport (Radix var) + cuộn nội bộ.
+            className="max-h-[var(--radix-popover-content-available-height)] w-auto max-w-[calc(100vw-1rem)] overflow-auto p-0"
+            align="start"
+            collisionPadding={8}
+          >
+            {pickerBody}
+          </PopoverContent>
+        </Popover>
+      )}
 
       {/* Description */}
       {description && !error && (

--- a/frontend/src/components/common/selectors/SmartOfferingSelector.tsx
+++ b/frontend/src/components/common/selectors/SmartOfferingSelector.tsx
@@ -45,6 +45,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useAllProgramOfferings } from "@/hooks/useOrganization";
 import type { ProgramOffering } from "@/types/organization.types";
+import { DEGREE_LEVEL_ABBR } from "@/constants";
 
 // =============================================================================
 // TYPES
@@ -94,15 +95,10 @@ const DEGREE_LEVEL_LABELS: Record<string, string> = {
   "Trung cấp": "📖 TRUNG CẤP",
 };
 
-// Compact bậc cho nhãn TRIGGER (giá trị đã chọn). Dropdown đã phân nhóm theo
-// bậc, nhưng khi đóng lại trigger mất ngữ cảnh nhóm → "Công nghệ ô tô" không
-// phân biệt được TC vs CĐ (2 offering cùng tên khác bậc). Thêm bậc rút gọn vào
-// nhãn trigger để disambiguate.
-const DEGREE_LEVEL_SHORT: Record<string, string> = {
-  "Đại học": "ĐH",
-  "Cao đẳng": "CĐ",
-  "Trung cấp": "TC",
-};
+// Bậc rút gọn cho nhãn TRIGGER (giá trị đã chọn): dropdown phân nhóm theo bậc,
+// nhưng khi đóng lại trigger mất ngữ cảnh nhóm → "Công nghệ ô tô" không phân biệt
+// được TC vs CĐ (2 offering cùng tên khác bậc). Dùng CHUNG DEGREE_LEVEL_ABBR với
+// card/bảng lead (undefined khi bậc lạ → bỏ hậu tố, giữ hành vi cũ).
 
 // =============================================================================
 // HELPER FUNCTIONS
@@ -136,7 +132,7 @@ function processOfferings(
       const degreeLevel = offering.program?.degree_level || "Khác";
       const offeringType = offering.offering_type || "Chính quy";
 
-      const shortLevel = DEGREE_LEVEL_SHORT[degreeLevel];
+      const shortLevel = DEGREE_LEVEL_ABBR[degreeLevel];
       return {
         ...offering,
         // Display format trong dropdown: "Ngành - Loại hình" (bậc đã ở group header)

--- a/frontend/src/components/finance/VietQRDisplay.tsx
+++ b/frontend/src/components/finance/VietQRDisplay.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { AmountDisplay } from "./AmountDisplay"
 import type { VietQRResponse } from "@/types/finance.types"
 import { toast } from "sonner"
+import { copyToClipboard } from "@/lib/clipboard"
 
 interface VietQRDisplayProps {
   data?: VietQRResponse
@@ -18,8 +19,8 @@ interface VietQRDisplayProps {
 
 export function VietQRDisplay({ data, isLoading, error, onRetry }: VietQRDisplayProps) {
   const copy = React.useCallback(async (value: string, label: string) => {
-    await navigator.clipboard.writeText(value)
-    toast.success(`Đã sao chép ${label}`)
+    if (await copyToClipboard(value)) toast.success(`Đã sao chép ${label}`)
+    else toast.error("Không sao chép được")
   }, [])
 
   return (

--- a/frontend/src/components/leads/LeadTimelineTab.tsx
+++ b/frontend/src/components/leads/LeadTimelineTab.tsx
@@ -41,7 +41,7 @@ import {
 } from "@/components/ui/dialog";
 import { format, isToday, isYesterday, parseISO } from "date-fns";
 import { cn, sanitizeColorCode } from "@/lib/utils";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -239,6 +239,21 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
   const [reschedulingConsultation, setReschedulingConsultation] = useState<Consultation | null>(null);
   const [rescheduleDate, setRescheduleDate] = useState<Date | undefined>(undefined);
 
+  // Sắp xếp mới→cũ MỘT lần theo dữ liệu. useMemo đặt ở đầu component (trước các
+  // early return) để tuân rules-of-hooks; guard `timeline` vì hook chạy TRƯỚC nhánh
+  // `if (!timeline)`. Tránh re-sort + cấp phát Date mỗi lần re-render do state dialog.
+  const sortedTimeline = useMemo(
+    () =>
+      timeline
+        ? [...(timeline as TimelineItem[])].sort(
+            (a, b) =>
+              new Date(b.timestamp || 0).getTime() -
+              new Date(a.timestamp || 0).getTime()
+          )
+        : [],
+    [timeline]
+  );
+
   if (isLoading || !timeline) {
     return (
       <div className="space-y-4">
@@ -288,9 +303,8 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
           const lossReasonCode = consultData?.loss_reason_code;
           const lossReasonNote = consultData?.loss_reason_note;
 
-          const compactDataId = isConsultation
-            ? (eventData as { id?: number })?.id
-            : isAssignment
+          const compactDataId =
+            isConsultation || isAssignment
               ? (eventData as { id?: number })?.id
               : undefined;
           const compactKey = `${event.type}-${event.timestamp}-${compactDataId ?? index}`;
@@ -400,11 +414,8 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
   // scans better than date dividers in both the 3-item panel and the long sheet.
   const hasLimit = maxItems && maxItems > 0 && !showAll;
   const totalItems = timeline.length;
-  const itemsToShow = hasLimit ? maxItems : totalItems;
-  const sortedTimeline = [...(timeline as TimelineItem[])].sort(
-    (a, b) => new Date(b.timestamp || 0).getTime() - new Date(a.timestamp || 0).getTime()
-  );
-  const visibleTimeline = hasLimit ? sortedTimeline.slice(0, itemsToShow) : sortedTimeline;
+  // sortedTimeline đã memo ở đầu component (rules-of-hooks).
+  const visibleTimeline = hasLimit ? sortedTimeline.slice(0, maxItems) : sortedTimeline;
   const remainingItems = Math.max(0, totalItems - visibleTimeline.length);
 
   // Quyền thao tác lịch hẹn: officer chỉ sửa được consultation MỚI NHẤT (khớp
@@ -570,9 +581,8 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
             actorName = event.actor?.full_name || "";
           }
 
-          const itemId = isConsultation
-            ? (eventData as { id?: number })?.id
-            : isAssignment
+          const itemId =
+            isConsultation || isAssignment
               ? (eventData as { id?: number })?.id
               : undefined;
           const itemKey = `${event.type}-${event.timestamp}-${itemId ?? index}`;

--- a/frontend/src/components/leads/LeadTimelineTab.tsx
+++ b/frontend/src/components/leads/LeadTimelineTab.tsx
@@ -4,18 +4,15 @@
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
   Clock,
   User,
-  FileText,
   Phone,
   Mail,
   MessageSquare,
@@ -43,7 +40,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { format, isToday, isYesterday, parseISO } from "date-fns";
-import { vi } from "date-fns/locale";
 import { cn, sanitizeColorCode } from "@/lib/utils";
 import { useState } from "react";
 import {
@@ -162,7 +158,7 @@ const getEventConfig = (eventType: string, method?: string) => {
   };
 };
 
-// Get outcome type styling
+// Get outcome type styling (compact mode)
 const getOutcomeStyles = (outcomeType?: string | null) => {
   switch (outcomeType) {
     case "positive":
@@ -187,48 +183,42 @@ const getOutcomeStyles = (outcomeType?: string | null) => {
   }
 };
 
-// Format date for grouping
-const formatDateGroup = (dateString: string) => {
-  const date = parseISO(dateString);
-  if (isToday(date)) return "Hôm nay";
-  if (isYesterday(date)) return "Hôm qua";
-  return format(date, "EEEE, dd/MM/yyyy", { locale: vi });
-};
-
-// Group timeline by date
-const groupTimelineByDate = (timeline: TimelineItem[]) => {
-  const groups: Record<string, typeof timeline> = {};
-
-  // Sort by date descending (newest first)
-  const sorted = [...timeline].sort((a, b) => {
-    const dateA = new Date(a.timestamp || 0);
-    const dateB = new Date(b.timestamp || 0);
-    return dateB.getTime() - dateA.getTime();
-  });
-
-  sorted.forEach((event) => {
-    const dateKey = format(
-      parseISO(event.timestamp || new Date().toISOString()),
-      "yyyy-MM-dd"
-    );
-    if (!groups[dateKey]) {
-      groups[dateKey] = [];
-    }
-    groups[dateKey].push(event);
-  });
-
-  return groups;
-};
-
-// Get initials from name
-const getInitials = (name: string) => {
-  return name
-    .split(" ")
-    .filter(Boolean)
-    .map((n) => n[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
+// ── "Đường mạch kết quả" (outcome spine) theme — full mode ────────────────────
+// The vertical spine + node encode the OUTCOME of each touch, so an officer reads
+// the relationship's trajectory in one glance. Restraint: only positive/negative
+// carry saturated color; neutral stays quiet so the eye catches the turning points.
+// All tokens are theme-aware (dark variants + /alpha) — no hardcoded white.
+const getOutcomeSpine = (outcomeType?: string | null) => {
+  switch (outcomeType) {
+    case "positive":
+      return {
+        seg: "bg-success-500/70",
+        node: "bg-success-500/10 dark:bg-success-500/15",
+        icon: "text-success-600 dark:text-success-400",
+        tag: "bg-success-500/10 text-success-700 dark:text-success-300",
+        tagLabel: "Tích cực",
+        emphasize: true,
+      };
+    case "negative":
+      return {
+        seg: "bg-error-500/70",
+        node: "bg-error-500/10 dark:bg-error-500/15",
+        icon: "text-error-600 dark:text-error-400",
+        tag: "bg-error-500/10 text-error-700 dark:text-error-300",
+        tagLabel: "Tiêu cực",
+        emphasize: true,
+      };
+    default:
+      // neutral / null / assignment → quiet
+      return {
+        seg: "bg-border",
+        node: "bg-muted",
+        icon: "text-muted-foreground",
+        tag: "",
+        tagLabel: "",
+        emphasize: false,
+      };
+  }
 };
 
 export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimelineTabProps) {
@@ -404,17 +394,18 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
     );
   }
 
-  const groupedTimeline = groupTimelineByDate(timeline);
-  const dateKeys = Object.keys(groupedTimeline).sort().reverse();
-
-  // Calculate items to show based on maxItems prop
+  // ── Full mode — "Đường mạch kết quả" ────────────────────────────────────────
+  // Flatten to a single outcome-ordered rail (newest → oldest). No heavy date
+  // headers: per-row relative time ("2 giờ trước") answers recency directly and
+  // scans better than date dividers in both the 3-item panel and the long sheet.
   const hasLimit = maxItems && maxItems > 0 && !showAll;
   const totalItems = timeline.length;
-  const remainingItems = hasLimit ? Math.max(0, totalItems - maxItems) : 0;
-  
-  // Limit items if maxItems is set and showAll is false
   const itemsToShow = hasLimit ? maxItems : totalItems;
-  let itemCount = 0;
+  const sortedTimeline = [...(timeline as TimelineItem[])].sort(
+    (a, b) => new Date(b.timestamp || 0).getTime() - new Date(a.timestamp || 0).getTime()
+  );
+  const visibleTimeline = hasLimit ? sortedTimeline.slice(0, itemsToShow) : sortedTimeline;
+  const remainingItems = Math.max(0, totalItems - visibleTimeline.length);
 
   // Quyền thao tác lịch hẹn: officer chỉ sửa được consultation MỚI NHẤT (khớp
   // BE leads.py:1091 → tránh bấm rồi ăn 403); manager/admin sửa bất kỳ.
@@ -439,6 +430,22 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
     }
     return best?.id ?? null;
   })();
+
+  // Relative "time ago" — hydration-safe: absolute on SSR (now===null), relative
+  // on client. Tabular mono rendering keeps the time column aligned like a log.
+  const formatWhen = (ts: string): string => {
+    const d = parseISO(ts);
+    if (now === null) return format(d, "dd/MM HH:mm");
+    const diffMs = now - d.getTime();
+    const mins = Math.floor(diffMs / 60000);
+    if (mins < 1) return "vừa xong";
+    if (mins < 60) return `${mins} phút trước`;
+    if (isToday(d)) return `${Math.floor(mins / 60)} giờ trước`;
+    if (isYesterday(d)) return `Hôm qua ${format(d, "HH:mm")}`;
+    const days = Math.floor(diffMs / 86400000);
+    if (days < 7) return `${days} ngày trước`;
+    return format(d, "dd/MM/yyyy");
+  };
 
   const handleEditConsultation = (consultation: Consultation) => {
     setEditingConsultation(consultation);
@@ -517,329 +524,256 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
 
   return (
     <>
-      <div className="space-y-8">
-        {dateKeys.map((dateKey) => {
-          // Get items for this date
-          const dateItems = groupedTimeline[dateKey];
-          
-          // Filter items based on limit
-          const visibleItems = dateItems.filter(() => {
-            if (!hasLimit) return true;
-            if (itemCount >= itemsToShow) return false;
-            itemCount++;
-            return true;
-          });
+      <div className="animate-in fade-in duration-300">
+        {visibleTimeline.map((event, index) => {
+          const eventType = event.type || "lead_created";
+          const eventData = event.data || {};
 
-          // Skip entire date group if no visible items
-          if (visibleItems.length === 0) return null;
+          const isConsultation =
+            eventType === "consultation" ||
+            eventType === "consultation_added" ||
+            eventType === "consultation_updated";
+          const isAssignment = eventType === "assignment" || eventType === "assigned";
+
+          const config = getEventConfig(
+            eventType,
+            isConsultation ? (eventData as { method?: string }).method : undefined
+          );
+          const Icon = config.icon;
+
+          const consultData = isConsultation ? (eventData as Consultation) : null;
+          const outcomeType = consultData?.consultation_status?.outcome_type;
+          const spine = getOutcomeSpine(isConsultation ? outcomeType : null);
+
+          // Title / note / actor
+          let title = "";
+          let note = "";
+          let actorName = "";
+          if (isConsultation && consultData) {
+            const statusName = consultData.consultation_status?.name || "Tư vấn";
+            title = statusName;
+            // Bỏ note tự-sinh (trùng tên trạng thái) — chỉ giữ ghi chú thật.
+            const rawNotes = consultData.notes || "";
+            const autoPatterns = [
+              `Ghi nhận nhanh: ${statusName}`,
+              `Ghi nhận: ${statusName}`,
+            ];
+            if (rawNotes && !autoPatterns.includes(rawNotes)) note = rawNotes;
+            actorName = consultData.officer?.full_name || "";
+          } else if (isAssignment) {
+            const assignData = eventData as { reason?: string; officer?: { full_name?: string } };
+            title = "Phân công lead";
+            note = assignData.reason || "";
+            actorName = assignData.officer?.full_name || "";
+          } else {
+            title = event.description || config.label;
+            actorName = event.actor?.full_name || "";
+          }
+
+          const itemId = isConsultation
+            ? (eventData as { id?: number })?.id
+            : isAssignment
+              ? (eventData as { id?: number })?.id
+              : undefined;
+          const itemKey = `${event.type}-${event.timestamp}-${itemId ?? index}`;
+          const isLast = index === visibleTimeline.length - 1;
+
+          // Lịch hẹn: chỉ cho thao tác khi hẹn ở TƯƠNG LAI (client-time) + có quyền.
+          const schedMs = consultData?.scheduled_at
+            ? new Date(consultData.scheduled_at).getTime()
+            : null;
+          const isFutureAppt = now !== null && schedMs !== null && schedMs > now;
+          const canActOnAppt = isPrivilegedActor || consultData?.id === latestConsultationId;
+
+          const durationMin =
+            consultData?.duration_minutes && consultData.duration_minutes > 0
+              ? consultData.duration_minutes
+              : null;
+
+          const assignMethod = isAssignment ? (eventData as { method?: string }).method : undefined;
+          const assignMethodLabel =
+            assignMethod === "automatic"
+              ? "Tự động"
+              : assignMethod === "officer_reassign"
+                ? "Yêu cầu phân công lại"
+                : assignMethod === "manual"
+                  ? "Thủ công"
+                  : null;
 
           return (
-          <div key={dateKey}>
-            {/* Date Header */}
-            <div className="flex items-center gap-3 mb-4">
-              <Calendar className="h-4 w-4 text-muted-foreground" />
-              <span className="text-sm font-semibold text-foreground">
-                {formatDateGroup(dateKey + "T00:00:00")}
-              </span>
-              <div className="flex-1 h-px bg-border" />
-            </div>
+            <div key={itemKey} className="group relative flex gap-3 pb-5 last:pb-0">
+              {/* Spine + node — the outcome-colored rail */}
+              <div className="relative flex w-6 shrink-0 justify-center">
+                {!isLast && (
+                  <span
+                    className={cn(
+                      "absolute left-1/2 top-6 -bottom-5 w-0.5 -translate-x-1/2 rounded-full",
+                      spine.seg
+                    )}
+                  />
+                )}
+                <span
+                  className={cn(
+                    "relative z-10 flex h-6 w-6 items-center justify-center rounded-lg ring-4 ring-background",
+                    spine.node
+                  )}
+                >
+                  <Icon className={cn("h-3.5 w-3.5", spine.icon)} />
+                </span>
+              </div>
 
-            {/* Events for this date - with connecting line */}
-            <div className="relative pl-6 space-y-6">
-              {/* Connecting line */}
-              <div className="absolute left-[15px] top-3 bottom-3 w-0.5 bg-gradient-to-b from-border via-border to-transparent" />
-
-              {visibleItems.map((event, index) => {
-                const eventType = event.type || "lead_created";
-                // ✅ TECHNICAL DEBT FIX: Use typed event data instead of `as any`
-                const eventData = event.data || {};
-
-                // ✅ FIX: Match actual backend event types ("consultation", "assignment")
-                // Backend sends: type: "consultation" | "assignment"
-                // NOT "consultation_added", "consultation_updated", or "assigned"
-                const isConsultation = eventType === "consultation" || eventType === "consultation_added" || eventType === "consultation_updated";
-                const isAssignment = eventType === "assignment" || eventType === "assigned";
-
-                const config = getEventConfig(
-                  eventType,
-                  isConsultation ? (eventData.method as string) : undefined
-                );
-                const Icon = config.icon;
-
-                // Generate title and subtitle
-                let title = "";
-                let subtitle = "";
-                let actorName = "";
-
-                // Type assertion for consultation data (used in JSX below)
-                const consultData = isConsultation ? (eventData as Consultation) : null;
-                const statusColor = consultData?.consultation_status?.color_code;
-                const outcomeType = consultData?.consultation_status?.outcome_type;
-                const outcomeStyles = getOutcomeStyles(outcomeType);
-
-                if (isConsultation && consultData) {
-                  const statusName = consultData.consultation_status?.name || "Tư vấn";
-                  title = statusName;
-
-                  // Only show notes if it's not the auto-generated pattern
-                  const notes = consultData.notes || "";
-                  const autoPatterns = [
-                    `Ghi nhận nhanh: ${statusName}`,
-                    `Ghi nhận: ${statusName}`,
-                  ];
-                  if (notes && !autoPatterns.includes(notes)) {
-                    subtitle = notes;
-                  }
-
-                  actorName = consultData.officer?.full_name || "";
-                } else if (isAssignment) {
-                  // Type assertion for assignment data
-                  const assignData = eventData as { reason?: string; officer?: { full_name?: string } };
-                  title = "Phân công lead";
-                  subtitle = assignData.reason || "";
-                  actorName = assignData.officer?.full_name || "";
-                } else {
-                  // Fallback for other event types (lead_created, pipeline_moved, etc.)
-                  title = event.description || config.label;
-                  actorName = event.actor?.full_name || "";
-                }
-
-                const consultId = isConsultation ? (eventData as { id?: number })?.id : undefined;
-                const assignId = isAssignment ? (eventData as { id?: number })?.id : undefined;
-                const itemId = consultId ?? assignId;
-                const itemKey = `${event.type}-${event.timestamp}-${itemId ?? index}`;
-
-                return (
-                  <div key={itemKey} className="relative flex gap-3 group">
-                    {/* Timeline Dot (Icon) - smaller and neutral */}
-                    <div
+              {/* Content */}
+              <div className="min-w-0 flex-1">
+                {/* Line 1: status · outcome tag · time · actions */}
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-semibold text-foreground">{title}</span>
+                  {spine.emphasize && (
+                    <span
                       className={cn(
-                        "relative z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 border-white shadow-sm transition-shadow ring-1",
-                        config.bgColor,
-                        config.ringColor
+                        "shrink-0 rounded px-1.5 py-px text-[10px] font-bold uppercase tracking-wide",
+                        spine.tag
                       )}
                     >
-                      <Icon className={cn("h-3.5 w-3.5", config.color)} />
-                    </div>
+                      {spine.tagLabel}
+                    </span>
+                  )}
+                  <time
+                    suppressHydrationWarning
+                    className="ml-auto shrink-0 font-mono text-[11px] tabular-nums tracking-tight text-muted-foreground"
+                  >
+                    {formatWhen(event.timestamp || "")}
+                  </time>
 
-                    {/* Content Block */}
-                    <div className="flex-1 bg-card rounded-lg border shadow-sm transition-shadow hover:shadow-md hover:border-primary/30">
-                      <div className="p-4">
-                        {/* Header: Title, Actor, Time, Actions */}
-                        <div className="flex items-start justify-between gap-3 mb-2">
-                          <div className="flex-1 min-w-0">
-                            {/* Title with status color and method badge */}
-                            <div className="flex items-center gap-2 mb-1 flex-wrap">
-                              {isConsultation && statusColor ? (
-                                <Badge
-                                  variant="outline"
-                                  className={cn(
-                                    "text-xs font-semibold px-2 py-0.5 border",
-                                    outcomeStyles.badgeBg,
-                                    outcomeStyles.badgeText,
-                                    outcomeStyles.badgeBorder
-                                  )}
-                                >
-                                  <span
-                                    className="w-2 h-2 rounded-full mr-1.5 flex-shrink-0"
-                                    style={{ backgroundColor: sanitizeColorCode(statusColor) }}
-                                  />
-                                  {title}
-                                </Badge>
-                              ) : (
-                                <h4 className="font-semibold text-sm text-foreground">
-                                  {title}
-                                </h4>
-                              )}
-                              {isConsultation && consultData?.method && (
-                                <Badge
-                                  variant="secondary"
-                                  className={cn(
-                                    "text-[10px] px-1.5 py-0 font-normal",
-                                    config.bgColor,
-                                    config.color
-                                  )}
-                                >
-                                  <Icon className="w-2.5 h-2.5 mr-1" />
-                                  {config.label}
-                                </Badge>
-                              )}
-                            </div>
+                  {/* Overflow menu: Sửa / Xóa (lịch hẹn có control riêng bên dưới) */}
+                  {isConsultation && consultData?.id && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-11 w-11 sm:h-7 sm:w-7 p-0 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity shrink-0"
+                        >
+                          <MoreVertical className="h-4 w-4 text-muted-foreground" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => handleEditConsultation(consultData)}>
+                          <Edit className="mr-2 h-4 w-4" />
+                          Sửa
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="text-destructive focus:text-destructive"
+                          onClick={() => handleDeleteConsultation(consultData.id)}
+                        >
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          Xóa
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </div>
 
-                            {/* Actor and time */}
-                            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                              {actorName && (
-                                <>
-                                  <Avatar className="h-4 w-4">
-                                    <AvatarFallback className="text-[8px] bg-primary/10">
-                                      {getInitials(actorName)}
-                                    </AvatarFallback>
-                                  </Avatar>
-                                  <span className="font-medium">{actorName}</span>
-                                  <span>•</span>
-                                </>
-                              )}
-                              <time suppressHydrationWarning>
-                                {format(parseISO(event.timestamp || ""), "HH:mm")}
-                              </time>
-                            </div>
-                          </div>
-
-                          {/* Actions Menu */}
-                          {isConsultation && consultData?.id && (
-                            <DropdownMenu>
-                              <DropdownMenuTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  className="h-11 w-11 sm:h-7 sm:w-7 p-0 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
-                                >
-                                  <MoreVertical className="h-4 w-4 text-muted-foreground" />
-                                </Button>
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent align="end">
-                                {(() => {
-                                  // Chỉ hiện khi: hẹn ở TƯƠNG LAI (client-time, tránh
-                                  // hydration) + có quyền (privileged, hoặc officer trên
-                                  // consultation MỚI NHẤT — khớp BE, tránh 403).
-                                  const schedMs = consultData?.scheduled_at
-                                    ? new Date(consultData.scheduled_at).getTime()
-                                    : null;
-                                  const isFutureAppt =
-                                    now !== null && schedMs !== null && schedMs > now;
-                                  const canActOnAppt =
-                                    isPrivilegedActor ||
-                                    consultData?.id === latestConsultationId;
-                                  if (!isFutureAppt || !canActOnAppt || !consultData?.id) {
-                                    return null;
-                                  }
-                                  const cid = consultData.id;
-                                  return (
-                                    <>
-                                      <DropdownMenuItem onClick={() => openReschedule(consultData)}>
-                                        <CalendarClock className="h-4 w-4 mr-2" />
-                                        Dời lịch
-                                      </DropdownMenuItem>
-                                      <DropdownMenuItem onClick={() => openCancelAppointment(cid)}>
-                                        <CalendarX2 className="h-4 w-4 mr-2" />
-                                        Hủy lịch hẹn
-                                      </DropdownMenuItem>
-                                      <DropdownMenuSeparator />
-                                    </>
-                                  );
-                                })()}
-                                <DropdownMenuItem
-                                  onClick={() => handleEditConsultation(consultData)}
-                                >
-                                  <Edit className="h-4 w-4 mr-2" />
-                                  Sửa
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                  className="text-destructive focus:text-destructive"
-                                  onClick={() => handleDeleteConsultation(consultData.id)}
-                                >
-                                  <Trash2 className="h-4 w-4 mr-2" />
-                                  Xóa
-                                </DropdownMenuItem>
-                              </DropdownMenuContent>
-                            </DropdownMenu>
-                          )}
-                        </div>
-
-                        {/* Body: Description/Notes - only if not redundant */}
-                        {subtitle && (
-                          <div className="text-sm text-muted-foreground leading-relaxed mb-3">
-                            <div className="flex items-start gap-2">
-                              <FileText className="h-3.5 w-3.5 shrink-0 mt-0.5 opacity-40" />
-                              <p className="flex-1">{subtitle}</p>
-                            </div>
-                          </div>
-                        )}
-
-                        {/* Footer: Metadata badges */}
+                {/* Line 2: method · actor · duration · assignment method */}
+                {(isConsultation || isAssignment || actorName) && (
+                  <div className="mt-0.5 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground">
+                    {(isConsultation || isAssignment) && (
+                      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+                        {config.label}
+                      </span>
+                    )}
+                    {actorName && (
+                      <>
                         {(isConsultation || isAssignment) && (
-                          <div className="flex flex-wrap gap-2">
-                            {/* Consultation: Outcome indicator */}
-                            {isConsultation && outcomeType && (
-                              <Badge
-                                variant="outline"
-                                className={cn(
-                                  "text-xs font-normal gap-1",
-                                  outcomeType === "positive" && "border-success-200 bg-success-50 text-success-700",
-                                  outcomeType === "negative" && "border-error-200 bg-error-50 text-error-700",
-                                  outcomeType === "neutral" && "border-border bg-muted text-muted-foreground"
-                                )}
-                              >
-                                {outcomeType === "positive" && "✓ Tích cực"}
-                                {outcomeType === "negative" && "✗ Tiêu cực"}
-                                {outcomeType === "neutral" && "○ Trung lập"}
-                              </Badge>
-                            )}
-
-                            {/* Consultation: Scheduled follow-up */}
-                            {isConsultation && consultData?.scheduled_at && (
-                              <Badge
-                                variant="outline"
-                                className="text-xs font-normal gap-1 border-info-200 bg-info-50 text-info-700"
-                              >
-                                <Calendar className="h-3 w-3" />
-                                <span suppressHydrationWarning>Hẹn: {format(parseISO(consultData.scheduled_at), "dd/MM HH:mm")}</span>
-                              </Badge>
-                            )}
-
-                            {/* Consultation: Loss reason */}
-                            {isConsultation && consultData?.loss_reason_code && (() => {
-                              const labels = getLossReasonLabelMap();
-                              const label = consultData.loss_reason_code === "OTHER"
-                                ? (consultData.loss_reason_note || "Lý do khác")
-                                : labels[consultData.loss_reason_code] || consultData.loss_reason_code;
-                              return (
-                                <Badge
-                                  variant="outline"
-                                  className="text-xs font-normal gap-1 border-amber-200 bg-amber-50 text-amber-700"
-                                >
-                                  <AlertTriangle className="h-3 w-3" />
-                                  Lý do: {label}
-                                </Badge>
-                              );
-                            })()}
-
-                            {/* Consultation: Duration */}
-                            {isConsultation && consultData?.duration_minutes && consultData.duration_minutes > 0 && (
-                              <Badge
-                                variant="outline"
-                                className="text-xs font-normal gap-1 border-border bg-muted text-muted-foreground"
-                              >
-                                <Clock className="h-3 w-3" />
-                                {consultData.duration_minutes} phút
-                              </Badge>
-                            )}
-
-                            {/* Assignment: Method (automatic, officer_reassign, manual) */}
-                            {isAssignment && (eventData as { method?: string }).method && (
-                              <Badge
-                                variant="outline"
-                                className={cn(
-                                  "text-xs font-normal gap-1",
-                                  (eventData as { method?: string }).method === "automatic" && "border-purple-200 bg-purple-50 text-purple-700",
-                                  (eventData as { method?: string }).method === "officer_reassign" && "border-info-200 bg-info-50 text-info-700",
-                                  (eventData as { method?: string }).method === "manual" && "border-orange-200 bg-orange-50 text-orange-700"
-                                )}
-                              >
-                                {(eventData as { method?: string }).method === "automatic" && "Tự động"}
-                                {(eventData as { method?: string }).method === "officer_reassign" && "Yêu cầu phân công lại"}
-                                {(eventData as { method?: string }).method === "manual" && "Thủ công"}
-                              </Badge>
-                            )}
-                          </div>
+                          <span className="text-muted-foreground/40">·</span>
                         )}
-                      </div>
-                    </div>
+                        <span className="inline-flex items-center gap-1">
+                          <User className="h-3 w-3" />
+                          {actorName}
+                        </span>
+                      </>
+                    )}
+                    {durationMin && (
+                      <>
+                        <span className="text-muted-foreground/40">·</span>
+                        <span className="inline-flex items-center gap-1">
+                          <Clock className="h-3 w-3" />
+                          {durationMin} phút
+                        </span>
+                      </>
+                    )}
+                    {assignMethodLabel && (
+                      <>
+                        <span className="text-muted-foreground/40">·</span>
+                        <span>{assignMethodLabel}</span>
+                      </>
+                    )}
                   </div>
-                );
-              })}
+                )}
+
+                {/* Note — quiet secondary line */}
+                {note && (
+                  <p className="mt-1.5 border-l-2 border-border pl-2.5 text-[13px] leading-relaxed text-muted-foreground">
+                    {note}
+                  </p>
+                )}
+
+                {/* Loss reason */}
+                {isConsultation && consultData?.loss_reason_code && (() => {
+                  const labels = getLossReasonLabelMap();
+                  const label = consultData.loss_reason_code === "OTHER"
+                    ? (consultData.loss_reason_note || "Lý do khác")
+                    : labels[consultData.loss_reason_code] || consultData.loss_reason_code;
+                  return (
+                    <div className="mt-1.5 inline-flex items-center gap-1.5 text-xs font-medium text-amber-600 dark:text-amber-400">
+                      <AlertTriangle className="h-3 w-3 shrink-0" />
+                      Lý do: {label}
+                    </div>
+                  );
+                })()}
+
+                {/* Follow-up appointment — actionable when scheduled in the future */}
+                {isConsultation && consultData?.scheduled_at && (
+                  <div
+                    className={cn(
+                      "mt-2 flex flex-wrap items-center gap-2 rounded-lg px-2.5 py-1.5",
+                      isFutureAppt ? "bg-primary/5 dark:bg-primary/10" : "bg-muted"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-1.5 text-xs font-semibold",
+                        isFutureAppt ? "text-primary" : "text-muted-foreground"
+                      )}
+                    >
+                      <Calendar className="h-3.5 w-3.5 shrink-0" />
+                      <span suppressHydrationWarning>
+                        Hẹn {format(parseISO(consultData.scheduled_at), "HH:mm dd/MM")}
+                      </span>
+                    </span>
+                    {isFutureAppt && canActOnAppt && consultData?.id && (
+                      <span className="ml-auto flex gap-1.5">
+                        <button
+                          type="button"
+                          onClick={() => openReschedule(consultData)}
+                          className="inline-flex min-h-8 items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
+                        >
+                          <CalendarClock className="h-3 w-3" />
+                          Dời
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => openCancelAppointment(consultData.id)}
+                          className="inline-flex min-h-8 items-center gap-1 rounded-md border border-border bg-background px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-error-300 hover:text-error-600"
+                        >
+                          <CalendarX2 className="h-3 w-3" />
+                          Hủy
+                        </button>
+                      </span>
+                    )}
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
           );
         })}
       </div>

--- a/frontend/src/components/leads/QuickConsultationSectionV2.tsx
+++ b/frontend/src/components/leads/QuickConsultationSectionV2.tsx
@@ -735,7 +735,9 @@ export function QuickConsultationSectionV2({
       {/* STEP 2: Choose Result                                           */}
       {/* ================================================================ */}
       <div className="border-t pt-4 space-y-3">
-        <div className="flex items-center gap-2">
+        {/* Mobile: xếp DỌC (tiêu đề trên, gợi ý dưới) để không chật/wrap xấu;
+            ngang từ sm+. */}
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
           <Label className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
             Bước 2: Kết quả tư vấn
           </Label>

--- a/frontend/src/components/leads/QuickConsultationSectionV2.tsx
+++ b/frontend/src/components/leads/QuickConsultationSectionV2.tsx
@@ -18,6 +18,7 @@ import {
   ChevronDown,
   Check,
   AlertTriangle,
+  Pencil,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -700,14 +701,31 @@ export function QuickConsultationSectionV2({
                 </div>
               )}
 
-              {scheduleOption !== "none" && (
-                <div className="flex items-center gap-2 rounded-md border border-primary/10 bg-primary/5 px-3 py-2">
-                  <CalendarClock className="h-4 w-4 flex-shrink-0 text-primary" />
-                  <span className="text-sm font-medium text-primary">
-                    {getSchedulePreviewText(scheduleOption, customDateTime)}
-                  </span>
-                </div>
-              )}
+              {scheduleOption !== "none" &&
+                (scheduleOption === "custom" ? (
+                  // Custom: box preview = nút MỞ LẠI picker để chỉnh ngày giờ
+                  // (picker hideTrigger + chỉ auto-mở khi ĐỔI toggle sang custom →
+                  // sau khi bấm Xong không còn đường mở lại; box này là trigger).
+                  <button
+                    type="button"
+                    onClick={() => setIsDatePickerOpen(true)}
+                    aria-label="Chỉnh sửa ngày giờ hẹn"
+                    className="flex min-h-11 w-full items-center gap-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-left transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:min-h-0"
+                  >
+                    <CalendarClock className="h-4 w-4 flex-shrink-0 text-primary" />
+                    <span className="flex-1 text-sm font-medium text-primary">
+                      {getSchedulePreviewText(scheduleOption, customDateTime)}
+                    </span>
+                    <Pencil className="h-3.5 w-3.5 flex-shrink-0 text-primary/60" aria-hidden="true" />
+                  </button>
+                ) : (
+                  <div className="flex items-center gap-2 rounded-md border border-primary/10 bg-primary/5 px-3 py-2">
+                    <CalendarClock className="h-4 w-4 flex-shrink-0 text-primary" />
+                    <span className="text-sm font-medium text-primary">
+                      {getSchedulePreviewText(scheduleOption, customDateTime)}
+                    </span>
+                  </div>
+                ))}
             </div>
           )}
         </div>

--- a/frontend/src/components/leads/command-center/LeadActionMenu.tsx
+++ b/frontend/src/components/leads/command-center/LeadActionMenu.tsx
@@ -6,12 +6,14 @@
  * desktop (RowActions) và card mobile. Một nguồn duy nhất → 3 nơi luôn khớp
  * (trước đây card/hàng chỉ có Sửa/Xóa còn panel đủ Email/Gán/Chuyển giao → lệch).
  *
- * Mobile → MobileActionSheet, desktop → DropdownMenu (giống panel). Tự sở hữu
- * AssignLeadDialog (chuyển giao) + ReassignLeadDialog (xin đổi phụ trách).
+ * `variant`: caller quyết định "sheet" (MobileActionSheet) vs "dropdown"
+ * (DropdownMenu) — card list dùng "sheet", panel tự tính qua useIsMobile. Tránh
+ * gọi useIsMobile trong CHÍNH component (list N hàng ⇒ N subscription matchMedia)
+ * và khớp đúng breakpoint layout (card hiện ở <1024 nhưng useIsMobile là ≤767).
  *
- * Thin-client: hiển thị "Chuyển giao lead" / "Yêu cầu đổi người phụ trách" theo
- * cờ lead.permissions?.can_transfer_lead / can_request_reassign do backend cấp
- * (list = LeadListItem, chi tiết = LeadDetail) — KHÔNG đọc user.role ở FE.
+ * Thin-client: Gán/Chuyển giao/Yêu cầu đổi hiển thị theo cờ
+ * lead.permissions?.can_assign_lead / can_transfer_lead / can_request_reassign do
+ * backend cấp (list = LeadListItem, chi tiết = LeadDetail) — KHÔNG đọc user.role FE.
  */
 
 import React, { useState } from "react";
@@ -32,7 +34,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
-import { useIsMobile } from "@/hooks/useMediaQuery";
 import { MobileActionSheet } from "@/components/common/MobileActionSheet";
 import { AssignLeadDialog } from "@/components/leads/AssignLeadDialog";
 import { ReassignLeadDialog } from "@/components/leads/ReassignLeadDialog";
@@ -44,6 +45,11 @@ interface LeadActionMenuProps {
   onDelete: (lead: Lead) => void;
   /** "Gán cho cán bộ" khi lead CHƯA có người phụ trách (parent mở dialog gán). */
   onAssign: (lead: Lead) => void;
+  /**
+   * Kiểu hiển thị menu. "sheet" = MobileActionSheet (card mobile), "dropdown" =
+   * DropdownMenu (desktop). Panel truyền theo useIsMobile của chính nó.
+   */
+  variant: "sheet" | "dropdown";
   /** className nút trigger. Mặc định responsive (44px touch mobile / 28px desktop). */
   triggerClassName?: string;
   /** aria-label nút trigger. */
@@ -54,7 +60,8 @@ interface LeadActionMenuProps {
   align?: "start" | "end" | "center";
   /**
    * Chặn click nổi lên phần tử cha (card/hàng có onClick mở panel). Bật cho
-   * card/row, tắt cho panel (không có cha click-able).
+   * card/row, tắt cho panel (không có cha click-able). Áp cho CẢ click của
+   * trigger LẪN của item menu trong portal (React bubble theo cây React).
    */
   stopPropagation?: boolean;
 }
@@ -64,182 +71,196 @@ export function LeadActionMenu({
   onEdit,
   onDelete,
   onAssign,
+  variant,
   triggerClassName,
   triggerLabel = "Mở menu thao tác",
   sheetTitle = "Thao tác",
   align = "end",
   stopPropagation = false,
 }: LeadActionMenuProps) {
-  const isMobile = useIsMobile();
   const [assignOpen, setAssignOpen] = useState(false);
   const [reassignOpen, setReassignOpen] = useState(false);
   const [actionSheetOpen, setActionSheetOpen] = useState(false);
+  // Latch: giữ dialog mounted SAU lần mở đầu tiên (để Radix chạy animation ĐÓNG),
+  // nhưng card chưa từng mở thì KHÔNG mount → list N hàng không tốn N cặp dialog.
+  const [assignSeen, setAssignSeen] = useState(false);
+  const [reassignSeen, setReassignSeen] = useState(false);
 
+  const openAssign = () => {
+    setAssignSeen(true);
+    setAssignOpen(true);
+  };
+  const openReassign = () => {
+    setReassignSeen(true);
+    setReassignOpen(true);
+  };
+
+  // Thin-client: đọc THẲNG cờ backend (không && lại với hasOfficer — backend đã
+  // gate can_transfer/reassign kèm điều kiện lead đã gán rồi).
   const hasOfficer = !!lead.assigned_officer;
-  const canTransfer = hasOfficer && !!lead.permissions?.can_transfer_lead;
-  const canReassign = hasOfficer && !!lead.permissions?.can_request_reassign;
+  const canAssign = !hasOfficer && !!lead.permissions?.can_assign_lead;
+  const canTransfer = !!lead.permissions?.can_transfer_lead;
+  const canReassign = !!lead.permissions?.can_request_reassign;
+  // Nhóm giữa (gán/chuyển giao/xin đổi) có mục nào không → có thì mới thêm
+  // divider dưới (tránh 2 divider liền khi nhóm rỗng).
+  const hasAssignGroup = canAssign || canTransfer || canReassign;
 
   const triggerBtnClass = cn("h-11 w-11 sm:h-7 sm:w-7 p-0", triggerClassName);
 
-  const handleTriggerClick = (e: React.MouseEvent) => {
-    if (stopPropagation) e.stopPropagation();
-  };
-
-  return (
-    <>
-      {isMobile ? (
-        <>
+  const menu =
+    variant === "sheet" ? (
+      <>
+        <Button
+          variant="ghost"
+          size="sm"
+          className={triggerBtnClass}
+          onClick={() => setActionSheetOpen(true)}
+          aria-label={triggerLabel}
+        >
+          <MoreVertical className="h-4 w-4" />
+        </Button>
+        <MobileActionSheet
+          open={actionSheetOpen}
+          onOpenChange={setActionSheetOpen}
+          title={sheetTitle}
+        >
+          <MobileActionSheet.Item
+            icon={Edit}
+            onClick={() => {
+              setActionSheetOpen(false);
+              onEdit(lead);
+            }}
+          >
+            Chỉnh sửa
+          </MobileActionSheet.Item>
+          {lead.email && (
+            <MobileActionSheet.Item
+              icon={Mail}
+              href={`mailto:${lead.email}`}
+              onClick={() => setActionSheetOpen(false)}
+            >
+              Gửi email
+            </MobileActionSheet.Item>
+          )}
+          <MobileActionSheet.Divider />
+          {canAssign && (
+            <MobileActionSheet.Item
+              icon={UserPlus}
+              onClick={() => {
+                setActionSheetOpen(false);
+                onAssign(lead);
+              }}
+            >
+              Gán cho cán bộ
+            </MobileActionSheet.Item>
+          )}
+          {canTransfer && (
+            <MobileActionSheet.Item
+              icon={UserPlus}
+              onClick={() => {
+                setActionSheetOpen(false);
+                openAssign();
+              }}
+            >
+              Chuyển giao lead
+            </MobileActionSheet.Item>
+          )}
+          {canReassign && (
+            <MobileActionSheet.Item
+              icon={RefreshCcw}
+              onClick={() => {
+                setActionSheetOpen(false);
+                openReassign();
+              }}
+            >
+              Yêu cầu đổi người phụ trách
+            </MobileActionSheet.Item>
+          )}
+          {hasAssignGroup && <MobileActionSheet.Divider />}
+          <MobileActionSheet.Item
+            icon={Trash2}
+            variant="destructive"
+            onClick={() => {
+              setActionSheetOpen(false);
+              onDelete(lead);
+            }}
+          >
+            Xóa lead
+          </MobileActionSheet.Item>
+          <MobileActionSheet.Cancel onClick={() => setActionSheetOpen(false)} />
+        </MobileActionSheet>
+      </>
+    ) : (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
             className={triggerBtnClass}
-            onClick={(e) => {
-              handleTriggerClick(e);
-              setActionSheetOpen(true);
-            }}
             aria-label={triggerLabel}
           >
             <MoreVertical className="h-4 w-4" />
           </Button>
-          <MobileActionSheet
-            open={actionSheetOpen}
-            onOpenChange={setActionSheetOpen}
-            title={sheetTitle}
-          >
-            <MobileActionSheet.Item
-              icon={Edit}
-              onClick={() => {
-                setActionSheetOpen(false);
-                onEdit(lead);
-              }}
-            >
-              Chỉnh sửa
-            </MobileActionSheet.Item>
-            {lead.email && (
-              <MobileActionSheet.Item
-                icon={Mail}
-                href={`mailto:${lead.email}`}
-                onClick={() => setActionSheetOpen(false)}
-              >
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align={align} className="w-48">
+          <DropdownMenuItem onClick={() => onEdit(lead)}>
+            <Edit className="mr-2 h-4 w-4" />
+            Chỉnh sửa
+          </DropdownMenuItem>
+          {lead.email && (
+            <DropdownMenuItem asChild>
+              <a href={`mailto:${lead.email}`}>
+                <Mail className="mr-2 h-4 w-4" />
                 Gửi email
-              </MobileActionSheet.Item>
-            )}
-            <MobileActionSheet.Divider />
-            {!hasOfficer && (
-              <MobileActionSheet.Item
-                icon={UserPlus}
-                onClick={() => {
-                  setActionSheetOpen(false);
-                  onAssign(lead);
-                }}
-              >
-                Gán cho cán bộ
-              </MobileActionSheet.Item>
-            )}
-            {canTransfer && (
-              <MobileActionSheet.Item
-                icon={UserPlus}
-                onClick={() => {
-                  setActionSheetOpen(false);
-                  setAssignOpen(true);
-                }}
-              >
-                Chuyển giao lead
-              </MobileActionSheet.Item>
-            )}
-            {canReassign && (
-              <MobileActionSheet.Item
-                icon={RefreshCcw}
-                onClick={() => {
-                  setActionSheetOpen(false);
-                  setReassignOpen(true);
-                }}
-              >
-                Yêu cầu đổi người phụ trách
-              </MobileActionSheet.Item>
-            )}
-            <MobileActionSheet.Divider />
-            <MobileActionSheet.Item
-              icon={Trash2}
-              variant="destructive"
-              onClick={() => {
-                setActionSheetOpen(false);
-                onDelete(lead);
-              }}
-            >
-              Xóa lead
-            </MobileActionSheet.Item>
-            <MobileActionSheet.Cancel onClick={() => setActionSheetOpen(false)} />
-          </MobileActionSheet>
-        </>
-      ) : (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className={triggerBtnClass}
-              onClick={handleTriggerClick}
-              aria-label={triggerLabel}
-            >
-              <MoreVertical className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align={align} className="w-48">
-            <DropdownMenuItem onClick={() => onEdit(lead)}>
-              <Edit className="mr-2 h-4 w-4" />
-              Chỉnh sửa
+              </a>
             </DropdownMenuItem>
-            {lead.email && (
-              <DropdownMenuItem asChild>
-                <a href={`mailto:${lead.email}`}>
-                  <Mail className="mr-2 h-4 w-4" />
-                  Gửi email
-                </a>
-              </DropdownMenuItem>
-            )}
-            <DropdownMenuSeparator />
-            {!hasOfficer && (
-              <DropdownMenuItem onClick={() => onAssign(lead)}>
-                <UserPlus className="mr-2 h-4 w-4" />
-                Gán cho cán bộ
-              </DropdownMenuItem>
-            )}
-            {canTransfer && (
-              <DropdownMenuItem onClick={() => setAssignOpen(true)}>
-                <UserPlus className="mr-2 h-4 w-4" />
-                Chuyển giao lead
-              </DropdownMenuItem>
-            )}
-            {canReassign && (
-              <DropdownMenuItem onClick={() => setReassignOpen(true)}>
-                <RefreshCcw className="mr-2 h-4 w-4" />
-                Yêu cầu đổi người phụ trách
-              </DropdownMenuItem>
-            )}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onClick={() => onDelete(lead)}
-              className="text-destructive focus:text-destructive"
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Xóa lead
+          )}
+          <DropdownMenuSeparator />
+          {canAssign && (
+            <DropdownMenuItem onClick={() => onAssign(lead)}>
+              <UserPlus className="mr-2 h-4 w-4" />
+              Gán cho cán bộ
             </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
+          )}
+          {canTransfer && (
+            <DropdownMenuItem onClick={openAssign}>
+              <UserPlus className="mr-2 h-4 w-4" />
+              Chuyển giao lead
+            </DropdownMenuItem>
+          )}
+          {canReassign && (
+            <DropdownMenuItem onClick={openReassign}>
+              <RefreshCcw className="mr-2 h-4 w-4" />
+              Yêu cầu đổi người phụ trách
+            </DropdownMenuItem>
+          )}
+          {hasAssignGroup && <DropdownMenuSeparator />}
+          <DropdownMenuItem
+            onClick={() => onDelete(lead)}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            Xóa lead
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
 
-      {/* Lazy-mount: chỉ dựng dialog khi thực sự mở → list N hàng KHÔNG mount N
-          cặp dialog (mỗi cái gọi hook/query). Đóng dialog rồi unmount luôn. */}
-      {assignOpen && (
+  // `display:contents` → span không tạo box (giữ nguyên layout flex của card),
+  // nhưng vẫn là node DOM nhận sự kiện. Click từ trigger/menu-item (kể cả nội
+  // dung portal của sheet/dropdown/dialog — React bubble theo cây React, không
+  // theo DOM) nổi tới đây → stopPropagation, KHÔNG chạm onClick của card/hàng.
+  return (
+    <span
+      style={{ display: "contents" }}
+      onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
+    >
+      {menu}
+      {assignSeen && (
         // Chuyển giao (manager/admin) — đổi trực tiếp người phụ trách
-        <AssignLeadDialog
-          open={assignOpen}
-          onOpenChange={setAssignOpen}
-          lead={lead}
-        />
+        <AssignLeadDialog open={assignOpen} onOpenChange={setAssignOpen} lead={lead} />
       )}
-      {reassignOpen && (
+      {reassignSeen && (
         // Xin đổi phụ trách (officer được giao) — chờ manager/admin duyệt
         <ReassignLeadDialog
           open={reassignOpen}
@@ -247,7 +268,7 @@ export function LeadActionMenu({
           lead={lead}
         />
       )}
-    </>
+    </span>
   );
 }
 

--- a/frontend/src/components/leads/command-center/LeadActionMenu.tsx
+++ b/frontend/src/components/leads/command-center/LeadActionMenu.tsx
@@ -1,0 +1,254 @@
+// src/components/leads/command-center/LeadActionMenu.tsx
+"use client";
+
+/**
+ * LeadActionMenu — menu thao tác lead DÙNG CHUNG cho panel chi tiết, hàng bảng
+ * desktop (RowActions) và card mobile. Một nguồn duy nhất → 3 nơi luôn khớp
+ * (trước đây card/hàng chỉ có Sửa/Xóa còn panel đủ Email/Gán/Chuyển giao → lệch).
+ *
+ * Mobile → MobileActionSheet, desktop → DropdownMenu (giống panel). Tự sở hữu
+ * AssignLeadDialog (chuyển giao) + ReassignLeadDialog (xin đổi phụ trách).
+ *
+ * Thin-client: hiển thị "Chuyển giao lead" / "Yêu cầu đổi người phụ trách" theo
+ * cờ lead.permissions?.can_transfer_lead / can_request_reassign do backend cấp
+ * (list = LeadListItem, chi tiết = LeadDetail) — KHÔNG đọc user.role ở FE.
+ */
+
+import React, { useState } from "react";
+import {
+  Edit,
+  Trash2,
+  UserPlus,
+  Mail,
+  RefreshCcw,
+  MoreVertical,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/useMediaQuery";
+import { MobileActionSheet } from "@/components/common/MobileActionSheet";
+import { AssignLeadDialog } from "@/components/leads/AssignLeadDialog";
+import { ReassignLeadDialog } from "@/components/leads/ReassignLeadDialog";
+import type { Lead } from "@/types/lead.types";
+
+interface LeadActionMenuProps {
+  lead: Lead;
+  onEdit: (lead: Lead) => void;
+  onDelete: (lead: Lead) => void;
+  /** "Gán cho cán bộ" khi lead CHƯA có người phụ trách (parent mở dialog gán). */
+  onAssign: (lead: Lead) => void;
+  /** className nút trigger. Mặc định responsive (44px touch mobile / 28px desktop). */
+  triggerClassName?: string;
+  /** aria-label nút trigger. */
+  triggerLabel?: string;
+  /** Tiêu đề action sheet mobile. */
+  sheetTitle?: string;
+  /** Căn dropdown desktop. */
+  align?: "start" | "end" | "center";
+  /**
+   * Chặn click nổi lên phần tử cha (card/hàng có onClick mở panel). Bật cho
+   * card/row, tắt cho panel (không có cha click-able).
+   */
+  stopPropagation?: boolean;
+}
+
+export function LeadActionMenu({
+  lead,
+  onEdit,
+  onDelete,
+  onAssign,
+  triggerClassName,
+  triggerLabel = "Mở menu thao tác",
+  sheetTitle = "Thao tác",
+  align = "end",
+  stopPropagation = false,
+}: LeadActionMenuProps) {
+  const isMobile = useIsMobile();
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [reassignOpen, setReassignOpen] = useState(false);
+  const [actionSheetOpen, setActionSheetOpen] = useState(false);
+
+  const hasOfficer = !!lead.assigned_officer;
+  const canTransfer = hasOfficer && !!lead.permissions?.can_transfer_lead;
+  const canReassign = hasOfficer && !!lead.permissions?.can_request_reassign;
+
+  const triggerBtnClass = cn("h-11 w-11 sm:h-7 sm:w-7 p-0", triggerClassName);
+
+  const handleTriggerClick = (e: React.MouseEvent) => {
+    if (stopPropagation) e.stopPropagation();
+  };
+
+  return (
+    <>
+      {isMobile ? (
+        <>
+          <Button
+            variant="ghost"
+            size="sm"
+            className={triggerBtnClass}
+            onClick={(e) => {
+              handleTriggerClick(e);
+              setActionSheetOpen(true);
+            }}
+            aria-label={triggerLabel}
+          >
+            <MoreVertical className="h-4 w-4" />
+          </Button>
+          <MobileActionSheet
+            open={actionSheetOpen}
+            onOpenChange={setActionSheetOpen}
+            title={sheetTitle}
+          >
+            <MobileActionSheet.Item
+              icon={Edit}
+              onClick={() => {
+                setActionSheetOpen(false);
+                onEdit(lead);
+              }}
+            >
+              Chỉnh sửa
+            </MobileActionSheet.Item>
+            {lead.email && (
+              <MobileActionSheet.Item
+                icon={Mail}
+                href={`mailto:${lead.email}`}
+                onClick={() => setActionSheetOpen(false)}
+              >
+                Gửi email
+              </MobileActionSheet.Item>
+            )}
+            <MobileActionSheet.Divider />
+            {!hasOfficer && (
+              <MobileActionSheet.Item
+                icon={UserPlus}
+                onClick={() => {
+                  setActionSheetOpen(false);
+                  onAssign(lead);
+                }}
+              >
+                Gán cho cán bộ
+              </MobileActionSheet.Item>
+            )}
+            {canTransfer && (
+              <MobileActionSheet.Item
+                icon={UserPlus}
+                onClick={() => {
+                  setActionSheetOpen(false);
+                  setAssignOpen(true);
+                }}
+              >
+                Chuyển giao lead
+              </MobileActionSheet.Item>
+            )}
+            {canReassign && (
+              <MobileActionSheet.Item
+                icon={RefreshCcw}
+                onClick={() => {
+                  setActionSheetOpen(false);
+                  setReassignOpen(true);
+                }}
+              >
+                Yêu cầu đổi người phụ trách
+              </MobileActionSheet.Item>
+            )}
+            <MobileActionSheet.Divider />
+            <MobileActionSheet.Item
+              icon={Trash2}
+              variant="destructive"
+              onClick={() => {
+                setActionSheetOpen(false);
+                onDelete(lead);
+              }}
+            >
+              Xóa lead
+            </MobileActionSheet.Item>
+            <MobileActionSheet.Cancel onClick={() => setActionSheetOpen(false)} />
+          </MobileActionSheet>
+        </>
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className={triggerBtnClass}
+              onClick={handleTriggerClick}
+              aria-label={triggerLabel}
+            >
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align={align} className="w-48">
+            <DropdownMenuItem onClick={() => onEdit(lead)}>
+              <Edit className="mr-2 h-4 w-4" />
+              Chỉnh sửa
+            </DropdownMenuItem>
+            {lead.email && (
+              <DropdownMenuItem asChild>
+                <a href={`mailto:${lead.email}`}>
+                  <Mail className="mr-2 h-4 w-4" />
+                  Gửi email
+                </a>
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
+            {!hasOfficer && (
+              <DropdownMenuItem onClick={() => onAssign(lead)}>
+                <UserPlus className="mr-2 h-4 w-4" />
+                Gán cho cán bộ
+              </DropdownMenuItem>
+            )}
+            {canTransfer && (
+              <DropdownMenuItem onClick={() => setAssignOpen(true)}>
+                <UserPlus className="mr-2 h-4 w-4" />
+                Chuyển giao lead
+              </DropdownMenuItem>
+            )}
+            {canReassign && (
+              <DropdownMenuItem onClick={() => setReassignOpen(true)}>
+                <RefreshCcw className="mr-2 h-4 w-4" />
+                Yêu cầu đổi người phụ trách
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => onDelete(lead)}
+              className="text-destructive focus:text-destructive"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Xóa lead
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+
+      {/* Lazy-mount: chỉ dựng dialog khi thực sự mở → list N hàng KHÔNG mount N
+          cặp dialog (mỗi cái gọi hook/query). Đóng dialog rồi unmount luôn. */}
+      {assignOpen && (
+        // Chuyển giao (manager/admin) — đổi trực tiếp người phụ trách
+        <AssignLeadDialog
+          open={assignOpen}
+          onOpenChange={setAssignOpen}
+          lead={lead}
+        />
+      )}
+      {reassignOpen && (
+        // Xin đổi phụ trách (officer được giao) — chờ manager/admin duyệt
+        <ReassignLeadDialog
+          open={reassignOpen}
+          onOpenChange={setReassignOpen}
+          lead={lead}
+        />
+      )}
+    </>
+  );
+}
+
+export default LeadActionMenu;

--- a/frontend/src/components/leads/command-center/LeadActionMenu.tsx
+++ b/frontend/src/components/leads/command-center/LeadActionMenu.tsx
@@ -95,8 +95,12 @@ export function LeadActionMenu({
     setReassignOpen(true);
   };
 
-  // Thin-client: đọc THẲNG cờ backend (không && lại với hasOfficer — backend đã
-  // gate can_transfer/reassign kèm điều kiện lead đã gán rồi).
+  // can_transfer_lead / can_request_reassign: đọc THẲNG cờ backend (BE đã gate KÈM
+  // điều kiện "lead đã có người phụ trách"). RIÊNG can_assign_lead backend chỉ
+  // role-gate (endpoint /assign = admin/manager-only, KHÔNG gate assigned-state),
+  // nên "chỉ hiện nút Gán khi lead chưa có người" là điều kiện HIỂN THỊ ghép ở FE
+  // qua !hasOfficer. (Muốn thuần thin-client thì đẩy `and not lead_assigned` vào
+  // can_assign_lead ở backend — đổi contract + test, defer chờ owner chốt.)
   const hasOfficer = !!lead.assigned_officer;
   const canAssign = !hasOfficer && !!lead.permissions?.can_assign_lead;
   const canTransfer = !!lead.permissions?.can_transfer_lead;
@@ -253,6 +257,10 @@ export function LeadActionMenu({
   return (
     <span
       style={{ display: "contents" }}
+      // data-swipe-ignore: nằm trong card có SwipeToCall (bấm-giữ-kéo-gọi), báo cho
+      // container BỎ QUA pointerdown trên trigger/menu-item để long-press mở menu
+      // không bị nuốt thành cử chỉ gọi. Vô hại ở ngữ cảnh không có SwipeToCall.
+      data-swipe-ignore
       onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
     >
       {menu}

--- a/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
@@ -33,6 +33,8 @@ import {
   ExternalLink,
   RefreshCcw,
   MoreVertical,
+  FileText,
+  ArrowRight,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -55,6 +57,7 @@ import { ReassignLeadDialog } from "@/components/leads/ReassignLeadDialog";
 import { CopyableCell } from "@/components/common/CopyableCell";
 import { STAGE_COLORS } from "@/types/pipeline.types";
 import { getEducationLevelLabel } from "@/constants";
+import { getStatusConfig, getStatusDotColor } from "@/lib/status-config";
 import { OfficerRatingInput } from "@/components/leads/OfficerRatingInput";
 import type { Lead } from "@/types/lead.types";
 
@@ -412,6 +415,55 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
       {/* Scrollable Content */}
       <ScrollArea className="flex-1" ref={scrollAreaRef}>
         <div className="space-y-3 p-3 sm:space-y-4 sm:p-4">
+          {/* ================================================== */}
+          {/* CỬA VÀO HỒ SƠ — 1 chạm sang /admissions khi đã có hồ sơ */}
+          {/* Đặt trên cùng: khi lead đã có hồ sơ thì hồ sơ là ưu tiên. */}
+          {/* Thin-client: label/màu lấy từ getStatusConfig('admission'). */}
+          {/* ================================================== */}
+          {(() => {
+            const profile = lead.admission_profiles?.[0];
+            if (!profile) return null;
+            const cfg = getStatusConfig(profile.status, "admission");
+            const extraCount = (lead.admission_profiles?.length ?? 1) - 1;
+            return (
+              <Link
+                href={`/admissions/${profile.id}`}
+                aria-label={`Xem hồ sơ tuyển sinh #${profile.id} — ${cfg.label}`}
+                className="group relative flex min-h-14 items-center gap-3 overflow-hidden rounded-xl border bg-card p-2.5 pl-3 shadow-sm transition-colors hover:border-primary/40 active:scale-[0.995]"
+              >
+                {/* Vạch màu trạng thái (viền-trái) */}
+                <span className={cn("absolute inset-y-0 left-0 w-1", getStatusDotColor(profile.status))} />
+                {/* Chip nhận diện hồ sơ, tô theo trạng thái */}
+                <span className={cn("flex h-10 w-10 shrink-0 items-center justify-center rounded-lg", cfg.badgeColor)}>
+                  <FileText className="h-[18px] w-[18px]" />
+                </span>
+                {/* Nội dung: eyebrow + trạng thái + mã SV */}
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                    Hồ sơ tuyển sinh
+                    <span className="font-mono font-semibold tracking-tight text-muted-foreground/80">#{profile.id}</span>
+                    {extraCount > 0 && (
+                      <span className="font-sans font-medium normal-case text-muted-foreground/70">· +{extraCount} hồ sơ</span>
+                    )}
+                  </span>
+                  <span className="mt-0.5 flex items-baseline gap-1.5 truncate text-[15px] font-semibold leading-tight text-foreground">
+                    {cfg.label}
+                    {profile.student_code && (
+                      <span className="truncate font-mono text-[11px] font-medium tracking-tight text-muted-foreground">
+                        · Mã SV {profile.student_code}
+                      </span>
+                    )}
+                  </span>
+                </span>
+                {/* Lối vào — chevron trỏ sang module tuyển sinh */}
+                <span className="flex shrink-0 items-center gap-1 pr-0.5 text-xs font-semibold text-muted-foreground transition-colors group-hover:text-primary">
+                  Xem
+                  <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5 motion-reduce:transition-none" />
+                </span>
+              </Link>
+            );
+          })()}
+
           {/* ================================================== */}
           {/* SECTION 1: Thông tin học viên (Combined) */}
           {/* ================================================== */}

--- a/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import React, { useRef, useEffect, useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -12,12 +11,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
   Edit,
   Trash2,
   UserPlus,
@@ -25,8 +18,6 @@ import {
   Mail,
   MapPin,
   GraduationCap,
-  Building,
-  Calendar,
   User,
   Zap,
   History,
@@ -35,6 +26,7 @@ import {
   MoreVertical,
   FileText,
   ArrowRight,
+  AlertCircle,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -48,8 +40,6 @@ import { useIsMobile } from "@/hooks/useMediaQuery";
 import { MobileActionSheet } from "@/components/common/MobileActionSheet";
 import { DynamicColorBadge } from "@/components/ui/dynamic-color-badge";
 import { useLead } from "@/hooks/useLeads";
-import { useAuth } from "@/hooks/useAuth";
-import { isManagerOrAbove } from "@/lib/utils/permissions";
 import { LeadTimelineTab } from "@/components/leads/LeadTimelineTab";
 import { QuickConsultationSectionV2 } from "@/components/leads/QuickConsultationSectionV2";
 import { AssignLeadDialog } from "@/components/leads/AssignLeadDialog";
@@ -109,9 +99,7 @@ const getInitials = (name: string) => {
 };
 
 export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDetailPanelProps) {
-  const { data: lead, isLoading } = useLead(leadId || 0, !!leadId);
-  const { user } = useAuth();
-  const hasManagerAccess = isManagerOrAbove(user);
+  const { data: lead, isLoading, isError, refetch } = useLead(leadId || 0, !!leadId);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const [assignOpen, setAssignOpen] = useState(false);
   const [reassignOpen, setReassignOpen] = useState(false);
@@ -164,8 +152,32 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
           </div>
           <div>
             <p className="text-muted-foreground font-medium">Chọn lead để xem chi tiết</p>
-            <p className="text-muted-foreground/70 text-sm">Click vào lead trong danh sách</p>
+            <p className="text-muted-foreground/70 text-sm">Chọn lead trong danh sách</p>
           </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state — fetch lỗi (network/403/404). Tránh kẹt skeleton vĩnh viễn:
+  // báo rõ + cho thử lại (mẫu như trang /leads/[id]).
+  if (isError) {
+    return (
+      <div className="flex h-full items-center justify-center p-4">
+        <div className="max-w-xs space-y-3 text-center">
+          <div className="bg-error-50 dark:bg-error-950/40 mx-auto flex h-12 w-12 items-center justify-center rounded-full">
+            <AlertCircle className="text-error-500 h-6 w-6" />
+          </div>
+          <div>
+            <p className="text-foreground font-medium">Không tải được thông tin lead</p>
+            <p className="text-muted-foreground text-sm">
+              Có thể do mất mạng hoặc bạn không có quyền xem lead này.
+            </p>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            <RefreshCcw className="mr-1.5 h-3.5 w-3.5" />
+            Thử lại
+          </Button>
         </div>
       </div>
     );
@@ -204,7 +216,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
                 {getInitials(lead.full_name)}
               </AvatarFallback>
             </Avatar>
-            <h2 className="truncate text-sm font-semibold font-display">
+            <h2 className="truncate text-base font-semibold font-display">
               {lead.full_name}
             </h2>
           </div>
@@ -256,23 +268,21 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
                 Xem
               </Link>
             </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-11 sm:h-7 px-2 text-xs"
-              onClick={() => window.open(`tel:${lead.phone}`, "_blank")}
-            >
-              <Phone className="h-3.5 w-3.5 mr-1" />
-              Gọi
+            <Button variant="outline" size="sm" className="h-11 sm:h-7 px-2 text-xs" asChild>
+              <a href={`tel:${lead.phone}`}>
+                <Phone className="h-3.5 w-3.5 mr-1" />
+                Gọi
+              </a>
             </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-11 sm:h-7 px-2 text-xs"
-              onClick={() => window.open(`https://zalo.me/${lead.phone?.replace(/\D/g, '')}`, "_blank")}
-            >
-              <span className="font-bold mr-1">Z</span>
-              Zalo
+            <Button variant="outline" size="sm" className="h-11 sm:h-7 px-2 text-xs" asChild>
+              <a
+                href={`https://zalo.me/${lead.phone?.replace(/\D/g, '')}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span className="font-bold mr-1">Z</span>
+                Zalo
+              </a>
             </Button>
           </div>
 
@@ -305,10 +315,8 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
                 {lead.email && (
                   <MobileActionSheet.Item
                     icon={Mail}
-                    onClick={() => {
-                      setActionSheetOpen(false);
-                      window.open(`mailto:${lead.email}`, "_blank");
-                    }}
+                    href={`mailto:${lead.email}`}
+                    onClick={() => setActionSheetOpen(false)}
                   >
                     Gửi email
                   </MobileActionSheet.Item>
@@ -325,7 +333,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
                     Gán cho cán bộ
                   </MobileActionSheet.Item>
                 )}
-                {lead.assigned_officer && hasManagerAccess && (
+                {lead.assigned_officer && lead.permissions.can_transfer_lead && (
                   <MobileActionSheet.Item
                     icon={UserPlus}
                     onClick={() => {
@@ -336,7 +344,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
                     Chuyển giao lead
                   </MobileActionSheet.Item>
                 )}
-                {lead.assigned_officer && !hasManagerAccess && (
+                {lead.assigned_officer && lead.permissions.can_request_reassign && (
                   <MobileActionSheet.Item
                     icon={RefreshCcw}
                     onClick={() => {
@@ -374,9 +382,11 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
                   Chỉnh sửa
                 </DropdownMenuItem>
                 {lead.email && (
-                  <DropdownMenuItem onClick={() => window.open(`mailto:${lead.email}`, "_blank")}>
-                    <Mail className="mr-2 h-4 w-4" />
-                    Gửi email
+                  <DropdownMenuItem asChild>
+                    <a href={`mailto:${lead.email}`}>
+                      <Mail className="mr-2 h-4 w-4" />
+                      Gửi email
+                    </a>
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuSeparator />
@@ -386,13 +396,13 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
                     Gán cho cán bộ
                   </DropdownMenuItem>
                 )}
-                {lead.assigned_officer && hasManagerAccess && (
+                {lead.assigned_officer && lead.permissions.can_transfer_lead && (
                   <DropdownMenuItem onClick={() => setAssignOpen(true)}>
                     <UserPlus className="mr-2 h-4 w-4" />
                     Chuyển giao lead
                   </DropdownMenuItem>
                 )}
-                {lead.assigned_officer && !hasManagerAccess && (
+                {lead.assigned_officer && lead.permissions.can_request_reassign && (
                   <DropdownMenuItem onClick={() => setReassignOpen(true)}>
                     <RefreshCcw className="mr-2 h-4 w-4" />
                     Yêu cầu đổi người phụ trách
@@ -533,9 +543,9 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
                       size="sm"
                       variant="outline"
                       className="h-11 sm:h-5 px-2 text-xs sm:text-[10px] border-amber-300 text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300"
-                      onClick={() => window.open(`tel:${lead.phone}`, "_blank")}
+                      asChild
                     >
-                      Gọi ngay
+                      <a href={`tel:${lead.phone}`}>Gọi ngay</a>
                     </Button>
                   </div>
                 </div>
@@ -595,7 +605,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
 
                   {/* Days in Stage */}
                   <div className="flex items-center justify-between h-5">
-                    <span className="text-muted-foreground">Ngày trong stage:</span>
+                    <span className="text-muted-foreground">Ngày trong giai đoạn:</span>
                     <span className="font-semibold">{lead.days_in_stage ?? 0}</span>
                   </div>
 

--- a/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
@@ -11,8 +11,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  Edit,
-  Trash2,
   UserPlus,
   Phone,
   Mail,
@@ -23,27 +21,16 @@ import {
   History,
   ExternalLink,
   RefreshCcw,
-  MoreVertical,
   FileText,
   ArrowRight,
   AlertCircle,
 } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { cn, sanitizeColorCode } from "@/lib/utils";
-import { useIsMobile } from "@/hooks/useMediaQuery";
-import { MobileActionSheet } from "@/components/common/MobileActionSheet";
 import { DynamicColorBadge } from "@/components/ui/dynamic-color-badge";
 import { useLead } from "@/hooks/useLeads";
 import { LeadTimelineTab } from "@/components/leads/LeadTimelineTab";
 import { QuickConsultationSectionV2 } from "@/components/leads/QuickConsultationSectionV2";
-import { AssignLeadDialog } from "@/components/leads/AssignLeadDialog";
-import { ReassignLeadDialog } from "@/components/leads/ReassignLeadDialog";
+import { LeadActionMenu } from "@/components/leads/command-center/LeadActionMenu";
 import { CopyableCell } from "@/components/common/CopyableCell";
 import { STAGE_COLORS } from "@/types/pipeline.types";
 import { getEducationLevelLabel } from "@/constants";
@@ -101,10 +88,6 @@ const getInitials = (name: string) => {
 export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDetailPanelProps) {
   const { data: lead, isLoading, isError, refetch } = useLead(leadId || 0, !!leadId);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
-  const [assignOpen, setAssignOpen] = useState(false);
-  const [reassignOpen, setReassignOpen] = useState(false);
-  const [actionSheetOpen, setActionSheetOpen] = useState(false);
-  const isMobile = useIsMobile();
 
   // ✅ FIX: Calculate days since contact in useEffect to avoid impure Date.now() in render
   // Also prevents hydration mismatch (useState defaults to null, matching SSR)
@@ -286,139 +269,14 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
             </Button>
           </div>
 
-          {/* More Actions - Mobile: ActionSheet, Desktop: Dropdown */}
-          {isMobile ? (
-            <>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-11 w-11 sm:h-7 sm:w-7 p-0"
-                onClick={() => setActionSheetOpen(true)}
-                aria-label="Mở menu thao tác"
-              >
-                <MoreVertical className="h-4 w-4" />
-              </Button>
-              <MobileActionSheet
-                open={actionSheetOpen}
-                onOpenChange={setActionSheetOpen}
-                title="Thao tác"
-              >
-                <MobileActionSheet.Item
-                  icon={Edit}
-                  onClick={() => {
-                    setActionSheetOpen(false);
-                    onEdit(lead);
-                  }}
-                >
-                  Chỉnh sửa
-                </MobileActionSheet.Item>
-                {lead.email && (
-                  <MobileActionSheet.Item
-                    icon={Mail}
-                    href={`mailto:${lead.email}`}
-                    onClick={() => setActionSheetOpen(false)}
-                  >
-                    Gửi email
-                  </MobileActionSheet.Item>
-                )}
-                <MobileActionSheet.Divider />
-                {!lead.assigned_officer && (
-                  <MobileActionSheet.Item
-                    icon={UserPlus}
-                    onClick={() => {
-                      setActionSheetOpen(false);
-                      onAssign(lead);
-                    }}
-                  >
-                    Gán cho cán bộ
-                  </MobileActionSheet.Item>
-                )}
-                {lead.assigned_officer && lead.permissions.can_transfer_lead && (
-                  <MobileActionSheet.Item
-                    icon={UserPlus}
-                    onClick={() => {
-                      setActionSheetOpen(false);
-                      setAssignOpen(true);
-                    }}
-                  >
-                    Chuyển giao lead
-                  </MobileActionSheet.Item>
-                )}
-                {lead.assigned_officer && lead.permissions.can_request_reassign && (
-                  <MobileActionSheet.Item
-                    icon={RefreshCcw}
-                    onClick={() => {
-                      setActionSheetOpen(false);
-                      setReassignOpen(true);
-                    }}
-                  >
-                    Yêu cầu đổi người phụ trách
-                  </MobileActionSheet.Item>
-                )}
-                <MobileActionSheet.Divider />
-                <MobileActionSheet.Item
-                  icon={Trash2}
-                  variant="destructive"
-                  onClick={() => {
-                    setActionSheetOpen(false);
-                    onDelete(lead);
-                  }}
-                >
-                  Xóa lead
-                </MobileActionSheet.Item>
-                <MobileActionSheet.Cancel onClick={() => setActionSheetOpen(false)} />
-              </MobileActionSheet>
-            </>
-          ) : (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="h-11 w-11 sm:h-7 sm:w-7 p-0" aria-label="Mở menu thao tác">
-                  <MoreVertical className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
-                <DropdownMenuItem onClick={() => onEdit(lead)}>
-                  <Edit className="mr-2 h-4 w-4" />
-                  Chỉnh sửa
-                </DropdownMenuItem>
-                {lead.email && (
-                  <DropdownMenuItem asChild>
-                    <a href={`mailto:${lead.email}`}>
-                      <Mail className="mr-2 h-4 w-4" />
-                      Gửi email
-                    </a>
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuSeparator />
-                {!lead.assigned_officer && (
-                  <DropdownMenuItem onClick={() => onAssign(lead)}>
-                    <UserPlus className="mr-2 h-4 w-4" />
-                    Gán cho cán bộ
-                  </DropdownMenuItem>
-                )}
-                {lead.assigned_officer && lead.permissions.can_transfer_lead && (
-                  <DropdownMenuItem onClick={() => setAssignOpen(true)}>
-                    <UserPlus className="mr-2 h-4 w-4" />
-                    Chuyển giao lead
-                  </DropdownMenuItem>
-                )}
-                {lead.assigned_officer && lead.permissions.can_request_reassign && (
-                  <DropdownMenuItem onClick={() => setReassignOpen(true)}>
-                    <RefreshCcw className="mr-2 h-4 w-4" />
-                    Yêu cầu đổi người phụ trách
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={() => onDelete(lead)}
-                  className="text-destructive focus:text-destructive"
-                >
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Xóa lead
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
+          {/* Menu thao tác — dùng chung LeadActionMenu (khớp card + hàng bảng) */}
+          <LeadActionMenu
+            lead={lead}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onAssign={onAssign}
+            sheetTitle="Thao tác"
+          />
         </div>
       </div>
 
@@ -684,19 +542,6 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
           </Card>
         </div>
       </ScrollArea>
-      
-      {/* Assign Dialog (Manager/Admin: direct reassign) */}
-      <AssignLeadDialog
-        open={assignOpen}
-        onOpenChange={setAssignOpen}
-        lead={lead}
-      />
-      {/* Reassign Dialog (Officer: request reassign) */}
-      <ReassignLeadDialog
-        open={reassignOpen}
-        onOpenChange={setReassignOpen}
-        lead={lead}
-      />
     </div>
   );
 }

--- a/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
@@ -207,7 +207,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
     >
       {/* Header - Mobile Optimized, Full Width Rows */}
       {/* Note: pr-10 to avoid Sheet close button overlap */}
-      <div className="bg-background shrink-0 border-b p-3 pr-10 space-y-2">
+      <div className="bg-background shrink-0 border-b p-3 pr-12 space-y-2">
         {/* Row 1: Avatar + Name + Assignment Status */}
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2 min-w-0">

--- a/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
@@ -26,6 +26,7 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { cn, sanitizeColorCode } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import { DynamicColorBadge } from "@/components/ui/dynamic-color-badge";
 import { useLead } from "@/hooks/useLeads";
 import { LeadTimelineTab } from "@/components/leads/LeadTimelineTab";
@@ -88,6 +89,8 @@ const getInitials = (name: string) => {
 export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDetailPanelProps) {
   const { data: lead, isLoading, isError, refetch } = useLead(leadId || 0, !!leadId);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
+  // 1 instance duy nhất (panel không phải list) → chọn sheet/dropdown cho menu.
+  const isMobile = useIsMobile();
 
   // ✅ FIX: Calculate days since contact in useEffect to avoid impure Date.now() in render
   // Also prevents hydration mismatch (useState defaults to null, matching SSR)
@@ -275,6 +278,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
             onEdit={onEdit}
             onDelete={onDelete}
             onAssign={onAssign}
+            variant={isMobile ? "sheet" : "dropdown"}
             sheetTitle="Thao tác"
           />
         </div>

--- a/frontend/src/components/leads/command-center/LeadsTable.test.tsx
+++ b/frontend/src/components/leads/command-center/LeadsTable.test.tsx
@@ -140,6 +140,7 @@ describe("LeadsTable", () => {
     onSelectLead: vi.fn(),
     onEditLead: vi.fn(),
     onDeleteLead: vi.fn(),
+    onAssignLead: vi.fn(),
   };
 
   beforeEach(() => {

--- a/frontend/src/components/leads/command-center/LeadsTable.tsx
+++ b/frontend/src/components/leads/command-center/LeadsTable.tsx
@@ -37,14 +37,11 @@ import {
   ArrowUpDown,
   ArrowUp,
   ArrowDown,
-  MoreHorizontal,
   ChevronLeft,
   SearchX,
   ChevronRight,
   GripVertical,
   Zap,
-  Edit,
-  Trash2,
 } from "lucide-react";
 import {
   Table,
@@ -57,12 +54,6 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
@@ -73,7 +64,7 @@ import {
 import { cn, sanitizeColorCode } from "@/lib/utils";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import { DynamicColorBadge } from "@/components/ui/dynamic-color-badge";
-import { MobileActionSheet } from "@/components/common/MobileActionSheet";
+import { LeadActionMenu } from "./LeadActionMenu";
 import type { Lead } from "@/types/lead.types";
 import { LEAD_SOURCE_OPTIONS, getLeadScoreTextColor } from "@/constants";
 import { STAGE_COLORS } from "@/types/pipeline.types";
@@ -95,6 +86,8 @@ interface LeadsTableProps {
   onSelectLead: (lead: Lead) => void;
   onEditLead: (lead: Lead) => void;
   onDeleteLead: (lead: Lead) => void;
+  /** "Gán cho cán bộ" cho lead chưa phân công (mở dialog gán ở parent). */
+  onAssignLead: (lead: Lead) => void;
   isLoading?: boolean;
   // Pagination props
   page?: number;
@@ -164,89 +157,29 @@ const getSourceLabel = (value: string) =>
   LEAD_SOURCE_OPTIONS.find((o) => o.value === value)?.label || value;
 
 // =============================================================================
-// ROW ACTIONS COMPONENT - Responsive (mobile: action sheet, desktop: dropdown)
+// ROW ACTIONS COMPONENT — dùng chung LeadActionMenu (khớp card + panel)
 // =============================================================================
 
 interface RowActionsProps {
   lead: Lead;
   onEdit: (lead: Lead) => void;
   onDelete: (lead: Lead) => void;
+  onAssign: (lead: Lead) => void;
 }
 
-function RowActions({ lead, onEdit, onDelete }: RowActionsProps) {
-  const isMobile = useIsMobile();
-  const [actionSheetOpen, setActionSheetOpen] = React.useState(false);
-
-  if (isMobile) {
-    return (
-      <>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-8 w-8 p-0"
-          onClick={(e) => {
-            e.stopPropagation();
-            setActionSheetOpen(true);
-          }}
-          aria-label="Mở menu thao tác"
-        >
-          <MoreHorizontal className="h-4 w-4" />
-        </Button>
-        <MobileActionSheet
-          open={actionSheetOpen}
-          onOpenChange={setActionSheetOpen}
-          title={lead.full_name}
-        >
-          <MobileActionSheet.Item
-            icon={Edit}
-            onClick={() => {
-              setActionSheetOpen(false);
-              onEdit(lead);
-            }}
-          >
-            Chỉnh sửa
-          </MobileActionSheet.Item>
-          <MobileActionSheet.Item
-            icon={Trash2}
-            variant="destructive"
-            onClick={() => {
-              setActionSheetOpen(false);
-              onDelete(lead);
-            }}
-          >
-            Xóa
-          </MobileActionSheet.Item>
-          <MobileActionSheet.Cancel onClick={() => setActionSheetOpen(false)} />
-        </MobileActionSheet>
-      </>
-    );
-  }
-
+function RowActions({ lead, onEdit, onDelete, onAssign }: RowActionsProps) {
+  // stopPropagation: hàng có onClick chọn lead → không cho click menu chọn hàng.
+  // triggerClassName h-8 giữ chiều cao hàng bảng ổn định.
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-8 w-8 p-0"
-          onClick={(e) => e.stopPropagation()}
-          aria-label="Mở menu thao tác"
-        >
-          <MoreHorizontal className="h-4 w-4" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => onEdit(lead)}>
-          Chỉnh sửa
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => onDelete(lead)}
-          className="text-destructive"
-        >
-          Xóa
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <LeadActionMenu
+      lead={lead}
+      onEdit={onEdit}
+      onDelete={onDelete}
+      onAssign={onAssign}
+      sheetTitle={lead.full_name}
+      triggerClassName="h-8 w-8 sm:h-8 sm:w-8"
+      stopPropagation
+    />
   );
 }
 
@@ -260,6 +193,7 @@ export function LeadsTable({
   onSelectLead,
   onEditLead,
   onDeleteLead,
+  onAssignLead,
   isLoading = false,
   page = 1,
   pageSize = 50,
@@ -599,6 +533,7 @@ export function LeadsTable({
             lead={row.original}
             onEdit={onEditLead}
             onDelete={onDeleteLead}
+            onAssign={onAssignLead}
           />
         ),
         size: 50,
@@ -606,7 +541,7 @@ export function LeadsTable({
         enableHiding: false,
       }),
     ],
-    [onEditLead, onDeleteLead]
+    [onEditLead, onDeleteLead, onAssignLead]
   );
 
   // Table instance
@@ -805,6 +740,7 @@ export function LeadsTable({
               onSelectLead={onSelectLead}
               onEditLead={onEditLead}
               onDeleteLead={onDeleteLead}
+              onAssignLead={onAssignLead}
             />
           )}
         </div>

--- a/frontend/src/components/leads/command-center/LeadsTable.tsx
+++ b/frontend/src/components/leads/command-center/LeadsTable.tsx
@@ -66,7 +66,7 @@ import { useIsMobile } from "@/hooks/useMediaQuery";
 import { DynamicColorBadge } from "@/components/ui/dynamic-color-badge";
 import { LeadActionMenu } from "./LeadActionMenu";
 import type { Lead } from "@/types/lead.types";
-import { LEAD_SOURCE_OPTIONS, getLeadScoreTextColor } from "@/constants";
+import { getLeadSourceLabel, getLeadScoreTextColor } from "@/constants";
 import { STAGE_COLORS } from "@/types/pipeline.types";
 import { TableToolbar, type DensityMode } from "./TableToolbar";
 import { BulkActionsBar } from "./BulkActionsBar";
@@ -153,9 +153,6 @@ const DENSITY_CONFIG: Record<DensityMode, { rowHeight: number; cellPadding: stri
 
 const columnHelper = createColumnHelper<Lead>();
 
-const getSourceLabel = (value: string) =>
-  LEAD_SOURCE_OPTIONS.find((o) => o.value === value)?.label || value;
-
 // =============================================================================
 // ROW ACTIONS COMPONENT — dùng chung LeadActionMenu (khớp card + panel)
 // =============================================================================
@@ -176,6 +173,7 @@ function RowActions({ lead, onEdit, onDelete, onAssign }: RowActionsProps) {
       onEdit={onEdit}
       onDelete={onDelete}
       onAssign={onAssign}
+      variant="dropdown"
       sheetTitle={lead.full_name}
       triggerClassName="h-8 w-8 sm:h-8 sm:w-8"
       stopPropagation
@@ -367,7 +365,7 @@ export function LeadsTable({
           if (!source) return <span className="text-muted-foreground">—</span>;
           return (
             <Badge variant="outline" className="text-[10px] h-5 px-2 font-normal">
-              {getSourceLabel(source)}
+              {getLeadSourceLabel(source)}
             </Badge>
           );
         },

--- a/frontend/src/components/leads/command-center/LeadsTable.tsx
+++ b/frontend/src/components/leads/command-center/LeadsTable.tsx
@@ -66,7 +66,7 @@ import { useIsMobile } from "@/hooks/useMediaQuery";
 import { DynamicColorBadge } from "@/components/ui/dynamic-color-badge";
 import { LeadActionMenu } from "./LeadActionMenu";
 import type { Lead } from "@/types/lead.types";
-import { getLeadSourceLabel, getLeadScoreTextColor } from "@/constants";
+import { getLeadSourceLabel, getLeadScoreTextColor, getDegreeLevelAbbr } from "@/constants";
 import { STAGE_COLORS } from "@/types/pipeline.types";
 import { TableToolbar, type DensityMode } from "./TableToolbar";
 import { BulkActionsBar } from "./BulkActionsBar";
@@ -355,6 +355,32 @@ export function LeadsTable({
           />
         ),
         size: 120,
+      }),
+
+      // Ngành column — đồng bộ với card list (trình độ viết tắt CĐ/TC + tên ngành)
+      columnHelper.accessor("offering", {
+        id: "offering",
+        header: "Ngành",
+        enableSorting: false,
+        cell: ({ row }) => {
+          const offering = row.original.offering;
+          const major = offering?.program?.name || offering?.offering_type;
+          if (!major) return <span className="text-muted-foreground">—</span>;
+          const degreeShort = getDegreeLevelAbbr(offering?.program?.degree_level);
+          return (
+            <span className="flex items-center gap-1.5 text-sm">
+              {degreeShort && (
+                <span className="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold">
+                  {degreeShort}
+                </span>
+              )}
+              <span className="truncate" title={major}>
+                {major}
+              </span>
+            </span>
+          );
+        },
+        size: 180,
       }),
 
       // Source column
@@ -714,7 +740,7 @@ export function LeadsTable({
             {selectedLeads.length > 0 ? (
               <span className="text-primary font-medium">{selectedLeads.length} đã chọn</span>
             ) : (
-              `${totalCount.toLocaleString()} lead`
+              `${totalCount.toLocaleString("vi-VN")} lead`
             )}
           </span>
         </div>
@@ -948,7 +974,7 @@ export function LeadsTable({
       <div className="bg-muted/30 flex shrink-0 items-center justify-between border-t px-4 py-2">
         <div className="text-muted-foreground text-sm tabular-nums">
           Hiển thị {leads.length > 0 ? (page - 1) * pageSize + 1 : 0}-
-          {Math.min(page * pageSize, totalCount)} / {totalCount.toLocaleString()} lead
+          {Math.min(page * pageSize, totalCount)} / {totalCount.toLocaleString("vi-VN")} lead
         </div>
         <div className="flex items-center gap-2">
           <Button

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -21,15 +21,7 @@ import { LeadActionMenu } from "./LeadActionMenu";
 import { SwipeToCall } from "@/components/common/SwipeToCall";
 import { isLeadOverdue } from "@/lib/leads/overdue";
 import type { Lead } from "@/types/lead.types";
-import { getLeadSourceLabel } from "@/constants";
-
-// Viết tắt trình độ ngành cho gọn mặt card (fallback nhãn đầy nếu gặp giá trị lạ).
-const DEGREE_ABBR: Record<string, string> = {
-  "Đại học": "ĐH",
-  "Cao đẳng": "CĐ",
-  "Trung cấp": "TC",
-  "Sơ cấp": "SC",
-};
+import { getLeadSourceLabel, getDegreeLevelAbbr } from "@/constants";
 
 interface MobileLeadCardProps {
   lead: Lead;
@@ -71,11 +63,25 @@ export function MobileLeadCard({
   // — đã là nhãn VN sẵn) + tên ngành. Lấy từ offering nên lead có chọn ngành là có
   // (KHÁC education_level của lead — gần như trống). Ghép bằng " " đọc tự nhiên
   // ("Cao đẳng Công nghệ ô tô"); rỗng cả hai → "Chưa chọn ngành".
-  const degreeLevel = lead.offering?.program?.degree_level || null;
-  const degreeShort = degreeLevel ? DEGREE_ABBR[degreeLevel] ?? degreeLevel : null;
+  const degreeShort = getDegreeLevelAbbr(lead.offering?.program?.degree_level);
   const eduMajor = [degreeShort, major].filter(Boolean).join(" ") || "Chưa chọn ngành";
   // Overdue tính client theo next_activity_at (cache is_overdue có thể trễ ~14h).
   const overdue = isLeadOverdue({ next_activity_at: lead.next_activity_at ?? null });
+  // "Thời gian" gộp thành 1 span suppressed (text + class). Trang /leads SSR với
+  // initialData nên card render trên SERVER; overdue/relative-time phụ thuộc "now"
+  // → server≠client. suppressHydrationWarning trên 1 span duy nhất phủ CẢ text LẪN
+  // className, nên dù nhánh overdue lật giữa SSR↔hydrate vẫn không mismatch.
+  const when = overdue
+    ? { text: "Quá hạn", cls: "font-medium text-error-600 dark:text-error-500" }
+    : lead.last_consultation_at
+      ? {
+          text: formatDistanceToNowStrict(new Date(lead.last_consultation_at), {
+            addSuffix: true,
+            locale: vi,
+          }),
+          cls: "tabular-nums",
+        }
+      : { text: "Chưa liên hệ", cls: "text-muted-foreground/60" };
   const selected = isSelected || isChecked;
 
   return (
@@ -138,23 +144,9 @@ export function MobileLeadCard({
               <span className="truncate text-foreground/90">{eduMajor}</span>
             </span>
             <span className="text-muted-foreground/40">·</span>
-            {overdue ? (
-              <span
-                className="shrink-0 font-medium text-error-600 dark:text-error-500"
-                suppressHydrationWarning
-              >
-                Quá hạn
-              </span>
-            ) : lead.last_consultation_at ? (
-              <span className="shrink-0 tabular-nums" suppressHydrationWarning>
-                {formatDistanceToNowStrict(new Date(lead.last_consultation_at), {
-                  addSuffix: true,
-                  locale: vi,
-                })}
-              </span>
-            ) : (
-              <span className="shrink-0 text-muted-foreground/60">Chưa liên hệ</span>
-            )}
+            <span className={cn("shrink-0", when.cls)} suppressHydrationWarning>
+              {when.text}
+            </span>
             <span className="text-muted-foreground/40">·</span>
             <span className="shrink-0 text-muted-foreground/80">
               {getLeadSourceLabel(lead.source)}

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -21,7 +21,7 @@ import { LeadActionMenu } from "./LeadActionMenu";
 import { SwipeToCall } from "@/components/common/SwipeToCall";
 import { isLeadOverdue } from "@/lib/leads/overdue";
 import type { Lead } from "@/types/lead.types";
-import { getLeadSourceLabel, getEducationLevelLabel } from "@/constants";
+import { getLeadSourceLabel } from "@/constants";
 
 interface MobileLeadCardProps {
   lead: Lead;
@@ -59,10 +59,12 @@ export function MobileLeadCard({
   const owner = lead.assigned_officer?.full_name;
   const major =
     lead.offering?.program?.name || lead.offering?.offering_type || null;
-  // "Trình độ Ngành học" = trình độ học vấn của LEAD (education_level, có nhãn VN)
-  // + ngành đăng ký. Ghép phần có sẵn; rỗng cả hai → "Chưa chọn ngành".
-  const eduLabel = getEducationLevelLabel(lead.education_level);
-  const eduMajor = [eduLabel, major].filter(Boolean).join(" · ") || "Chưa chọn ngành";
+  // "Trình độ Ngành học" = trình độ của NGÀNH (degree_level: "Cao đẳng"/"Trung cấp"
+  // — đã là nhãn VN sẵn) + tên ngành. Lấy từ offering nên lead có chọn ngành là có
+  // (KHÁC education_level của lead — gần như trống). Ghép bằng " " đọc tự nhiên
+  // ("Cao đẳng Công nghệ ô tô"); rỗng cả hai → "Chưa chọn ngành".
+  const degreeLevel = lead.offering?.program?.degree_level || null;
+  const eduMajor = [degreeLevel, major].filter(Boolean).join(" ") || "Chưa chọn ngành";
   // Overdue tính client theo next_activity_at (cache is_overdue có thể trễ ~14h).
   const overdue = isLeadOverdue({ next_activity_at: lead.next_activity_at ?? null });
   const selected = isSelected || isChecked;

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -1,32 +1,26 @@
 // src/components/leads/command-center/MobileLeadCard.tsx
 /**
- * MobileLeadCard - Card-based lead display for mobile devices
+ * MobileLeadCard — thẻ lead cho mobile, thiết kế "Chấm trạng thái" (dot-only).
  *
- * Uses BaseCard System for consistent layout.
- * Provides a touch-friendly interface for viewing and interacting with leads.
+ * 3 tầng: (1) tên + 🔥hot + thời-gian-gần-nhất + menu · (2) 🎓 ngành + SĐT ·
+ * (3) ●trạng-thái · phụ-trách · nguồn. Màu consultation_status dồn vào CHẤM ●
+ * (có ring để chấm nhạt vẫn thấy) — KHÔNG tô chữ (nhiều mã màu sáng như vàng
+ * #FACC15 sẽ không đọc được nếu làm màu chữ). Bỏ vạch spine đầy chiều cao (rối
+ * khi cả cột nhiều màu). Giữ SwipeToCall + LeadActionMenu + chạm mở panel.
  */
 "use client";
 
 import React from "react";
-import { Phone, Zap } from "lucide-react";
-import { sanitizeColorCode } from "@/lib/utils";
-import { Badge } from "@/components/ui/badge";
-import { DynamicColorBadge } from "@/components/ui/dynamic-color-badge";
-import { UrgencyBadge } from "@/components/common/UrgencyBadge";
+import { GraduationCap, User, UserPlus, Flame } from "lucide-react";
+import { formatDistanceToNowStrict } from "date-fns";
+import { vi } from "date-fns/locale";
+import { cn, sanitizeColorCode } from "@/lib/utils";
+import { Checkbox } from "@/components/ui/checkbox";
 import { LeadActionMenu } from "./LeadActionMenu";
-import {
-  BaseCard,
-  CardHeader,
-  CardBody,
-  CardField,
-  CardMeta,
-  CardTime,
-  CardActions,
-} from "@/components/ui/base-card";
 import { SwipeToCall } from "@/components/common/SwipeToCall";
+import { isLeadOverdue } from "@/lib/leads/overdue";
 import type { Lead } from "@/types/lead.types";
 import { LEAD_SOURCE_OPTIONS } from "@/constants";
-import { STAGE_COLORS } from "@/types/pipeline.types";
 
 interface MobileLeadCardProps {
   lead: Lead;
@@ -55,87 +49,141 @@ export function MobileLeadCard({
   onAssign,
   showCheckbox = false,
 }: MobileLeadCardProps) {
-  // Get stage color
-  const stageColor = sanitizeColorCode(lead.pipeline_stage?.color_code) ||
-    STAGE_COLORS[lead.pipeline_stage?.id || ""] ||
-    "#6B7280";
-
-  // Bấm card → mở panel chi tiết. Nút menu (LeadActionMenu) tự stopPropagation
-  // nên không kích hoạt onSelect khi thao tác menu.
+  // Bấm card → mở panel chi tiết. LeadActionMenu/checkbox tự stopPropagation
+  // nên không kích hoạt onSelect khi thao tác chúng.
   const handleCardClick = () => onSelect(lead);
+
+  // Màu trạng thái tư vấn dồn vào CHẤM ● (chữ để foreground cho dễ đọc — nhiều
+  // color_code rất sáng như #FACC15/#FBBF24 sẽ không đọc được nếu làm màu chữ).
+  const statusColor = sanitizeColorCode(lead.consultation_status?.color_code);
+  const statusName = lead.consultation_status?.name ?? "Chưa tư vấn";
+  const owner = lead.assigned_officer?.full_name;
+  const major =
+    lead.offering?.program?.name || lead.offering?.offering_type || null;
+  // Overdue tính client theo next_activity_at (cache is_overdue có thể trễ ~14h).
+  const overdue = isLeadOverdue({ next_activity_at: lead.next_activity_at ?? null });
+  const selected = isSelected || isChecked;
 
   return (
     <SwipeToCall phone={lead.phone} label={lead.full_name}>
-    <BaseCard
-      selected={isSelected || isChecked}
-      onSelect={(checked) => onCheck?.(checked)}
-      showCheckbox={showCheckbox}
-      onClick={handleCardClick}
-      className="touch-manipulation virtual-card active:bg-muted/50"
-    >
-      {/* Header: Name + Urgency Badge */}
-      <CardHeader
-        title={lead.full_name}
-        badge={
-          lead.cached_urgency_score !== undefined && lead.cached_urgency_score > 0 ? (
-            <UrgencyBadge score={lead.cached_urgency_score} compact />
-          ) : undefined
-        }
-      />
-
-      {/* Body: Phone number */}
-      <CardBody>
-        <CardField
-          icon={<Phone className="h-3 w-3" />}
-          label="SĐT"
-          value={lead.phone || "Chưa có"}
-        />
-      </CardBody>
-
-      {/* Meta: Stage + Source + Score + Last activity */}
-      <CardMeta>
-        {/* Stage badge */}
-        {lead.pipeline_stage && (
-          <DynamicColorBadge color={stageColor}>
-            {lead.pipeline_stage.name}
-          </DynamicColorBadge>
+      <div
+        onClick={handleCardClick}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onSelect(lead);
+          }
+        }}
+        className={cn(
+          "virtual-card relative flex gap-2.5 rounded-xl border bg-card p-3 shadow-sm",
+          "cursor-pointer touch-manipulation transition-colors active:bg-muted/50",
+          selected
+            ? "border-primary/50 ring-1 ring-primary/20"
+            : "hover:border-border hover:bg-accent/40"
+        )}
+      >
+        {/* Checkbox bulk-select (hiếm khi bật trên mobile) */}
+        {showCheckbox && (
+          <div className="shrink-0 pt-0.5" onClick={(e) => e.stopPropagation()}>
+            <Checkbox
+              checked={isChecked}
+              onCheckedChange={(c) => onCheck?.(c === true)}
+              aria-label="Chọn lead"
+            />
+          </div>
         )}
 
-        {/* Source */}
-        <Badge variant="outline">
-          {getSourceLabel(lead.source)}
-        </Badge>
+        <div className="min-w-0 flex-1 space-y-1.5">
+          {/* Tầng 1: tên · 🔥hot · thời gian gần nhất · menu */}
+          <div className="flex items-center gap-2">
+            <span className="min-w-0 flex-1 truncate text-[15px] font-semibold leading-tight">
+              {lead.full_name}
+            </span>
+            {lead.is_hot_lead && (
+              <span className="inline-flex shrink-0 items-center gap-0.5 rounded-md bg-orange-100 px-1.5 py-px text-[10px] font-bold uppercase tracking-wide text-orange-600 dark:bg-orange-950/50 dark:text-orange-400">
+                <Flame className="h-3 w-3" />
+                Hot
+              </span>
+            )}
+            {overdue ? (
+              <span
+                className="shrink-0 font-mono text-[11px] font-semibold tabular-nums text-error-600 dark:text-error-500"
+                suppressHydrationWarning
+              >
+                Quá hạn
+              </span>
+            ) : lead.last_consultation_at ? (
+              <span
+                className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground"
+                suppressHydrationWarning
+              >
+                {formatDistanceToNowStrict(new Date(lead.last_consultation_at), {
+                  addSuffix: true,
+                  locale: vi,
+                })}
+              </span>
+            ) : (
+              <span className="shrink-0 text-[11px] text-muted-foreground/60">
+                Chưa liên hệ
+              </span>
+            )}
+            <LeadActionMenu
+              lead={lead}
+              onEdit={onEdit}
+              onDelete={onDelete}
+              onAssign={onAssign}
+              sheetTitle={lead.full_name}
+              triggerClassName="h-11 w-11 sm:h-11 sm:w-11 -my-2 -mr-2"
+              stopPropagation
+            />
+          </div>
 
-        {/* Lead score (if high) */}
-        {lead.lead_score > 70 && (
-          <Badge
-            variant="secondary"
-            className="bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
-          >
-            <Zap className="h-2.5 w-2.5 mr-0.5" />
-            {lead.lead_score}
-          </Badge>
-        )}
+          {/* Tầng 2: 🎓 ngành + SĐT */}
+          <div className="flex items-center gap-2">
+            <span className="inline-flex min-w-0 flex-1 items-center gap-1.5 text-[13.5px] text-foreground">
+              <GraduationCap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="truncate">{major ?? "Chưa chọn ngành"}</span>
+            </span>
+            {lead.phone && (
+              <span className="shrink-0 font-mono text-[11.5px] tracking-tight text-muted-foreground">
+                {lead.phone}
+              </span>
+            )}
+          </div>
 
-        {/* Last activity */}
-        {lead.last_consultation_at && (
-          <CardTime date={lead.last_consultation_at} format="date" className="ml-auto" />
-        )}
-      </CardMeta>
-
-      {/* Menu thao tác — dùng chung LeadActionMenu (khớp panel + hàng bảng) */}
-      <CardActions>
-        <LeadActionMenu
-          lead={lead}
-          onEdit={onEdit}
-          onDelete={onDelete}
-          onAssign={onAssign}
-          sheetTitle={lead.full_name}
-          triggerClassName="h-11 w-11 sm:h-11 sm:w-11"
-          stopPropagation
-        />
-      </CardActions>
-    </BaseCard>
+          {/* Tầng 3: ● trạng thái · phụ trách · nguồn */}
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11.5px] text-muted-foreground">
+            <span className="inline-flex shrink-0 items-center gap-1.5">
+              <span
+                className={cn(
+                  "h-2.5 w-2.5 shrink-0 rounded-full ring-1 ring-inset ring-black/10 dark:ring-white/15",
+                  !statusColor && "bg-muted-foreground/40"
+                )}
+                style={statusColor ? { backgroundColor: statusColor } : undefined}
+              />
+              <span className="font-medium text-foreground/90">{statusName}</span>
+            </span>
+            <span className="text-muted-foreground/40">·</span>
+            {owner ? (
+              <span className="inline-flex min-w-0 items-center gap-1">
+                <User className="h-3 w-3 shrink-0 opacity-70" />
+                <span className="truncate">{owner}</span>
+              </span>
+            ) : (
+              <span className="inline-flex shrink-0 items-center gap-1 font-semibold text-amber-600 dark:text-amber-500">
+                <UserPlus className="h-3 w-3" />
+                Chưa phân công
+              </span>
+            )}
+            <span className="text-muted-foreground/40">·</span>
+            <span className="shrink-0 text-muted-foreground/80">
+              {getSourceLabel(lead.source)}
+            </span>
+          </div>
+        </div>
+      </div>
     </SwipeToCall>
   );
 }

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -8,13 +8,12 @@
 "use client";
 
 import React from "react";
-import { Phone, MoreVertical, Zap, Edit, Trash2, UserPlus, ArrowRightLeft } from "lucide-react";
+import { Phone, Zap } from "lucide-react";
 import { sanitizeColorCode } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { DynamicColorBadge } from "@/components/ui/dynamic-color-badge";
 import { UrgencyBadge } from "@/components/common/UrgencyBadge";
-import { MobileActionSheet } from "@/components/common/MobileActionSheet";
+import { LeadActionMenu } from "./LeadActionMenu";
 import {
   BaseCard,
   CardHeader,
@@ -37,8 +36,8 @@ interface MobileLeadCardProps {
   onCheck?: (checked: boolean) => void;
   onEdit: (lead: Lead) => void;
   onDelete: (lead: Lead) => void;
-  onAssign?: (lead: Lead) => void;
-  onChangeStage?: (lead: Lead) => void;
+  /** "Gán cho cán bộ" khi lead chưa phân công (mở dialog gán ở parent). */
+  onAssign: (lead: Lead) => void;
   showCheckbox?: boolean;
 }
 
@@ -54,22 +53,16 @@ export function MobileLeadCard({
   onEdit,
   onDelete,
   onAssign,
-  onChangeStage,
   showCheckbox = false,
 }: MobileLeadCardProps) {
-  const [actionSheetOpen, setActionSheetOpen] = React.useState(false);
-
   // Get stage color
   const stageColor = sanitizeColorCode(lead.pipeline_stage?.color_code) ||
     STAGE_COLORS[lead.pipeline_stage?.id || ""] ||
     "#6B7280";
 
-  // Handle card click - only trigger if action sheet is closed
-  const handleCardClick = () => {
-    if (!actionSheetOpen) {
-      onSelect(lead);
-    }
-  };
+  // Bấm card → mở panel chi tiết. Nút menu (LeadActionMenu) tự stopPropagation
+  // nên không kích hoạt onSelect khi thao tác menu.
+  const handleCardClick = () => onSelect(lead);
 
   return (
     <SwipeToCall phone={lead.phone} label={lead.full_name}>
@@ -130,67 +123,18 @@ export function MobileLeadCard({
         )}
       </CardMeta>
 
-      {/* Actions */}
+      {/* Menu thao tác — dùng chung LeadActionMenu (khớp panel + hàng bảng) */}
       <CardActions>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-11 w-11"
-          onClick={() => setActionSheetOpen(true)}
-          aria-label="Mở menu hành động"
-        >
-          <MoreVertical className="h-4 w-4" />
-        </Button>
+        <LeadActionMenu
+          lead={lead}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          onAssign={onAssign}
+          sheetTitle={lead.full_name}
+          triggerClassName="h-11 w-11 sm:h-11 sm:w-11"
+          stopPropagation
+        />
       </CardActions>
-
-      {/* Action Sheet */}
-      <MobileActionSheet
-        open={actionSheetOpen}
-        onOpenChange={setActionSheetOpen}
-        title={lead.full_name}
-      >
-        <MobileActionSheet.Item
-          icon={Edit}
-          onClick={() => {
-            setActionSheetOpen(false);
-            onEdit(lead);
-          }}
-        >
-          Chỉnh sửa
-        </MobileActionSheet.Item>
-        {onAssign && (
-          <MobileActionSheet.Item
-            icon={UserPlus}
-            onClick={() => {
-              setActionSheetOpen(false);
-              onAssign(lead);
-            }}
-          >
-            Gán cán bộ
-          </MobileActionSheet.Item>
-        )}
-        {onChangeStage && (
-          <MobileActionSheet.Item
-            icon={ArrowRightLeft}
-            onClick={() => {
-              setActionSheetOpen(false);
-              onChangeStage(lead);
-            }}
-          >
-            Đổi giai đoạn
-          </MobileActionSheet.Item>
-        )}
-        <MobileActionSheet.Item
-          icon={Trash2}
-          variant="destructive"
-          onClick={() => {
-            setActionSheetOpen(false);
-            onDelete(lead);
-          }}
-        >
-          Xóa lead
-        </MobileActionSheet.Item>
-      </MobileActionSheet>
     </BaseCard>
     </SwipeToCall>
   );
@@ -206,8 +150,7 @@ interface MobileLeadListProps {
   onSelectLead: (lead: Lead) => void;
   onEditLead: (lead: Lead) => void;
   onDeleteLead: (lead: Lead) => void;
-  onAssignLead?: (lead: Lead) => void;
-  onChangeStage?: (lead: Lead) => void;
+  onAssignLead: (lead: Lead) => void;
   // Bulk selection
   selectedLeads?: Lead[];
   onSelectionChange?: (leads: Lead[]) => void;
@@ -221,7 +164,6 @@ export function MobileLeadList({
   onEditLead,
   onDeleteLead,
   onAssignLead,
-  onChangeStage,
   selectedLeads = [],
   onSelectionChange,
   showBulkSelect = false,
@@ -255,7 +197,6 @@ export function MobileLeadList({
           onEdit={onEditLead}
           onDelete={onDeleteLead}
           onAssign={onAssignLead}
-          onChangeStage={onChangeStage}
           showCheckbox={showBulkSelect}
         />
       ))}

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -1,17 +1,18 @@
 // src/components/leads/command-center/MobileLeadCard.tsx
 /**
- * MobileLeadCard — thẻ lead cho mobile, thiết kế "Chấm trạng thái" (dot-only).
- *
- * 3 tầng: (1) tên + 🔥hot + thời-gian-gần-nhất + menu · (2) 🎓 ngành + SĐT ·
- * (3) ●trạng-thái · phụ-trách · nguồn. Màu consultation_status dồn vào CHẤM ●
- * (có ring để chấm nhạt vẫn thấy) — KHÔNG tô chữ (nhiều mã màu sáng như vàng
- * #FACC15 sẽ không đọc được nếu làm màu chữ). Bỏ vạch spine đầy chiều cao (rối
- * khi cả cột nhiều màu). Giữ SwipeToCall + LeadActionMenu + chạm mở panel.
+ * MobileLeadCard — thẻ lead mobile, 3 tầng gọn:
+ *   1. Tên lead (đầy chiều rộng → đỡ bị cắt) + menu ⋮
+ *   2. 🎓 Trình độ · Ngành học · Thời gian · Nguồn
+ *   3. ● Trạng thái · Người tư vấn
+ * Tầng 2 & 3 CÙNG cỡ chữ (text-xs). Màu consultation_status dồn vào CHẤM ●
+ * (chữ để foreground vì nhiều color_code sáng như #FACC15 khó đọc). Giữ
+ * SwipeToCall + LeadActionMenu + chạm mở panel. (SĐT bỏ khỏi mặt card — vẫn gọi
+ * được qua vuốt-để-gọi / menu / chi tiết.)
  */
 "use client";
 
 import React from "react";
-import { GraduationCap, User, UserPlus, Flame } from "lucide-react";
+import { GraduationCap, User, UserPlus } from "lucide-react";
 import { formatDistanceToNowStrict } from "date-fns";
 import { vi } from "date-fns/locale";
 import { cn, sanitizeColorCode } from "@/lib/utils";
@@ -20,7 +21,7 @@ import { LeadActionMenu } from "./LeadActionMenu";
 import { SwipeToCall } from "@/components/common/SwipeToCall";
 import { isLeadOverdue } from "@/lib/leads/overdue";
 import type { Lead } from "@/types/lead.types";
-import { getLeadSourceLabel } from "@/constants";
+import { getLeadSourceLabel, getEducationLevelLabel } from "@/constants";
 
 interface MobileLeadCardProps {
   lead: Lead;
@@ -58,6 +59,10 @@ export function MobileLeadCard({
   const owner = lead.assigned_officer?.full_name;
   const major =
     lead.offering?.program?.name || lead.offering?.offering_type || null;
+  // "Trình độ Ngành học" = trình độ học vấn của LEAD (education_level, có nhãn VN)
+  // + ngành đăng ký. Ghép phần có sẵn; rỗng cả hai → "Chưa chọn ngành".
+  const eduLabel = getEducationLevelLabel(lead.education_level);
+  const eduMajor = [eduLabel, major].filter(Boolean).join(" · ") || "Chưa chọn ngành";
   // Overdue tính client theo next_activity_at (cache is_overdue có thể trễ ~14h).
   const overdue = isLeadOverdue({ next_activity_at: lead.next_activity_at ?? null });
   const selected = isSelected || isChecked;
@@ -98,39 +103,11 @@ export function MobileLeadCard({
         )}
 
         <div className="min-w-0 flex-1 space-y-1.5">
-          {/* Tầng 1: tên · 🔥hot · thời gian gần nhất · menu */}
+          {/* Tầng 1: tên lead (đầy chiều rộng) + menu */}
           <div className="flex items-center gap-2">
             <span className="min-w-0 flex-1 truncate text-[15px] font-semibold leading-tight">
               {lead.full_name}
             </span>
-            {lead.is_hot_lead && (
-              <span className="inline-flex shrink-0 items-center gap-0.5 rounded-md bg-orange-100 px-1.5 py-px text-[10px] font-bold uppercase tracking-wide text-orange-600 dark:bg-orange-950/50 dark:text-orange-400">
-                <Flame className="h-3 w-3" />
-                Hot
-              </span>
-            )}
-            {overdue ? (
-              <span
-                className="shrink-0 font-mono text-[11px] font-semibold tabular-nums text-error-600 dark:text-error-500"
-                suppressHydrationWarning
-              >
-                Quá hạn
-              </span>
-            ) : lead.last_consultation_at ? (
-              <span
-                className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground"
-                suppressHydrationWarning
-              >
-                {formatDistanceToNowStrict(new Date(lead.last_consultation_at), {
-                  addSuffix: true,
-                  locale: vi,
-                })}
-              </span>
-            ) : (
-              <span className="shrink-0 text-[11px] text-muted-foreground/60">
-                Chưa liên hệ
-              </span>
-            )}
             <LeadActionMenu
               lead={lead}
               onEdit={onEdit}
@@ -143,22 +120,39 @@ export function MobileLeadCard({
             />
           </div>
 
-          {/* Tầng 2: 🎓 ngành + SĐT */}
-          <div className="flex items-center gap-2">
-            <span className="inline-flex min-w-0 flex-1 items-center gap-1.5 text-[13.5px] text-foreground">
-              <GraduationCap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <span className="truncate">{major ?? "Chưa chọn ngành"}</span>
+          {/* Tầng 2: 🎓 Trình độ · Ngành học · Thời gian · Nguồn */}
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+              <GraduationCap className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" />
+              <span className="truncate text-foreground/90">{eduMajor}</span>
             </span>
-            {lead.phone && (
-              <span className="shrink-0 font-mono text-[11.5px] tracking-tight text-muted-foreground">
-                {lead.phone}
+            <span className="text-muted-foreground/40">·</span>
+            {overdue ? (
+              <span
+                className="shrink-0 font-medium text-error-600 dark:text-error-500"
+                suppressHydrationWarning
+              >
+                Quá hạn
               </span>
+            ) : lead.last_consultation_at ? (
+              <span className="shrink-0 tabular-nums" suppressHydrationWarning>
+                {formatDistanceToNowStrict(new Date(lead.last_consultation_at), {
+                  addSuffix: true,
+                  locale: vi,
+                })}
+              </span>
+            ) : (
+              <span className="shrink-0 text-muted-foreground/60">Chưa liên hệ</span>
             )}
+            <span className="text-muted-foreground/40">·</span>
+            <span className="shrink-0 text-muted-foreground/80">
+              {getLeadSourceLabel(lead.source)}
+            </span>
           </div>
 
-          {/* Tầng 3: ● trạng thái · phụ trách · nguồn */}
-          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11.5px] text-muted-foreground">
-            <span className="inline-flex shrink-0 items-center gap-1.5">
+          {/* Tầng 3: ● Trạng thái · Người tư vấn (cùng cỡ chữ tầng 2) */}
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="inline-flex min-w-0 items-center gap-1.5">
               <span
                 className={cn(
                   "h-2.5 w-2.5 shrink-0 rounded-full ring-1 ring-inset ring-black/10 dark:ring-white/15",
@@ -166,24 +160,20 @@ export function MobileLeadCard({
                 )}
                 style={statusColor ? { backgroundColor: statusColor } : undefined}
               />
-              <span className="font-medium text-foreground/90">{statusName}</span>
+              <span className="truncate font-medium text-foreground/90">{statusName}</span>
             </span>
-            <span className="text-muted-foreground/40">·</span>
+            <span className="shrink-0 text-muted-foreground/40">·</span>
             {owner ? (
-              <span className="inline-flex min-w-0 items-center gap-1">
+              <span className="inline-flex min-w-0 flex-1 items-center gap-1">
                 <User className="h-3 w-3 shrink-0 opacity-70" />
                 <span className="truncate">{owner}</span>
               </span>
             ) : (
-              <span className="inline-flex shrink-0 items-center gap-1 font-semibold text-amber-600 dark:text-amber-500">
+              <span className="inline-flex shrink-0 items-center gap-1 font-medium text-amber-600 dark:text-amber-500">
                 <UserPlus className="h-3 w-3" />
                 Chưa phân công
               </span>
             )}
-            <span className="text-muted-foreground/40">·</span>
-            <span className="shrink-0 text-muted-foreground/80">
-              {getLeadSourceLabel(lead.source)}
-            </span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -24,6 +24,7 @@ import {
   CardTime,
   CardActions,
 } from "@/components/ui/base-card";
+import { SwipeToCall } from "@/components/common/SwipeToCall";
 import type { Lead } from "@/types/lead.types";
 import { LEAD_SOURCE_OPTIONS } from "@/constants";
 import { STAGE_COLORS } from "@/types/pipeline.types";
@@ -71,6 +72,7 @@ export function MobileLeadCard({
   };
 
   return (
+    <SwipeToCall phone={lead.phone} label={lead.full_name}>
     <BaseCard
       selected={isSelected || isChecked}
       onSelect={(checked) => onCheck?.(checked)}
@@ -190,6 +192,7 @@ export function MobileLeadCard({
         </MobileActionSheet.Item>
       </MobileActionSheet>
     </BaseCard>
+    </SwipeToCall>
   );
 }
 

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -23,6 +23,14 @@ import { isLeadOverdue } from "@/lib/leads/overdue";
 import type { Lead } from "@/types/lead.types";
 import { getLeadSourceLabel } from "@/constants";
 
+// Viết tắt trình độ ngành cho gọn mặt card (fallback nhãn đầy nếu gặp giá trị lạ).
+const DEGREE_ABBR: Record<string, string> = {
+  "Đại học": "ĐH",
+  "Cao đẳng": "CĐ",
+  "Trung cấp": "TC",
+  "Sơ cấp": "SC",
+};
+
 interface MobileLeadCardProps {
   lead: Lead;
   isSelected?: boolean;
@@ -64,7 +72,8 @@ export function MobileLeadCard({
   // (KHÁC education_level của lead — gần như trống). Ghép bằng " " đọc tự nhiên
   // ("Cao đẳng Công nghệ ô tô"); rỗng cả hai → "Chưa chọn ngành".
   const degreeLevel = lead.offering?.program?.degree_level || null;
-  const eduMajor = [degreeLevel, major].filter(Boolean).join(" ") || "Chưa chọn ngành";
+  const degreeShort = degreeLevel ? DEGREE_ABBR[degreeLevel] ?? degreeLevel : null;
+  const eduMajor = [degreeShort, major].filter(Boolean).join(" ") || "Chưa chọn ngành";
   // Overdue tính client theo next_activity_at (cache is_overdue có thể trễ ~14h).
   const overdue = isLeadOverdue({ next_activity_at: lead.next_activity_at ?? null });
   const selected = isSelected || isChecked;

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -20,7 +20,7 @@ import { LeadActionMenu } from "./LeadActionMenu";
 import { SwipeToCall } from "@/components/common/SwipeToCall";
 import { isLeadOverdue } from "@/lib/leads/overdue";
 import type { Lead } from "@/types/lead.types";
-import { LEAD_SOURCE_OPTIONS } from "@/constants";
+import { getLeadSourceLabel } from "@/constants";
 
 interface MobileLeadCardProps {
   lead: Lead;
@@ -34,9 +34,6 @@ interface MobileLeadCardProps {
   onAssign: (lead: Lead) => void;
   showCheckbox?: boolean;
 }
-
-const getSourceLabel = (value: string) =>
-  LEAD_SOURCE_OPTIONS.find((o) => o.value === value)?.label || value;
 
 export function MobileLeadCard({
   lead,
@@ -55,7 +52,8 @@ export function MobileLeadCard({
 
   // Màu trạng thái tư vấn dồn vào CHẤM ● (chữ để foreground cho dễ đọc — nhiều
   // color_code rất sáng như #FACC15/#FBBF24 sẽ không đọc được nếu làm màu chữ).
-  const statusColor = sanitizeColorCode(lead.consultation_status?.color_code);
+  // fallback "" (KHÔNG mặc định #6B7280) để nhánh dot trung tính theo-theme sống.
+  const statusColor = sanitizeColorCode(lead.consultation_status?.color_code, "");
   const statusName = lead.consultation_status?.name ?? "Chưa tư vấn";
   const owner = lead.assigned_officer?.full_name;
   const major =
@@ -71,6 +69,10 @@ export function MobileLeadCard({
         role="button"
         tabIndex={0}
         onKeyDown={(e) => {
+          // Chỉ act khi CHÍNH card được focus — không nuốt Enter/Space của nút
+          // menu ⋮ / checkbox con (chúng bubble lên đây; guard target tránh
+          // preventDefault chặn kích hoạt của chúng).
+          if (e.target !== e.currentTarget) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             onSelect(lead);
@@ -134,6 +136,7 @@ export function MobileLeadCard({
               onEdit={onEdit}
               onDelete={onDelete}
               onAssign={onAssign}
+              variant="sheet"
               sheetTitle={lead.full_name}
               triggerClassName="h-11 w-11 sm:h-11 sm:w-11 -my-2 -mr-2"
               stopPropagation
@@ -179,7 +182,7 @@ export function MobileLeadCard({
             )}
             <span className="text-muted-foreground/40">·</span>
             <span className="shrink-0 text-muted-foreground/80">
-              {getSourceLabel(lead.source)}
+              {getLeadSourceLabel(lead.source)}
             </span>
           </div>
         </div>

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -36,7 +36,11 @@ interface MobileLeadCardProps {
   showCheckbox?: boolean;
 }
 
-export function MobileLeadCard({
+// React.memo: list mobile không virtualize nên mỗi lần chọn lead (setSelectedLeadId
+// ở LeadsClient) re-render CẢ danh sách. leads array ref ổn định (React Query
+// structural sharing) → memo bỏ qua card không đổi, tránh chạy lại format ngày /
+// isLeadOverdue / subtree framer-motion cho từng card.
+export const MobileLeadCard = React.memo(function MobileLeadCard({
   lead,
   isSelected,
   isChecked,
@@ -110,7 +114,11 @@ export function MobileLeadCard({
       >
         {/* Checkbox bulk-select (hiếm khi bật trên mobile) */}
         {showCheckbox && (
-          <div className="shrink-0 pt-0.5" onClick={(e) => e.stopPropagation()}>
+          <div
+            className="shrink-0 pt-0.5"
+            data-swipe-ignore
+            onClick={(e) => e.stopPropagation()}
+          >
             <Checkbox
               checked={isChecked}
               onCheckedChange={(c) => onCheck?.(c === true)}
@@ -182,7 +190,7 @@ export function MobileLeadCard({
       </div>
     </SwipeToCall>
   );
-}
+});
 
 // =============================================================================
 // MOBILE LEAD LIST - Container for card list with bulk selection

--- a/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
+++ b/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
@@ -37,6 +37,7 @@ const bulkBar = read("./command-center/BulkActionsBar.tsx");
 const filterBar = read("./command-center/LeadFilterBar.tsx");
 const filterPanel = read("./command-center/LeadFilterPanel.tsx");
 const mobileCard = read("./command-center/MobileLeadCard.tsx");
+const actionMenu = read("./command-center/LeadActionMenu.tsx");
 const detailClient = read("../../app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx");
 const infoTabs = read("../../app/(dashboard)/leads/[id]/_components/LeadInfoTabs.tsx");
 const sidebar = read("../../app/(dashboard)/leads/[id]/_components/LeadSidebar.tsx");
@@ -135,10 +136,13 @@ describe("Round 2 #8 — command-center touch targets + bulk-bar overflow", () =
     expect(filterBar).not.toMatch(/FilterDropdown/);
   });
 
-  it("MobileLeadCard action button 44px + labelled", () => {
-    expect(mobileCard).toMatch(/h-11 w-11/);
-    expect(mobileCard).toMatch(/aria-label="Mở menu hành động"/);
+  it("MobileLeadCard action menu 44px + labelled (shared LeadActionMenu)", () => {
+    // Nút menu dùng chung LeadActionMenu; card truyền triggerClassName 44px.
+    expect(mobileCard).toMatch(/triggerClassName="h-11 w-11/);
     expect(mobileCard).not.toMatch(/className="h-10 w-10"/);
+    // LeadActionMenu: nút trigger có aria-label + mặc định 44px touch trên mobile.
+    expect(actionMenu).toMatch(/aria-label=\{triggerLabel\}/);
+    expect(actionMenu).toMatch(/h-11 w-11/);
   });
 });
 

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -64,12 +64,15 @@ const SheetContent = React.forwardRef<
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
-      {/* 44px touch target (Apple HIG) — the icon stays 16px but the hit
-          area is padded out so it's tappable on mobile. inline-flex
-          centers the icon; -m-2 keeps the visual position aligned with
-          the original right-4/top-4 inset. */}
-      <SheetPrimitive.Close className="absolute right-4 top-4 -m-2 inline-flex h-11 w-11 items-center justify-center rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" aria-hidden="true" />
+      {/* 44px touch target (Apple HIG) — hit area is padded out so it's
+          tappable on mobile; -m-2 keeps alignment with the right-4/top-4 inset.
+          The X sits on a translucent, blurred pill (bg-background/70 +
+          backdrop-blur) with a hairline border + shadow so it stays clearly
+          readable over ANY content scrolled behind the sheet edge. */}
+      <SheetPrimitive.Close className="group absolute right-4 top-4 -m-2 inline-flex h-11 w-11 items-center justify-center rounded-full ring-offset-background transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none">
+        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-border/60 bg-background/70 text-foreground/80 shadow-sm backdrop-blur-md transition-colors group-hover:bg-background group-hover:text-foreground">
+          <X className="h-4 w-4" aria-hidden="true" />
+        </span>
         <span className="sr-only">Đóng</span>
       </SheetPrimitive.Close>
       {children}

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -24,6 +24,7 @@ export {
   getLeadScoreLabel,
   getLeadScoreLabelShort,
   getEducationLevelLabel,
+  DEGREE_LEVEL_ABBR,
   getDegreeLevelAbbr,
   isComplexStatus,
   isSchedulableStatus,

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -24,6 +24,7 @@ export {
   getLeadScoreLabel,
   getLeadScoreLabelShort,
   getEducationLevelLabel,
+  getDegreeLevelAbbr,
   isComplexStatus,
   isSchedulableStatus,
 } from "./lead.constants";

--- a/frontend/src/constants/lead.constants.ts
+++ b/frontend/src/constants/lead.constants.ts
@@ -231,6 +231,20 @@ export const getEducationLevelLabel = (level: EducationLevel | string | null | u
   return EDUCATION_LEVEL_LABELS[level] || level;
 };
 
+// Viết tắt TRÌNH ĐỘ CỦA NGÀNH (program.degree_level đã lưu nhãn VN đầy đủ:
+// "Cao đẳng"/"Trung cấp"...). Dùng chung cho card lead + bảng lead để đồng bộ.
+// Gặp giá trị lạ → trả nguyên nhãn (không mất thông tin).
+export const DEGREE_LEVEL_ABBR: Record<string, string> = {
+  "Đại học": "ĐH",
+  "Cao đẳng": "CĐ",
+  "Trung cấp": "TC",
+  "Sơ cấp": "SC",
+};
+
+export const getDegreeLevelAbbr = (
+  degree: string | null | undefined
+): string | null => (degree ? DEGREE_LEVEL_ABBR[degree] ?? degree : null);
+
 // =============================================================================
 // LEAD VALIDITY OPTIONS (CTV System)
 // =============================================================================

--- a/frontend/src/hooks/useCopyToClipboard.ts
+++ b/frontend/src/hooks/useCopyToClipboard.ts
@@ -2,6 +2,7 @@
 "use client"
 
 import { useCallback, useEffect, useRef, useState } from "react"
+import { copyToClipboard } from "@/lib/clipboard"
 
 /**
  * Copy-to-clipboard với trạng thái `copied` tự tắt sau `resetMs` — gom pattern
@@ -22,15 +23,14 @@ export function useCopyToClipboard(resetMs = 2000) {
 
   const copy = useCallback(
     async (text: string): Promise<boolean> => {
-      try {
-        await navigator.clipboard.writeText(text)
+      // copyToClipboard tự fallback execCommand khi HTTP/insecure (không throw).
+      const ok = await copyToClipboard(text)
+      if (ok) {
         setCopied(true)
         if (timer.current) clearTimeout(timer.current)
         timer.current = setTimeout(() => setCopied(false), resetMs)
-        return true
-      } catch {
-        return false
       }
+      return ok
     },
     [resetMs],
   )

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -5,34 +5,36 @@
  * Usage:
  * const isMobile = useMediaQuery("(max-width: 768px)");
  * const isDesktop = useMediaQuery("(min-width: 1024px)");
+ *
+ * SSR-safe + KHÔNG flash: giá trị khởi tạo = false (khớp SSR → không hydration
+ * mismatch), rồi được set về giá trị THẬT trong useLayoutEffect — chạy đồng bộ
+ * SAU hydrate nhưng TRƯỚC khi trình duyệt paint. Nhờ vậy màn desktop paint thẳng
+ * layout desktop, KHÔNG nháy mobile→desktop như khi dùng useSyncExternalStore
+ * (re-sync của nó xảy ra sau paint → nháy). Mobile giữ nguyên (false → false).
  */
 
-import { useSyncExternalStore, useCallback } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
+
+// useLayoutEffect chỉ chạy ở client; trên server React cảnh báo "does nothing on
+// the server" → fallback useEffect ở server để im lặng (effect không chạy SSR).
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 export function useMediaQuery(query: string): boolean {
-  // Subscribe function for useSyncExternalStore
-  const subscribe = useCallback(
-    (callback: () => void) => {
-      const mediaQuery = window.matchMedia(query);
-      mediaQuery.addEventListener("change", callback);
-      return () => {
-        mediaQuery.removeEventListener("change", callback);
-      };
-    },
-    [query]
-  );
+  // false ở SSR + lần render client đầu (hydrate) → khớp, không mismatch.
+  const [matches, setMatches] = useState(false);
 
-  // Get current snapshot
-  const getSnapshot = useCallback(() => {
-    return window.matchMedia(query).matches;
+  useIsomorphicLayoutEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    // Set giá trị THẬT trước paint đầu tiên → không flash.
+    setMatches(mediaQuery.matches);
+
+    const onChange = () => setMatches(mediaQuery.matches);
+    mediaQuery.addEventListener("change", onChange);
+    return () => mediaQuery.removeEventListener("change", onChange);
   }, [query]);
 
-  // Server snapshot (SSR safe - default to false)
-  const getServerSnapshot = useCallback(() => {
-    return false;
-  }, []);
-
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  return matches;
 }
 
 // Convenience hooks for common breakpoints (Tailwind defaults)

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,66 @@
+// src/lib/clipboard.ts
+/**
+ * Sao chép text vào clipboard — CÓ FALLBACK cho insecure context.
+ *
+ * `navigator.clipboard` chỉ tồn tại trên SECURE CONTEXT (HTTPS hoặc localhost).
+ * Khi truy cập qua IP LAN HTTP (vd http://192.168.88.125:3000 — dùng test trên
+ * điện thoại) thì `navigator.clipboard` là `undefined` → mọi nút copy (SĐT, magic
+ * link, mã…) hỏng. Hàm này thử Clipboard API trước, thất bại thì fallback về
+ * `document.execCommand('copy')` (chạy được trên HTTP). Trả `true/false` thành/bại
+ * để caller báo toast.
+ *
+ * Lưu ý: prod chạy HTTPS nên dùng đường Clipboard API chuẩn; fallback chủ yếu cứu
+ * luồng test LAN + phone.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  // Đường chuẩn (secure context).
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Một số trình duyệt vẫn chặn quyền dù secure → rơi xuống fallback.
+    }
+  }
+
+  // Fallback execCommand cho insecure/HTTP.
+  if (typeof document === "undefined") return false;
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  // Ẩn khỏi tầm nhìn nhưng vẫn selectable (position:fixed tránh cuộn nhảy).
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.width = "1px";
+  textarea.style.height = "1px";
+  textarea.style.padding = "0";
+  textarea.style.border = "none";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+  document.body.appendChild(textarea);
+
+  const selection = document.getSelection();
+  const savedRange =
+    selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+
+  let ok = false;
+  try {
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, text.length); // iOS cần range tường minh
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  } finally {
+    document.body.removeChild(textarea);
+    // Khôi phục vùng chọn của người dùng nếu có.
+    if (savedRange && selection) {
+      selection.removeAllRanges();
+      selection.addRange(savedRange);
+    }
+  }
+
+  return ok;
+}

--- a/frontend/src/types/lead.types.ts
+++ b/frontend/src/types/lead.types.ts
@@ -143,6 +143,12 @@ export interface Lead {
   validity_status: string | null;
   created_via: string | null;
   referrer: CollaboratorShallow | null;
+
+  // Thin-client action flags. Populated on the paginated list (LeadListItem:
+  // can_transfer_lead / can_request_reassign) and fully on LeadDetail
+  // (create_admission, can_reopen, ...). Absent on create/update responses →
+  // optional. Gate visibility via lead.permissions?.<flag>, NOT user.role.
+  permissions?: Record<string, boolean>;
 }
 
 /**


### PR DESCRIPTION
## Tổng quan
Đại tu UI quản lý lead (card / menu / panel) desktop + mobile, thêm cờ phân quyền BE (thin-client), và loạt fix mobile UX. **Đã rebase lên `main` (#475), up-to-date, 0 conflict.** Branch = 21 commit.

## Thay đổi chính
- **Lịch sử tư vấn (`LeadTimelineTab`):** signature "Đường mạch kết quả" — spine dọc tô màu theo `outcome_type`, mỗi lần TV = 1 node (bỏ card-lồng-card), lịch hẹn tương lai tách chip Dời/Hủy. Fix bug dark-mode `border-white` → `ring-background`.
- **Card lead (`MobileLeadCard`) dot-only 3 tầng:** tên+menu · trình độ-ngành·thời gian·nguồn · ●trạng thái·người tư vấn. Màu `consultation_status` vào CHẤM (chữ giữ foreground — nhiều color_code quá sáng đọc không ra).
- **Đồng bộ menu (`LeadActionMenu`):** 1 component dùng chung card / hàng-bảng / panel (mobile→ActionSheet, desktop→Dropdown) → parity Chỉnh sửa·Chuyển giao·Xóa. BE query-free permission flags chảy vào list.
- **DateTimePicker mobile → bottom sheet:** Popover neo-trigger giới hạn chiều cao (đo live: content 662px > chỗ trống 457px → khối giờ tụt dưới mép cuộn); đổi `Sheet side="bottom"` chứa đủ lịch+giờ, không cuộn ẩn. Desktop giữ Popover. + nút chỉnh-lại-giờ sau khi chọn.
- **Thẻ "Cửa vào hồ sơ":** lead có hồ sơ TS → thẻ 1-chạm sang `/admissions/{id}`.
- **Fix khác:** copy SĐT HTTP-LAN (`execCommand` fallback), hydration (`toLocaleString` vi-VN), flash SSR mobile→desktop (`useMediaQuery`→`useLayoutEffect`), cột Ngành bảng, **SwipeToCall bấm-giữ ⋮/checkbox không nuốt tap** (`data-swipe-ignore`), BƯỚC 2 header mobile xuống dòng, các fix `/code-review max`.

## Backend
Thêm cờ phân quyền vào `LeadDetail`/`LeadListItem.permissions` (`can_transfer_lead`, `can_request_reassign`, `can_assign_lead`) — query-free. **KHÔNG migration.**
⚠️ **Deploy BE + FE CÙNG NHAU** (FE đọc cờ thay cho role-check).

## Kiểm thử
- FE type-check **0** · lint **0 error** (167 warn baseline) · vitest **1844/1844**
- BE unit `test_lead_action_permissions` **6/6**
- **Live smoke mobile 390px** (chrome-devtools emulate): card · menu ActionSheet · datetime bottom-sheet + chỉnh lại giờ · **gesture ⋮ bấm-giữ không nuốt tap** — ALL GREEN
- Desktop smoke: menu parity · Popover · cột Ngành OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)