### PR TITLE
feat(leads): Nhịp hẹn / Trợ lý nhắc hẹn (#3) — nhắc lịch gọi lại + phân quyền

### DIFF
--- a/Backend_FastAPI/alembic/versions/apptacctdeny20260713_accountant_appointments_deny.py
+++ b/Backend_FastAPI/alembic/versions/apptacctdeny20260713_accountant_appointments_deny.py
@@ -1,0 +1,60 @@
+"""deny accountant GET /api/leads/my/appointments (separation-of-duties)
+
+Feature "Nhịp hẹn" added `GET /api/leads/my/appointments` granted to
+role:officer (migration apptcasbin20260713). Because role:accountant inherits
+role:officer (g, role:accountant, role:officer), that single officer allow-row
+ALSO reaches accountant → finance staff could read lead name/phone + assigned
+officer name from the appointments feed. This breaks the separation-of-duties
+contract enforced for every other lead endpoint (see ACCOUNTANT_TEMPLATE deny
+block: /api/leads, /api/leads/{id}, export, bulk-*, ...).
+
+Fix: insert an explicit accountant DENY row. Casbin's effect policy
+(deny overrides allow) bounces the inherited officer allow → clean 403 at the
+Casbin gateway, mirroring the existing /api/leads accountant denies.
+
+Insert WITH v3='deny' — every existing p-row carries an eft; a NULL eft makes
+Casbin `load_policy` crash on next reload (memory casbin-insert-must-include-eft).
+Idempotent (WHERE NOT EXISTS) so re-runs are safe.
+
+Revision ID: apptacctdeny20260713
+Revises: apptcasbin20260713
+Create Date: 2026-07-13
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "apptacctdeny20260713"
+down_revision = "apptcasbin20260713"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # template_id='_legacy' khớp row officer appointments cùng feature
+    # (apptcasbin20260713) → không bị coi orphan bởi logic tracking template.
+    op.execute(
+        """
+        INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id)
+        SELECT 'p', 'role:accountant', '/api/leads/my/appointments', 'GET', 'deny', '_legacy'
+        WHERE NOT EXISTS (
+            SELECT 1 FROM casbin_rule
+            WHERE ptype = 'p'
+              AND v0 = 'role:accountant'
+              AND v1 = '/api/leads/my/appointments'
+              AND v2 = 'GET'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM casbin_rule
+        WHERE ptype = 'p'
+          AND v0 = 'role:accountant'
+          AND v1 = '/api/leads/my/appointments'
+          AND v2 = 'GET'
+          AND v3 = 'deny'
+        """
+    )

--- a/Backend_FastAPI/alembic/versions/apptcasbin20260713_officer_appointments_policy.py
+++ b/Backend_FastAPI/alembic/versions/apptcasbin20260713_officer_appointments_policy.py
@@ -1,0 +1,53 @@
+"""add casbin policy: officer GET /api/leads/my/appointments
+
+Feature "Nhịp hẹn" (Trợ lý nhắc hẹn) added `GET /api/leads/my/appointments`
+gated by CasbinAuth, but the matching officer policy was never added → officers
+(the intended users) got 403 PERMISSION_DENIED. role:manager / role:accountant
+inherit role:officer via g-policies, so this single officer row covers them;
+role:admin already has broad access.
+
+Insert WITH v3='allow' — every existing p-row carries an eft; a NULL eft makes
+Casbin `load_policy` crash on next reload (see memory casbin-insert-must-include-eft).
+Idempotent (WHERE NOT EXISTS) so re-runs are safe.
+
+Revision ID: apptcasbin20260713
+Revises: refundsrc20260711
+Create Date: 2026-07-13
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "apptcasbin20260713"
+down_revision = "refundsrc20260711"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # template_id='_legacy' khớp các row role:officer hiện có (core OFFICER_TEMPLATE)
+    # → row mới không bị logic quản-lý-template coi là orphan.
+    op.execute(
+        """
+        INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id)
+        SELECT 'p', 'role:officer', '/api/leads/my/appointments', 'GET', 'allow', '_legacy'
+        WHERE NOT EXISTS (
+            SELECT 1 FROM casbin_rule
+            WHERE ptype = 'p'
+              AND v0 = 'role:officer'
+              AND v1 = '/api/leads/my/appointments'
+              AND v2 = 'GET'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM casbin_rule
+        WHERE ptype = 'p'
+          AND v0 = 'role:officer'
+          AND v1 = '/api/leads/my/appointments'
+          AND v2 = 'GET'
+        """
+    )

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -129,6 +129,7 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/leads/{id}/insights", "action": "GET"},  # Lead insights
         {"subject": "{role}", "object": "/api/leads/{id}/audit-logs", "action": "GET"},  # Lead audit log history
         {"subject": "{role}", "object": "/api/leads/my/reassign-quota", "action": "GET"},  # Reassign quota
+        {"subject": "{role}", "object": "/api/leads/my/appointments", "action": "GET"},  # Nhịp hẹn — lịch hẹn gọi lại của tôi
         {"subject": "{role}", "object": "/api/leads/import/template", "action": "GET"},  # Import template
         {"subject": "{role}", "object": "/api/leads/import", "action": "POST"},  # Import leads
         # SMS consult officer (P2-3 §16.7) — tạo link tư vấn + xem interest ngành của lead.

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -533,6 +533,14 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/leads/check-duplicate",     "action": "GET",  "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads/import",              "action": "POST", "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads/import/template",     "action": "GET",  "eft": "deny"},
+        # Feature "Nhịp hẹn" (#3) — GET /api/leads/my/appointments granted to
+        # officer (OFFICER_TEMPLATE) so accountant inherits it via
+        # `g, role:accountant, role:officer`. Response carries lead name/phone +
+        # assigned-officer name → PII + separation-of-duties: finance staff have
+        # no business viewing consultation follow-up schedules. Explicit deny
+        # bounces the inherited allow (mirror the /api/leads deny above).
+        # Migration: apptacctdeny20260713.
+        {"subject": "{role}", "object": "/api/leads/my/appointments",     "action": "GET",  "eft": "deny"},
         # PR #324 Commit 5 — mirror OFFICER_TEMPLATE block above for the
         # 4 lead static routes. Separation-of-duties: finance staff never
         # operate the lead distribution / export / bulk-assign / bulk-delete

--- a/Backend_FastAPI/app/repositories/lead_repository.py
+++ b/Backend_FastAPI/app/repositories/lead_repository.py
@@ -1476,12 +1476,16 @@ class LeadRepository(BaseRepository[models.Lead]):
         officer_ids: Optional[List[int]],
         since: datetime,
         until: datetime,
+        unit_id: Optional[int] = None,
         limit: int = 60,
     ) -> List[models.Lead]:
         """
         Lead có lịch gọi lại (next_activity_at) trong [since, until].
 
-        officer_ids=None → TOÀN BỘ (admin/manager); [id] → của officer đó (own).
+        Scope (mirror LeadListFilter — cùng nguồn quy tắc với lead listing):
+          - officer_ids=None + unit_id=None → TOÀN BỘ (admin).
+          - officer_ids=None + unit_id=X    → theo ĐƠN VỊ (manager, Lead.unit_id==X).
+          - officer_ids=[id]                → của officer đó (own).
         next_activity_at = MIN(scheduled_at) các consultation follow-up còn sống →
         query theo nó tự lọc "hẹn còn hiệu lực", khỏi join consultation_status.
         Eager-load offering→program (trình độ/ngành) + assigned_officer (tên NV,
@@ -1505,6 +1509,8 @@ class LeadRepository(BaseRepository[models.Lead]):
         )
         if officer_ids is not None:
             query = query.where(models.Lead.assigned_officer_id.in_(officer_ids))
+        if unit_id is not None:
+            query = query.where(models.Lead.unit_id == unit_id)
         query = query.order_by(models.Lead.next_activity_at.asc()).limit(limit)
         result = await self.db.execute(query)
         return list(result.scalars().all())

--- a/Backend_FastAPI/app/repositories/lead_repository.py
+++ b/Backend_FastAPI/app/repositories/lead_repository.py
@@ -1473,19 +1473,20 @@ class LeadRepository(BaseRepository[models.Lead]):
 
     async def get_my_appointments(
         self,
-        officer_id: int,
+        officer_ids: Optional[List[int]],
         since: datetime,
         until: datetime,
-        limit: int = 40,
+        limit: int = 60,
     ) -> List[models.Lead]:
         """
-        Lead của officer có lịch gọi lại (next_activity_at) trong [since, until].
+        Lead có lịch gọi lại (next_activity_at) trong [since, until].
 
+        officer_ids=None → TOÀN BỘ (admin/manager); [id] → của officer đó (own).
         next_activity_at = MIN(scheduled_at) các consultation follow-up còn sống →
         query theo nó tự lọc "hẹn còn hiệu lực", khỏi join consultation_status.
-        Eager-load offering→program để hiện trình độ/ngành. Order ASC theo
-        next_activity_at (quá hạn giờ nhỏ hơn now tự đứng trước). Dùng index
-        ix_lead_officer_status_deleted_activity.
+        Eager-load offering→program (trình độ/ngành) + assigned_officer (tên NV,
+        hiện khi admin/manager xem toàn bộ). Order ASC theo next_activity_at (quá
+        hạn giờ nhỏ hơn now tự đứng trước). Dùng index ix_lead_officer_status_deleted_activity.
         """
         query = (
             select(models.Lead)
@@ -1493,17 +1494,18 @@ class LeadRepository(BaseRepository[models.Lead]):
                 selectinload(models.Lead.offering).selectinload(
                     models.ProgramOffering.program
                 ),
+                selectinload(models.Lead.assigned_officer),
             )
             .where(
-                models.Lead.assigned_officer_id == officer_id,
                 models.Lead.next_activity_at.isnot(None),
                 models.Lead.next_activity_at >= since,
                 models.Lead.next_activity_at <= until,
                 models.Lead.deleted_at.is_(None),
             )
-            .order_by(models.Lead.next_activity_at.asc())
-            .limit(limit)
         )
+        if officer_ids is not None:
+            query = query.where(models.Lead.assigned_officer_id.in_(officer_ids))
+        query = query.order_by(models.Lead.next_activity_at.asc()).limit(limit)
         result = await self.db.execute(query)
         return list(result.scalars().all())
 

--- a/Backend_FastAPI/app/repositories/lead_repository.py
+++ b/Backend_FastAPI/app/repositories/lead_repository.py
@@ -1471,16 +1471,30 @@ class LeadRepository(BaseRepository[models.Lead]):
         result = await self.db.execute(stmt)
         return result.rowcount
 
+    def _my_appointments_scope(self, officer_ids, until, unit_id):
+        """Predicate dùng chung cho get_/count_my_appointments — MỘT nguồn để
+        list và count KHÔNG lệch scope. KHÔNG chặn dưới: mọi hẹn quá hạn đều
+        tính (hẹn quá hạn lâu nhất = cần gọi gấp nhất)."""
+        conds = [
+            models.Lead.next_activity_at.isnot(None),
+            models.Lead.next_activity_at <= until,
+            models.Lead.deleted_at.is_(None),
+        ]
+        if officer_ids is not None:
+            conds.append(models.Lead.assigned_officer_id.in_(officer_ids))
+        if unit_id is not None:
+            conds.append(models.Lead.unit_id == unit_id)
+        return conds
+
     async def get_my_appointments(
         self,
         officer_ids: Optional[List[int]],
-        since: datetime,
         until: datetime,
         unit_id: Optional[int] = None,
         limit: int = 60,
     ) -> List[models.Lead]:
         """
-        Lead có lịch gọi lại (next_activity_at) trong [since, until].
+        Lead có lịch gọi lại (next_activity_at) ≤ until, KHÔNG chặn dưới.
 
         Scope (mirror LeadListFilter — cùng nguồn quy tắc với lead listing):
           - officer_ids=None + unit_id=None → TOÀN BỘ (admin).
@@ -1500,20 +1514,30 @@ class LeadRepository(BaseRepository[models.Lead]):
                 ),
                 selectinload(models.Lead.assigned_officer),
             )
-            .where(
-                models.Lead.next_activity_at.isnot(None),
-                models.Lead.next_activity_at >= since,
-                models.Lead.next_activity_at <= until,
-                models.Lead.deleted_at.is_(None),
-            )
+            .where(*self._my_appointments_scope(officer_ids, until, unit_id))
+            .order_by(models.Lead.next_activity_at.asc())
+            .limit(limit)
         )
-        if officer_ids is not None:
-            query = query.where(models.Lead.assigned_officer_id.in_(officer_ids))
-        if unit_id is not None:
-            query = query.where(models.Lead.unit_id == unit_id)
-        query = query.order_by(models.Lead.next_activity_at.asc()).limit(limit)
         result = await self.db.execute(query)
         return list(result.scalars().all())
+
+    async def count_my_appointments(
+        self,
+        officer_ids: Optional[List[int]],
+        now: datetime,
+        until: datetime,
+        unit_id: Optional[int] = None,
+    ) -> Tuple[int, int]:
+        """(overdue_count, upcoming_count) TỔNG THẬT trên toàn tập khớp scope —
+        KHÔNG bị cap limit như get_my_appointments. overdue = next_activity_at <
+        now; upcoming = ≥ now (đều ≤ until). Dùng count(*) FILTER 1 query."""
+        conds = self._my_appointments_scope(officer_ids, until, unit_id)
+        query = select(
+            func.count().filter(models.Lead.next_activity_at < now),
+            func.count().filter(models.Lead.next_activity_at >= now),
+        ).where(*conds)
+        row = (await self.db.execute(query)).one()
+        return int(row[0]), int(row[1])
 
     async def get_leads_by_referrer(
         self,

--- a/Backend_FastAPI/app/repositories/lead_repository.py
+++ b/Backend_FastAPI/app/repositories/lead_repository.py
@@ -1471,6 +1471,42 @@ class LeadRepository(BaseRepository[models.Lead]):
         result = await self.db.execute(stmt)
         return result.rowcount
 
+    async def get_my_appointments(
+        self,
+        officer_id: int,
+        since: datetime,
+        until: datetime,
+        limit: int = 40,
+    ) -> List[models.Lead]:
+        """
+        Lead của officer có lịch gọi lại (next_activity_at) trong [since, until].
+
+        next_activity_at = MIN(scheduled_at) các consultation follow-up còn sống →
+        query theo nó tự lọc "hẹn còn hiệu lực", khỏi join consultation_status.
+        Eager-load offering→program để hiện trình độ/ngành. Order ASC theo
+        next_activity_at (quá hạn giờ nhỏ hơn now tự đứng trước). Dùng index
+        ix_lead_officer_status_deleted_activity.
+        """
+        query = (
+            select(models.Lead)
+            .options(
+                selectinload(models.Lead.offering).selectinload(
+                    models.ProgramOffering.program
+                ),
+            )
+            .where(
+                models.Lead.assigned_officer_id == officer_id,
+                models.Lead.next_activity_at.isnot(None),
+                models.Lead.next_activity_at >= since,
+                models.Lead.next_activity_at <= until,
+                models.Lead.deleted_at.is_(None),
+            )
+            .order_by(models.Lead.next_activity_at.asc())
+            .limit(limit)
+        )
+        result = await self.db.execute(query)
+        return list(result.scalars().all())
+
     async def get_leads_by_referrer(
         self,
         referrer_id: int,

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -94,8 +94,9 @@ async def get_my_reassign_quota(
     return quota
 
 
-@limiter.limit(RateLimits.DATA_READ)  # 1000/hour
 @router.get("/my/appointments", response_model=schemas.MyAppointmentsResponse)
+@limiter.limit(RateLimits.DATA_READ)  # 1000/hour — @router TRÊN @limiter (thứ tự
+# slowapi ĐÚNG: limiter phải bọc endpoint; đảo lại = decorator bị bỏ = no-op)
 async def get_my_appointments(
     request: Request,
     db: AsyncSession = Depends(database.get_db),

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -94,6 +94,19 @@ async def get_my_reassign_quota(
     return quota
 
 
+@router.get("/my/appointments", response_model=schemas.MyAppointmentsResponse)
+async def get_my_appointments(
+    request: Request,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    """
+    Lịch hẹn gọi lại của tôi ("Nhịp hẹn") — lead có giờ hẹn còn sống, bucket
+    quá hạn / sắp tới, kèm server_time cho đồng hồ đếm phía FE. Chỉ đọc.
+    """
+    return await lead_service.get_my_appointments(db, current_user)
+
+
 @limiter.limit(RateLimits.DATA_READ)  # 1000/hour
 @router.get(
     "/distribution-preview",

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -94,6 +94,7 @@ async def get_my_reassign_quota(
     return quota
 
 
+@limiter.limit(RateLimits.DATA_READ)  # 1000/hour
 @router.get("/my/appointments", response_model=schemas.MyAppointmentsResponse)
 async def get_my_appointments(
     request: Request,

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -137,6 +137,8 @@ from .lead import (
     LeadImportResult,
     LeadInsights,
     LeadsPage,
+    MyAppointmentItem,  # ✅ Nhịp hẹn: 1 lịch gọi lại của officer
+    MyAppointmentsResponse,  # ✅ Nhịp hẹn: bucket overdue/upcoming + server_time
     LeadUpdate,
     LeadStatusUpdate,  # ✅ FSM v3.0: Status update schema
     BulkStageSkippedItem,

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -577,6 +577,32 @@ class LeadsPage(BaseModel):
     consultation_status_counts: Optional[Dict[str, int]] = None
 
 
+# =========================================================================
+# My Appointments — bảng nhắc lịch hẹn cho tư vấn viên ("Nhịp hẹn")
+# Nguồn: Lead có next_activity_at (MIN scheduled_at của consultation còn sống).
+# =========================================================================
+class MyAppointmentItem(BaseModel):
+    """Một lịch gọi lại của officer (1 lead = 1 hẹn kế tiếp còn sống)."""
+    lead_id: int
+    lead_name: str
+    phone: str
+    source: str
+    scheduled_at: datetime          # = lead.next_activity_at (giờ hẹn gọi lại gần nhất)
+    is_overdue: bool                # scheduled_at < server_time (realtime, đồng bộ isLeadOverdue FE)
+    degree_level: Optional[str] = None   # trình độ ngành (Cao đẳng/Đại học…) → FE getDegreeLevelAbbr
+    major: Optional[str] = None          # tên ngành
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MyAppointmentsResponse(BaseModel):
+    """Lịch hẹn của tôi, đã bucket theo giờ máy chủ (thin-client: BE là nguồn thật)."""
+    server_time: datetime           # để FE đếm giờ chính xác (khỏi lệ thuộc đồng hồ client)
+    overdue_count: int
+    upcoming_count: int
+    # order: repo sort ASC theo scheduled_at → quá hạn (giờ < now) tự đứng trước, rồi sắp tới.
+    appointments: List[MyAppointmentItem]
+
+
 class BulkAssignLeadsSchema(BaseModel):
     lead_ids: List[int] = Field(..., min_length=1)
 

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -591,12 +591,14 @@ class MyAppointmentItem(BaseModel):
     is_overdue: bool                # scheduled_at < server_time (realtime, đồng bộ isLeadOverdue FE)
     degree_level: Optional[str] = None   # trình độ ngành (Cao đẳng/Đại học…) → FE getDegreeLevelAbbr
     major: Optional[str] = None          # tên ngành
+    officer_name: Optional[str] = None   # NV phụ trách — hiện khi admin/manager xem toàn bộ
     model_config = ConfigDict(from_attributes=True)
 
 
 class MyAppointmentsResponse(BaseModel):
-    """Lịch hẹn của tôi, đã bucket theo giờ máy chủ (thin-client: BE là nguồn thật)."""
+    """Lịch hẹn (theo scope role), đã bucket theo giờ máy chủ (thin-client: BE là nguồn thật)."""
     server_time: datetime           # để FE đếm giờ chính xác (khỏi lệ thuộc đồng hồ client)
+    scope: str                      # "own" (officer, của mình) | "all" (admin/manager, toàn bộ)
     overdue_count: int
     upcoming_count: int
     # order: repo sort ASC theo scheduled_at → quá hạn (giờ < now) tự đứng trước, rồi sắp tới.

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -588,7 +588,8 @@ class MyAppointmentItem(BaseModel):
     phone: str
     source: str
     scheduled_at: datetime          # = lead.next_activity_at (giờ hẹn gọi lại gần nhất)
-    is_overdue: bool                # scheduled_at < server_time (realtime, đồng bộ isLeadOverdue FE)
+    # (bỏ is_overdue: FE tự tính realtime từ server_time — field snapshot lệch tới
+    #  ~60s trong cửa refetch, KHÔNG consumer nào đọc → không ship nữa)
     degree_level: Optional[str] = None   # trình độ ngành (Cao đẳng/Đại học…) → FE getDegreeLevelAbbr
     major: Optional[str] = None          # tên ngành
     officer_name: Optional[str] = None   # NV phụ trách — hiện khi admin/manager xem toàn bộ

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -3313,14 +3313,28 @@ async def get_my_appointments(
     since = now - timedelta(days=overdue_days)
     until = now + timedelta(hours=upcoming_hours)
 
-    # Scope theo role: admin/manager thấy TOÀN BỘ lịch hẹn; officer chỉ của mình.
+    # Scope theo role — KHỚP LeadListFilter (deps.get_lead_list_filter):
+    #   - admin  : TOÀN BỘ (không giới hạn)
+    #   - manager: theo ĐƠN VỊ của mình (Lead.unit_id == current_user.unit_id) —
+    #              KHÔNG phải all-scope như admin, chống xem chéo đơn vị (IDOR).
+    #   - officer / accountant / user: chỉ lead được giao cho mình.
+    # is_privileged (admin+manager) chỉ quyết định có đính kèm officer_name hay
+    # không; KHÔNG dùng để mở all-scope cho manager nữa.
     is_privileged = current_user.role in (UserRole.ADMIN, UserRole.MANAGER)
-    officer_ids = None if is_privileged else [current_user.id]
+    if current_user.role == UserRole.ADMIN:
+        officer_ids = None
+        unit_scope_id = None
+    elif current_user.role == UserRole.MANAGER:
+        officer_ids = None
+        unit_scope_id = current_user.unit_id
+    else:
+        officer_ids = [current_user.id]
+        unit_scope_id = None
     scope = "all" if is_privileged else "own"
 
     repo = LeadRepository(db)
     leads = await repo.get_my_appointments(
-        officer_ids=officer_ids, since=since, until=until
+        officer_ids=officer_ids, since=since, until=until, unit_id=unit_scope_id
     )
 
     items: List[MyAppointmentItem] = []

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -3313,9 +3313,14 @@ async def get_my_appointments(
     since = now - timedelta(days=overdue_days)
     until = now + timedelta(hours=upcoming_hours)
 
+    # Scope theo role: admin/manager thấy TOÀN BỘ lịch hẹn; officer chỉ của mình.
+    is_privileged = current_user.role in (UserRole.ADMIN, UserRole.MANAGER)
+    officer_ids = None if is_privileged else [current_user.id]
+    scope = "all" if is_privileged else "own"
+
     repo = LeadRepository(db)
     leads = await repo.get_my_appointments(
-        officer_id=current_user.id, since=since, until=until
+        officer_ids=officer_ids, since=since, until=until
     )
 
     items: List[MyAppointmentItem] = []
@@ -3343,11 +3348,18 @@ async def get_my_appointments(
                 is_overdue=is_overdue,
                 degree_level=prog.degree_level if prog else None,
                 major=prog.name if prog else None,
+                # NV phụ trách — chỉ đính kèm khi xem toàn bộ (admin/manager)
+                officer_name=(
+                    lead.assigned_officer.full_name
+                    if (is_privileged and lead.assigned_officer)
+                    else None
+                ),
             )
         )
 
     return MyAppointmentsResponse(
         server_time=now,
+        scope=scope,
         overdue_count=overdue_count,
         upcoming_count=upcoming_count,
         appointments=items,

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -3290,63 +3290,67 @@ async def check_reassign_quota(db: AsyncSession, officer_id: int) -> dict:
     }
 
 
+def _resolve_appointment_scope(
+    user: models.User,
+) -> Tuple[Optional[List[int]], Optional[int]]:
+    """(officer_ids, unit_id) cho feed "Nhịp hẹn" theo role.
+
+    KHỚP quy tắc gốc của ``LeadListFilter`` (deps.get_lead_list_filter):
+      - admin                       → (None, None)  = TOÀN BỘ.
+      - manager CÓ đơn vị            → (None, unit)  = theo ĐƠN VỊ mình.
+      - manager CHƯA gán đơn vị      → ([id], None)  = CHỈ của mình — KHÔNG mở
+        all-scope (chống leo thang xem chéo lead PII khi unit_id NULL).
+      - officer / accountant / user  → ([id], None)  = của mình.
+
+    ``officer_ids is None`` ⇒ đang xem toàn bộ/đơn vị ⇒ caller đính kèm
+    officer_name + scope="all"; ngược lại "own".
+    """
+    role = user.role
+    if role == UserRole.ADMIN:
+        return None, None
+    if role == UserRole.MANAGER and user.unit_id is not None:
+        return None, user.unit_id
+    # manager-không-đơn-vị + officer/accountant/user → chỉ của mình
+    return [user.id], None
+
+
 async def get_my_appointments(
     db: AsyncSession,
     current_user: models.User,
-    overdue_days: int = 7,
     upcoming_hours: int = 24,
 ):
     """
     Lịch hẹn gọi lại của officer đang login ("Nhịp hẹn").
 
-    Trả các lead có next_activity_at (giờ hẹn còn sống) trong cửa sổ
-    [now - overdue_days, now + upcoming_hours], kèm cờ is_overdue realtime
-    (= next_activity_at < now, đồng bộ isLeadOverdue FE) + server_time để FE
-    đếm giờ chính xác. Repo sort ASC theo next_activity_at → quá hạn tự đứng
-    trước sắp tới. Chỉ đọc, không mutation.
+    Trả các lead có next_activity_at (giờ hẹn còn sống) tới +upcoming_hours —
+    KHÔNG chặn dưới: mọi hẹn QUÁ HẠN (bất kể lâu bao nhiêu) đều hiện, vì hẹn
+    quá hạn lâu nhất chính là việc cần gọi lại gấp nhất (danh sách sort ASC nên
+    quá hạn đứng trước, cap 60 để không tràn UI). overdue_count/upcoming_count
+    là TỔNG THẬT (count query, KHÔNG suy từ 60 dòng đã cắt). Trạng thái overdue
+    do FE tự tính realtime từ server_time. Chỉ đọc, không mutation.
     """
     from datetime import timedelta
     from app.repositories.lead_repository import LeadRepository
     from app.schemas.lead import MyAppointmentItem, MyAppointmentsResponse
 
     now = datetime.now(timezone.utc)
-    since = now - timedelta(days=overdue_days)
     until = now + timedelta(hours=upcoming_hours)
 
-    # Scope theo role — KHỚP LeadListFilter (deps.get_lead_list_filter):
-    #   - admin  : TOÀN BỘ (không giới hạn)
-    #   - manager: theo ĐƠN VỊ của mình (Lead.unit_id == current_user.unit_id) —
-    #              KHÔNG phải all-scope như admin, chống xem chéo đơn vị (IDOR).
-    #   - officer / accountant / user: chỉ lead được giao cho mình.
-    # is_privileged (admin+manager) chỉ quyết định có đính kèm officer_name hay
-    # không; KHÔNG dùng để mở all-scope cho manager nữa.
-    is_privileged = current_user.role in (UserRole.ADMIN, UserRole.MANAGER)
-    if current_user.role == UserRole.ADMIN:
-        officer_ids = None
-        unit_scope_id = None
-    elif current_user.role == UserRole.MANAGER:
-        officer_ids = None
-        unit_scope_id = current_user.unit_id
-    else:
-        officer_ids = [current_user.id]
-        unit_scope_id = None
+    officer_ids, unit_scope_id = _resolve_appointment_scope(current_user)
+    is_privileged = officer_ids is None  # xem toàn bộ/đơn vị → kèm officer_name
     scope = "all" if is_privileged else "own"
 
     repo = LeadRepository(db)
     leads = await repo.get_my_appointments(
-        officer_ids=officer_ids, since=since, until=until, unit_id=unit_scope_id
+        officer_ids=officer_ids, until=until, unit_id=unit_scope_id
+    )
+    # Đếm TỔNG THẬT (không bị cap 60) để badge/summary FE không báo thiếu.
+    overdue_count, upcoming_count = await repo.count_my_appointments(
+        officer_ids=officer_ids, now=now, until=until, unit_id=unit_scope_id
     )
 
     items: List[MyAppointmentItem] = []
-    overdue_count = 0
-    upcoming_count = 0
     for lead in leads:
-        sched = lead.next_activity_at
-        is_overdue = sched < now
-        if is_overdue:
-            overdue_count += 1
-        else:
-            upcoming_count += 1
         prog = (
             lead.offering.program
             if (lead.offering and lead.offering.program)
@@ -3358,8 +3362,7 @@ async def get_my_appointments(
                 lead_name=lead.full_name,
                 phone=lead.phone,
                 source=lead.source,
-                scheduled_at=sched,
-                is_overdue=is_overdue,
+                scheduled_at=lead.next_activity_at,
                 degree_level=prog.degree_level if prog else None,
                 major=prog.name if prog else None,
                 # NV phụ trách — chỉ đính kèm khi xem toàn bộ (admin/manager)

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -3290,6 +3290,70 @@ async def check_reassign_quota(db: AsyncSession, officer_id: int) -> dict:
     }
 
 
+async def get_my_appointments(
+    db: AsyncSession,
+    current_user: models.User,
+    overdue_days: int = 7,
+    upcoming_hours: int = 24,
+):
+    """
+    Lịch hẹn gọi lại của officer đang login ("Nhịp hẹn").
+
+    Trả các lead có next_activity_at (giờ hẹn còn sống) trong cửa sổ
+    [now - overdue_days, now + upcoming_hours], kèm cờ is_overdue realtime
+    (= next_activity_at < now, đồng bộ isLeadOverdue FE) + server_time để FE
+    đếm giờ chính xác. Repo sort ASC theo next_activity_at → quá hạn tự đứng
+    trước sắp tới. Chỉ đọc, không mutation.
+    """
+    from datetime import timedelta
+    from app.repositories.lead_repository import LeadRepository
+    from app.schemas.lead import MyAppointmentItem, MyAppointmentsResponse
+
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(days=overdue_days)
+    until = now + timedelta(hours=upcoming_hours)
+
+    repo = LeadRepository(db)
+    leads = await repo.get_my_appointments(
+        officer_id=current_user.id, since=since, until=until
+    )
+
+    items: List[MyAppointmentItem] = []
+    overdue_count = 0
+    upcoming_count = 0
+    for lead in leads:
+        sched = lead.next_activity_at
+        is_overdue = sched < now
+        if is_overdue:
+            overdue_count += 1
+        else:
+            upcoming_count += 1
+        prog = (
+            lead.offering.program
+            if (lead.offering and lead.offering.program)
+            else None
+        )
+        items.append(
+            MyAppointmentItem(
+                lead_id=lead.id,
+                lead_name=lead.full_name,
+                phone=lead.phone,
+                source=lead.source,
+                scheduled_at=sched,
+                is_overdue=is_overdue,
+                degree_level=prog.degree_level if prog else None,
+                major=prog.name if prog else None,
+            )
+        )
+
+    return MyAppointmentsResponse(
+        server_time=now,
+        overdue_count=overdue_count,
+        upcoming_count=upcoming_count,
+        appointments=items,
+    )
+
+
 async def process_officer_action(
     db: AsyncSession, lead_id: int, officer: models.User, action: str, reason: str
 ) -> models.Lead:

--- a/Backend_FastAPI/requirements.txt
+++ b/Backend_FastAPI/requirements.txt
@@ -23,7 +23,7 @@ celery==5.5.3
 certifi==2025.10.5
 cffi==2.0.0
 charset-normalizer==3.4.4
-click==8.3.0
+click==8.3.3
 click-didyoumean==0.3.1
 click-plugins==1.1.1.2
 click-repl==0.3.0
@@ -61,7 +61,7 @@ packaging==25.0
 paginate==0.5.7
 pandas==2.3.3
 passlib==1.7.4
-Pillow==12.2.0
+Pillow==12.3.0
 prometheus_client==0.23.1
 prompt_toolkit==3.0.52
 propcache==0.4.1

--- a/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
+++ b/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
@@ -484,6 +484,10 @@ async def test_accountant_deny_rows_seeded(setup_test_database):
             ("/api/leads/bulk-assign",                             "POST"),
             ("/api/leads/bulk-delete",                             "POST"),
             ("/api/leads/distribution-preview",                    "GET"),
+            # Nhịp hẹn (#3, 2026-07-13) — GET /api/leads/my/appointments trả
+            # lead name/phone (PII); accountant kế thừa officer allow → deny
+            # (separation-of-duties). Migration `apptacctdeny20260713`.
+            ("/api/leads/my/appointments",                         "GET"),
         }
         assert observed == expected, (
             f"Accountant deny-row set drifted. "

--- a/Backend_FastAPI/tests/services/test_lead.py
+++ b/Backend_FastAPI/tests/services/test_lead.py
@@ -3203,3 +3203,94 @@ class TestNextActivityAggregation:
         assert sent == keep
         assert result["sent"] == 3
 
+
+class TestMyAppointmentsScope:
+    """Khóa regression P1 (/code-review): ``get_my_appointments`` PHẢI scope
+    theo role — admin TOÀN BỘ, manager theo ĐƠN VỊ của mình (KHÔNG xem chéo
+    unit khác), officer/accountant/user chỉ của mình.
+
+    Trước fix, manager rơi vào all-scope như admin (officer_ids=None, không
+    filter unit) → thấy lịch hẹn (kèm tên + SĐT lead + tên NV phụ trách) của
+    MỌI đơn vị, phá vỡ manager unit-scope/IDOR contract của lead listing.
+    """
+
+    async def _lead_with_appt(
+        self,
+        db: AsyncSession,
+        seeded_dependencies: dict,
+        *,
+        unit_id: int,
+        officer_id: Optional[int],
+        phone: str,
+        email: str,
+        when: datetime,
+    ) -> models.Lead:
+        lead = models.Lead(
+            full_name="Appt Scope Lead",
+            phone=phone,
+            email=email,
+            source="Website",
+            unit_id=unit_id,
+            status=seeded_dependencies["initial_status_id"],
+            consultation_status_id=seeded_dependencies["initial_status_id"],
+            pipeline_stage_id=seeded_dependencies["stage_id"],
+            assigned_officer_id=officer_id,
+            assigned_at=datetime.now(timezone.utc),
+            next_activity_at=when,
+        )
+        db.add(lead)
+        await db.flush()
+        await db.refresh(lead)
+        return lead
+
+    async def test_manager_scoped_to_own_unit_not_cross_unit(
+        self,
+        db: AsyncSession,
+        seeded_dependencies: dict,
+        manager_user: models.User,
+        officer_user: models.User,
+        admin_user: models.User,
+    ):
+        now = datetime.now(timezone.utc)
+        soon = now + timedelta(hours=2)  # trong cửa sổ [now-7d, now+24h]
+
+        # Đơn vị thứ 2 — KHÁC đơn vị của manager (manager thuộc seeded unit).
+        other_unit = models.OrganizationUnit(
+            id=1002, name="Other Unit", type="department"
+        )
+        db.add(other_unit)
+        await db.flush()
+
+        my_unit_id = seeded_dependencies["unit_id"]
+        assert manager_user.unit_id == my_unit_id  # tiền đề: manager ở unit này
+
+        lead_mine = await self._lead_with_appt(
+            db, seeded_dependencies,
+            unit_id=my_unit_id, officer_id=officer_user.id,
+            phone="0900000001", email="appt_mine@test.com", when=soon,
+        )
+        lead_other = await self._lead_with_appt(
+            db, seeded_dependencies,
+            unit_id=other_unit.id, officer_id=None,
+            phone="0900000002", email="appt_other@test.com", when=soon,
+        )
+
+        # MANAGER: chỉ lịch hẹn của ĐƠN VỊ mình, KHÔNG lộ unit khác.
+        res_mgr = await lead_service.get_my_appointments(db, manager_user)
+        mgr_ids = {a.lead_id for a in res_mgr.appointments}
+        assert lead_mine.id in mgr_ids
+        assert lead_other.id not in mgr_ids  # P1: chống xem chéo đơn vị
+        assert res_mgr.scope == "all"  # giữ label FE "Toàn đơn vị" (không đổi contract)
+
+        # ADMIN: thấy CẢ HAI đơn vị (không regression all-scope).
+        res_admin = await lead_service.get_my_appointments(db, admin_user)
+        admin_ids = {a.lead_id for a in res_admin.appointments}
+        assert {lead_mine.id, lead_other.id} <= admin_ids
+
+        # OFFICER: chỉ lead được giao cho mình.
+        res_off = await lead_service.get_my_appointments(db, officer_user)
+        off_ids = {a.lead_id for a in res_off.appointments}
+        assert lead_mine.id in off_ids
+        assert lead_other.id not in off_ids
+        assert res_off.scope == "own"
+

--- a/Backend_FastAPI/tests/services/test_lead.py
+++ b/Backend_FastAPI/tests/services/test_lead.py
@@ -3252,7 +3252,7 @@ class TestMyAppointmentsScope:
         admin_user: models.User,
     ):
         now = datetime.now(timezone.utc)
-        soon = now + timedelta(hours=2)  # trong cửa sổ [now-7d, now+24h]
+        soon = now + timedelta(hours=2)  # trong cửa sổ (≤ now+24h)
 
         # Đơn vị thứ 2 — KHÁC đơn vị của manager (manager thuộc seeded unit).
         other_unit = models.OrganizationUnit(
@@ -3293,4 +3293,77 @@ class TestMyAppointmentsScope:
         assert lead_mine.id in off_ids
         assert lead_other.id not in off_ids
         assert res_off.scope == "own"
+
+    async def test_manager_without_unit_does_not_leak_cross_unit(
+        self,
+        db: AsyncSession,
+        seeded_dependencies: dict,
+        manager_user: models.User,
+        officer_user: models.User,
+    ):
+        """Khóa P1 (/code-review): manager có unit_id=None (User.unit_id nullable)
+        KHÔNG được rơi vào all-scope → chỉ thấy lead của mình, KHÔNG leak unit khác."""
+        now = datetime.now(timezone.utc)
+        soon = now + timedelta(hours=2)
+
+        other_unit = models.OrganizationUnit(
+            id=1002, name="Other Unit", type="department"
+        )
+        db.add(other_unit)
+        await db.flush()
+
+        my_unit_id = seeded_dependencies["unit_id"]
+        lead_my_unit = await self._lead_with_appt(
+            db, seeded_dependencies,
+            unit_id=my_unit_id, officer_id=officer_user.id,
+            phone="0900000011", email="appt_u1@test.com", when=soon,
+        )
+        lead_other = await self._lead_with_appt(
+            db, seeded_dependencies,
+            unit_id=other_unit.id, officer_id=None,
+            phone="0900000012", email="appt_u2@test.com", when=soon,
+        )
+
+        # Manager MẤT đơn vị (unit_id=None) — tài khoản manager chưa gán đơn vị.
+        manager_user.unit_id = None
+        await db.flush()
+
+        res = await lead_service.get_my_appointments(db, manager_user)
+        ids = {a.lead_id for a in res.appointments}
+        assert res.scope == "own"  # KHÔNG all-scope
+        assert lead_my_unit.id not in ids  # không assigned cho manager → không thấy
+        assert lead_other.id not in ids  # P1: KHÔNG leak unit khác
+
+    async def test_overdue_beyond_lookback_shown_and_counts_are_totals(
+        self,
+        db: AsyncSession,
+        seeded_dependencies: dict,
+        officer_user: models.User,
+    ):
+        """Khóa #15+#4: hẹn quá hạn >7d KHÔNG bị ẩn (bỏ chặn dưới); overdue_count/
+        upcoming_count là TỔNG THẬT (count query), không suy từ list cap-60."""
+        now = datetime.now(timezone.utc)
+        old_overdue = now - timedelta(days=10)  # quá hạn 10 ngày (cũ hơn 7d)
+        soon = now + timedelta(hours=1)
+
+        my_unit_id = seeded_dependencies["unit_id"]
+        lead_old = await self._lead_with_appt(
+            db, seeded_dependencies,
+            unit_id=my_unit_id, officer_id=officer_user.id,
+            phone="0900000021", email="appt_old@test.com", when=old_overdue,
+        )
+        lead_soon = await self._lead_with_appt(
+            db, seeded_dependencies,
+            unit_id=my_unit_id, officer_id=officer_user.id,
+            phone="0900000022", email="appt_soon@test.com", when=soon,
+        )
+
+        res = await lead_service.get_my_appointments(db, officer_user)
+        ids = {a.lead_id for a in res.appointments}
+        assert lead_old.id in ids  # #15: quá hạn >7d VẪN hiện (không bị chặn dưới)
+        assert lead_soon.id in ids
+        assert res.overdue_count == 1  # #4: đếm đúng tổng (1 quá hạn)
+        assert res.upcoming_count == 1  # 1 sắp tới
+        # order ASC theo scheduled_at → quá hạn (cũ) đứng trước
+        assert res.appointments[0].lead_id == lead_old.id
 

--- a/Backend_FastAPI/tests/unit/test_casbin_b1_deny_first.py
+++ b/Backend_FastAPI/tests/unit/test_casbin_b1_deny_first.py
@@ -188,11 +188,24 @@ class TestApplyTemplateEmits4Field:
             "Accountant lost core state-machine deny(s) from PLAN §3.3.b: "
             f"{sorted(missing)}"
         )
-        # Separation-of-duties: lead appointments feed carries name/phone PII →
-        # accountant MUST stay denied (finding /code-review, apptacctdeny20260713).
-        assert ("/api/leads/my/appointments", "GET") in deny_paths, (
-            "Accountant deny for /api/leads/my/appointments GET missing — "
-            "finance staff would read lead PII via officer inheritance."
+        # Separation-of-duties: các endpoint mang PII lead/thí sinh (tên/SĐT) mà
+        # accountant kế thừa qua g,role:accountant→role:officer PHẢI giữ deny.
+        # Pin lại (thay cho exact-count cũ đã stale) để 1 PR sau không âm thầm gỡ.
+        pii_separation_of_duties = {
+            ("/api/leads", "GET"),                       # list 391 lead + SĐT
+            ("/api/leads/{id}", "GET"),                  # chi tiết lead
+            ("/api/leads/{id}/timeline", "GET"),
+            ("/api/leads/{id}/consultations", "GET"),
+            ("/api/leads/export", "GET"),                # xuất PII
+            ("/api/leads/my/appointments", "GET"),       # feed Nhịp hẹn (name/phone)
+            ("/api/admissions", "GET"),                  # list hồ sơ
+            ("/api/admissions/{id}", "GET"),
+            ("/api/admissions/pending-diploma", "GET"),  # nợ bằng (name/phone)
+        }
+        missing_pii = pii_separation_of_duties - deny_paths
+        assert not missing_pii, (
+            "Accountant lost PII separation-of-duties deny(s) — finance staff "
+            f"would read lead/thí sinh PII via officer inheritance: {sorted(missing_pii)}"
         )
 
     def test_accountant_deny_rules_all_target_role_accountant(self):

--- a/Backend_FastAPI/tests/unit/test_casbin_b1_deny_first.py
+++ b/Backend_FastAPI/tests/unit/test_casbin_b1_deny_first.py
@@ -159,17 +159,23 @@ class TestApplyTemplateEmits4Field:
         for r in rules:
             assert r["subject"] == "role:test", r
 
-    def test_accountant_template_has_six_explicit_deny_rules(self):
-        """Lock the deny set so a future PR cannot quietly add or drop
-        accountant deny rules without touching this test."""
+    def test_accountant_core_state_machine_denies_preserved(self):
+        """Lock the CORE admission state-machine deny set (PLAN §3.3.b) as a
+        MUST-CONTAIN subset, so a future PR cannot silently DROP any of the 6
+        original guards.
+
+        NOTE: the accountant deny set has since grown well beyond these 6
+        (F8/F9 2026-05-16 lead + admission list denies, PR #324 lead static
+        routes, Q9 #07 priority denies, Nhịp hẹn appointments) — so this test
+        no longer pins an EXACT count (that assertion was stale: 6 vs 47). It
+        pins that the state-machine guards remain AND that the appointments
+        separation-of-duties deny is present.
+        """
         rules = apply_template("accountant", "role:accountant")
-        deny_rules = [r for r in rules if r["eft"] == "deny"]
-        assert len(deny_rules) == 6, (
-            f"Accountant deny rule count must equal 6 (PLAN §3.3.b); "
-            f"got {len(deny_rules)}"
-        )
-        deny_paths = {(r["object"], r["action"]) for r in deny_rules}
-        expected = {
+        deny_paths = {
+            (r["object"], r["action"]) for r in rules if r["eft"] == "deny"
+        }
+        core_state_machine = {
             ("/api/v2/admissions/*/claim",            "POST"),
             ("/api/v2/admissions/*/request-revision", "POST"),
             ("/api/v2/admissions/*/publish-result",   "POST"),
@@ -177,9 +183,16 @@ class TestApplyTemplateEmits4Field:
             ("/api/v2/admissions/*/waitlist-reject",  "POST"),
             ("/api/v2/admissions/*/admin-rollback",   "POST"),
         }
-        assert deny_paths == expected, (
-            "Accountant deny route set drifted from PLAN §3.3.b. "
-            f"Expected: {sorted(expected)}; got: {sorted(deny_paths)}"
+        missing = core_state_machine - deny_paths
+        assert not missing, (
+            "Accountant lost core state-machine deny(s) from PLAN §3.3.b: "
+            f"{sorted(missing)}"
+        )
+        # Separation-of-duties: lead appointments feed carries name/phone PII →
+        # accountant MUST stay denied (finding /code-review, apptacctdeny20260713).
+        assert ("/api/leads/my/appointments", "GET") in deny_paths, (
+            "Accountant deny for /api/leads/my/appointments GET missing — "
+            "finance staff would read lead PII via officer inheritance."
         )
 
     def test_accountant_deny_rules_all_target_role_accountant(self):

--- a/Backend_FastAPI/tests/unit/test_casbin_phase3_routes.py
+++ b/Backend_FastAPI/tests/unit/test_casbin_phase3_routes.py
@@ -250,6 +250,21 @@ def test_payment_queue_read_enforce(enforcer):
     assert enforcer.enforce("role:manager", "/api/payments/42", "GET") is True
 
 
+def test_appointments_accountant_deny_officer_manager_allow(enforcer):
+    """/code-review finding — GET /api/leads/my/appointments returns lead
+    name/phone + assigned-officer name. Officer (intended user) and manager
+    (inherits officer, unit-scoped at service layer) may read; accountant —
+    despite inheriting officer via `g, role:accountant, role:officer` — is
+    BOUNCED by the explicit ACCOUNTANT_TEMPLATE deny (mirror the /api/leads
+    accountant denies). Locks separation-of-duties for finance staff
+    (migration apptacctdeny20260713).
+    """
+    route = "/api/leads/my/appointments"
+    assert enforcer.enforce("role:officer", route, "GET") is True
+    assert enforcer.enforce("role:manager", route, "GET") is True
+    assert enforcer.enforce("role:accountant", route, "GET") is False
+
+
 # ----------------------------------------------------------------------
 # T17 admin-rollback — Casbin DENY for ALL roles via diamond inheritance
 # ----------------------------------------------------------------------

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -2,16 +2,12 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import dynamic from "next/dynamic";
 import { useState, useEffect } from "react";
 import { Toaster } from "sonner";
 import { AxiosError } from "axios"; // <<< THÊM IMPORT NÀY
 
-// ✅ PERF: Lazy-load DevTools - chỉ dùng trong development
-const ReactQueryDevtools = dynamic(
-  () => import("@tanstack/react-query-devtools").then(m => ({ default: m.ReactQueryDevtools })),
-  { ssr: false }
-);
+// RQ Devtools đã tắt: nút floating của nó nằm góc dưới-phải, đè bong bóng
+// "Trợ lý nhắc hẹn" (AppointmentAssistant). Cần debug query thì bật lại tạm.
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -85,7 +81,6 @@ export function Providers({ children }: { children: React.ReactNode }) {
           },
         }}
       />
-      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );
 }

--- a/frontend/src/components/layouts/DashboardLayout.tsx
+++ b/frontend/src/components/layouts/DashboardLayout.tsx
@@ -39,6 +39,16 @@ const CommandPalette = dynamic(
   { ssr: false }
 );
 
+// Trợ lý nhắc hẹn (#3): bong bóng góc màn + nudge tự bung khi tới giờ. Lazy
+// client-only (như CommandPalette) — UI phụ, tránh SSR/hydrate + không chặn tải.
+const AppointmentAssistant = dynamic(
+  () =>
+    import("@/components/leads/AppointmentAssistant").then(m => ({
+      default: m.AppointmentAssistant,
+    })),
+  { ssr: false }
+);
+
 function SidebarSkeleton() {
   return (
     <div className="hidden lg:flex fixed inset-y-0 left-0 z-50 w-[var(--sidebar-width-collapsed)] flex-col border-r bg-background">
@@ -230,6 +240,9 @@ export function DashboardLayout({
         <Suspense fallback={<MobileBottomNavSkeleton />}>
           <MobileBottomNav />
         </Suspense>
+
+        {/* Trợ lý nhắc hẹn — bong bóng góc màn + nudge tự bung khi tới giờ */}
+        <AppointmentAssistant />
       </div>
     </>
   );

--- a/frontend/src/components/layouts/dashboard/Header.test.tsx
+++ b/frontend/src/components/layouts/dashboard/Header.test.tsx
@@ -48,6 +48,9 @@ vi.mock("@/components/ui/theme-toggle", () => ({
 vi.mock("@/components/notifications/NotificationDropdown", () => ({
   NotificationDropdown: () => <div data-testid="notification-dropdown" />,
 }));
+vi.mock("@/components/leads/AppointmentReminder", () => ({
+  AppointmentReminder: () => <div data-testid="appointment-reminder" />,
+}));
 
 // ── Helpers ────────────────────────────────────────────────────────
 

--- a/frontend/src/components/layouts/dashboard/Header.tsx
+++ b/frontend/src/components/layouts/dashboard/Header.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { NotificationDropdown } from "@/components/notifications/NotificationDropdown";
+import { AppointmentReminder } from "@/components/leads/AppointmentReminder";
 import { useCommandPalette } from "@/hooks/useCommandPalette";
 import { useShouldShowSecurityBanner, SECURITY_BANNER_HEIGHT } from "@/components/layouts/SecurityBanner";
 import { useAuth } from "@/hooks/useAuth";
@@ -112,6 +113,9 @@ export function Header() {
 
         {/* Theme Toggle */}
         <ThemeToggle />
+
+        {/* Nhắc lịch hẹn ("Nhịp hẹn") */}
+        <AppointmentReminder />
 
         {/* Notification Dropdown */}
         <NotificationDropdown />

--- a/frontend/src/components/leads/AppointmentAssistant.test.tsx
+++ b/frontend/src/components/leads/AppointmentAssistant.test.tsx
@@ -7,8 +7,9 @@ import { AppointmentAssistant } from "./AppointmentAssistant";
 // useAppointmentNudges chạy THẬT để kiểm hành vi nudge theo thời gian.
 vi.mock("@/hooks/useMyAppointments", () => ({
   useMyAppointments: vi.fn(),
+  isForbiddenError: vi.fn(() => false),
 }));
-import { useMyAppointments } from "@/hooks/useMyAppointments";
+import { useMyAppointments, isForbiddenError } from "@/hooks/useMyAppointments";
 
 const mockUse = useMyAppointments as unknown as ReturnType<typeof vi.fn>;
 
@@ -74,6 +75,7 @@ describe("AppointmentAssistant — trợ lý nhắc hẹn", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(BASE);
+    vi.mocked(isForbiddenError).mockReturnValue(false); // reset (clearAllMocks giữ impl)
   });
   afterEach(() => {
     vi.useRealTimers();
@@ -115,6 +117,22 @@ describe("AppointmentAssistant — trợ lý nhắc hẹn", () => {
     render(<AppointmentAssistant />);
     tick(4);
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("ẩn HẲN trợ lý khi role bị Casbin deny (403) — không hiện bong bóng", () => {
+    // accountant/user: endpoint trả 403 → isForbiddenError=true → widget null.
+    vi.mocked(isForbiddenError).mockReturnValue(true);
+    mockUse.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { response: { status: 403 } },
+    });
+    const { container } = render(<AppointmentAssistant />);
+    expect(container).toBeEmptyDOMElement();
+    expect(
+      screen.queryByRole("button", { name: /Trợ lý nhắc hẹn/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("dời lịch → nudge LẠI đúng giờ mới (khóa dedupe lead@scheduled_at)", () => {

--- a/frontend/src/components/leads/AppointmentAssistant.test.tsx
+++ b/frontend/src/components/leads/AppointmentAssistant.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+
+import { AppointmentAssistant } from "./AppointmentAssistant";
+
+// Mock hook dữ liệu — cô lập khỏi React Query / network. useServerNow +
+// useAppointmentNudges chạy THẬT để kiểm hành vi nudge theo thời gian.
+vi.mock("@/hooks/useMyAppointments", () => ({
+  useMyAppointments: vi.fn(),
+}));
+import { useMyAppointments } from "@/hooks/useMyAppointments";
+
+const mockUse = useMyAppointments as unknown as ReturnType<typeof vi.fn>;
+
+const BASE = new Date("2026-07-13T02:58:00.000Z");
+const iso = (offsetMs: number) => new Date(BASE.getTime() + offsetMs).toISOString();
+
+/**
+ * 1 hẹn ĐÃ quá giờ (seed baseline → không nudge) + 1 hẹn sẽ chạm giờ sau +3s
+ * (→ nudge bung khi thời gian trôi qua). `scope` quyết định officer/admin.
+ */
+function data(scope: "own" | "all") {
+  return {
+    data: {
+      server_time: BASE.toISOString(),
+      scope,
+      overdue_count: 1,
+      upcoming_count: 1,
+      appointments: [
+        {
+          lead_id: 1,
+          lead_name: "Nguyễn Văn Bình",
+          phone: "0900000001",
+          source: "Website",
+          scheduled_at: iso(-3600_000), // quá hạn 1h → seed, không nudge
+          is_overdue: true,
+          degree_level: "Cao đẳng",
+          major: "Điều dưỡng",
+          officer_name: null,
+        },
+        {
+          lead_id: 2,
+          lead_name: "Bùi Hoan",
+          phone: "0900000002",
+          source: "Zalo",
+          scheduled_at: iso(3000), // chạm giờ sau 3s → nudge
+          is_overdue: false,
+          degree_level: "Cao đẳng",
+          major: "Dược",
+          officer_name: null,
+        },
+      ],
+    },
+    isLoading: false,
+    isError: false,
+  };
+}
+
+describe("AppointmentAssistant — trợ lý nhắc hẹn", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("bong bóng hiện badge số hẹn trễ (lớp A)", () => {
+    mockUse.mockReturnValue(data("own"));
+    render(<AppointmentAssistant />);
+    expect(
+      screen.getByRole("button", { name: /Trợ lý nhắc hẹn · 1 hẹn trễ/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("nudge TỰ BUNG khi hẹn tới giờ — tư vấn viên (scope=own, lớp B)", () => {
+    mockUse.mockReturnValue(data("own"));
+    render(<AppointmentAssistant />);
+
+    // Chưa tới giờ → chưa có nudge
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+
+    // Trôi 4s (server_now vượt mốc hẹn +3s) → nudge bung
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+
+    const toast = screen.getByRole("alertdialog", { name: "Nhắc gọi lại" });
+    expect(toast).toBeInTheDocument();
+    expect(screen.getByText(/Tới giờ gọi lại/)).toBeInTheDocument();
+    expect(screen.getByText("Bùi Hoan")).toBeInTheDocument();
+    // Gọi ngay = tel: của hẹn tới giờ
+    expect(screen.getByText("Gọi ngay").closest("a")).toHaveAttribute(
+      "href",
+      "tel:0900000002",
+    );
+    // Hẹn đã-quá-giờ lúc tải KHÔNG bung (đã seed baseline)
+    expect(screen.queryByText("Nguyễn Văn Bình")).not.toBeInTheDocument();
+  });
+
+  it("KHÔNG nudge cho admin/manager (scope=all quá ồn)", () => {
+    mockUse.mockReturnValue(data("all"));
+    render(<AppointmentAssistant />);
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/leads/AppointmentAssistant.test.tsx
+++ b/frontend/src/components/leads/AppointmentAssistant.test.tsx
@@ -15,45 +15,58 @@ const mockUse = useMyAppointments as unknown as ReturnType<typeof vi.fn>;
 const BASE = new Date("2026-07-13T02:58:00.000Z");
 const iso = (offsetMs: number) => new Date(BASE.getTime() + offsetMs).toISOString();
 
-/**
- * 1 hẹn ĐÃ quá giờ (seed baseline → không nudge) + 1 hẹn sẽ chạm giờ sau +3s
- * (→ nudge bung khi thời gian trôi qua). `scope` quyết định officer/admin.
- */
-function data(scope: "own" | "all") {
+// Tick từng giây MỘT (mỗi lần 1 act = 1 flush) — mô phỏng đúng nhịp setInterval
+// 1s thật: engine "arm khi thấy tương lai" cần quan sát hẹn ở từng mốc trước khi
+// nó chạm giờ. (Nhảy `advanceTimersByTime(4000)` một phát bị React gộp thành 1
+// render → bỏ qua các mốc trung gian → không giống thực tế.)
+function tick(seconds: number) {
+  for (let i = 0; i < seconds; i++) {
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+  }
+}
+
+function appt(
+  id: number,
+  offsetMs: number,
+  is_overdue: boolean,
+  name = `Lead ${id}`,
+) {
   return {
-    data: {
-      server_time: BASE.toISOString(),
-      scope,
-      overdue_count: 1,
-      upcoming_count: 1,
-      appointments: [
-        {
-          lead_id: 1,
-          lead_name: "Nguyễn Văn Bình",
-          phone: "0900000001",
-          source: "Website",
-          scheduled_at: iso(-3600_000), // quá hạn 1h → seed, không nudge
-          is_overdue: true,
-          degree_level: "Cao đẳng",
-          major: "Điều dưỡng",
-          officer_name: null,
-        },
-        {
-          lead_id: 2,
-          lead_name: "Bùi Hoan",
-          phone: "0900000002",
-          source: "Zalo",
-          scheduled_at: iso(3000), // chạm giờ sau 3s → nudge
-          is_overdue: false,
-          degree_level: "Cao đẳng",
-          major: "Dược",
-          officer_name: null,
-        },
-      ],
-    },
+    lead_id: id,
+    lead_name: name,
+    phone: `090000000${id}`,
+    source: "Website",
+    scheduled_at: iso(offsetMs),
+    is_overdue,
+    degree_level: "Cao đẳng",
+    major: "Dược",
+    officer_name: null,
+  };
+}
+
+function resp(
+  scope: "own" | "all",
+  appointments: ReturnType<typeof appt>[],
+  overdue_count = 0,
+  upcoming_count = 0,
+) {
+  return {
+    data: { server_time: BASE.toISOString(), scope, overdue_count, upcoming_count, appointments },
     isLoading: false,
     isError: false,
   };
+}
+
+/** Kịch bản mặc định: 1 hẹn đã quá giờ (đã lỡ) + 1 hẹn chạm giờ sau +3s. */
+function data(scope: "own" | "all") {
+  return resp(
+    scope,
+    [appt(1, -3600_000, true, "Nguyễn Văn Bình"), appt(2, 3000, false, "Bùi Hoan")],
+    1,
+    1,
+  );
 }
 
 describe("AppointmentAssistant — trợ lý nhắc hẹn", () => {
@@ -82,9 +95,7 @@ describe("AppointmentAssistant — trợ lý nhắc hẹn", () => {
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
 
     // Trôi 4s (server_now vượt mốc hẹn +3s) → nudge bung
-    act(() => {
-      vi.advanceTimersByTime(4000);
-    });
+    tick(4);
 
     const toast = screen.getByRole("alertdialog", { name: "Nhắc gọi lại" });
     expect(toast).toBeInTheDocument();
@@ -95,16 +106,42 @@ describe("AppointmentAssistant — trợ lý nhắc hẹn", () => {
       "href",
       "tel:0900000002",
     );
-    // Hẹn đã-quá-giờ lúc tải KHÔNG bung (đã seed baseline)
+    // Hẹn đã-quá-giờ lúc tải KHÔNG bung (đã ghi nhận là "đã lỡ")
     expect(screen.queryByText("Nguyễn Văn Bình")).not.toBeInTheDocument();
   });
 
   it("KHÔNG nudge cho admin/manager (scope=all quá ồn)", () => {
     mockUse.mockReturnValue(data("all"));
     render(<AppointmentAssistant />);
-    act(() => {
-      vi.advanceTimersByTime(4000);
-    });
+    tick(4);
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("dời lịch → nudge LẠI đúng giờ mới (khóa dedupe lead@scheduled_at)", () => {
+    mockUse.mockReturnValue(resp("own", [appt(7, 3000, false, "Phan Đức")], 0, 1));
+    render(<AppointmentAssistant />);
+    tick(4); // vượt +3s → nudge lần 1
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+    // Cùng lead 7 nhưng scheduled_at MỚI (dời sang +9s) → khóa mới
+    mockUse.mockReturnValue(resp("own", [appt(7, 9000, false, "Phan Đức")], 0, 1));
+    tick(1); // re-render nhận data mới → toast cũ auto-đóng (khóa cũ biến mất), arm khóa mới
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+
+    tick(5); // tới +10s > +9s → nudge LẠI (khóa cũ chỉ theo lead_id sẽ bị chặn)
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(screen.getByText("Phan Đức")).toBeInTheDocument();
+  });
+
+  it("hẹn quá-giờ XUẤT HIỆN muộn (refetch) KHÔNG bung — chỉ crossing thật mới nudge", () => {
+    mockUse.mockReturnValue(resp("own", [appt(8, 30_000, false)], 0, 1)); // hẹn tương lai xa
+    render(<AppointmentAssistant />);
+    tick(2); // A armed, chưa tới giờ
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+
+    // Refetch thêm hẹn ĐÃ quá giờ (lần đầu thấy đã trễ) → phải im
+    mockUse.mockReturnValue(resp("own", [appt(8, 30_000, false), appt(9, -1000, true)], 1, 1));
+    tick(1);
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/leads/AppointmentAssistant.tsx
+++ b/frontend/src/components/leads/AppointmentAssistant.tsx
@@ -12,7 +12,7 @@ import {
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import { useIsMobile } from "@/hooks/useMediaQuery";
-import { useMyAppointments } from "@/hooks/useMyAppointments";
+import { useMyAppointments, isForbiddenError } from "@/hooks/useMyAppointments";
 import { useServerNow } from "@/hooks/useServerNow";
 import { useAppointmentNudges } from "@/hooks/useAppointmentNudges";
 import {
@@ -156,12 +156,14 @@ function NudgePrefsBar({
   soundOn,
   notifyOn,
   notifySupported,
+  notifyBlocked,
   onToggleSound,
   onToggleNotify,
 }: {
   soundOn: boolean;
   notifyOn: boolean;
   notifySupported: boolean;
+  notifyBlocked: boolean;
   onToggleSound: () => void;
   onToggleNotify: () => void;
 }) {
@@ -173,7 +175,7 @@ function NudgePrefsBar({
         : "border-border text-muted-foreground hover:text-foreground",
     );
   return (
-    <div className="flex items-center gap-2 border-t px-3 py-2">
+    <div className="flex flex-wrap items-center gap-2 border-t px-3 py-2">
       <span className="text-[11px] font-medium text-muted-foreground">Nhắc bằng</span>
       <button
         type="button"
@@ -196,6 +198,11 @@ function NudgePrefsBar({
           Thông báo
         </button>
       )}
+      {notifyBlocked && (
+        <span className="w-full text-[10px] leading-tight text-amber-600 dark:text-amber-400">
+          Thông báo đang bị chặn — hãy bật lại trong cài đặt trình duyệt cho trang này.
+        </span>
+      )}
     </div>
   );
 }
@@ -204,16 +211,21 @@ function NudgePrefsBar({
 export function AppointmentAssistant() {
   const isMobile = useIsMobile();
   const [open, setOpen] = React.useState(false);
-  const { data } = useMyAppointments();
+  const { data, error, dataUpdatedAt } = useMyAppointments();
 
   const overdue = data?.overdue_count ?? 0;
   const enabled = data?.scope === "own"; // nudge chỉ cho tư vấn viên
   // Chỉ chạy nhịp đồng hồ 1s khi thật cần: officer (dò nudge) HOẶC panel đang mở
   // (đếm sống). Admin/manager đóng panel → không tick mỗi giây suốt phiên.
-  const serverNow = useServerNow(data?.server_time, enabled || open);
+  // dataUpdatedAt → skew đúng tuổi snapshot server_time (khỏi lệch ~30s).
+  const serverNow = useServerNow(data?.server_time, enabled || open, dataUpdatedAt);
   const nudges = useAppointmentNudges(data?.appointments, serverNow, enabled, open);
 
   const close = React.useCallback(() => setOpen(false), []);
+
+  // Role bị Casbin deny (accountant/user) → 403 → ẩn hẳn trợ lý (query tự ngừng
+  // poll). Sau MỌI hook để giữ thứ tự hook ổn định (thin-client: theo response).
+  if (isForbiddenError(error)) return null;
 
   const panel = (
     <div className="flex flex-col overflow-hidden">
@@ -223,6 +235,7 @@ export function AppointmentAssistant() {
           soundOn={nudges.soundOn}
           notifyOn={nudges.notifyOn}
           notifySupported={nudges.notifySupported}
+          notifyBlocked={nudges.notifyBlocked}
           onToggleSound={nudges.toggleSound}
           onToggleNotify={nudges.toggleNotify}
         />

--- a/frontend/src/components/leads/AppointmentAssistant.tsx
+++ b/frontend/src/components/leads/AppointmentAssistant.tsx
@@ -1,0 +1,276 @@
+// src/components/leads/AppointmentAssistant.tsx
+"use client";
+
+import * as React from "react";
+import { Bell, Clock, Headphones, Monitor, Phone, X } from "lucide-react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/useMediaQuery";
+import { useMyAppointments } from "@/hooks/useMyAppointments";
+import { useServerNow } from "@/hooks/useServerNow";
+import { useAppointmentNudges } from "@/hooks/useAppointmentNudges";
+import {
+  apptDelta,
+  eduLine,
+  formatDelta,
+  hhmm,
+} from "@/lib/leads/appointment-clock";
+import type { MyAppointmentItem } from "@/lib/api/leads";
+import { ReminderBody } from "./AppointmentReminder";
+
+// =============================================================================
+// Trợ lý nhắc hẹn (#3) — nâng cấp "Nhịp hẹn" từ icon-header thụ động thành trợ lý
+// chủ động ở góc màn:
+//   (A) Bong bóng nổi góc dưới-phải — badge số hẹn trễ + pulse đỏ; bấm → bung
+//       bảng Nhịp hẹn (tái dùng ReminderBody).
+//   (B) Nudge tự bung khi tới giờ — toast [Gọi ngay]/[Hoãn 5'], chỉ tư vấn viên.
+//   (C) Tùy chọn chuông + thông báo hệ thống (báo cả khi tab ẩn).
+// Không cần backend mới: dùng lại /api/leads/my/appointments + server_time.
+// =============================================================================
+
+// ── Bong bóng (trigger dùng chung Popover/Sheet) ─────────────────────────────
+const AssistantBubble = React.forwardRef<
+  HTMLButtonElement,
+  { overdue: number } & React.ButtonHTMLAttributes<HTMLButtonElement>
+>(function AssistantBubble({ overdue, className, ...props }, ref) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      aria-label={`Trợ lý nhắc hẹn${overdue ? ` · ${overdue} hẹn trễ` : ""}`}
+      className={cn(
+        "group relative grid h-14 w-14 place-items-center rounded-full text-white outline-none",
+        "bg-gradient-to-br from-indigo-500 to-violet-500 shadow-lg shadow-indigo-500/30",
+        "transition-transform hover:scale-105 active:scale-95",
+        "focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        className,
+      )}
+      {...props}
+    >
+      {/* nhẫn pulse đỏ khi có hẹn trễ */}
+      {overdue > 0 && (
+        <span
+          aria-hidden
+          className="absolute inset-0 rounded-full bg-red-500/40 motion-safe:animate-ping"
+        />
+      )}
+      <Headphones className="relative h-6 w-6" />
+      {overdue > 0 && (
+        <span className="absolute -right-0.5 -top-0.5 grid h-6 min-w-6 place-items-center rounded-full border-2 border-background bg-red-600 px-1 font-mono text-[11px] font-bold tabular-nums text-white">
+          {overdue > 9 ? "9+" : overdue}
+        </span>
+      )}
+    </button>
+  );
+});
+
+// ── Nudge toast (lớp B) ──────────────────────────────────────────────────────
+function NudgeToast({
+  item,
+  serverNow,
+  onCall,
+  onSnooze,
+  onDismiss,
+}: {
+  item: MyAppointmentItem;
+  serverNow: number;
+  onCall: () => void;
+  onSnooze: () => void;
+  onDismiss: () => void;
+}) {
+  const delta = apptDelta(item.scheduled_at, serverNow);
+  const late = delta < 0;
+  return (
+    <div
+      role="alertdialog"
+      aria-live="assertive"
+      aria-label="Nhắc gọi lại"
+      className="relative w-[340px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-2xl border border-amber-500/40 bg-popover text-popover-foreground shadow-xl"
+    >
+      <div className="h-[3px] bg-gradient-to-r from-amber-500 to-orange-400" />
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Đóng nhắc"
+        className="absolute right-2 top-2.5 grid h-6 w-6 place-items-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <X className="h-4 w-4" />
+      </button>
+      <div className="p-4">
+        <div className="flex items-center gap-2.5">
+          <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-gradient-to-br from-indigo-500 to-violet-500 text-white">
+            <Headphones className="h-[18px] w-[18px]" />
+          </div>
+          <div className="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider text-amber-600 dark:text-amber-400">
+            <span className="h-1.5 w-1.5 rounded-full bg-amber-500 motion-safe:animate-pulse" />
+            {late ? "Tới giờ gọi lại" : "Sắp tới giờ gọi"}
+          </div>
+        </div>
+
+        <div className="mt-2.5 text-[15px] font-bold leading-snug">
+          Gọi lại{" "}
+          <span className="text-amber-600 dark:text-amber-400">{item.lead_name}</span>{" "}
+          {late ? "ngay nhé" : "trong ít phút"}.
+        </div>
+        <div className="mt-0.5 text-xs text-muted-foreground">
+          {eduLine(item)} · nguồn {item.source} · hẹn{" "}
+          <b className="font-mono tabular-nums text-foreground">{hhmm(item.scheduled_at)}</b>{" "}
+          <span className="font-mono tabular-nums">
+            ({late ? "trễ " : "còn "}
+            {formatDelta(delta)})
+          </span>
+        </div>
+
+        <div className="mt-3 flex gap-2">
+          <a
+            href={`tel:${item.phone}`}
+            onClick={onCall}
+            className="flex h-10 flex-[1.5] items-center justify-center gap-2 rounded-lg bg-amber-600 text-sm font-bold text-white transition-colors hover:bg-amber-600/90"
+          >
+            <Phone className="h-4 w-4" />
+            Gọi ngay
+          </a>
+          <button
+            type="button"
+            onClick={onSnooze}
+            className="flex h-10 flex-1 items-center justify-center gap-1.5 rounded-lg border border-border bg-background text-sm font-semibold transition-colors hover:border-amber-500/40 hover:text-amber-600 dark:hover:text-amber-400"
+          >
+            <Clock className="h-3.5 w-3.5" />
+            Hoãn 5&apos;
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Thanh tùy chọn nhắc (lớp C) ──────────────────────────────────────────────
+function NudgePrefsBar({
+  soundOn,
+  notifyOn,
+  notifySupported,
+  onToggleSound,
+  onToggleNotify,
+}: {
+  soundOn: boolean;
+  notifyOn: boolean;
+  notifySupported: boolean;
+  onToggleSound: () => void;
+  onToggleNotify: () => void;
+}) {
+  const btn = (active: boolean) =>
+    cn(
+      "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold transition-colors",
+      active
+        ? "border-indigo-500/40 bg-indigo-500/10 text-indigo-600 dark:text-indigo-300"
+        : "border-border text-muted-foreground hover:text-foreground",
+    );
+  return (
+    <div className="flex items-center gap-2 border-t px-3 py-2">
+      <span className="text-[11px] font-medium text-muted-foreground">Nhắc bằng</span>
+      <button
+        type="button"
+        onClick={onToggleSound}
+        aria-pressed={soundOn}
+        className={btn(soundOn)}
+      >
+        <Bell className="h-3.5 w-3.5" />
+        Chuông
+      </button>
+      {notifySupported && (
+        <button
+          type="button"
+          onClick={onToggleNotify}
+          aria-pressed={notifyOn}
+          className={btn(notifyOn)}
+          title="Báo cả khi tab đang ẩn"
+        >
+          <Monitor className="h-3.5 w-3.5" />
+          Thông báo
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Trợ lý (bong bóng + panel + nudge) ───────────────────────────────────────
+export function AppointmentAssistant() {
+  const isMobile = useIsMobile();
+  const { data } = useMyAppointments();
+  const serverNow = useServerNow(data?.server_time);
+  const [open, setOpen] = React.useState(false);
+
+  const overdue = data?.overdue_count ?? 0;
+  const enabled = data?.scope === "own"; // nudge chỉ cho tư vấn viên
+  const nudges = useAppointmentNudges(data?.appointments, serverNow, enabled);
+
+  const close = React.useCallback(() => setOpen(false), []);
+
+  const panel = (
+    <div className="flex flex-col overflow-hidden">
+      <ReminderBody onNavigate={close} />
+      {enabled && (
+        <NudgePrefsBar
+          soundOn={nudges.soundOn}
+          notifyOn={nudges.notifyOn}
+          notifySupported={nudges.notifySupported}
+          onToggleSound={nudges.toggleSound}
+          onToggleNotify={nudges.toggleNotify}
+        />
+      )}
+    </div>
+  );
+
+  return (
+    <div className="fixed bottom-20 right-4 z-40 flex flex-col items-end gap-3 print:hidden md:bottom-6 md:right-6">
+      {/* Nudge tự bung — ẩn khi panel đang mở (tránh chồng) */}
+      {enabled && !open && nudges.active && (
+        <NudgeToast
+          item={nudges.active}
+          serverNow={serverNow}
+          onCall={nudges.markCalled}
+          onSnooze={nudges.snooze}
+          onDismiss={nudges.dismiss}
+        />
+      )}
+
+      {isMobile ? (
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>
+            <AssistantBubble overdue={overdue} />
+          </SheetTrigger>
+          <SheetContent
+            side="bottom"
+            aria-describedby={undefined}
+            className="max-h-[92vh] gap-0 overflow-hidden p-0"
+          >
+            <SheetTitle className="sr-only">Trợ lý nhắc hẹn</SheetTitle>
+            {panel}
+          </SheetContent>
+        </Sheet>
+      ) : (
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <AssistantBubble overdue={overdue} />
+          </PopoverTrigger>
+          <PopoverContent
+            side="top"
+            align="end"
+            sideOffset={12}
+            className="w-[384px] overflow-hidden rounded-xl p-0"
+          >
+            {panel}
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}
+
+export default AppointmentAssistant;

--- a/frontend/src/components/leads/AppointmentAssistant.tsx
+++ b/frontend/src/components/leads/AppointmentAssistant.tsx
@@ -211,7 +211,7 @@ export function AppointmentAssistant() {
   // Chỉ chạy nhịp đồng hồ 1s khi thật cần: officer (dò nudge) HOẶC panel đang mở
   // (đếm sống). Admin/manager đóng panel → không tick mỗi giây suốt phiên.
   const serverNow = useServerNow(data?.server_time, enabled || open);
-  const nudges = useAppointmentNudges(data?.appointments, serverNow, enabled);
+  const nudges = useAppointmentNudges(data?.appointments, serverNow, enabled, open);
 
   const close = React.useCallback(() => setOpen(false), []);
 

--- a/frontend/src/components/leads/AppointmentAssistant.tsx
+++ b/frontend/src/components/leads/AppointmentAssistant.tsx
@@ -25,8 +25,9 @@ import type { MyAppointmentItem } from "@/lib/api/leads";
 import { ReminderBody } from "./AppointmentReminder";
 
 // =============================================================================
-// Trợ lý nhắc hẹn (#3) — nâng cấp "Nhịp hẹn" từ icon-header thụ động thành trợ lý
-// chủ động ở góc màn:
+// Trợ lý nhắc hẹn (#3) — trợ lý CHỦ ĐỘNG ở góc màn, BỔ SUNG (không thay thế) icon
+// "Nhịp hẹn" thụ động trên header: icon header = lối tra cứu nhanh, trợ lý = nhắc
+// chủ động. Cả hai mở cùng bảng ReminderBody một cách có chủ đích.
 //   (A) Bong bóng nổi góc dưới-phải — badge số hẹn trễ + pulse đỏ; bấm → bung
 //       bảng Nhịp hẹn (tái dùng ReminderBody).
 //   (B) Nudge tự bung khi tới giờ — toast [Gọi ngay]/[Hoãn 5'], chỉ tư vấn viên.
@@ -202,12 +203,14 @@ function NudgePrefsBar({
 // ── Trợ lý (bong bóng + panel + nudge) ───────────────────────────────────────
 export function AppointmentAssistant() {
   const isMobile = useIsMobile();
-  const { data } = useMyAppointments();
-  const serverNow = useServerNow(data?.server_time);
   const [open, setOpen] = React.useState(false);
+  const { data } = useMyAppointments();
 
   const overdue = data?.overdue_count ?? 0;
   const enabled = data?.scope === "own"; // nudge chỉ cho tư vấn viên
+  // Chỉ chạy nhịp đồng hồ 1s khi thật cần: officer (dò nudge) HOẶC panel đang mở
+  // (đếm sống). Admin/manager đóng panel → không tick mỗi giây suốt phiên.
+  const serverNow = useServerNow(data?.server_time, enabled || open);
   const nudges = useAppointmentNudges(data?.appointments, serverNow, enabled);
 
   const close = React.useCallback(() => setOpen(false), []);

--- a/frontend/src/components/leads/AppointmentReminder.test.tsx
+++ b/frontend/src/components/leads/AppointmentReminder.test.tsx
@@ -17,6 +17,7 @@ function withData() {
   return {
     data: {
       server_time: NOW,
+      scope: "all", // admin/manager xem toàn bộ → có officer_name
       overdue_count: 2,
       upcoming_count: 1,
       appointments: [
@@ -29,6 +30,7 @@ function withData() {
           is_overdue: true,
           degree_level: "Cao đẳng",
           major: "Điều dưỡng",
+          officer_name: "Trần Quản Lý",
         },
         {
           lead_id: 2,
@@ -39,6 +41,7 @@ function withData() {
           is_overdue: true,
           degree_level: "Trung cấp",
           major: "Kế toán",
+          officer_name: "Lê Tư Vấn",
         },
         {
           lead_id: 3,
@@ -49,6 +52,7 @@ function withData() {
           is_overdue: false,
           degree_level: "Đại học",
           major: "Công nghệ thông tin",
+          officer_name: "Phạm Officer",
         },
       ],
     },
@@ -74,13 +78,15 @@ describe("AppointmentReminder / ReminderBody", () => {
     // Gọi ngay = tel: của hero
     const call = screen.getByText("Gọi ngay").closest("a");
     expect(call).toHaveAttribute("href", "tel:0900000001");
-    // trình độ viết tắt (getDegreeLevelAbbr): "Cao đẳng" → "CĐ"
-    expect(screen.getByText(/CĐ Điều dưỡng/)).toBeInTheDocument();
+    // trình độ viết tắt (getDegreeLevelAbbr): "Cao đẳng" → "CĐ" + tên NV (scope=all)
+    expect(screen.getByText(/CĐ Điều dưỡng · Trần Quản Lý/)).toBeInTheDocument();
+    // scope=all (admin/manager) → tiêu đề "Lịch hẹn tư vấn" (không phải "của bạn")
+    expect(screen.getByText("Lịch hẹn tư vấn")).toBeInTheDocument();
   });
 
   it("empty state khi không có lịch hẹn", () => {
     mockUse.mockReturnValue({
-      data: { server_time: NOW, overdue_count: 0, upcoming_count: 0, appointments: [] },
+      data: { server_time: NOW, scope: "own", overdue_count: 0, upcoming_count: 0, appointments: [] },
       isLoading: false,
       isError: false,
     });

--- a/frontend/src/components/leads/AppointmentReminder.test.tsx
+++ b/frontend/src/components/leads/AppointmentReminder.test.tsx
@@ -6,6 +6,7 @@ import { ReminderBody } from "./AppointmentReminder";
 // Mock hook dữ liệu — cô lập component khỏi React Query / network.
 vi.mock("@/hooks/useMyAppointments", () => ({
   useMyAppointments: vi.fn(),
+  isForbiddenError: () => false, // mặc định không bị 403 → widget render
 }));
 import { useMyAppointments } from "@/hooks/useMyAppointments";
 

--- a/frontend/src/components/leads/AppointmentReminder.test.tsx
+++ b/frontend/src/components/leads/AppointmentReminder.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { ReminderBody } from "./AppointmentReminder";
+
+// Mock hook dữ liệu — cô lập component khỏi React Query / network.
+vi.mock("@/hooks/useMyAppointments", () => ({
+  useMyAppointments: vi.fn(),
+}));
+import { useMyAppointments } from "@/hooks/useMyAppointments";
+
+const mockUse = useMyAppointments as unknown as ReturnType<typeof vi.fn>;
+
+const NOW = "2026-07-13T02:58:00.000Z";
+
+function withData() {
+  return {
+    data: {
+      server_time: NOW,
+      overdue_count: 2,
+      upcoming_count: 1,
+      appointments: [
+        {
+          lead_id: 1,
+          lead_name: "Nguyễn Văn Bình",
+          phone: "0900000001",
+          source: "Website",
+          scheduled_at: "2026-07-12T23:46:00.000Z", // quá hạn nhất → hero
+          is_overdue: true,
+          degree_level: "Cao đẳng",
+          major: "Điều dưỡng",
+        },
+        {
+          lead_id: 2,
+          lead_name: "Bùi Hoan",
+          phone: "0900000002",
+          source: "Zalo",
+          scheduled_at: "2026-07-13T02:32:00.000Z", // quá hạn
+          is_overdue: true,
+          degree_level: "Trung cấp",
+          major: "Kế toán",
+        },
+        {
+          lead_id: 3,
+          lead_name: "Thanh Hương",
+          phone: "0900000003",
+          source: "Facebook",
+          scheduled_at: "2026-07-13T03:40:00.000Z", // sắp tới
+          is_overdue: false,
+          degree_level: "Đại học",
+          major: "Công nghệ thông tin",
+        },
+      ],
+    },
+    isLoading: false,
+    isError: false,
+  };
+}
+
+describe("AppointmentReminder / ReminderBody", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("render hero + hàng + đường BÂY GIỜ + Gọi ngay khi có lịch hẹn", () => {
+    mockUse.mockReturnValue(withData());
+    render(<ReminderBody />);
+
+    // hero = lead quá hạn nhất (đầu danh sách ASC)
+    expect(screen.getByText("Nguyễn Văn Bình")).toBeInTheDocument();
+    // các hàng còn lại
+    expect(screen.getByText("Bùi Hoan")).toBeInTheDocument();
+    expect(screen.getByText("Thanh Hương")).toBeInTheDocument();
+    // signature: đường BÂY GIỜ chia quá hạn / sắp tới
+    expect(screen.getByText(/BÂY GIỜ/)).toBeInTheDocument();
+    // Gọi ngay = tel: của hero
+    const call = screen.getByText("Gọi ngay").closest("a");
+    expect(call).toHaveAttribute("href", "tel:0900000001");
+    // trình độ viết tắt (getDegreeLevelAbbr): "Cao đẳng" → "CĐ"
+    expect(screen.getByText(/CĐ Điều dưỡng/)).toBeInTheDocument();
+  });
+
+  it("empty state khi không có lịch hẹn", () => {
+    mockUse.mockReturnValue({
+      data: { server_time: NOW, overdue_count: 0, upcoming_count: 0, appointments: [] },
+      isLoading: false,
+      isError: false,
+    });
+    render(<ReminderBody />);
+    expect(screen.getByText(/Hết hẹn/)).toBeInTheDocument();
+  });
+
+  it("error state không crash", () => {
+    mockUse.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    render(<ReminderBody />);
+    expect(screen.getByText(/Không tải được/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/leads/AppointmentReminder.tsx
+++ b/frontend/src/components/leads/AppointmentReminder.tsx
@@ -27,8 +27,8 @@ import {
   STATE_STYLE,
   formatDelta,
   hhmm,
+  hhmmFromMs,
   metaLine,
-  pad,
   stateOf,
 } from "@/lib/leads/appointment-clock";
 import type { MyAppointmentItem } from "@/lib/api/leads";
@@ -139,7 +139,6 @@ function ApptRow({ item, serverNow }: { item: MyAppointmentItem; serverNow: numb
 }
 
 function NowLine({ serverNow }: { serverNow: number }) {
-  const d = new Date(serverNow);
   return (
     <div className="my-2 flex items-center gap-2.5 text-muted-foreground">
       <span className="h-px flex-1 bg-gradient-to-r from-transparent to-border" />
@@ -147,7 +146,7 @@ function NowLine({ serverNow }: { serverNow: number }) {
         <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_8px] shadow-emerald-500/60" />
         BÂY GIỜ ·{" "}
         <span className="font-mono text-emerald-600 dark:text-emerald-400">
-          {pad(d.getHours())}:{pad(d.getMinutes())}
+          {hhmmFromMs(serverNow)}
         </span>
       </span>
       <span className="h-px flex-1 bg-gradient-to-l from-transparent to-border" />
@@ -163,10 +162,10 @@ export function ReminderBody({ onNavigate }: { onNavigate?: () => void }) {
   const appts = data?.appointments ?? [];
   const hero = appts[0];
   const rest = appts.slice(1);
-  // chỉ số hàng đầu tiên KHÔNG quá hạn trong `rest` → chèn đường BÂY GIỜ trước nó
-  const firstUpcomingIdx = rest.findIndex((a) => !a.is_overdue);
-
-  const clock = new Date(serverNow);
+  // vị trí hàng KHÔNG-quá-hạn đầu tiên trong TOÀN danh sách (kể cả hero) → chèn
+  // đường BÂY GIỜ ngay TRƯỚC nó. Nếu hero đã là sắp-tới (không có hẹn trễ), đường
+  // nằm TRÊN hero — tránh việc một hẹn tương lai đứng trên đường "bây giờ".
+  const firstUpcomingIdx = appts.findIndex((a) => !a.is_overdue);
 
   return (
     <div className="flex flex-col">
@@ -182,7 +181,7 @@ export function ReminderBody({ onNavigate }: { onNavigate?: () => void }) {
         </div>
         <div className="text-right">
           <div className="font-mono text-lg font-bold tabular-nums" suppressHydrationWarning>
-            {pad(clock.getHours())}:{pad(clock.getMinutes())}
+            {hhmmFromMs(serverNow)}
           </div>
           {data && (
             <div className="mt-0.5 flex justify-end gap-1.5 text-[11px] font-semibold">
@@ -224,10 +223,12 @@ export function ReminderBody({ onNavigate }: { onNavigate?: () => void }) {
             </div>
           ) : (
             <>
+              {/* hero chính là hẹn sắp-tới đầu tiên → đường BÂY GIỜ nằm trên hero */}
+              {firstUpcomingIdx === 0 && <NowLine serverNow={serverNow} />}
               <Hero item={hero} serverNow={serverNow} />
               {rest.map((item, idx) => (
                 <React.Fragment key={item.lead_id}>
-                  {idx === firstUpcomingIdx && <NowLine serverNow={serverNow} />}
+                  {idx + 1 === firstUpcomingIdx && <NowLine serverNow={serverNow} />}
                   <ApptRow item={item} serverNow={serverNow} />
                 </React.Fragment>
               ))}

--- a/frontend/src/components/leads/AppointmentReminder.tsx
+++ b/frontend/src/components/leads/AppointmentReminder.tsx
@@ -20,9 +20,17 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
-import { getDegreeLevelAbbr } from "@/constants";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import { useMyAppointments } from "@/hooks/useMyAppointments";
+import { useServerNow } from "@/hooks/useServerNow";
+import {
+  STATE_STYLE,
+  formatDelta,
+  hhmm,
+  metaLine,
+  pad,
+  stateOf,
+} from "@/lib/leads/appointment-clock";
 import type { MyAppointmentItem } from "@/lib/api/leads";
 
 // =============================================================================
@@ -30,91 +38,15 @@ import type { MyAppointmentItem } from "@/lib/api/leads";
 // Hero = việc cần làm bây giờ (hẹn khẩn nhất) + đồng hồ đếm sống; đường "BÂY GIỜ"
 // chia quá hạn / sắp tới. Đếm giờ đồng bộ theo server_time (khỏi lệ thuộc đồng
 // hồ máy client). Desktop = dropdown; mobile = bottom sheet.
+//
+// Helper thuần (stateOf/formatDelta/hhmm/metaLine/STATE_STYLE) + hook đồng hồ
+// (useServerNow) tách sang lib/leads/appointment-clock + hooks/useServerNow để
+// dùng chung với AppointmentAssistant (bong bóng + nudge).
 // =============================================================================
-
-const DUE_SOON_MS = 10 * 60 * 1000; // ≤10 phút tới = "đến giờ" (hổ phách)
-
-type ApptState = "overdue" | "due" | "soon";
-
-function stateOf(item: MyAppointmentItem, serverNow: number): ApptState {
-  const delta = new Date(item.scheduled_at).getTime() - serverNow;
-  if (delta < 0) return "overdue";
-  if (delta <= DUE_SOON_MS) return "due";
-  return "soon";
-}
-
-const pad = (n: number) => String(n).padStart(2, "0");
-
-/** Định dạng khoảng cách tới giờ hẹn: ngày → H:MM:SS → MM:SS (đếm sống). */
-function formatDelta(ms: number): string {
-  const s = Math.abs(Math.floor(ms / 1000));
-  const d = Math.floor(s / 86400);
-  const h = Math.floor((s % 86400) / 3600);
-  const m = Math.floor((s % 3600) / 60);
-  const sec = s % 60;
-  if (d >= 1) return `${d} ngày${h ? ` ${h}h` : ""}`;
-  if (h >= 1) return `${h}:${pad(m)}:${pad(sec)}`;
-  return `${pad(m)}:${pad(sec)}`;
-}
-
-function hhmm(iso: string): string {
-  const d = new Date(iso);
-  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
-/**
- * Đồng hồ tick 1s, căn theo server_time (bù lệch đồng hồ client).
- * `now` giữ ở state — KHÔNG gọi Date.now() trong render (react-compiler cấm
- * impure trong render). Init từ server_time (parse chuỗi cố định = pure);
- * Date.now() chỉ dùng trong effect (được phép).
- */
-function useServerNow(serverTimeIso?: string): number {
-  const skew = React.useRef(0);
-  const [now, setNow] = React.useState<number>(() =>
-    serverTimeIso ? new Date(serverTimeIso).getTime() : 0,
-  );
-  React.useEffect(() => {
-    if (!serverTimeIso) return;
-    skew.current = new Date(serverTimeIso).getTime() - Date.now();
-    setNow(Date.now() + skew.current);
-    const id = setInterval(() => setNow(Date.now() + skew.current), 1000);
-    return () => clearInterval(id);
-  }, [serverTimeIso]);
-  return now;
-}
-
-const STATE_STYLE: Record<ApptState, { text: string; bar: string; pill: string }> = {
-  overdue: {
-    text: "text-red-600 dark:text-red-400",
-    bar: "bg-red-500",
-    pill: "text-red-600 dark:text-red-300 bg-red-500/10",
-  },
-  due: {
-    text: "text-amber-600 dark:text-amber-400",
-    bar: "bg-amber-500",
-    pill: "text-amber-700 dark:text-amber-300 bg-amber-500/10",
-  },
-  soon: {
-    text: "text-blue-600 dark:text-blue-400",
-    bar: "bg-blue-500",
-    pill: "text-blue-600 dark:text-blue-300 bg-blue-500/10",
-  },
-};
-
-function eduLine(item: MyAppointmentItem): string {
-  const deg = getDegreeLevelAbbr(item.degree_level ?? undefined);
-  const parts = [deg, item.major].filter(Boolean);
-  return parts.length ? parts.join(" ") : "Chưa chọn ngành";
-}
-
-/** Dòng phụ: ngành · NV phụ trách (tên NV chỉ có khi admin/manager xem toàn bộ). */
-function metaLine(item: MyAppointmentItem): string {
-  return item.officer_name ? `${eduLine(item)} · ${item.officer_name}` : eduLine(item);
-}
 
 // ── Hero: việc cần làm bây giờ ────────────────────────────────────────────────
 function Hero({ item, serverNow }: { item: MyAppointmentItem; serverNow: number }) {
-  const st = stateOf(item, serverNow);
+  const st = stateOf(item.scheduled_at, serverNow);
   const style = STATE_STYLE[st];
   const delta = new Date(item.scheduled_at).getTime() - serverNow;
   const label =
@@ -182,7 +114,7 @@ function Hero({ item, serverNow }: { item: MyAppointmentItem; serverNow: number 
 
 // ── Hàng trong danh sách ──────────────────────────────────────────────────────
 function ApptRow({ item, serverNow }: { item: MyAppointmentItem; serverNow: number }) {
-  const st = stateOf(item, serverNow);
+  const st = stateOf(item.scheduled_at, serverNow);
   const style = STATE_STYLE[st];
   const delta = new Date(item.scheduled_at).getTime() - serverNow;
   return (

--- a/frontend/src/components/leads/AppointmentReminder.tsx
+++ b/frontend/src/components/leads/AppointmentReminder.tsx
@@ -21,7 +21,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { useIsMobile } from "@/hooks/useMediaQuery";
-import { useMyAppointments } from "@/hooks/useMyAppointments";
+import { useMyAppointments, isForbiddenError } from "@/hooks/useMyAppointments";
 import { useServerNow } from "@/hooks/useServerNow";
 import {
   STATE_STYLE,
@@ -157,8 +157,10 @@ function NowLine({ serverNow }: { serverNow: number }) {
 
 // ── Nội dung popup (dùng chung dropdown & sheet) ─────────────────────────────
 export function ReminderBody({ onNavigate }: { onNavigate?: () => void }) {
-  const { data, isLoading, isError } = useMyAppointments();
-  const serverNow = useServerNow(data?.server_time);
+  const { data, isLoading, isError, dataUpdatedAt } = useMyAppointments();
+  // dataUpdatedAt = mốc client nhận server_time → skew đúng tuổi snapshot (khỏi
+  // lệch ~30s khi remount panel với data đã cache).
+  const serverNow = useServerNow(data?.server_time, true, dataUpdatedAt);
 
   const appts = data?.appointments ?? [];
   const hero = appts[0];
@@ -260,8 +262,13 @@ export function ReminderBody({ onNavigate }: { onNavigate?: () => void }) {
 export function AppointmentReminder() {
   const [open, setOpen] = React.useState(false);
   const isMobile = useIsMobile();
-  const { data } = useMyAppointments();
+  const { data, error } = useMyAppointments();
   const overdue = data?.overdue_count ?? 0;
+
+  // Role bị Casbin deny (accountant/user) → 403 → ẩn hẳn widget (không hiện icon
+  // lỗi + query tự ngừng poll qua useMyAppointments). Dựa vào RESPONSE, KHÔNG
+  // check user.role (thin-client).
+  if (isForbiddenError(error)) return null;
 
   const trigger = (
     <Button

--- a/frontend/src/components/leads/AppointmentReminder.tsx
+++ b/frontend/src/components/leads/AppointmentReminder.tsx
@@ -1,0 +1,365 @@
+// src/components/leads/AppointmentReminder.tsx
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { CalendarClock, Phone, Clock, ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Sheet,
+  SheetContent,
+  SheetTrigger,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { getDegreeLevelAbbr } from "@/constants";
+import { useIsMobile } from "@/hooks/useMediaQuery";
+import { useMyAppointments } from "@/hooks/useMyAppointments";
+import type { MyAppointmentItem } from "@/lib/api/leads";
+
+// =============================================================================
+// Nhịp hẹn — bảng nhắc lịch hẹn cho tư vấn viên.
+// Hero = việc cần làm bây giờ (hẹn khẩn nhất) + đồng hồ đếm sống; đường "BÂY GIỜ"
+// chia quá hạn / sắp tới. Đếm giờ đồng bộ theo server_time (khỏi lệ thuộc đồng
+// hồ máy client). Desktop = dropdown; mobile = bottom sheet.
+// =============================================================================
+
+const DUE_SOON_MS = 10 * 60 * 1000; // ≤10 phút tới = "đến giờ" (hổ phách)
+
+type ApptState = "overdue" | "due" | "soon";
+
+function stateOf(item: MyAppointmentItem, serverNow: number): ApptState {
+  const delta = new Date(item.scheduled_at).getTime() - serverNow;
+  if (delta < 0) return "overdue";
+  if (delta <= DUE_SOON_MS) return "due";
+  return "soon";
+}
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/** Định dạng khoảng cách tới giờ hẹn: ngày → H:MM:SS → MM:SS (đếm sống). */
+function formatDelta(ms: number): string {
+  const s = Math.abs(Math.floor(ms / 1000));
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  if (d >= 1) return `${d} ngày${h ? ` ${h}h` : ""}`;
+  if (h >= 1) return `${h}:${pad(m)}:${pad(sec)}`;
+  return `${pad(m)}:${pad(sec)}`;
+}
+
+function hhmm(iso: string): string {
+  const d = new Date(iso);
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * Đồng hồ tick 1s, căn theo server_time (bù lệch đồng hồ client).
+ * `now` giữ ở state — KHÔNG gọi Date.now() trong render (react-compiler cấm
+ * impure trong render). Init từ server_time (parse chuỗi cố định = pure);
+ * Date.now() chỉ dùng trong effect (được phép).
+ */
+function useServerNow(serverTimeIso?: string): number {
+  const skew = React.useRef(0);
+  const [now, setNow] = React.useState<number>(() =>
+    serverTimeIso ? new Date(serverTimeIso).getTime() : 0,
+  );
+  React.useEffect(() => {
+    if (!serverTimeIso) return;
+    skew.current = new Date(serverTimeIso).getTime() - Date.now();
+    setNow(Date.now() + skew.current);
+    const id = setInterval(() => setNow(Date.now() + skew.current), 1000);
+    return () => clearInterval(id);
+  }, [serverTimeIso]);
+  return now;
+}
+
+const STATE_STYLE: Record<ApptState, { text: string; bar: string; pill: string }> = {
+  overdue: {
+    text: "text-red-600 dark:text-red-400",
+    bar: "bg-red-500",
+    pill: "text-red-600 dark:text-red-300 bg-red-500/10",
+  },
+  due: {
+    text: "text-amber-600 dark:text-amber-400",
+    bar: "bg-amber-500",
+    pill: "text-amber-700 dark:text-amber-300 bg-amber-500/10",
+  },
+  soon: {
+    text: "text-blue-600 dark:text-blue-400",
+    bar: "bg-blue-500",
+    pill: "text-blue-600 dark:text-blue-300 bg-blue-500/10",
+  },
+};
+
+function eduLine(item: MyAppointmentItem): string {
+  const deg = getDegreeLevelAbbr(item.degree_level ?? undefined);
+  const parts = [deg, item.major].filter(Boolean);
+  return parts.length ? parts.join(" ") : "Chưa chọn ngành";
+}
+
+// ── Hero: việc cần làm bây giờ ────────────────────────────────────────────────
+function Hero({ item, serverNow }: { item: MyAppointmentItem; serverNow: number }) {
+  const st = stateOf(item, serverNow);
+  const style = STATE_STYLE[st];
+  const delta = new Date(item.scheduled_at).getTime() - serverNow;
+  const label =
+    st === "overdue"
+      ? "Trễ hẹn · gọi lại ngay"
+      : st === "due"
+        ? "Đến giờ gọi"
+        : "Sắp gọi";
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-xl border p-4",
+        st === "overdue"
+          ? "border-red-500/30 bg-red-500/[0.06]"
+          : st === "due"
+            ? "border-amber-500/30 bg-amber-500/[0.06]"
+            : "border-blue-500/30 bg-blue-500/[0.06]",
+      )}
+    >
+      <div className={cn("flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-wider", style.text)}>
+        <span className={cn("h-1.5 w-1.5 rounded-full", style.bar, st === "overdue" && "motion-safe:animate-pulse")} />
+        {label}
+      </div>
+      <div className="mt-2 truncate text-lg font-bold font-display leading-tight">
+        {item.lead_name}
+      </div>
+      <div className="mt-0.5 truncate text-xs text-muted-foreground">{eduLine(item)}</div>
+
+      <div className="mt-3 flex items-center gap-3">
+        <div className={cn("font-mono text-3xl font-bold leading-none tabular-nums", style.text)}>
+          {formatDelta(delta)}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {st === "overdue" ? "trễ so với hẹn" : "còn tới hẹn"}{" "}
+          <b className="text-foreground">{hhmm(item.scheduled_at)}</b>
+          <br />
+          nguồn {item.source}
+        </div>
+      </div>
+
+      <div className="mt-4 flex gap-2">
+        <Button
+          asChild
+          className={cn(
+            "h-11 flex-[1.6] gap-2 border-none text-white",
+            st === "overdue"
+              ? "bg-red-600 hover:bg-red-600/90"
+              : st === "due"
+                ? "bg-amber-600 hover:bg-amber-600/90"
+                : "bg-blue-600 hover:bg-blue-600/90",
+          )}
+        >
+          <a href={`tel:${item.phone}`}>
+            <Phone className="h-4 w-4" />
+            Gọi ngay
+          </a>
+        </Button>
+        <Button asChild variant="outline" className="h-11 flex-1">
+          <Link href={`/leads/${item.lead_id}`}>Mở lead</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── Hàng trong danh sách ──────────────────────────────────────────────────────
+function ApptRow({ item, serverNow }: { item: MyAppointmentItem; serverNow: number }) {
+  const st = stateOf(item, serverNow);
+  const style = STATE_STYLE[st];
+  const delta = new Date(item.scheduled_at).getTime() - serverNow;
+  return (
+    <Link
+      href={`/leads/${item.lead_id}`}
+      className="flex items-center gap-3 rounded-lg border border-transparent px-2.5 py-2.5 transition-colors hover:border-border hover:bg-muted/50"
+    >
+      <div className="w-11 shrink-0 text-right">
+        <div className="font-mono text-sm font-bold tabular-nums">{hhmm(item.scheduled_at)}</div>
+      </div>
+      <div className={cn("h-9 w-[3px] shrink-0 rounded-full", style.bar)} />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-semibold font-display leading-tight">{item.lead_name}</div>
+        <div className="truncate text-xs text-muted-foreground">{eduLine(item)}</div>
+      </div>
+      <div className={cn("shrink-0 rounded-md px-2 py-1 font-mono text-xs font-semibold tabular-nums", style.pill)}>
+        {st === "overdue" ? "trễ " : "còn "}
+        {formatDelta(delta)}
+      </div>
+    </Link>
+  );
+}
+
+function NowLine({ serverNow }: { serverNow: number }) {
+  const d = new Date(serverNow);
+  return (
+    <div className="my-2 flex items-center gap-2.5 text-muted-foreground">
+      <span className="h-px flex-1 bg-gradient-to-r from-transparent to-border" />
+      <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-[11px] font-bold tracking-wider">
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_8px] shadow-emerald-500/60" />
+        BÂY GIỜ ·{" "}
+        <span className="font-mono text-emerald-600 dark:text-emerald-400">
+          {pad(d.getHours())}:{pad(d.getMinutes())}
+        </span>
+      </span>
+      <span className="h-px flex-1 bg-gradient-to-l from-transparent to-border" />
+    </div>
+  );
+}
+
+// ── Nội dung popup (dùng chung dropdown & sheet) ─────────────────────────────
+export function ReminderBody({ onNavigate }: { onNavigate?: () => void }) {
+  const { data, isLoading, isError } = useMyAppointments();
+  const serverNow = useServerNow(data?.server_time);
+
+  const appts = data?.appointments ?? [];
+  const hero = appts[0];
+  const rest = appts.slice(1);
+  // chỉ số hàng đầu tiên KHÔNG quá hạn trong `rest` → chèn đường BÂY GIỜ trước nó
+  const firstUpcomingIdx = rest.findIndex((a) => !a.is_overdue);
+
+  const clock = new Date(serverNow);
+
+  return (
+    <div className="flex flex-col">
+      {/* Header */}
+      <div className="flex items-start justify-between border-b p-4">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Việc cần làm bây giờ
+          </div>
+          <h2 className="font-display text-lg font-bold">Lịch hẹn của bạn</h2>
+        </div>
+        <div className="text-right">
+          <div className="font-mono text-lg font-bold tabular-nums" suppressHydrationWarning>
+            {pad(clock.getHours())}:{pad(clock.getMinutes())}
+          </div>
+          {data && (
+            <div className="mt-0.5 flex justify-end gap-1.5 text-[11px] font-semibold">
+              {data.overdue_count > 0 && (
+                <span className="rounded-full bg-red-500/10 px-2 py-0.5 text-red-600 dark:text-red-300">
+                  {data.overdue_count} trễ
+                </span>
+              )}
+              {data.upcoming_count > 0 && (
+                <span className="rounded-full bg-blue-500/10 px-2 py-0.5 text-blue-600 dark:text-blue-300">
+                  {data.upcoming_count} sắp tới
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <ScrollArea className="max-h-[62vh] md:max-h-[460px]">
+        <div className="space-y-1 p-3" onClick={onNavigate}>
+          {isLoading ? (
+            <div className="space-y-3 p-1">
+              <Skeleton className="h-32 w-full rounded-xl" />
+              <Skeleton className="h-12 w-full rounded-lg" />
+              <Skeleton className="h-12 w-full rounded-lg" />
+            </div>
+          ) : isError ? (
+            <div className="flex flex-col items-center gap-2 py-12 text-center">
+              <CalendarClock className="h-9 w-9 text-destructive" />
+              <p className="text-sm text-destructive">Không tải được lịch hẹn</p>
+            </div>
+          ) : !hero ? (
+            <div className="flex flex-col items-center gap-2 py-14 text-center">
+              <Clock className="h-9 w-9 text-muted-foreground" />
+              <p className="text-sm font-medium">Hết hẹn — bạn đã theo sát tất cả 🌙</p>
+              <p className="text-xs text-muted-foreground">
+                Đặt lịch gọi lại khi tư vấn để không bỏ lỡ lead.
+              </p>
+            </div>
+          ) : (
+            <>
+              <Hero item={hero} serverNow={serverNow} />
+              {rest.map((item, idx) => (
+                <React.Fragment key={item.lead_id}>
+                  {idx === firstUpcomingIdx && <NowLine serverNow={serverNow} />}
+                  <ApptRow item={item} serverNow={serverNow} />
+                </React.Fragment>
+              ))}
+              {/* nếu toàn bộ đều quá hạn → đường BÂY GIỜ ở cuối để nhấn "chưa có hẹn sắp tới" */}
+              {rest.length > 0 && firstUpcomingIdx === -1 && <NowLine serverNow={serverNow} />}
+            </>
+          )}
+        </div>
+      </ScrollArea>
+
+      {hero && (
+        <div className="border-t p-2">
+          <Button asChild variant="ghost" className="h-9 w-full text-xs font-medium text-muted-foreground">
+            <Link href="/leads" onClick={onNavigate}>
+              Mở danh sách lead <ChevronRight className="ml-1 h-3.5 w-3.5" />
+            </Link>
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Trigger + wrapper (dropdown desktop / sheet mobile) ──────────────────────
+export function AppointmentReminder() {
+  const [open, setOpen] = React.useState(false);
+  const isMobile = useIsMobile();
+  const { data } = useMyAppointments();
+  const overdue = data?.overdue_count ?? 0;
+
+  const trigger = (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="relative h-11 w-11 rounded-full md:h-9 md:w-9"
+      aria-label={`Lịch hẹn${overdue ? ` · ${overdue} trễ` : ""}`}
+    >
+      <CalendarClock className="h-5 w-5" />
+      {overdue > 0 && (
+        <span className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-red-600 px-1 text-[10px] font-bold text-white">
+          {overdue > 9 ? "9+" : overdue}
+        </span>
+      )}
+      <span className="sr-only">Lịch hẹn của bạn</span>
+    </Button>
+  );
+
+  if (isMobile) {
+    return (
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger asChild>{trigger}</SheetTrigger>
+        <SheetContent
+          side="bottom"
+          aria-describedby={undefined}
+          className="max-h-[92vh] gap-0 overflow-hidden p-0"
+        >
+          <SheetTitle className="sr-only">Lịch hẹn của bạn</SheetTitle>
+          <ReminderBody onNavigate={() => setOpen(false)} />
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={8} className="w-[384px] overflow-hidden p-0">
+        <ReminderBody onNavigate={() => setOpen(false)} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export default AppointmentReminder;

--- a/frontend/src/components/leads/AppointmentReminder.tsx
+++ b/frontend/src/components/leads/AppointmentReminder.tsx
@@ -107,6 +107,11 @@ function eduLine(item: MyAppointmentItem): string {
   return parts.length ? parts.join(" ") : "Chưa chọn ngành";
 }
 
+/** Dòng phụ: ngành · NV phụ trách (tên NV chỉ có khi admin/manager xem toàn bộ). */
+function metaLine(item: MyAppointmentItem): string {
+  return item.officer_name ? `${eduLine(item)} · ${item.officer_name}` : eduLine(item);
+}
+
 // ── Hero: việc cần làm bây giờ ────────────────────────────────────────────────
 function Hero({ item, serverNow }: { item: MyAppointmentItem; serverNow: number }) {
   const st = stateOf(item, serverNow);
@@ -136,7 +141,7 @@ function Hero({ item, serverNow }: { item: MyAppointmentItem; serverNow: number 
       <div className="mt-2 truncate text-lg font-bold font-display leading-tight">
         {item.lead_name}
       </div>
-      <div className="mt-0.5 truncate text-xs text-muted-foreground">{eduLine(item)}</div>
+      <div className="mt-0.5 truncate text-xs text-muted-foreground">{metaLine(item)}</div>
 
       <div className="mt-3 flex items-center gap-3">
         <div className={cn("font-mono text-3xl font-bold leading-none tabular-nums", style.text)}>
@@ -191,7 +196,7 @@ function ApptRow({ item, serverNow }: { item: MyAppointmentItem; serverNow: numb
       <div className={cn("h-9 w-[3px] shrink-0 rounded-full", style.bar)} />
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-semibold font-display leading-tight">{item.lead_name}</div>
-        <div className="truncate text-xs text-muted-foreground">{eduLine(item)}</div>
+        <div className="truncate text-xs text-muted-foreground">{metaLine(item)}</div>
       </div>
       <div className={cn("shrink-0 rounded-md px-2 py-1 font-mono text-xs font-semibold tabular-nums", style.pill)}>
         {st === "overdue" ? "trễ " : "còn "}
@@ -237,9 +242,11 @@ export function ReminderBody({ onNavigate }: { onNavigate?: () => void }) {
       <div className="flex items-start justify-between border-b p-4">
         <div>
           <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-            Việc cần làm bây giờ
+            {data?.scope === "all" ? "Toàn đơn vị · hôm nay" : "Việc cần làm bây giờ"}
           </div>
-          <h2 className="font-display text-lg font-bold">Lịch hẹn của bạn</h2>
+          <h2 className="font-display text-lg font-bold">
+            {data?.scope === "all" ? "Lịch hẹn tư vấn" : "Lịch hẹn của bạn"}
+          </h2>
         </div>
         <div className="text-right">
           <div className="font-mono text-lg font-bold tabular-nums" suppressHydrationWarning>

--- a/frontend/src/components/leads/AppointmentReminder.tsx
+++ b/frontend/src/components/leads/AppointmentReminder.tsx
@@ -25,6 +25,7 @@ import { useMyAppointments } from "@/hooks/useMyAppointments";
 import { useServerNow } from "@/hooks/useServerNow";
 import {
   STATE_STYLE,
+  apptDelta,
   formatDelta,
   hhmm,
   hhmmFromMs,
@@ -164,8 +165,10 @@ export function ReminderBody({ onNavigate }: { onNavigate?: () => void }) {
   const rest = appts.slice(1);
   // vị trí hàng KHÔNG-quá-hạn đầu tiên trong TOÀN danh sách (kể cả hero) → chèn
   // đường BÂY GIỜ ngay TRƯỚC nó. Nếu hero đã là sắp-tới (không có hẹn trễ), đường
-  // nằm TRÊN hero — tránh việc một hẹn tương lai đứng trên đường "bây giờ".
-  const firstUpcomingIdx = appts.findIndex((a) => !a.is_overdue);
+  // nằm TRÊN hero — tránh việc một hẹn tương lai đứng trên đường "bây giờ". Dùng
+  // đồng hồ LIVE (serverNow) — khớp màu overdue/upcoming của Hero/ApptRow (stateOf),
+  // không lệ thuộc is_overdue snapshot lúc fetch (lệch tới ~60s trong cửa refetch).
+  const firstUpcomingIdx = appts.findIndex((a) => apptDelta(a.scheduled_at, serverNow) >= 0);
 
   return (
     <div className="flex flex-col">
@@ -232,8 +235,9 @@ export function ReminderBody({ onNavigate }: { onNavigate?: () => void }) {
                   <ApptRow item={item} serverNow={serverNow} />
                 </React.Fragment>
               ))}
-              {/* nếu toàn bộ đều quá hạn → đường BÂY GIỜ ở cuối để nhấn "chưa có hẹn sắp tới" */}
-              {rest.length > 0 && firstUpcomingIdx === -1 && <NowLine serverNow={serverNow} />}
+              {/* toàn bộ đều quá hạn (kể cả khi chỉ có 1 hẹn) → đường BÂY GIỜ ở cuối
+                  để nhấn "chưa có hẹn sắp tới" */}
+              {firstUpcomingIdx === -1 && <NowLine serverNow={serverNow} />}
             </>
           )}
         </div>

--- a/frontend/src/hooks/useAppointmentNudges.ts
+++ b/frontend/src/hooks/useAppointmentNudges.ts
@@ -5,7 +5,11 @@ import * as React from "react";
 
 import type { MyAppointmentItem } from "@/lib/api/leads";
 import { apptDelta, eduLine, hhmm } from "@/lib/leads/appointment-clock";
-import { playNotificationSound, requestNotificationPermission } from "@/lib/sound";
+import {
+  installAudioUnlockOnce,
+  playNotificationSound,
+  requestNotificationPermission,
+} from "@/lib/sound";
 
 // =============================================================================
 // Engine "nudge" cho Trợ lý nhắc hẹn (lớp B) + tùy chọn chuông/thông báo (lớp C).
@@ -49,6 +53,8 @@ export interface UseAppointmentNudges {
   soundOn: boolean;
   notifyOn: boolean;
   notifySupported: boolean;
+  /** OS đã CHẶN quyền thông báo (denied) → bật không có tác dụng, cần báo user. */
+  notifyBlocked: boolean;
   toggleSound: () => void;
   toggleNotify: () => void;
 }
@@ -80,8 +86,15 @@ export function useAppointmentNudges(
   // ── Prefs (đọc localStorage trong effect → SSR-safe) ──
   const [soundOn, setSoundOn] = React.useState(false);
   const [notifyOn, setNotifyOn] = React.useState(false);
+  const [notifyBlocked, setNotifyBlocked] = React.useState(false);
   const soundOnRef = React.useRef(false);
   const notifyOnRef = React.useRef(false);
+
+  // Mở khóa AudioContext ở gesture đầu (officer) → chuông LS-restore kêu được
+  // dù bung từ timer (không phải user-gesture). Xem @/lib/sound.
+  React.useEffect(() => {
+    if (enabled) installAudioUnlockOnce();
+  }, [enabled]);
   React.useEffect(() => {
     soundOnRef.current = soundOn;
   }, [soundOn]);
@@ -107,6 +120,24 @@ export function useAppointmentNudges(
     [appointments],
   );
 
+  // Dọn khóa không còn trong feed mỗi refetch: (1) chống Set/Map phình vô hạn
+  // suốt phiên dài; (2) fix latent — dời lịch khỏi mốc T rồi dời VỀ đúng T sẽ
+  // sinh lại khóa cũ; nếu khóa còn trong firedRef → bị chặn nhắc vĩnh viễn. Prune
+  // theo khóa-đang-sống → khóa quay lại được arm/nhắc lại đúng.
+  React.useEffect(() => {
+    const live = byKey;
+    const prune = (s: Set<string>) => {
+      for (const k of s) if (!live.has(k)) s.delete(k);
+    };
+    prune(armedRef.current);
+    prune(firedRef.current);
+    prune(calledRef.current);
+    for (const k of Array.from(snoozeRef.current.keys())) {
+      if (!live.has(k)) snoozeRef.current.delete(k);
+    }
+    queueRef.current = queueRef.current.filter((k) => live.has(k));
+  }, [byKey]);
+
   // ── Vòng dò nudge: chạy mỗi tick server_now ──
   React.useEffect(() => {
     if (!enabled) {
@@ -119,8 +150,15 @@ export function useAppointmentNudges(
     // bỏ pass đầu — bỏ pass đầu chỉ tạo cửa-sổ-chết cho hẹn chạm giờ trong ~1s đầu.)
     if (!Number.isFinite(serverNow) || serverNow <= 0) return;
 
-    // Hẹn đang mở nhưng khóa đã biến mất (dời lịch / xử lý nơi khác) → đóng toast.
-    if (activeRef.current && !byKey.has(keyOf(activeRef.current))) setActive(null);
+    // Hẹn đang mở: khóa biến mất (dời lịch / xử lý nơi khác) → đóng toast; còn
+    // khóa nhưng object đổi (refetch cập nhật tên/SĐT/ngành cùng mốc) → đồng bộ
+    // lại để toast + tel: không hiện dữ liệu cũ.
+    if (activeRef.current) {
+      const ak = keyOf(activeRef.current);
+      const fresh = byKey.get(ak);
+      if (!fresh) setActive(null);
+      else if (fresh !== activeRef.current) setActive(fresh);
+    }
 
     // Phát hiện hẹn vừa chạm giờ (arm-based).
     for (const a of byKey.values()) {
@@ -245,6 +283,9 @@ export function useAppointmentNudges(
         const ok = perm === "granted";
         notifyOnRef.current = ok;
         setNotifyOn(ok);
+        // denied = OS đã CHẶN (browser không hỏi lại) → báo user chỉnh trong cài
+        // đặt trình duyệt, tránh nút "im lặng không tác dụng" trông như hỏng.
+        setNotifyBlocked(perm === "denied");
         try {
           localStorage.setItem(LS_NOTIFY, ok ? "1" : "0");
         } catch {
@@ -264,6 +305,7 @@ export function useAppointmentNudges(
     soundOn,
     notifyOn,
     notifySupported: notifySupported(),
+    notifyBlocked,
     toggleSound,
     toggleNotify,
   };

--- a/frontend/src/hooks/useAppointmentNudges.ts
+++ b/frontend/src/hooks/useAppointmentNudges.ts
@@ -57,6 +57,7 @@ export function useAppointmentNudges(
   appointments: MyAppointmentItem[] | undefined,
   serverNow: number,
   enabled: boolean,
+  panelOpen: boolean,
 ): UseAppointmentNudges {
   const [active, setActiveState] = React.useState<MyAppointmentItem | null>(null);
   const activeRef = React.useRef<MyAppointmentItem | null>(null);
@@ -70,7 +71,11 @@ export function useAppointmentNudges(
   const calledRef = React.useRef<Set<string>>(new Set()); // đã gọi → loại
   const snoozeRef = React.useRef<Map<string, number>>(new Map()); // khóa → mốc hết hoãn
   const queueRef = React.useRef<string[]>([]);
-  const readyRef = React.useRef(false); // bỏ qua lần dò đầu (serverNow có thể chưa hiệu chỉnh skew)
+
+  const openRef = React.useRef(panelOpen); // panel đang mở? (gate chuông)
+  React.useEffect(() => {
+    openRef.current = panelOpen;
+  }, [panelOpen]);
 
   // ── Prefs (đọc localStorage trong effect → SSR-safe) ──
   const [soundOn, setSoundOn] = React.useState(false);
@@ -110,14 +115,9 @@ export function useAppointmentNudges(
     }
     // Chặn NaN (server_time hỏng): NaN<=0 là false nên guard cũ lọt → engine chết
     // thầm + render "NaN". Number.isFinite chặn cả NaN lẫn giá trị chưa load (0).
+    // (serverNow lúc mount = server_time đã hiệu chỉnh skew ngay từ init, KHÔNG cần
+    // bỏ pass đầu — bỏ pass đầu chỉ tạo cửa-sổ-chết cho hẹn chạm giờ trong ~1s đầu.)
     if (!Number.isFinite(serverNow) || serverNow <= 0) return;
-    // Bỏ qua lần dò ĐẦU: serverNow lúc mount có thể lấy từ cache server_time cũ,
-    // chưa hiệu chỉnh skew (useServerNow set giá trị chuẩn trong effect ngay sau).
-    // Bỏ pass này → arm/seed đều chạy trên đồng hồ đã chuẩn.
-    if (!readyRef.current) {
-      readyRef.current = true;
-      return;
-    }
 
     // Hẹn đang mở nhưng khóa đã biến mất (dời lịch / xử lý nơi khác) → đóng toast.
     if (activeRef.current && !byKey.has(keyOf(activeRef.current))) setActive(null);
@@ -164,7 +164,11 @@ export function useAppointmentNudges(
   const activeKey = active ? keyOf(active) : null;
   React.useEffect(() => {
     if (!activeKey || !active) return;
-    if (soundOnRef.current) playNotificationSound(); // dùng chung AudioContext của @/lib/sound
+    // Chuông: dùng chung AudioContext của @/lib/sound. KHÔNG kêu khi tab đang hiện
+    // VÀ panel đang mở (toast bị ẩn để tránh chồng → một "ping" không toast sẽ khó
+    // hiểu); vẫn kêu khi tab ẩn (cảnh báo âm thanh có ích).
+    const hidden = typeof document !== "undefined" && document.hidden;
+    if (soundOnRef.current && (hidden || !openRef.current)) playNotificationSound();
     // OS notification: chỉ khi bật + đã cấp quyền + tab đang ẩn (tránh trùng toast).
     // Giữ inline (không dùng showBrowserNotification) để có onclick → focus.
     if (
@@ -236,16 +240,20 @@ export function useAppointmentNudges(
       return;
     }
     if (!notifySupported()) return;
-    void requestNotificationPermission().then((perm) => {
-      const ok = perm === "granted";
-      notifyOnRef.current = ok;
-      setNotifyOn(ok);
-      try {
-        localStorage.setItem(LS_NOTIFY, ok ? "1" : "0");
-      } catch {
-        /* noop */
-      }
-    });
+    void requestNotificationPermission()
+      .then((perm) => {
+        const ok = perm === "granted";
+        notifyOnRef.current = ok;
+        setNotifyOn(ok);
+        try {
+          localStorage.setItem(LS_NOTIFY, ok ? "1" : "0");
+        } catch {
+          /* noop */
+        }
+      })
+      .catch(() => {
+        /* requestPermission bị từ chối/không hỗ trợ → giữ tắt */
+      });
   }, []);
 
   return {

--- a/frontend/src/hooks/useAppointmentNudges.ts
+++ b/frontend/src/hooks/useAppointmentNudges.ts
@@ -1,0 +1,269 @@
+// src/hooks/useAppointmentNudges.ts
+"use client";
+
+import * as React from "react";
+
+import type { MyAppointmentItem } from "@/lib/api/leads";
+import { apptDelta, eduLine, hhmm } from "@/lib/leads/appointment-clock";
+
+// =============================================================================
+// Engine "nudge" cho Trợ lý nhắc hẹn (lớp B) + tùy chọn chuông/thông báo (lớp C).
+//
+// Nudge = tự bung khi một hẹn CHẠM giờ (scheduled_at ≤ server_now) LẦN ĐẦU trong
+// phiên. Hẹn đã quá giờ ngay lúc tải = "đã lỡ" → KHÔNG bung dồn (chỉ seed baseline).
+// Mỗi hẹn nhắc 1 lần (dedupe); "Hoãn 5'" cho phép nhắc lại sau 5 phút; "Gọi ngay"
+// loại khỏi nhắc trong phiên. Chỉ bật cho tư vấn viên (enabled = scope==='own');
+// admin/manager xem toàn đơn vị 30+ hẹn → nudge quá ồn.
+//
+// Đồng hồ căn server_now (KHÔNG dùng đồng hồ máy client). react-compiler: mọi
+// thao tác thời-gian nằm trong effect, không có trong render.
+// =============================================================================
+
+const SNOOZE_MS = 5 * 60 * 1000;
+const LS_SOUND = "qlts.appt.sound";
+const LS_NOTIFY = "qlts.appt.notify";
+
+/** Chuông ngắn 2 nốt bằng WebAudio (không cần asset ngoài). */
+function playChime(ctxRef: React.MutableRefObject<AudioContext | null>) {
+  try {
+    const AC = window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AC) return;
+    const ctx = (ctxRef.current ??= new AC());
+    if (ctx.state === "suspended") void ctx.resume();
+    const t0 = ctx.currentTime;
+    [880, 1174.66].forEach((freq, i) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.value = freq;
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      const t = t0 + i * 0.13;
+      gain.gain.setValueAtTime(0.0001, t);
+      gain.gain.exponentialRampToValueAtTime(0.12, t + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.28);
+      osc.start(t);
+      osc.stop(t + 0.3);
+    });
+  } catch {
+    /* trình duyệt chặn audio → im lặng */
+  }
+}
+
+const notifySupported = () => typeof window !== "undefined" && "Notification" in window;
+
+export interface UseAppointmentNudges {
+  /** Hẹn đang được nhắc (null = không có nudge nào đang mở). */
+  active: MyAppointmentItem | null;
+  /** Đóng nudge, không nhắc lại hẹn này. */
+  dismiss: () => void;
+  /** Hoãn 5 phút — sẽ nhắc lại. */
+  snooze: () => void;
+  /** Đã bấm gọi — loại hẹn khỏi nhắc trong phiên. */
+  markCalled: () => void;
+  // ── Lớp C: tùy chọn ──
+  soundOn: boolean;
+  notifyOn: boolean;
+  notifySupported: boolean;
+  toggleSound: () => void;
+  toggleNotify: () => void;
+}
+
+export function useAppointmentNudges(
+  appointments: MyAppointmentItem[] | undefined,
+  serverNow: number,
+  enabled: boolean,
+): UseAppointmentNudges {
+  const [active, setActiveState] = React.useState<MyAppointmentItem | null>(null);
+  const activeRef = React.useRef<MyAppointmentItem | null>(null);
+  const setActive = React.useCallback((a: MyAppointmentItem | null) => {
+    activeRef.current = a;
+    setActiveState(a);
+  }, []);
+
+  const firedRef = React.useRef<Set<number>>(new Set()); // đã nhắc (dedupe)
+  const calledRef = React.useRef<Set<number>>(new Set()); // đã gọi → loại
+  const snoozeRef = React.useRef<Map<number, number>>(new Map()); // id → mốc hết hoãn
+  const queueRef = React.useRef<number[]>([]);
+  const seededRef = React.useRef(false);
+
+  const audioCtxRef = React.useRef<AudioContext | null>(null);
+
+  // ── Prefs (đọc localStorage trong effect → SSR-safe) ──
+  const [soundOn, setSoundOn] = React.useState(false);
+  const [notifyOn, setNotifyOn] = React.useState(false);
+  const soundOnRef = React.useRef(false);
+  const notifyOnRef = React.useRef(false);
+  React.useEffect(() => {
+    soundOnRef.current = soundOn;
+  }, [soundOn]);
+  React.useEffect(() => {
+    notifyOnRef.current = notifyOn;
+  }, [notifyOn]);
+  React.useEffect(() => {
+    try {
+      setSoundOn(localStorage.getItem(LS_SOUND) === "1");
+      setNotifyOn(
+        localStorage.getItem(LS_NOTIFY) === "1" &&
+          notifySupported() &&
+          Notification.permission === "granted",
+      );
+    } catch {
+      /* localStorage bị chặn → giữ mặc định tắt */
+    }
+  }, []);
+
+  // ── Vòng dò nudge: chạy mỗi tick server_now ──
+  React.useEffect(() => {
+    if (!enabled) {
+      if (activeRef.current) setActive(null);
+      return;
+    }
+    if (serverNow <= 0) return;
+    const list = appointments ?? [];
+    const byId = new Map(list.map((a) => [a.lead_id, a]));
+
+    // Seed baseline 1 lần: hẹn đã quá giờ lúc tải = "đã lỡ", không bung dồn.
+    if (!seededRef.current) {
+      list.forEach((a) => {
+        if (apptDelta(a.scheduled_at, serverNow) <= 0) firedRef.current.add(a.lead_id);
+      });
+      seededRef.current = true;
+      return;
+    }
+
+    // Hẹn đang mở nhưng đã biến mất khỏi danh sách (xử lý nơi khác) → đóng.
+    if (activeRef.current && !byId.has(activeRef.current.lead_id)) {
+      setActive(null);
+    }
+
+    // Phát hiện hẹn vừa chạm giờ.
+    list.forEach((a) => {
+      const id = a.lead_id;
+      if (calledRef.current.has(id)) return;
+      const until = snoozeRef.current.get(id);
+      if (until != null) {
+        if (serverNow < until) return; // còn trong thời gian hoãn
+        snoozeRef.current.delete(id); // hết hoãn → đủ điều kiện nhắc lại
+      }
+      if (firedRef.current.has(id)) return;
+      if (apptDelta(a.scheduled_at, serverNow) <= 0) {
+        firedRef.current.add(id);
+        if (!queueRef.current.includes(id)) queueRef.current.push(id);
+      }
+    });
+
+    // Trống chỗ → đưa hẹn kế trong hàng chờ lên.
+    if (!activeRef.current) {
+      while (queueRef.current.length) {
+        const id = queueRef.current.shift();
+        if (id == null) break;
+        const a = byId.get(id);
+        if (a && !calledRef.current.has(id)) {
+          setActive(a);
+          break;
+        }
+      }
+    }
+  }, [appointments, serverNow, enabled, setActive]);
+
+  // ── Side-effect khi một nudge xuất hiện: chuông + thông báo hệ thống ──
+  const activeId = active?.lead_id ?? null;
+  React.useEffect(() => {
+    if (activeId == null || !active) return;
+    if (soundOnRef.current) playChime(audioCtxRef);
+    // OS notification: chỉ khi bật + đã cấp quyền + tab đang ẩn (tránh trùng toast).
+    if (
+      notifyOnRef.current &&
+      notifySupported() &&
+      Notification.permission === "granted" &&
+      typeof document !== "undefined" &&
+      document.hidden
+    ) {
+      try {
+        const n = new Notification(`Tới giờ gọi lại ${active.lead_name}`, {
+          body: `${eduLine(active)} · hẹn ${hhmm(active.scheduled_at)}`,
+          tag: `qlts-appt-${active.lead_id}`,
+        });
+        n.onclick = () => {
+          window.focus();
+          n.close();
+        };
+      } catch {
+        /* một số trình duyệt cấm Notification trong ngữ cảnh này */
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeId]);
+
+  const dismiss = React.useCallback(() => {
+    setActive(null);
+  }, [setActive]);
+
+  const snooze = React.useCallback(() => {
+    const a = activeRef.current;
+    if (a) {
+      snoozeRef.current.set(a.lead_id, serverNow + SNOOZE_MS);
+      firedRef.current.delete(a.lead_id); // cho phép nhắc lại sau khi hết hoãn
+    }
+    setActive(null);
+  }, [serverNow, setActive]);
+
+  const markCalled = React.useCallback(() => {
+    const a = activeRef.current;
+    if (a) calledRef.current.add(a.lead_id);
+    setActive(null);
+  }, [setActive]);
+
+  const toggleSound = React.useCallback(() => {
+    setSoundOn((v) => {
+      const next = !v;
+      try {
+        localStorage.setItem(LS_SOUND, next ? "1" : "0");
+      } catch {
+        /* noop */
+      }
+      if (next) playChime(audioCtxRef); // vừa xác nhận vừa mở khóa AudioContext (user gesture)
+      return next;
+    });
+  }, []);
+
+  const toggleNotify = React.useCallback(() => {
+    if (notifyOnRef.current) {
+      setNotifyOn(false);
+      try {
+        localStorage.setItem(LS_NOTIFY, "0");
+      } catch {
+        /* noop */
+      }
+      return;
+    }
+    if (!notifySupported()) return;
+    const apply = (perm: NotificationPermission) => {
+      const ok = perm === "granted";
+      setNotifyOn(ok);
+      try {
+        localStorage.setItem(LS_NOTIFY, ok ? "1" : "0");
+      } catch {
+        /* noop */
+      }
+    };
+    if (Notification.permission === "default") {
+      void Notification.requestPermission().then(apply).catch(() => apply("denied"));
+    } else {
+      apply(Notification.permission);
+    }
+  }, []);
+
+  return {
+    active,
+    dismiss,
+    snooze,
+    markCalled,
+    soundOn,
+    notifyOn,
+    notifySupported: notifySupported(),
+    toggleSound,
+    toggleNotify,
+  };
+}

--- a/frontend/src/hooks/useAppointmentNudges.ts
+++ b/frontend/src/hooks/useAppointmentNudges.ts
@@ -5,61 +5,45 @@ import * as React from "react";
 
 import type { MyAppointmentItem } from "@/lib/api/leads";
 import { apptDelta, eduLine, hhmm } from "@/lib/leads/appointment-clock";
+import { playNotificationSound, requestNotificationPermission } from "@/lib/sound";
 
 // =============================================================================
 // Engine "nudge" cho Trợ lý nhắc hẹn (lớp B) + tùy chọn chuông/thông báo (lớp C).
 //
-// Nudge = tự bung khi một hẹn CHẠM giờ (scheduled_at ≤ server_now) LẦN ĐẦU trong
-// phiên. Hẹn đã quá giờ ngay lúc tải = "đã lỡ" → KHÔNG bung dồn (chỉ seed baseline).
-// Mỗi hẹn nhắc 1 lần (dedupe); "Hoãn 5'" cho phép nhắc lại sau 5 phút; "Gọi ngay"
-// loại khỏi nhắc trong phiên. Chỉ bật cho tư vấn viên (enabled = scope==='own');
-// admin/manager xem toàn đơn vị 30+ hẹn → nudge quá ồn.
+// Nudge bung khi một hẹn CHUYỂN từ "còn tương lai" sang "chạm giờ": chỉ khi đã
+// từng thấy nó còn-tương-lai (ARM) rồi delta≤0 mới bung. Hẹn LẦN ĐẦU đã thấy quá
+// giờ (đã lỡ lúc tải, hoặc lead mới gán đã trễ tới sau) → chỉ ghi nhận, KHÔNG bung.
 //
-// Đồng hồ căn server_now (KHÔNG dùng đồng hồ máy client). react-compiler: mọi
-// thao tác thời-gian nằm trong effect, không có trong render.
+// Khóa dedupe = `lead_id@scheduled_at` → dời lịch (đổi scheduled_at) sinh khóa
+// MỚI ⇒ arm lại và nhắc đúng giờ mới (cũ chỉ theo lead_id nên dời lịch bị chặn
+// vĩnh viễn). "Hoãn 5'" cho nhắc lại sau 5 phút; "Gọi ngay" loại theo khóa (dời
+// lịch sau đó vẫn nhắc). Chỉ bật cho tư vấn viên (enabled = scope==='own');
+// admin/manager 30+ hẹn → quá ồn.
+//
+// Chuông + Notification tái dùng @/lib/sound (một AudioContext chung toàn app).
+// react-compiler: mọi thao tác thời-gian nằm trong effect, không có trong render.
+// ⚠️ Giới hạn nền tảng: dựa trên setInterval 1s (useServerNow); tab ẩn bị trình
+// duyệt throttle timer → thông báo có thể trễ vài chục giây — cần server push để
+// chính xác tuyệt đối.
 // =============================================================================
 
 const SNOOZE_MS = 5 * 60 * 1000;
 const LS_SOUND = "qlts.appt.sound";
 const LS_NOTIFY = "qlts.appt.notify";
 
-/** Chuông ngắn 2 nốt bằng WebAudio (không cần asset ngoài). */
-function playChime(ctxRef: React.MutableRefObject<AudioContext | null>) {
-  try {
-    const AC = window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-    if (!AC) return;
-    const ctx = (ctxRef.current ??= new AC());
-    if (ctx.state === "suspended") void ctx.resume();
-    const t0 = ctx.currentTime;
-    [880, 1174.66].forEach((freq, i) => {
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.type = "sine";
-      osc.frequency.value = freq;
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-      const t = t0 + i * 0.13;
-      gain.gain.setValueAtTime(0.0001, t);
-      gain.gain.exponentialRampToValueAtTime(0.12, t + 0.02);
-      gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.28);
-      osc.start(t);
-      osc.stop(t + 0.3);
-    });
-  } catch {
-    /* trình duyệt chặn audio → im lặng */
-  }
-}
+/** Khóa dedupe theo lead + đúng mốc hẹn → dời lịch = khóa mới. */
+const keyOf = (a: MyAppointmentItem) => `${a.lead_id}@${a.scheduled_at}`;
 
 const notifySupported = () => typeof window !== "undefined" && "Notification" in window;
 
 export interface UseAppointmentNudges {
   /** Hẹn đang được nhắc (null = không có nudge nào đang mở). */
   active: MyAppointmentItem | null;
-  /** Đóng nudge, không nhắc lại hẹn này. */
+  /** Đóng nudge, không nhắc lại hẹn này (mốc hiện tại). */
   dismiss: () => void;
   /** Hoãn 5 phút — sẽ nhắc lại. */
   snooze: () => void;
-  /** Đã bấm gọi — loại hẹn khỏi nhắc trong phiên. */
+  /** Đã bấm gọi — loại hẹn (mốc hiện tại) khỏi nhắc trong phiên. */
   markCalled: () => void;
   // ── Lớp C: tùy chọn ──
   soundOn: boolean;
@@ -81,13 +65,12 @@ export function useAppointmentNudges(
     setActiveState(a);
   }, []);
 
-  const firedRef = React.useRef<Set<number>>(new Set()); // đã nhắc (dedupe)
-  const calledRef = React.useRef<Set<number>>(new Set()); // đã gọi → loại
-  const snoozeRef = React.useRef<Map<number, number>>(new Map()); // id → mốc hết hoãn
-  const queueRef = React.useRef<number[]>([]);
-  const seededRef = React.useRef(false);
-
-  const audioCtxRef = React.useRef<AudioContext | null>(null);
+  const armedRef = React.useRef<Set<string>>(new Set()); // đã thấy còn-tương-lai → đủ điều kiện bung
+  const firedRef = React.useRef<Set<string>>(new Set()); // đã nhắc / đã ghi nhận (dedupe)
+  const calledRef = React.useRef<Set<string>>(new Set()); // đã gọi → loại
+  const snoozeRef = React.useRef<Map<string, number>>(new Map()); // khóa → mốc hết hoãn
+  const queueRef = React.useRef<string[]>([]);
+  const readyRef = React.useRef(false); // bỏ qua lần dò đầu (serverNow có thể chưa hiệu chỉnh skew)
 
   // ── Prefs (đọc localStorage trong effect → SSR-safe) ──
   const [soundOn, setSoundOn] = React.useState(false);
@@ -113,66 +96,77 @@ export function useAppointmentNudges(
     }
   }, []);
 
+  // Chỉ mục theo khóa — dựng lại 1 lần mỗi refetch (60s), KHÔNG mỗi tick 1s.
+  const byKey = React.useMemo(
+    () => new Map((appointments ?? []).map((a) => [keyOf(a), a] as const)),
+    [appointments],
+  );
+
   // ── Vòng dò nudge: chạy mỗi tick server_now ──
   React.useEffect(() => {
     if (!enabled) {
       if (activeRef.current) setActive(null);
       return;
     }
-    if (serverNow <= 0) return;
-    const list = appointments ?? [];
-    const byId = new Map(list.map((a) => [a.lead_id, a]));
-
-    // Seed baseline 1 lần: hẹn đã quá giờ lúc tải = "đã lỡ", không bung dồn.
-    if (!seededRef.current) {
-      list.forEach((a) => {
-        if (apptDelta(a.scheduled_at, serverNow) <= 0) firedRef.current.add(a.lead_id);
-      });
-      seededRef.current = true;
+    // Chặn NaN (server_time hỏng): NaN<=0 là false nên guard cũ lọt → engine chết
+    // thầm + render "NaN". Number.isFinite chặn cả NaN lẫn giá trị chưa load (0).
+    if (!Number.isFinite(serverNow) || serverNow <= 0) return;
+    // Bỏ qua lần dò ĐẦU: serverNow lúc mount có thể lấy từ cache server_time cũ,
+    // chưa hiệu chỉnh skew (useServerNow set giá trị chuẩn trong effect ngay sau).
+    // Bỏ pass này → arm/seed đều chạy trên đồng hồ đã chuẩn.
+    if (!readyRef.current) {
+      readyRef.current = true;
       return;
     }
 
-    // Hẹn đang mở nhưng đã biến mất khỏi danh sách (xử lý nơi khác) → đóng.
-    if (activeRef.current && !byId.has(activeRef.current.lead_id)) {
-      setActive(null);
-    }
+    // Hẹn đang mở nhưng khóa đã biến mất (dời lịch / xử lý nơi khác) → đóng toast.
+    if (activeRef.current && !byKey.has(keyOf(activeRef.current))) setActive(null);
 
-    // Phát hiện hẹn vừa chạm giờ.
-    list.forEach((a) => {
-      const id = a.lead_id;
-      if (calledRef.current.has(id)) return;
-      const until = snoozeRef.current.get(id);
+    // Phát hiện hẹn vừa chạm giờ (arm-based).
+    for (const a of byKey.values()) {
+      const k = keyOf(a);
+      if (calledRef.current.has(k)) continue;
+      const until = snoozeRef.current.get(k);
       if (until != null) {
-        if (serverNow < until) return; // còn trong thời gian hoãn
-        snoozeRef.current.delete(id); // hết hoãn → đủ điều kiện nhắc lại
+        if (serverNow < until) continue; // còn trong thời gian hoãn
+        snoozeRef.current.delete(k); // hết hoãn → đủ điều kiện nhắc lại
       }
-      if (firedRef.current.has(id)) return;
-      if (apptDelta(a.scheduled_at, serverNow) <= 0) {
-        firedRef.current.add(id);
-        if (!queueRef.current.includes(id)) queueRef.current.push(id);
+      if (firedRef.current.has(k)) continue;
+      const delta = apptDelta(a.scheduled_at, serverNow);
+      if (delta > 0) {
+        armedRef.current.add(k); // còn tương lai → arm để chờ khoảnh khắc tới giờ
+        continue;
       }
-    });
+      // delta ≤ 0 (đã chạm giờ)
+      if (armedRef.current.has(k)) {
+        firedRef.current.add(k); // đã thấy tương lai trước đó → CHÍNH khoảnh khắc tới giờ → bung
+        if (!queueRef.current.includes(k)) queueRef.current.push(k);
+      } else {
+        firedRef.current.add(k); // lần đầu đã thấy quá giờ (đã lỡ) → ghi nhận, KHÔNG bung
+      }
+    }
 
     // Trống chỗ → đưa hẹn kế trong hàng chờ lên.
     if (!activeRef.current) {
       while (queueRef.current.length) {
-        const id = queueRef.current.shift();
-        if (id == null) break;
-        const a = byId.get(id);
-        if (a && !calledRef.current.has(id)) {
+        const k = queueRef.current.shift();
+        if (k == null) break;
+        const a = byKey.get(k);
+        if (a && !calledRef.current.has(k)) {
           setActive(a);
           break;
         }
       }
     }
-  }, [appointments, serverNow, enabled, setActive]);
+  }, [byKey, serverNow, enabled, setActive]);
 
   // ── Side-effect khi một nudge xuất hiện: chuông + thông báo hệ thống ──
-  const activeId = active?.lead_id ?? null;
+  const activeKey = active ? keyOf(active) : null;
   React.useEffect(() => {
-    if (activeId == null || !active) return;
-    if (soundOnRef.current) playChime(audioCtxRef);
+    if (!activeKey || !active) return;
+    if (soundOnRef.current) playNotificationSound(); // dùng chung AudioContext của @/lib/sound
     // OS notification: chỉ khi bật + đã cấp quyền + tab đang ẩn (tránh trùng toast).
+    // Giữ inline (không dùng showBrowserNotification) để có onclick → focus.
     if (
       notifyOnRef.current &&
       notifySupported() &&
@@ -194,7 +188,7 @@ export function useAppointmentNudges(
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeId]);
+  }, [activeKey]);
 
   const dismiss = React.useCallback(() => {
     setActive(null);
@@ -203,33 +197,36 @@ export function useAppointmentNudges(
   const snooze = React.useCallback(() => {
     const a = activeRef.current;
     if (a) {
-      snoozeRef.current.set(a.lead_id, serverNow + SNOOZE_MS);
-      firedRef.current.delete(a.lead_id); // cho phép nhắc lại sau khi hết hoãn
+      const k = keyOf(a);
+      snoozeRef.current.set(k, serverNow + SNOOZE_MS);
+      firedRef.current.delete(k); // cho nhắc lại (armedRef GIỮ nguyên → sẽ bung lại)
     }
     setActive(null);
   }, [serverNow, setActive]);
 
   const markCalled = React.useCallback(() => {
     const a = activeRef.current;
-    if (a) calledRef.current.add(a.lead_id);
+    if (a) calledRef.current.add(keyOf(a));
     setActive(null);
   }, [setActive]);
 
+  // Side-effect (chuông + ghi localStorage) NGOÀI updater setState — updater phải
+  // thuần (React 19 StrictMode gọi updater 2 lần → 2 chuông + 2 lần ghi).
   const toggleSound = React.useCallback(() => {
-    setSoundOn((v) => {
-      const next = !v;
-      try {
-        localStorage.setItem(LS_SOUND, next ? "1" : "0");
-      } catch {
-        /* noop */
-      }
-      if (next) playChime(audioCtxRef); // vừa xác nhận vừa mở khóa AudioContext (user gesture)
-      return next;
-    });
+    const next = !soundOnRef.current;
+    soundOnRef.current = next;
+    setSoundOn(next);
+    try {
+      localStorage.setItem(LS_SOUND, next ? "1" : "0");
+    } catch {
+      /* noop */
+    }
+    if (next) playNotificationSound(); // vừa xác nhận vừa mở khóa AudioContext (user gesture)
   }, []);
 
   const toggleNotify = React.useCallback(() => {
     if (notifyOnRef.current) {
+      notifyOnRef.current = false;
       setNotifyOn(false);
       try {
         localStorage.setItem(LS_NOTIFY, "0");
@@ -239,20 +236,16 @@ export function useAppointmentNudges(
       return;
     }
     if (!notifySupported()) return;
-    const apply = (perm: NotificationPermission) => {
+    void requestNotificationPermission().then((perm) => {
       const ok = perm === "granted";
+      notifyOnRef.current = ok;
       setNotifyOn(ok);
       try {
         localStorage.setItem(LS_NOTIFY, ok ? "1" : "0");
       } catch {
         /* noop */
       }
-    };
-    if (Notification.permission === "default") {
-      void Notification.requestPermission().then(apply).catch(() => apply("denied"));
-    } else {
-      apply(Notification.permission);
-    }
+    });
   }, []);
 
   return {

--- a/frontend/src/hooks/useMyAppointments.ts
+++ b/frontend/src/hooks/useMyAppointments.ts
@@ -8,19 +8,34 @@ import {
 
 export const myAppointmentsKey = ["leads", "my-appointments"] as const;
 
+/** 403 = role bị Casbin deny (accountant/user) → ẩn widget + ngừng poll.
+ *  Duck-typed để khỏi phụ thuộc kiểu AxiosError. */
+export function isForbiddenError(err: unknown): boolean {
+  return (
+    (err as { response?: { status?: number } } | null | undefined)?.response
+      ?.status === 403
+  );
+}
+
 /**
  * Lịch hẹn gọi lại của officer đang login ("Nhịp hẹn").
  *
- * Refetch mỗi 60s để re-bucket overdue/upcoming khi thời gian trôi (BE tính
- * is_overdue realtime). Đồng hồ đếm giây do component tự tick từ `server_time`.
+ * Refetch mỗi 60s để re-bucket overdue/upcoming khi thời gian trôi. Đồng hồ đếm
+ * giây do component tự tick từ `server_time`.
+ *
+ * Role bị Casbin deny (accountant/user) → API trả 403: KHÔNG retry, KHÔNG poll
+ * lại, KHÔNG refetch-on-focus (widget tự ẩn qua isForbiddenError) → tránh spam
+ * 403 vô hạn + log noise.
  */
 export function useMyAppointments(enabled = true) {
   return useQuery<MyAppointmentsResponse>({
     queryKey: myAppointmentsKey,
     queryFn: getMyAppointments,
     enabled,
-    refetchInterval: 60_000,
-    refetchOnWindowFocus: true,
+    refetchInterval: (query) =>
+      isForbiddenError(query.state.error) ? false : 60_000,
+    refetchOnWindowFocus: (query) => !isForbiddenError(query.state.error),
     staleTime: 30_000,
+    retry: (count, err) => !isForbiddenError(err) && count < 3,
   });
 }

--- a/frontend/src/hooks/useMyAppointments.ts
+++ b/frontend/src/hooks/useMyAppointments.ts
@@ -1,0 +1,26 @@
+// src/hooks/useMyAppointments.ts
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getMyAppointments,
+  type MyAppointmentsResponse,
+} from "@/lib/api/leads";
+
+export const myAppointmentsKey = ["leads", "my-appointments"] as const;
+
+/**
+ * Lịch hẹn gọi lại của officer đang login ("Nhịp hẹn").
+ *
+ * Refetch mỗi 60s để re-bucket overdue/upcoming khi thời gian trôi (BE tính
+ * is_overdue realtime). Đồng hồ đếm giây do component tự tick từ `server_time`.
+ */
+export function useMyAppointments(enabled = true) {
+  return useQuery<MyAppointmentsResponse>({
+    queryKey: myAppointmentsKey,
+    queryFn: getMyAppointments,
+    enabled,
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: true,
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/hooks/useServerNow.ts
+++ b/frontend/src/hooks/useServerNow.ts
@@ -9,6 +9,12 @@ import * as React from "react";
  * Date.now() chỉ dùng trong effect (được phép). Trả về 0 khi chưa có
  * server_time (chưa load) — caller nên chờ dữ liệu trước khi tính trạng thái.
  *
+ * `receivedAtMs` = mốc client NHẬN được server_time (React Query `dataUpdatedAt`).
+ * skew tính so với mốc nhận đó, KHÔNG so với Date.now() lúc effect chạy: server_time
+ * là snapshot cache (staleTime 30s), khi remount panel Date.now() đã trôi ~30s so
+ * với lúc fetch → nếu coi server_time là "bây giờ" thì đồng hồ chạy chậm ~30s.
+ * Truyền receivedAtMs để hiệu chỉnh đúng tuổi của snapshot (fallback Date.now()).
+ *
  * `active=false` → KHÔNG chạy interval (giữ nguyên giá trị cuối). Dùng để tắt
  * nhịp 1s khi không cần đếm sống (vd panel đóng + không phải officer) — tránh
  * re-render mỗi giây suốt phiên cho user không hưởng lợi.
@@ -17,17 +23,22 @@ import * as React from "react";
  * sau vài phút), nên đồng hồ có thể "nhảy" khi quay lại tab và thông báo dựa
  * trên nó có thể trễ khi tab bị ẩn lâu — chính xác tuyệt đối cần server push.
  */
-export function useServerNow(serverTimeIso?: string, active: boolean = true): number {
+export function useServerNow(
+  serverTimeIso?: string,
+  active: boolean = true,
+  receivedAtMs?: number,
+): number {
   const skew = React.useRef(0);
   const [now, setNow] = React.useState<number>(() =>
     serverTimeIso ? new Date(serverTimeIso).getTime() : 0,
   );
   React.useEffect(() => {
     if (!serverTimeIso || !active) return;
-    skew.current = new Date(serverTimeIso).getTime() - Date.now();
+    const base = receivedAtMs && receivedAtMs > 0 ? receivedAtMs : Date.now();
+    skew.current = new Date(serverTimeIso).getTime() - base;
     setNow(Date.now() + skew.current);
     const id = setInterval(() => setNow(Date.now() + skew.current), 1000);
     return () => clearInterval(id);
-  }, [serverTimeIso, active]);
+  }, [serverTimeIso, active, receivedAtMs]);
   return now;
 }

--- a/frontend/src/hooks/useServerNow.ts
+++ b/frontend/src/hooks/useServerNow.ts
@@ -8,18 +8,26 @@ import * as React from "react";
  * impure trong render). Init từ server_time (parse chuỗi cố định = pure);
  * Date.now() chỉ dùng trong effect (được phép). Trả về 0 khi chưa có
  * server_time (chưa load) — caller nên chờ dữ liệu trước khi tính trạng thái.
+ *
+ * `active=false` → KHÔNG chạy interval (giữ nguyên giá trị cuối). Dùng để tắt
+ * nhịp 1s khi không cần đếm sống (vd panel đóng + không phải officer) — tránh
+ * re-render mỗi giây suốt phiên cho user không hưởng lợi.
+ *
+ * ⚠️ Giới hạn: trình duyệt throttle setInterval ở tab ẩn/nền (tới ~1 lần/phút
+ * sau vài phút), nên đồng hồ có thể "nhảy" khi quay lại tab và thông báo dựa
+ * trên nó có thể trễ khi tab bị ẩn lâu — chính xác tuyệt đối cần server push.
  */
-export function useServerNow(serverTimeIso?: string): number {
+export function useServerNow(serverTimeIso?: string, active: boolean = true): number {
   const skew = React.useRef(0);
   const [now, setNow] = React.useState<number>(() =>
     serverTimeIso ? new Date(serverTimeIso).getTime() : 0,
   );
   React.useEffect(() => {
-    if (!serverTimeIso) return;
+    if (!serverTimeIso || !active) return;
     skew.current = new Date(serverTimeIso).getTime() - Date.now();
     setNow(Date.now() + skew.current);
     const id = setInterval(() => setNow(Date.now() + skew.current), 1000);
     return () => clearInterval(id);
-  }, [serverTimeIso]);
+  }, [serverTimeIso, active]);
   return now;
 }

--- a/frontend/src/hooks/useServerNow.ts
+++ b/frontend/src/hooks/useServerNow.ts
@@ -1,0 +1,25 @@
+// src/hooks/useServerNow.ts
+import * as React from "react";
+
+/**
+ * Đồng hồ tick 1s, căn theo server_time (bù lệch đồng hồ client).
+ *
+ * `now` giữ ở state — KHÔNG gọi Date.now() trong render (react-compiler cấm
+ * impure trong render). Init từ server_time (parse chuỗi cố định = pure);
+ * Date.now() chỉ dùng trong effect (được phép). Trả về 0 khi chưa có
+ * server_time (chưa load) — caller nên chờ dữ liệu trước khi tính trạng thái.
+ */
+export function useServerNow(serverTimeIso?: string): number {
+  const skew = React.useRef(0);
+  const [now, setNow] = React.useState<number>(() =>
+    serverTimeIso ? new Date(serverTimeIso).getTime() : 0,
+  );
+  React.useEffect(() => {
+    if (!serverTimeIso) return;
+    skew.current = new Date(serverTimeIso).getTime() - Date.now();
+    setNow(Date.now() + skew.current);
+    const id = setInterval(() => setNow(Date.now() + skew.current), 1000);
+    return () => clearInterval(id);
+  }, [serverTimeIso]);
+  return now;
+}

--- a/frontend/src/lib/api/leads.ts
+++ b/frontend/src/lib/api/leads.ts
@@ -149,6 +149,31 @@ export async function getReassignQuota(): Promise<ReassignQuota> {
   return response.data
 }
 
+// ── Nhịp hẹn — bảng nhắc lịch hẹn cho tư vấn viên ─────────────────────────
+export interface MyAppointmentItem {
+  lead_id: number
+  lead_name: string
+  phone: string
+  source: string
+  scheduled_at: string // ISO — giờ hẹn gọi lại (lead.next_activity_at)
+  is_overdue: boolean // BE tính realtime = scheduled_at < server_time
+  degree_level: string | null // trình độ ngành → getDegreeLevelAbbr
+  major: string | null
+}
+
+export interface MyAppointmentsResponse {
+  server_time: string // ISO — mốc để FE đếm giờ chính xác (khỏi lệ thuộc đồng hồ client)
+  overdue_count: number
+  upcoming_count: number
+  appointments: MyAppointmentItem[] // ASC theo scheduled_at: quá hạn trước, sắp tới sau
+}
+
+/** Lịch hẹn gọi lại của officer đang login ("Nhịp hẹn"). */
+export async function getMyAppointments(): Promise<MyAppointmentsResponse> {
+  const response = await api.get<MyAppointmentsResponse>('/api/leads/my/appointments')
+  return response.data
+}
+
 /**
  * Bulk assign leads to a specific officer
  * Sends officer_id as query param, lead_ids in request body

--- a/frontend/src/lib/api/leads.ts
+++ b/frontend/src/lib/api/leads.ts
@@ -156,7 +156,7 @@ export interface MyAppointmentItem {
   phone: string
   source: string
   scheduled_at: string // ISO — giờ hẹn gọi lại (lead.next_activity_at)
-  is_overdue: boolean // BE tính realtime = scheduled_at < server_time
+  // (bỏ is_overdue: FE tự tính overdue realtime từ server_time — xem appointment-clock.stateOf)
   degree_level: string | null // trình độ ngành → getDegreeLevelAbbr
   major: string | null
   officer_name: string | null // NV phụ trách — có khi admin/manager xem toàn bộ

--- a/frontend/src/lib/api/leads.ts
+++ b/frontend/src/lib/api/leads.ts
@@ -159,10 +159,12 @@ export interface MyAppointmentItem {
   is_overdue: boolean // BE tính realtime = scheduled_at < server_time
   degree_level: string | null // trình độ ngành → getDegreeLevelAbbr
   major: string | null
+  officer_name: string | null // NV phụ trách — có khi admin/manager xem toàn bộ
 }
 
 export interface MyAppointmentsResponse {
   server_time: string // ISO — mốc để FE đếm giờ chính xác (khỏi lệ thuộc đồng hồ client)
+  scope: "own" | "all" // own = officer (của mình) · all = admin/manager (toàn bộ)
   overdue_count: number
   upcoming_count: number
   appointments: MyAppointmentItem[] // ASC theo scheduled_at: quá hạn trước, sắp tới sau

--- a/frontend/src/lib/leads/appointment-clock.ts
+++ b/frontend/src/lib/leads/appointment-clock.ts
@@ -15,6 +15,21 @@ export type ApptState = "overdue" | "due" | "soon";
 
 export const pad = (n: number) => String(n).padStart(2, "0");
 
+// Giờ hẹn (server_time/scheduled_at) là instant UTC (backend `datetime.now(tz.utc)`).
+// Format LUÔN theo giờ Việt Nam để không lệ thuộc múi giờ máy client (máy đặt sai
+// TZ / đang ở nước ngoài vẫn hiện đúng giờ VN). Formatter dùng chung, cache 1 lần.
+const VN_HHMM = new Intl.DateTimeFormat("en-GB", {
+  timeZone: "Asia/Ho_Chi_Minh",
+  hour: "2-digit",
+  minute: "2-digit",
+  hourCycle: "h23",
+});
+
+/** "HH:MM" theo giờ VN từ một mốc epoch-ms. */
+export function hhmmFromMs(ms: number): string {
+  return VN_HHMM.format(new Date(ms));
+}
+
 /** Khoảng cách (ms) từ bây giờ tới giờ hẹn; âm = đã quá hạn. */
 export function apptDelta(scheduledAt: string, serverNow: number): number {
   return new Date(scheduledAt).getTime() - serverNow;
@@ -30,7 +45,8 @@ export function stateOf(scheduledAt: string, serverNow: number): ApptState {
 
 /** Định dạng khoảng cách tới giờ hẹn: ngày → H:MM:SS → MM:SS (đếm sống). */
 export function formatDelta(ms: number): string {
-  const s = Math.abs(Math.floor(ms / 1000));
+  // floor TRÊN trị tuyệt đối: delta âm (quá hạn) -300ms phải là 0s, không phải 1s.
+  const s = Math.floor(Math.abs(ms) / 1000);
   const d = Math.floor(s / 86400);
   const h = Math.floor((s % 86400) / 3600);
   const m = Math.floor((s % 3600) / 60);
@@ -41,8 +57,7 @@ export function formatDelta(ms: number): string {
 }
 
 export function hhmm(iso: string): string {
-  const d = new Date(iso);
-  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  return hhmmFromMs(new Date(iso).getTime());
 }
 
 /** Dòng ngành: "CĐ Dược" · "TC Kế toán" · fallback khi chưa chọn ngành. */

--- a/frontend/src/lib/leads/appointment-clock.ts
+++ b/frontend/src/lib/leads/appointment-clock.ts
@@ -1,0 +1,77 @@
+// src/lib/leads/appointment-clock.ts
+// =============================================================================
+// Helper thuần cho "Nhịp hẹn" / "Trợ lý nhắc hẹn" — dùng chung giữa
+// AppointmentReminder (bảng dropdown) và AppointmentAssistant (bong bóng + nudge).
+// Không phụ thuộc React; đồng hồ đếm sống dùng `useServerNow` (hooks/useServerNow).
+// =============================================================================
+
+import { getDegreeLevelAbbr } from "@/constants";
+import type { MyAppointmentItem } from "@/lib/api/leads";
+
+/** ≤10 phút tới giờ hẹn = "đến giờ" (hổ phách). */
+export const DUE_SOON_MS = 10 * 60 * 1000;
+
+export type ApptState = "overdue" | "due" | "soon";
+
+export const pad = (n: number) => String(n).padStart(2, "0");
+
+/** Khoảng cách (ms) từ bây giờ tới giờ hẹn; âm = đã quá hạn. */
+export function apptDelta(scheduledAt: string, serverNow: number): number {
+  return new Date(scheduledAt).getTime() - serverNow;
+}
+
+/** Trạng thái-thời-gian của một hẹn so với server_now. */
+export function stateOf(scheduledAt: string, serverNow: number): ApptState {
+  const delta = apptDelta(scheduledAt, serverNow);
+  if (delta < 0) return "overdue";
+  if (delta <= DUE_SOON_MS) return "due";
+  return "soon";
+}
+
+/** Định dạng khoảng cách tới giờ hẹn: ngày → H:MM:SS → MM:SS (đếm sống). */
+export function formatDelta(ms: number): string {
+  const s = Math.abs(Math.floor(ms / 1000));
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  if (d >= 1) return `${d} ngày${h ? ` ${h}h` : ""}`;
+  if (h >= 1) return `${h}:${pad(m)}:${pad(sec)}`;
+  return `${pad(m)}:${pad(sec)}`;
+}
+
+export function hhmm(iso: string): string {
+  const d = new Date(iso);
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/** Dòng ngành: "CĐ Dược" · "TC Kế toán" · fallback khi chưa chọn ngành. */
+export function eduLine(item: MyAppointmentItem): string {
+  const deg = getDegreeLevelAbbr(item.degree_level ?? undefined);
+  const parts = [deg, item.major].filter(Boolean);
+  return parts.length ? parts.join(" ") : "Chưa chọn ngành";
+}
+
+/** Dòng phụ: ngành · NV phụ trách (tên NV chỉ có khi admin/manager xem toàn bộ). */
+export function metaLine(item: MyAppointmentItem): string {
+  return item.officer_name ? `${eduLine(item)} · ${item.officer_name}` : eduLine(item);
+}
+
+/** Bảng class Tailwind theo trạng-thái-thời-gian (đỏ trễ → hổ phách → xanh). */
+export const STATE_STYLE: Record<ApptState, { text: string; bar: string; pill: string }> = {
+  overdue: {
+    text: "text-red-600 dark:text-red-400",
+    bar: "bg-red-500",
+    pill: "text-red-600 dark:text-red-300 bg-red-500/10",
+  },
+  due: {
+    text: "text-amber-600 dark:text-amber-400",
+    bar: "bg-amber-500",
+    pill: "text-amber-700 dark:text-amber-300 bg-amber-500/10",
+  },
+  soon: {
+    text: "text-blue-600 dark:text-blue-400",
+    bar: "bg-blue-500",
+    pill: "text-blue-600 dark:text-blue-300 bg-blue-500/10",
+  },
+};

--- a/frontend/src/lib/leads/appointment-clock.ts
+++ b/frontend/src/lib/leads/appointment-clock.ts
@@ -25,8 +25,10 @@ const VN_HHMM = new Intl.DateTimeFormat("en-GB", {
   hourCycle: "h23",
 });
 
-/** "HH:MM" theo giờ VN từ một mốc epoch-ms. */
+/** "HH:MM" theo giờ VN từ một mốc epoch-ms; ms không hợp lệ → "--:--"
+ *  (Intl.format(new Date(NaN)) THROW RangeError — phải chặn trước khi render). */
 export function hhmmFromMs(ms: number): string {
+  if (!Number.isFinite(ms)) return "--:--";
   return VN_HHMM.format(new Date(ms));
 }
 

--- a/frontend/src/lib/leads/appointment-clock.ts
+++ b/frontend/src/lib/leads/appointment-clock.ts
@@ -25,10 +25,12 @@ const VN_HHMM = new Intl.DateTimeFormat("en-GB", {
   hourCycle: "h23",
 });
 
-/** "HH:MM" theo giờ VN từ một mốc epoch-ms; ms không hợp lệ → "--:--"
- *  (Intl.format(new Date(NaN)) THROW RangeError — phải chặn trước khi render). */
+/** "HH:MM" theo giờ VN từ một mốc epoch-ms; ms không hợp lệ HOẶC ≤0 → "--:--".
+ *  ms≤0 = sentinel "chưa load" của useServerNow (0) → tránh render nhầm '07:00'
+ *  (giờ VN của epoch 1970). Intl.format(new Date(NaN)) THROW RangeError nên phải
+ *  chặn trước; mọi mốc thật (scheduled_at/server_time) luôn >0 nên không ảnh hưởng. */
 export function hhmmFromMs(ms: number): string {
-  if (!Number.isFinite(ms)) return "--:--";
+  if (!Number.isFinite(ms) || ms <= 0) return "--:--";
   return VN_HHMM.format(new Date(ms));
 }
 

--- a/frontend/src/lib/sound.ts
+++ b/frontend/src/lib/sound.ts
@@ -4,6 +4,7 @@
  */
 
 let audioContext: AudioContext | null = null;
+let unlockInstalled = false;
 
 /**
  * Initialize audio context (required for some browsers)
@@ -14,6 +15,35 @@ function getAudioContext(): AudioContext {
     audioContext = new (window.AudioContext || WebkitAudioContext!)();
   }
   return audioContext;
+}
+
+/**
+ * Mở khóa AudioContext ở user-gesture ĐẦU TIÊN (một lần cho cả phiên).
+ *
+ * Chrome autoplay policy: AudioContext tạo NGOÀI user-gesture (vd chuông được
+ * KHÔI PHỤC từ localStorage rồi kêu từ timer nudge) ở trạng thái "suspended" —
+ * resume() từ timer bị bỏ qua → chuông câm cả phiên. Đăng ký listener 1-lần cho
+ * pointerdown/keydown/touchstart để resume() context trong ngữ cảnh gesture hợp
+ * lệ; sau đó gỡ listener. Gọi khi bật tính năng nhắc (officer) để chuông LS-restore
+ * kêu được ở lần tương tác đầu.
+ */
+export function installAudioUnlockOnce(): void {
+  if (unlockInstalled || typeof window === "undefined") return;
+  unlockInstalled = true;
+  const unlock = () => {
+    try {
+      const ctx = getAudioContext();
+      if (ctx.state === "suspended") void ctx.resume();
+    } catch {
+      /* AudioContext không khả dụng → bỏ qua */
+    }
+    window.removeEventListener("pointerdown", unlock);
+    window.removeEventListener("keydown", unlock);
+    window.removeEventListener("touchstart", unlock);
+  };
+  window.addEventListener("pointerdown", unlock);
+  window.addEventListener("keydown", unlock);
+  window.addEventListener("touchstart", unlock);
 }
 
 /**

--- a/frontend/src/lib/sound.ts
+++ b/frontend/src/lib/sound.ts
@@ -24,6 +24,13 @@ export function playNotificationSound(): void {
   try {
     const context = getAudioContext();
 
+    // Chrome autoplay policy: context tạo lazy ngoài user-gesture (vd khi bật
+    // âm được KHÔI PHỤC từ localStorage lúc tải trang) sẽ ở trạng thái
+    // "suspended" → âm phát ra câm. Resume để chuông thật sự kêu.
+    if (context.state === "suspended") {
+      void context.resume();
+    }
+
     // Create oscillator for the notification sound
     const oscillator = context.createOscillator();
     const gainNode = context.createGain();


### PR DESCRIPTION
## Tính năng "Nhịp hẹn" / Trợ lý nhắc hẹn (#3)

Bảng + trợ lý chủ động nhắc tư vấn viên các lịch **gọi lại** (callback) để không bỏ lỡ lead, dựa trên `Lead.next_activity_at`.

### Kiến trúc
- **BE** `GET /api/leads/my/appointments` (CasbinAuth, chỉ đọc) — lead có hẹn còn sống, kèm `server_time` để FE đếm giờ realtime; scope theo role.
- **FE**: icon header (bảng tra cứu) + bong bóng góc màn (trợ lý chủ động) tái dùng `ReminderBody`; **engine nudge** tự bung khi tới giờ (officer-only, arm-based, khóa `lead@scheduled_at`) + chuông/thông báo OS.

### Phân quyền (đã smoke 4 role)
| Role | Widget | Scope |
|------|--------|-------|
| Officer | hiện | của mình (own) |
| Manager | hiện | **theo đơn vị** (unit-scoped, không xem chéo) |
| Admin | hiện | toàn tổ chức (kèm tên NV) |
| **Accountant/user** | **ẩn** | **Casbin deny** (separation-of-duties — feed chứa tên/SĐT lead PII) |

### 3 vòng /code-review max (đã xử lý)
- Vòng 1+2: 15 finding + 2 regression (engine nudge, giờ VN, layout) + Casbin policy officer.
- **Vòng 3 (15 finding):** manager `unit_id=None` guard (chống leak PII cross-unit) · accountant 403 → FE tự ẩn widget (theo response, không hardcode role) · `useServerNow` skew (dataUpdatedAt) · count tổng thật (không cap-60) · `@limiter` đúng thứ tự slowapi (rate-limit thật) · audio unlock gesture · nudge prune/resync · guard đồng hồ epoch · bỏ `is_overdue` dead field · window hiện hẹn quá hạn >7d.
- Accountant separation-of-duties: Casbin deny + migration `apptacctdeny20260713` + cập nhật frozen deny-set matrix test.

### Verify (CI-local xanh)
- BE: 73 fast-gate (ratelimit + casbin) + matrix (permissions + casbin 4×14 + collision) — pass
- FE: type-check 0 · lint 0-error · **vitest 1853 pass** · `next build` ✅
- Smoke chrome-devtools 4 role GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)