### PR TITLE
feat(leads): bảng lead command-center linh hoạt — resize/reorder/auto-fit + panel 25%

### DIFF
--- a/Backend_FastAPI/requirements.txt
+++ b/Backend_FastAPI/requirements.txt
@@ -23,7 +23,7 @@ celery==5.5.3
 certifi==2025.10.5
 cffi==2.0.0
 charset-normalizer==3.4.4
-click==8.3.0
+click==8.3.3
 click-didyoumean==0.3.1
 click-plugins==1.1.1.2
 click-repl==0.3.0
@@ -61,7 +61,7 @@ packaging==25.0
 paginate==0.5.7
 pandas==2.3.3
 passlib==1.7.4
-Pillow==12.2.0
+Pillow==12.3.0
 prometheus_client==0.23.1
 prompt_toolkit==3.0.52
 propcache==0.4.1

--- a/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
@@ -41,7 +41,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useMediaQueryState } from "@/hooks/useMediaQuery";
 import { useUIStore } from "@/lib/stores/ui.store";
 import { cn } from "@/lib/utils";
 
@@ -89,8 +89,14 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
   // ✅ Phase 1: Query client for prefetching
   const queryClient = useQueryClient();
 
-  // ✅ Mobile responsiveness: Detect desktop vs mobile
-  const isDesktop = useMediaQuery("(min-width: 1024px)");
+  // ✅ Mobile responsiveness: Detect desktop vs mobile.
+  // `layoutResolved` = đã đo viewport thật chưa. Nhánh desktop (master-detail
+  // split) vs mobile (card list) là 2 CÂY ELEMENT khác hẳn nhau; render trước
+  // khi resolved → hard-load nháy card-mobile → bảng-desktop (data SSR-prefetch
+  // nên nháy CARD THẬT, không phải skeleton). Hoãn nhánh tới khi resolved.
+  const { matches: isDesktop, resolved: layoutResolved } = useMediaQueryState(
+    "(min-width: 1024px)"
+  );
 
   // Mobile detail sheet state
   const [mobileDetailOpen, setMobileDetailOpen] = useState(false);
@@ -355,7 +361,35 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
     ? `${totalLeadCount.toLocaleString("vi-VN")} lead • Phạm vi: ${effectiveScopeLabel}${effectiveScopeSuffix}`
     : `${totalLeadCount.toLocaleString("vi-VN")} lead`;
   const hasDashboardContext = dashboardContext !== null;
-  
+
+  // Trạng thái dùng chung cho cả 3 nhánh (chưa-resolved / desktop / mobile) —
+  // 1 nguồn duy nhất, tránh 2 khối skeleton lệch nhau.
+  const loadingSkeleton = (
+    <div className="space-y-2 p-4">
+      {Array.from({ length: 10 }).map((_, i) => (
+        <motion.div
+          key={i}
+          initial={{ opacity: 0, x: -10 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ delay: i * 0.05, duration: 0.2 }}
+        >
+          <Skeleton className="h-12 w-full" />
+        </motion.div>
+      ))}
+    </div>
+  );
+
+  const errorState = (
+    <div className="flex h-40 items-center justify-center">
+      <div className="text-center">
+        <p className="text-sm font-medium text-error-600">Lỗi tải lead</p>
+        <p className="text-muted-foreground mt-1 text-xs">
+          {error?.message || "Lỗi không xác định"}
+        </p>
+      </div>
+    </div>
+  );
+
   return (
     // Mobile (<lg): document-flow — cuộn qua `Main` (single-scroll), bỏ app-shell
     // h-full/overflow-hidden để khỏi lồng scroll (đứt momentum "tê"). Desktop giữ
@@ -454,36 +488,24 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
       />
 
       {/* Main Content - Responsive Layout */}
+      {/* Chưa đo xong viewport (hard-load) → skeleton trung tính, KHÔNG commit
+          mobile/desktop để không nháy card-mobile → bảng-desktop (data
+          SSR-prefetch nên nháy CARD THẬT). Resolved xong mới chọn nhánh —
+          client-side nav resolved trước paint nên không thêm frame skeleton. */}
       {/* Desktop (lg+): Split View with ResizablePanel */}
       {/* Mobile (<lg): Full-width table + Sheet for detail */}
-      {isDesktop ? (
+      {!layoutResolved ? (
+        <div className="min-w-0">{loadingSkeleton}</div>
+      ) : isDesktop ? (
         // Desktop: Split View with Independent Scroll
         <ResizablePanelGroup direction="horizontal" className="min-h-0 flex-1">
           {/* Left: Data Table (75%) — min/max khớp detail (detail 22–50 ⇒ table 50–78) */}
           <ResizablePanel defaultSize={75} minSize={50} maxSize={78}>
             <div className="flex h-full flex-col overflow-y-auto">
               {isLoading ? (
-                <div className="space-y-2 p-4">
-                  {Array.from({ length: 10 }).map((_, i) => (
-                    <motion.div
-                      key={i}
-                      initial={{ opacity: 0, x: -10 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      transition={{ delay: i * 0.05, duration: 0.2 }}
-                    >
-                      <Skeleton className="h-12 w-full" />
-                    </motion.div>
-                  ))}
-                </div>
+                loadingSkeleton
               ) : isError ? (
-                <div className="flex h-40 items-center justify-center">
-                  <div className="text-center">
-                    <p className="text-sm font-medium text-error-600">Lỗi tải lead</p>
-                    <p className="text-muted-foreground mt-1 text-xs">
-                      {error?.message || "Lỗi không xác định"}
-                    </p>
-                  </div>
-                </div>
+                errorState
               ) : (
                 <LeadsTable
                   leads={filteredLeads}
@@ -533,27 +555,9 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
         // theo trang, cuộn qua `Main` (single-scroll).
         <div className="min-w-0">
           {isLoading ? (
-            <div className="space-y-2 p-4">
-              {Array.from({ length: 10 }).map((_, i) => (
-                <motion.div
-                  key={i}
-                  initial={{ opacity: 0, x: -10 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ delay: i * 0.05, duration: 0.2 }}
-                >
-                  <Skeleton className="h-12 w-full" />
-                </motion.div>
-              ))}
-            </div>
+            loadingSkeleton
           ) : isError ? (
-            <div className="flex h-40 items-center justify-center">
-              <div className="text-center">
-                <p className="text-sm font-medium text-error-600">Lỗi tải lead</p>
-                <p className="text-muted-foreground mt-1 text-xs">
-                  {error?.message || "Lỗi không xác định"}
-                </p>
-              </div>
-            </div>
+            errorState
           ) : (
             <LeadsTable
               leads={filteredLeads}

--- a/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
@@ -459,8 +459,8 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
       {isDesktop ? (
         // Desktop: Split View with Independent Scroll
         <ResizablePanelGroup direction="horizontal" className="min-h-0 flex-1">
-          {/* Left: Data Table (65%) */}
-          <ResizablePanel defaultSize={65} minSize={45} maxSize={80}>
+          {/* Left: Data Table (75%) */}
+          <ResizablePanel defaultSize={75} minSize={45} maxSize={80}>
             <div className="flex h-full flex-col overflow-y-auto">
               {isLoading ? (
                 <div className="space-y-2 p-4">
@@ -516,8 +516,8 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
 
           <ResizableHandle withHandle />
 
-          {/* Right: Detail Panel (35%) - Independent Scroll */}
-          <ResizablePanel defaultSize={35} minSize={25} maxSize={50}>
+          {/* Right: Detail Panel (25%) - Independent Scroll */}
+          <ResizablePanel defaultSize={25} minSize={22} maxSize={50}>
             <div ref={detailPanelRef} className="h-full overflow-y-auto bg-background">
               <LeadDetailPanel
                 leadId={selectedLeadId}

--- a/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
@@ -459,8 +459,8 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
       {isDesktop ? (
         // Desktop: Split View with Independent Scroll
         <ResizablePanelGroup direction="horizontal" className="min-h-0 flex-1">
-          {/* Left: Data Table (75%) */}
-          <ResizablePanel defaultSize={75} minSize={45} maxSize={80}>
+          {/* Left: Data Table (75%) — min/max khớp detail (detail 22–50 ⇒ table 50–78) */}
+          <ResizablePanel defaultSize={75} minSize={50} maxSize={78}>
             <div className="flex h-full flex-col overflow-y-auto">
               {isLoading ? (
                 <div className="space-y-2 p-4">

--- a/frontend/src/components/leads/command-center/LeadsTable.tsx
+++ b/frontend/src/components/leads/command-center/LeadsTable.tsx
@@ -31,6 +31,7 @@ import {
   type ColumnResizeMode,
   type VisibilityState,
   type ColumnSizingState,
+  type ColumnSizingInfoState,
   type ColumnOrderState,
   type Header,
 } from "@tanstack/react-table";
@@ -38,7 +39,6 @@ import {
   DndContext,
   closestCenter,
   PointerSensor,
-  KeyboardSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
@@ -255,26 +255,31 @@ function DraggableHeader({
       ref={setNodeRef}
       data-column-id={columnId}
       style={style}
-      className={cn("relative overflow-hidden whitespace-nowrap", headerHeightClass)}
+      className={cn("group/lh relative overflow-hidden whitespace-nowrap", headerHeightClass)}
     >
-      <div className="flex items-center gap-0.5 overflow-hidden">
-        {reorderable && (
-          <button
-            type="button"
-            className="text-muted-foreground/40 hover:text-foreground -ml-1 shrink-0 cursor-grab touch-none rounded p-0.5 active:cursor-grabbing"
-            aria-label="Kéo để đổi thứ tự cột"
-            {...attributes}
-            {...listeners}
-          >
-            <GripVertical className="h-3.5 w-3.5" />
-          </button>
-        )}
-        <div className="min-w-0 flex-1 truncate">
-          {header.isPlaceholder
-            ? null
-            : flexRender(header.column.columnDef.header, header.getContext())}
-        </div>
+      {/* Nội dung header chiếm TRỌN bề rộng (không bị grip đẩy) → caret sort không
+          bị cắt ở cột hẹp. Grip là overlay hiện-khi-hover, KHÔNG chiếm chỗ flow. */}
+      <div className="truncate">
+        {header.isPlaceholder
+          ? null
+          : flexRender(header.column.columnDef.header, header.getContext())}
       </div>
+      {reorderable && (
+        <button
+          type="button"
+          className={cn(
+            "absolute left-0 top-0 z-[1] flex h-full w-4 items-center justify-center",
+            "bg-gradient-to-r from-muted via-muted/80 to-transparent",
+            "text-muted-foreground/60 hover:text-foreground cursor-grab touch-none",
+            "opacity-0 transition-opacity group-hover/lh:opacity-100 active:cursor-grabbing",
+          )}
+          aria-label="Kéo để đổi thứ tự cột"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="h-3.5 w-3.5" />
+        </button>
+      )}
       {/* Resize handle — double-click = auto-fit theo nội dung */}
       {header.column.getCanResize() && (
         <div
@@ -347,14 +352,20 @@ export function LeadsTable({
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({ phone: false });
   // Bề rộng cột do người dùng kéo (persist) + thứ tự cột (kéo grip đổi chỗ).
   const [columnSizing, setColumnSizing] = React.useState<ColumnSizingState>({});
+  // Trạng thái đang-kéo-resize (isResizingColumn) → chỉ persist khi kéo XONG,
+  // tránh spam localStorage.setItem mỗi tick pointer-move.
+  const [columnSizingInfo, setColumnSizingInfo] = React.useState<ColumnSizingInfoState>(
+    {} as ColumnSizingInfoState,
+  );
   const [columnOrder, setColumnOrder] = React.useState<ColumnOrderState>(DEFAULT_COLUMN_ORDER);
   const [isHydrated, setIsHydrated] = React.useState(false);
 
   // dnd-kit: kéo grip tiêu đề đổi thứ tự cột. PointerSensor có ngưỡng 6px →
-  // click thường (sort/resize) KHÔNG kích hoạt drag.
+  // click thường (sort/resize) KHÔNG kích hoạt drag. (KHÔNG dùng KeyboardSensor:
+  // thiếu coordinateGetter nên arrow-reorder không chạy + đụng keydown-nav toàn
+  // cục — bỏ để tránh dead-weight/glitch.)
   const dndSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
-    useSensor(KeyboardSensor),
   );
 
   // Hydrate from localStorage after mount to avoid SSR mismatch
@@ -379,7 +390,15 @@ export function LeadsTable({
       const savedSizing = localStorage.getItem(COLUMN_SIZING_STORAGE_KEY);
       if (savedSizing) {
         const parsed = JSON.parse(savedSizing);
-        if (parsed && typeof parsed === "object") setColumnSizing(parsed);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          // CHỈ nhận entry là số hữu-hạn dương (giá trị phi-số như "180px" →
+          // getSize() ra NaN → width NaN → sập layout).
+          const clean: ColumnSizingState = {};
+          for (const [k, v] of Object.entries(parsed)) {
+            if (typeof v === "number" && Number.isFinite(v) && v > 0) clean[k] = v;
+          }
+          setColumnSizing(clean);
+        }
       }
     } catch {
       // Ignore parse errors
@@ -389,11 +408,15 @@ export function LeadsTable({
       const savedOrder = localStorage.getItem(COLUMN_ORDER_STORAGE_KEY);
       if (savedOrder) {
         const parsed = JSON.parse(savedOrder);
-        // Chỉ nhận khi ĐÚNG tập cột hiện tại (chống order cũ/hỏng thiếu-thừa cột).
+        // Chỉ nhận khi ĐÚNG tập cột hiện tại (chống order cũ/hỏng thiếu-thừa cột)
+        // VÀ giữ pin-invariant (select đầu / actions cuối) — permutation lạ để
+        // select ra giữa bảng sẽ bị từ chối.
         if (
           Array.isArray(parsed) &&
           parsed.length === DEFAULT_COLUMN_ORDER.length &&
-          DEFAULT_COLUMN_ORDER.every((id) => parsed.includes(id))
+          DEFAULT_COLUMN_ORDER.every((id) => parsed.includes(id)) &&
+          parsed[0] === PINNED_START &&
+          parsed[parsed.length - 1] === PINNED_END
         ) {
           setColumnOrder(parsed);
         }
@@ -422,15 +445,16 @@ export function LeadsTable({
     }
   }, [columnVisibility, isHydrated]);
 
-  // Persist column sizing + order (only after hydration)
+  // Persist column sizing (only after hydration) — CHỜ kéo resize XONG
+  // (isResizingColumn falsy) để không ghi localStorage mỗi tick pointer-move.
   useEffect(() => {
-    if (!isHydrated) return;
+    if (!isHydrated || columnSizingInfo.isResizingColumn) return;
     try {
       localStorage.setItem(COLUMN_SIZING_STORAGE_KEY, JSON.stringify(columnSizing));
     } catch {
       /* ignore quota/serialize errors */
     }
-  }, [columnSizing, isHydrated]);
+  }, [columnSizing, columnSizingInfo.isResizingColumn, isHydrated]);
 
   useEffect(() => {
     if (!isHydrated) return;
@@ -484,6 +508,7 @@ export function LeadsTable({
           />
         ),
         size: 40,
+        minSize: 40, // ghi đè defaultColumn.minSize=60 (cột checkbox tiện ích)
         enableResizing: false,
         enableHiding: false,
       }),
@@ -750,6 +775,7 @@ export function LeadsTable({
           />
         ),
         size: 50,
+        minSize: 48, // ghi đè defaultColumn.minSize=60 (cột hành động tiện ích)
         enableResizing: false,
         enableHiding: false,
       }),
@@ -769,6 +795,7 @@ export function LeadsTable({
       rowSelection,
       columnVisibility,
       columnSizing,
+      columnSizingInfo,
       columnOrder,
     },
     defaultColumn: { minSize: 60, maxSize: 400 },
@@ -776,6 +803,7 @@ export function LeadsTable({
     enableColumnResizing: true,
     columnResizeMode,
     onColumnSizingChange: setColumnSizing,
+    onColumnSizingInfoChange: setColumnSizingInfo,
     onColumnOrderChange: setColumnOrder,
     manualSorting: true,
     onSortingChange: (updater) => {
@@ -794,6 +822,23 @@ export function LeadsTable({
     onColumnVisibilityChange: setColumnVisibility,
     getCoreRowModel: getCoreRowModel(),
   });
+
+  // Dev-assert: DEFAULT_COLUMN_ORDER phải khớp tập cột thật (const module-level cho
+  // SSR-stable nên không derive được từ table). Thêm/xoá/đổi-tên cột mà quên list
+  // này → columnOrder lệch + guard hydration reject → fail-loud khi dev.
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+    const actual = table.getAllLeafColumns().map((c) => c.id);
+    const drift =
+      actual.length !== DEFAULT_COLUMN_ORDER.length ||
+      actual.some((id) => !DEFAULT_COLUMN_ORDER.includes(id));
+    if (drift) {
+      console.error(
+        "[LeadsTable] DEFAULT_COLUMN_ORDER lệch với columns — cập nhật hằng.",
+        { actual, expected: DEFAULT_COLUMN_ORDER },
+      );
+    }
+  }, [table]);
 
   // Get all rows for virtualization
   const rows = table.getRowModel().rows;
@@ -844,38 +889,59 @@ export function LeadsTable({
     });
   }, []);
 
-  // ── Double-click mép cột = auto-fit theo nội dung đang hiển thị ──
+  // ── Double-click mép cột = auto-fit theo nội dung ──
+  // Đo bề rộng TỰ NHIÊN: các ô đã `overflow-hidden`+`truncate` nên đo `scrollWidth`
+  // của chính ô = bề-rộng-ĐÃ-CLIP (chỉ nhích ~6px). Thay bằng clone phần nội dung
+  // vào probe đã GỠ overflow/truncate (white-space:nowrap, width:auto) → scrollWidth
+  // là bề rộng nội dung thật. (Chỉ đo các hàng đang render — virtualized.)
   const autoFitColumn = useCallback(
     (columnId: string) => {
       const col = table.getColumn(columnId);
       if (!col?.getCanResize()) return;
       const root = tableScrollRef.current;
       if (!root) return;
+      const probe = document.createElement("div");
+      probe.style.cssText =
+        "position:absolute;left:-9999px;top:-9999px;white-space:nowrap;pointer-events:none;";
+      document.body.appendChild(probe);
       let maxContent = 0;
-      root
-        .querySelectorAll<HTMLElement>(`[data-column-id="${columnId}"]`)
-        .forEach((el) => {
-          maxContent = Math.max(maxContent, el.scrollWidth);
-        });
+      try {
+        // ô/header có 1 con nội dung trực tiếp (div.truncate / span.flex / Badge…)
+        root
+          .querySelectorAll<HTMLElement>(`[data-column-id="${columnId}"] > *:not([aria-label="Kéo để đổi thứ tự cột"])`)
+          .forEach((content) => {
+            const clone = content.cloneNode(true) as HTMLElement;
+            const strip = (el: HTMLElement) => {
+              el.style.maxWidth = "none";
+              el.style.width = "auto";
+              el.style.overflow = "visible";
+              el.style.textOverflow = "clip";
+              el.style.whiteSpace = "nowrap";
+            };
+            strip(clone);
+            clone.querySelectorAll<HTMLElement>("*").forEach(strip);
+            probe.appendChild(clone);
+            maxContent = Math.max(maxContent, clone.scrollWidth);
+            probe.removeChild(clone);
+          });
+      } finally {
+        document.body.removeChild(probe);
+      }
       if (maxContent <= 0) return;
       const min = col.columnDef.minSize ?? 60;
       const max = col.columnDef.maxSize ?? 400;
-      const target = Math.max(min, Math.min(max, Math.round(maxContent) + 6));
+      // + padding ô (px-2 = 16) + đệm nhỏ cho grip/handle
+      const target = Math.max(min, Math.min(max, Math.round(maxContent) + 22));
       setColumnSizing((prev) => ({ ...prev, [columnId]: target }));
     },
     [table],
   );
 
   // ── Đặt lại bề rộng + thứ tự cột về mặc định ──
+  // (setState kích persist-effect ghi lại '{}'/default ngay → không cần removeItem.)
   const resetColumnLayout = useCallback(() => {
     setColumnSizing({});
     setColumnOrder(DEFAULT_COLUMN_ORDER);
-    try {
-      localStorage.removeItem(COLUMN_SIZING_STORAGE_KEY);
-      localStorage.removeItem(COLUMN_ORDER_STORAGE_KEY);
-    } catch {
-      /* ignore */
-    }
   }, []);
 
   // Keyboard navigation
@@ -1111,7 +1177,12 @@ export function LeadsTable({
           <TableHeader className="bg-muted/50 sticky top-0 z-10">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
-                <SortableContext items={columnOrder} strategy={horizontalListSortingStrategy}>
+                {/* items = đúng các header ĐANG render (cột hiện), không gồm cột
+                    ẩn như phone → tránh lệch animation shift khi kéo. */}
+                <SortableContext
+                  items={headerGroup.headers.map((h) => h.column.id)}
+                  strategy={horizontalListSortingStrategy}
+                >
                   {headerGroup.headers.map((header) => (
                     <DraggableHeader
                       key={header.id}

--- a/frontend/src/components/leads/command-center/LeadsTable.tsx
+++ b/frontend/src/components/leads/command-center/LeadsTable.tsx
@@ -30,15 +30,31 @@ import {
   type RowSelectionState,
   type ColumnResizeMode,
   type VisibilityState,
+  type ColumnSizingState,
+  type ColumnOrderState,
+  type Header,
 } from "@tanstack/react-table";
-import { format } from "date-fns";
-import { vi } from "date-fns/locale";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import {
   ArrowUpDown,
   ArrowUp,
   ArrowDown,
   ChevronLeft,
-  SearchX,
   ChevronRight,
   GripVertical,
   Zap,
@@ -127,6 +143,12 @@ interface LeadsTableProps {
 
 const COLUMN_VISIBILITY_STORAGE_KEY = "leads_table_columns";
 const DENSITY_MODE_STORAGE_KEY = "leads_table_density";
+const COLUMN_SIZING_STORAGE_KEY = "leads_table_sizing";
+const COLUMN_ORDER_STORAGE_KEY = "leads_table_order";
+
+/** Cột tiện ích cố định 2 đầu (không kéo đổi thứ tự, không resize). */
+const PINNED_START = "select";
+const PINNED_END = "actions";
 
 // Mapping between TanStack column IDs and backend sort_by field names
 const COLUMN_TO_BACKEND_SORT: Record<string, string> = {
@@ -178,6 +200,96 @@ function RowActions({ lead, onEdit, onDelete, onAssign }: RowActionsProps) {
       triggerClassName="h-8 w-8 sm:h-8 sm:w-8"
       stopPropagation
     />
+  );
+}
+
+// Thứ tự cột mặc định (khớp định nghĩa `columns` bên dưới). Dùng cho khởi tạo
+// columnOrder (SSR-safe: server + client render cùng thứ tự) + nút "Đặt lại".
+const DEFAULT_COLUMN_ORDER: ColumnOrderState = [
+  "select",
+  "full_name",
+  "phone",
+  "offering",
+  "source",
+  "pipeline_stage",
+  "consultation_status",
+  "assigned_officer",
+  "lead_score",
+  "activity",
+  "cached_urgency_score",
+  "actions",
+];
+
+// =============================================================================
+// DRAGGABLE HEADER — kéo grip đổi thứ tự (dnd-kit) · mép phải resize ·
+// double-click mép = auto-fit. Grip / sort-button / resize-handle tách vùng
+// tương tác nên KHÔNG xung đột nhau.
+// =============================================================================
+
+function DraggableHeader({
+  header,
+  headerHeightClass,
+  onAutoFit,
+}: {
+  header: Header<Lead, unknown>;
+  headerHeightClass: string;
+  onAutoFit: (columnId: string) => void;
+}) {
+  const columnId = header.column.id;
+  const reorderable = columnId !== PINNED_START && columnId !== PINNED_END;
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useSortable({
+    id: columnId,
+    disabled: !reorderable,
+  });
+
+  const style: React.CSSProperties = {
+    width: header.getSize(),
+    transform: CSS.Translate.toString(transform),
+    transition: isDragging ? "transform 0s" : "transform 150ms ease",
+    opacity: isDragging ? 0.65 : 1,
+    zIndex: isDragging ? 5 : undefined,
+  };
+
+  return (
+    <TableHead
+      ref={setNodeRef}
+      data-column-id={columnId}
+      style={style}
+      className={cn("relative overflow-hidden whitespace-nowrap", headerHeightClass)}
+    >
+      <div className="flex items-center gap-0.5 overflow-hidden">
+        {reorderable && (
+          <button
+            type="button"
+            className="text-muted-foreground/40 hover:text-foreground -ml-1 shrink-0 cursor-grab touch-none rounded p-0.5 active:cursor-grabbing"
+            aria-label="Kéo để đổi thứ tự cột"
+            {...attributes}
+            {...listeners}
+          >
+            <GripVertical className="h-3.5 w-3.5" />
+          </button>
+        )}
+        <div className="min-w-0 flex-1 truncate">
+          {header.isPlaceholder
+            ? null
+            : flexRender(header.column.columnDef.header, header.getContext())}
+        </div>
+      </div>
+      {/* Resize handle — double-click = auto-fit theo nội dung */}
+      {header.column.getCanResize() && (
+        <div
+          onMouseDown={header.getResizeHandler()}
+          onTouchStart={header.getResizeHandler()}
+          onDoubleClick={() => onAutoFit(columnId)}
+          title="Kéo để đổi rộng · double-click auto-fit"
+          className={cn(
+            "absolute top-0 right-0 h-full w-1.5 cursor-col-resize touch-none select-none",
+            "hover:bg-primary/50 active:bg-primary",
+            header.column.getIsResizing() && "bg-primary"
+          )}
+        />
+      )}
+    </TableHead>
   );
 }
 
@@ -233,7 +345,17 @@ export function LeadsTable({
   const [densityMode, setDensityMode] = React.useState<DensityMode>('regular');
   // Default: hide phone column for privacy protection
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({ phone: false });
+  // Bề rộng cột do người dùng kéo (persist) + thứ tự cột (kéo grip đổi chỗ).
+  const [columnSizing, setColumnSizing] = React.useState<ColumnSizingState>({});
+  const [columnOrder, setColumnOrder] = React.useState<ColumnOrderState>(DEFAULT_COLUMN_ORDER);
   const [isHydrated, setIsHydrated] = React.useState(false);
+
+  // dnd-kit: kéo grip tiêu đề đổi thứ tự cột. PointerSensor có ngưỡng 6px →
+  // click thường (sort/resize) KHÔNG kích hoạt drag.
+  const dndSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor),
+  );
 
   // Hydrate from localStorage after mount to avoid SSR mismatch
   useEffect(() => {
@@ -248,6 +370,33 @@ export function LeadsTable({
         const parsed = JSON.parse(savedVisibility);
         // Merge with defaults (user preferences override defaults)
         setColumnVisibility({ phone: false, ...parsed });
+      }
+    } catch {
+      // Ignore parse errors
+    }
+
+    try {
+      const savedSizing = localStorage.getItem(COLUMN_SIZING_STORAGE_KEY);
+      if (savedSizing) {
+        const parsed = JSON.parse(savedSizing);
+        if (parsed && typeof parsed === "object") setColumnSizing(parsed);
+      }
+    } catch {
+      // Ignore parse errors
+    }
+
+    try {
+      const savedOrder = localStorage.getItem(COLUMN_ORDER_STORAGE_KEY);
+      if (savedOrder) {
+        const parsed = JSON.parse(savedOrder);
+        // Chỉ nhận khi ĐÚNG tập cột hiện tại (chống order cũ/hỏng thiếu-thừa cột).
+        if (
+          Array.isArray(parsed) &&
+          parsed.length === DEFAULT_COLUMN_ORDER.length &&
+          DEFAULT_COLUMN_ORDER.every((id) => parsed.includes(id))
+        ) {
+          setColumnOrder(parsed);
+        }
       }
     } catch {
       // Ignore parse errors
@@ -272,6 +421,25 @@ export function LeadsTable({
       localStorage.setItem(COLUMN_VISIBILITY_STORAGE_KEY, JSON.stringify(columnVisibility));
     }
   }, [columnVisibility, isHydrated]);
+
+  // Persist column sizing + order (only after hydration)
+  useEffect(() => {
+    if (!isHydrated) return;
+    try {
+      localStorage.setItem(COLUMN_SIZING_STORAGE_KEY, JSON.stringify(columnSizing));
+    } catch {
+      /* ignore quota/serialize errors */
+    }
+  }, [columnSizing, isHydrated]);
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    try {
+      localStorage.setItem(COLUMN_ORDER_STORAGE_KEY, JSON.stringify(columnOrder));
+    } catch {
+      /* ignore quota/serialize errors */
+    }
+  }, [columnOrder, isHydrated]);
 
   // Reset row selection when resetSelectionKey changes (after bulk actions)
   useEffect(() => {
@@ -339,9 +507,13 @@ export function LeadsTable({
           </Button>
         ),
         cell: ({ row }) => (
-          <div className="text-sm font-medium">{row.original.full_name || "—"}</div>
+          <div className="truncate text-sm font-medium" title={row.original.full_name || undefined}>
+            {row.original.full_name || "—"}
+          </div>
         ),
         size: 180,
+        minSize: 110,
+        maxSize: 340,
       }),
 
       // Phone column - with copy to clipboard
@@ -355,6 +527,8 @@ export function LeadsTable({
           />
         ),
         size: 120,
+        minSize: 90,
+        maxSize: 180,
       }),
 
       // Ngành column — đồng bộ với card list (trình độ viết tắt CĐ/TC + tên ngành)
@@ -368,19 +542,19 @@ export function LeadsTable({
           if (!major) return <span className="text-muted-foreground">—</span>;
           const degreeShort = getDegreeLevelAbbr(offering?.program?.degree_level);
           return (
-            <span className="flex items-center gap-1.5 text-sm">
+            <span className="flex min-w-0 items-center gap-1.5 text-sm" title={major}>
               {degreeShort && (
                 <span className="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold">
                   {degreeShort}
                 </span>
               )}
-              <span className="truncate" title={major}>
-                {major}
-              </span>
+              <span className="min-w-0 flex-1 truncate">{major}</span>
             </span>
           );
         },
         size: 180,
+        minSize: 110,
+        maxSize: 360,
       }),
 
       // Source column
@@ -390,12 +564,14 @@ export function LeadsTable({
           const source = row.original.source;
           if (!source) return <span className="text-muted-foreground">—</span>;
           return (
-            <Badge variant="outline" className="text-[10px] h-5 px-2 font-normal">
+            <Badge variant="outline" className="text-[10px] h-5 px-2 font-normal whitespace-nowrap">
               {getLeadSourceLabel(source)}
             </Badge>
           );
         },
         size: 90,
+        minSize: 72,
+        maxSize: 160,
       }),
 
       // Pipeline Stage column
@@ -408,18 +584,21 @@ export function LeadsTable({
           const color = sanitizeColorCode(stage.color_code) || STAGE_COLORS[stage.id] || "#6B7280";
           return (
             <Badge
-              className="text-[10px] h-5 px-2 font-normal whitespace-nowrap"
+              title={stage.name}
+              className="text-[10px] h-5 px-2 font-normal max-w-full min-w-0"
               style={{
                 backgroundColor: `${color}20`,
                 color: color,
                 borderColor: color,
               }}
             >
-              {stage.name}
+              <span className="truncate">{stage.name}</span>
             </Badge>
           );
         },
         size: 110,
+        minSize: 84,
+        maxSize: 220,
       }),
 
       // Consultation Status column - using DynamicColorBadge
@@ -433,13 +612,15 @@ export function LeadsTable({
               color={status.color || status.color_code}
               variant="subtle"
               size="sm"
-              className="text-[10px] h-5 px-2 whitespace-nowrap"
+              className="text-[10px] h-5 px-2 max-w-full min-w-0"
             >
               {status.name}
             </DynamicColorBadge>
           );
         },
         size: 110,
+        minSize: 84,
+        maxSize: 260,
       }),
 
       // Officer column
@@ -449,10 +630,12 @@ export function LeadsTable({
           const officer = row.original.assigned_officer;
           if (!officer) return <span className="text-muted-foreground text-sm">Chưa gán</span>;
           return (
-            <div className="text-sm">{officer.full_name}</div>
+            <div className="truncate text-sm" title={officer.full_name}>{officer.full_name}</div>
           );
         },
         size: 140,
+        minSize: 90,
+        maxSize: 280,
       }),
 
       // Lead Score column - ✅ Now sortable
@@ -482,6 +665,8 @@ export function LeadsTable({
           );
         },
         size: 80,
+        minSize: 56,
+        maxSize: 120,
       }),
 
       // Activity column - ✅ FIX: Sort by last_consultation_at || created_at (same as display)
@@ -517,6 +702,8 @@ export function LeadsTable({
             return dateA - dateB;
           },
           size: 100,
+          minSize: 80,
+          maxSize: 180,
         }
       ),
 
@@ -547,6 +734,8 @@ export function LeadsTable({
           <UrgencyBadge score={row.original.cached_urgency_score} showLabel={false} />
         ),
         size: 50,
+        minSize: 44,
+        maxSize: 90,
       }),
 
       // Actions column - Responsive (mobile: action sheet, desktop: dropdown)
@@ -579,10 +768,15 @@ export function LeadsTable({
       sorting,
       rowSelection,
       columnVisibility,
+      columnSizing,
+      columnOrder,
     },
+    defaultColumn: { minSize: 60, maxSize: 400 },
     enableRowSelection: true,
     enableColumnResizing: true,
     columnResizeMode,
+    onColumnSizingChange: setColumnSizing,
+    onColumnOrderChange: setColumnOrder,
     manualSorting: true,
     onSortingChange: (updater) => {
       const newSorting = typeof updater === "function" ? updater(sorting) : updater;
@@ -632,6 +826,56 @@ export function LeadsTable({
   // Clear selection
   const handleClearSelection = useCallback(() => {
     setRowSelection({});
+  }, []);
+
+  // ── Cột: kéo grip đổi thứ tự (giữ select đầu / actions cuối) ──
+  const handleColumnDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setColumnOrder((prev) => {
+      const base = prev.length ? prev : DEFAULT_COLUMN_ORDER;
+      const oldIndex = base.indexOf(String(active.id));
+      const newIndex = base.indexOf(String(over.id));
+      if (oldIndex < 0 || newIndex < 0) return base;
+      const moved = arrayMove(base, oldIndex, newIndex).filter(
+        (id) => id !== PINNED_START && id !== PINNED_END,
+      );
+      return [PINNED_START, ...moved, PINNED_END];
+    });
+  }, []);
+
+  // ── Double-click mép cột = auto-fit theo nội dung đang hiển thị ──
+  const autoFitColumn = useCallback(
+    (columnId: string) => {
+      const col = table.getColumn(columnId);
+      if (!col?.getCanResize()) return;
+      const root = tableScrollRef.current;
+      if (!root) return;
+      let maxContent = 0;
+      root
+        .querySelectorAll<HTMLElement>(`[data-column-id="${columnId}"]`)
+        .forEach((el) => {
+          maxContent = Math.max(maxContent, el.scrollWidth);
+        });
+      if (maxContent <= 0) return;
+      const min = col.columnDef.minSize ?? 60;
+      const max = col.columnDef.maxSize ?? 400;
+      const target = Math.max(min, Math.min(max, Math.round(maxContent) + 6));
+      setColumnSizing((prev) => ({ ...prev, [columnId]: target }));
+    },
+    [table],
+  );
+
+  // ── Đặt lại bề rộng + thứ tự cột về mặc định ──
+  const resetColumnLayout = useCallback(() => {
+    setColumnSizing({});
+    setColumnOrder(DEFAULT_COLUMN_ORDER);
+    try {
+      localStorage.removeItem(COLUMN_SIZING_STORAGE_KEY);
+      localStorage.removeItem(COLUMN_ORDER_STORAGE_KEY);
+    } catch {
+      /* ignore */
+    }
   }, []);
 
   // Keyboard navigation
@@ -838,6 +1082,7 @@ export function LeadsTable({
               [columnId]: isVisible,
             }));
           }}
+          onResetColumns={resetColumnLayout}
         />
       </div>
 
@@ -846,42 +1091,36 @@ export function LeadsTable({
         ref={tableScrollRef}
         className="flex-1 overflow-x-auto overflow-y-auto"
       >
-        {/* ✅ Phase 3: ARIA improvements for accessibility */}
-        <Table 
-          className="w-full"
+        {/* DnD kéo grip tiêu đề đổi thứ tự cột. Chỉ header là sortable item;
+            ô body tự theo columnOrder qua getVisibleCells → không cần bọc. */}
+        <DndContext
+          sensors={dndSensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleColumnDragEnd}
+        >
+        {/* ✅ Phase 3: ARIA improvements for accessibility.
+            table-layout: fixed + width = getTotalSize() → bề rộng cột do người
+            dùng kiểm soát (resize/auto-fit thật), nội dung dài CẮT GỌN thay vì
+            nong cột; minWidth 100% để lấp đầy khi tổng < khung. */}
+        <Table
           role="grid"
           aria-label="Danh sách lead"
           aria-rowcount={totalCount}
+          style={{ width: table.getTotalSize(), minWidth: "100%", tableLayout: "fixed" }}
         >
           <TableHeader className="bg-muted/50 sticky top-0 z-10">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <TableHead
-                    key={header.id}
-                    style={{ width: header.getSize() }}
-                    className={cn(
-                      "relative whitespace-nowrap",
-                      densityConfig.headerHeight
-                    )}
-                  >
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(header.column.columnDef.header, header.getContext())}
-                    {/* Resize handle */}
-                    {header.column.getCanResize() && (
-                      <div
-                        onMouseDown={header.getResizeHandler()}
-                        onTouchStart={header.getResizeHandler()}
-                        className={cn(
-                          "absolute top-0 right-0 h-full w-1 cursor-col-resize select-none touch-none",
-                          "hover:bg-primary/50 active:bg-primary",
-                          header.column.getIsResizing() && "bg-primary"
-                        )}
-                      />
-                    )}
-                  </TableHead>
-                ))}
+                <SortableContext items={columnOrder} strategy={horizontalListSortingStrategy}>
+                  {headerGroup.headers.map((header) => (
+                    <DraggableHeader
+                      key={header.id}
+                      header={header}
+                      headerHeightClass={densityConfig.headerHeight}
+                      onAutoFit={autoFitColumn}
+                    />
+                  ))}
+                </SortableContext>
               </TableRow>
             ))}
           </TableHeader>
@@ -951,8 +1190,9 @@ export function LeadsTable({
                       {row.getVisibleCells().map((cell) => (
                         <TableCell
                           key={cell.id}
+                          data-column-id={cell.column.id}
                           style={{ width: cell.column.getSize() }}
-                          className={densityConfig.cellPadding}
+                          className={cn(densityConfig.cellPadding, "overflow-hidden")}
                         >
                           {flexRender(cell.column.columnDef.cell, cell.getContext())}
                         </TableCell>
@@ -968,6 +1208,7 @@ export function LeadsTable({
             )}
           </TableBody>
         </Table>
+        </DndContext>
       </div>
 
       {/* Footer with Pagination */}

--- a/frontend/src/components/leads/command-center/LeadsTable.tsx
+++ b/frontend/src/components/leads/command-center/LeadsTable.tsx
@@ -220,6 +220,25 @@ const DEFAULT_COLUMN_ORDER: ColumnOrderState = [
   "actions",
 ];
 
+// Nhãn hiển thị cho menu ẩn/hiện cột — key = column id (khớp DEFAULT_COLUMN_ORDER).
+// KHÔNG hardcode LẠI danh sách cột nào ẩn/hiện được ở TableToolbar (dễ lệch
+// contract): TableToolbar nhận thẳng list dẫn xuất từ `table.getAllLeafColumns()`
+// đã lọc `getCanHide()`. Map này chỉ cấp NHÃN; thiếu nhãn → fallback về id (lộ
+// ra ngay, không im lặng). `select`/`actions` `enableHiding:false` nên không vào
+// menu → không cần nhãn.
+const COLUMN_LABELS: Record<string, string> = {
+  full_name: "Tên Lead",
+  phone: "Số điện thoại",
+  offering: "Ngành",
+  source: "Nguồn",
+  pipeline_stage: "Giai đoạn",
+  consultation_status: "Trạng thái TĐ",
+  assigned_officer: "Cán bộ",
+  lead_score: "Điểm",
+  activity: "Hoạt động",
+  cached_urgency_score: "Độ khẩn cấp",
+};
+
 // =============================================================================
 // DRAGGABLE HEADER — kéo grip đổi thứ tự (dnd-kit) · mép phải resize ·
 // double-click mép = auto-fit. Grip / sort-button / resize-handle tách vùng
@@ -850,6 +869,18 @@ export function LeadsTable({
         { actual, expected: DEFAULT_COLUMN_ORDER },
       );
     }
+    // Mọi cột ẩn/hiện được PHẢI có nhãn trong COLUMN_LABELS, nếu không menu
+    // ẩn/hiện cột sẽ hiện id thô (vd "cached_urgency_score"). Fail-loud khi dev.
+    const missingLabels = table
+      .getAllLeafColumns()
+      .filter((c) => c.getCanHide() && !COLUMN_LABELS[c.id])
+      .map((c) => c.id);
+    if (missingLabels.length) {
+      console.error(
+        "[LeadsTable] Cột ẩn/hiện được thiếu nhãn COLUMN_LABELS — bổ sung nhãn.",
+        { missingLabels },
+      );
+    }
   }, [table]);
 
   // Get all rows for virtualization
@@ -861,6 +892,20 @@ export function LeadsTable({
   const sortableColumnIds = React.useMemo(
     () => columnOrder.filter((id) => columnVisibility[id] !== false),
     [columnOrder, columnVisibility],
+  );
+
+  // Danh sách cột cho menu ẩn/hiện — SINGLE SOURCE OF TRUTH từ chính bảng:
+  // lấy cột lá lọc `getCanHide()` (loại select/actions enableHiding:false),
+  // theo thứ tự định nghĩa (= DEFAULT_COLUMN_ORDER). Không hardcode lại ở
+  // TableToolbar để khỏi lệch id/thiếu cột. `table` là ref ổn định của
+  // react-table nên memo tính 1 lần (tập cột tĩnh theo runtime).
+  const hideableColumns = React.useMemo(
+    () =>
+      table
+        .getAllLeafColumns()
+        .filter((col) => col.getCanHide())
+        .map((col) => ({ id: col.id, label: COLUMN_LABELS[col.id] ?? col.id })),
+    [table],
   );
 
   // ✅ Option A: Virtualization setup
@@ -1169,6 +1214,7 @@ export function LeadsTable({
         <TableToolbar
           densityMode={densityMode}
           onDensityChange={setDensityMode}
+          columns={hideableColumns}
           columnVisibility={columnVisibility}
           onColumnVisibilityChange={(columnId, isVisible) => {
             setColumnVisibility((prev) => ({

--- a/frontend/src/components/leads/command-center/LeadsTable.tsx
+++ b/frontend/src/components/leads/command-center/LeadsTable.tsx
@@ -255,27 +255,34 @@ function DraggableHeader({
       ref={setNodeRef}
       data-column-id={columnId}
       style={style}
-      className={cn("group/lh relative overflow-hidden whitespace-nowrap", headerHeightClass)}
+      className={cn(
+        "group/lh relative overflow-hidden whitespace-nowrap",
+        // gutter TRÁI cho grip (chỉ cột kéo được) → grip nằm trong padding, KHÔNG
+        // chồng lên nút sort → click sort không bị grip nuốt; nội dung cắt gọn sau.
+        reorderable && "pl-4",
+        headerHeightClass,
+      )}
     >
-      {/* Nội dung header chiếm TRỌN bề rộng (không bị grip đẩy) → caret sort không
-          bị cắt ở cột hẹp. Grip là overlay hiện-khi-hover, KHÔNG chiếm chỗ flow. */}
       <div className="truncate">
         {header.isPlaceholder
           ? null
           : flexRender(header.column.columnDef.header, header.getContext())}
       </div>
       {reorderable && (
+        // Overlay grip trong gutter, hiện-khi-hover. pointer-events-none khi ẩn →
+        // không chặn hit-test; tabIndex=-1 → không là tab-stop no-op (đã bỏ KeyboardSensor).
         <button
           type="button"
           className={cn(
             "absolute left-0 top-0 z-[1] flex h-full w-4 items-center justify-center",
-            "bg-gradient-to-r from-muted via-muted/80 to-transparent",
-            "text-muted-foreground/60 hover:text-foreground cursor-grab touch-none",
-            "opacity-0 transition-opacity group-hover/lh:opacity-100 active:cursor-grabbing",
+            "text-muted-foreground/50 hover:text-foreground cursor-grab touch-none",
+            "pointer-events-none opacity-0 transition-opacity",
+            "group-hover/lh:pointer-events-auto group-hover/lh:opacity-100 active:cursor-grabbing",
           )}
           aria-label="Kéo để đổi thứ tự cột"
           {...attributes}
           {...listeners}
+          tabIndex={-1}
         >
           <GripVertical className="h-3.5 w-3.5" />
         </button>
@@ -354,9 +361,14 @@ export function LeadsTable({
   const [columnSizing, setColumnSizing] = React.useState<ColumnSizingState>({});
   // Trạng thái đang-kéo-resize (isResizingColumn) → chỉ persist khi kéo XONG,
   // tránh spam localStorage.setItem mỗi tick pointer-move.
-  const [columnSizingInfo, setColumnSizingInfo] = React.useState<ColumnSizingInfoState>(
-    {} as ColumnSizingInfoState,
-  );
+  const [columnSizingInfo, setColumnSizingInfo] = React.useState<ColumnSizingInfoState>({
+    startOffset: null,
+    startSize: null,
+    deltaOffset: null,
+    deltaPercentage: null,
+    isResizingColumn: false,
+    columnSizingStart: [],
+  });
   const [columnOrder, setColumnOrder] = React.useState<ColumnOrderState>(DEFAULT_COLUMN_ORDER);
   const [isHydrated, setIsHydrated] = React.useState(false);
 
@@ -843,6 +855,14 @@ export function LeadsTable({
   // Get all rows for virtualization
   const rows = table.getRowModel().rows;
 
+  // ID cột HIỆN (theo order + visibility) cho SortableContext — memo hóa để không
+  // tạo mảng mới mỗi render (SortableContext re-derive item-map mỗi drag-move).
+  // Derive trực tiếp từ columnOrder + columnVisibility (khớp header đang render).
+  const sortableColumnIds = React.useMemo(
+    () => columnOrder.filter((id) => columnVisibility[id] !== false),
+    [columnOrder, columnVisibility],
+  );
+
   // ✅ Option A: Virtualization setup
   const tableScrollRef = useRef<HTMLDivElement>(null);
   const rowVirtualizer = useVirtualizer({
@@ -906,11 +926,19 @@ export function LeadsTable({
       document.body.appendChild(probe);
       let maxContent = 0;
       try {
-        // ô/header có 1 con nội dung trực tiếp (div.truncate / span.flex / Badge…)
+        // `:first-child` = phần nội dung của ô (div.truncate / span.flex / Badge…);
+        // KHÔNG dính grip/resize-handle (là các con sau) → không cần loại theo label.
         root
-          .querySelectorAll<HTMLElement>(`[data-column-id="${columnId}"] > *:not([aria-label="Kéo để đổi thứ tự cột"])`)
+          .querySelectorAll<HTMLElement>(`[data-column-id="${columnId}"] > :first-child`)
           .forEach((content) => {
             const clone = content.cloneNode(true) as HTMLElement;
+            // Copy font THẬT (clone rời khỏi ngữ cảnh table → mất inherited text-sm/
+            // font-medium → đo sai). Áp computed-font để đo đúng cỡ/đậm chữ.
+            const cs = getComputedStyle(content);
+            clone.style.fontSize = cs.fontSize;
+            clone.style.fontWeight = cs.fontWeight;
+            clone.style.fontFamily = cs.fontFamily;
+            clone.style.letterSpacing = cs.letterSpacing;
             const strip = (el: HTMLElement) => {
               el.style.maxWidth = "none";
               el.style.width = "auto";
@@ -1177,12 +1205,9 @@ export function LeadsTable({
           <TableHeader className="bg-muted/50 sticky top-0 z-10">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
-                {/* items = đúng các header ĐANG render (cột hiện), không gồm cột
-                    ẩn như phone → tránh lệch animation shift khi kéo. */}
-                <SortableContext
-                  items={headerGroup.headers.map((h) => h.column.id)}
-                  strategy={horizontalListSortingStrategy}
-                >
+                {/* items = cột HIỆN (memo hóa) — không gồm cột ẩn như phone → tránh
+                    lệch animation shift + không tạo mảng mới mỗi render. */}
+                <SortableContext items={sortableColumnIds} strategy={horizontalListSortingStrategy}>
                   {headerGroup.headers.map((header) => (
                     <DraggableHeader
                       key={header.id}

--- a/frontend/src/components/leads/command-center/TableToolbar.tsx
+++ b/frontend/src/components/leads/command-center/TableToolbar.tsx
@@ -16,6 +16,7 @@ import {
   Minus,
   Equal,
   Menu,
+  RotateCcw,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -47,6 +48,8 @@ interface TableToolbarProps {
   onDensityChange: (mode: DensityMode) => void;
   columnVisibility: VisibilityState;
   onColumnVisibilityChange: (columnId: string, isVisible: boolean) => void;
+  /** Đặt lại bề rộng + thứ tự cột về mặc định (bảng desktop). */
+  onResetColumns?: () => void;
 }
 
 // Column config - order matters for display
@@ -76,6 +79,7 @@ export function TableToolbar({
   onDensityChange,
   columnVisibility,
   onColumnVisibilityChange,
+  onResetColumns,
 }: TableToolbarProps) {
   // Count visible columns (default to visible if not in state)
   const visibleCount = COLUMNS_CONFIG.filter(
@@ -149,6 +153,24 @@ export function TableToolbar({
             })}
           </DropdownMenuContent>
         </DropdownMenu>
+
+        {/* Đặt lại bề rộng + thứ tự cột */}
+        {onResetColumns && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0"
+                onClick={onResetColumns}
+                aria-label="Đặt lại bề rộng và thứ tự cột"
+              >
+                <RotateCcw className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Đặt lại cột (bề rộng &amp; thứ tự)</TooltipContent>
+          </Tooltip>
+        )}
 
         {/* ✅ Option C: Keyboard Shortcuts Help */}
         <KeyboardShortcutsHelp className="h-8 w-8 p-0" />

--- a/frontend/src/components/leads/command-center/TableToolbar.tsx
+++ b/frontend/src/components/leads/command-center/TableToolbar.tsx
@@ -46,23 +46,17 @@ export type DensityMode = 'condensed' | 'regular' | 'relaxed';
 interface TableToolbarProps {
   densityMode: DensityMode;
   onDensityChange: (mode: DensityMode) => void;
+  /**
+   * Cột ẩn/hiện được — DẪN XUẤT từ bảng thật (`getCanHide()`) ở LeadsTable,
+   * KHÔNG hardcode ở đây để tránh lệch id/thiếu cột. `id` phải khớp column id
+   * TanStack; `label` là nhãn tiếng Việt.
+   */
+  columns: { id: string; label: string }[];
   columnVisibility: VisibilityState;
   onColumnVisibilityChange: (columnId: string, isVisible: boolean) => void;
   /** Đặt lại bề rộng + thứ tự cột về mặc định (bảng desktop). */
   onResetColumns?: () => void;
 }
-
-// Column config - order matters for display
-const COLUMNS_CONFIG = [
-  { id: "full_name", label: "Tên Lead" },
-  { id: "phone", label: "Số điện thoại" },
-  { id: "source", label: "Nguồn" },
-  { id: "pipeline_stage", label: "Giai đoạn" },
-  { id: "consultation_status", label: "Trạng thái TĐ" },
-  { id: "assigned_officer", label: "Cán bộ" },
-  { id: "lead_score", label: "Điểm" },
-  { id: "created_at", label: "Hoạt động" },
-];
 
 const DENSITY_OPTIONS: { value: DensityMode; label: string; icon: React.ElementType }[] = [
   { value: 'condensed', label: 'Thu gọn', icon: Minus },
@@ -77,12 +71,13 @@ const DENSITY_OPTIONS: { value: DensityMode; label: string; icon: React.ElementT
 export function TableToolbar({
   densityMode,
   onDensityChange,
+  columns,
   columnVisibility,
   onColumnVisibilityChange,
   onResetColumns,
 }: TableToolbarProps) {
   // Count visible columns (default to visible if not in state)
-  const visibleCount = COLUMNS_CONFIG.filter(
+  const visibleCount = columns.filter(
     (col) => columnVisibility[col.id] !== false
   ).length;
 
@@ -135,7 +130,7 @@ export function TableToolbar({
           <DropdownMenuContent align="end" className="w-48">
             <DropdownMenuLabel>Hiển thị cột</DropdownMenuLabel>
             <DropdownMenuSeparator />
-            {COLUMNS_CONFIG.map((col) => {
+            {columns.map((col) => {
               // Default to visible (true) if not in state
               const isVisible = columnVisibility[col.id] !== false;
               return (

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -8,9 +8,18 @@
  *
  * SSR-safe + KHÔNG flash: giá trị khởi tạo = false (khớp SSR → không hydration
  * mismatch), rồi được set về giá trị THẬT trong useLayoutEffect — chạy đồng bộ
- * SAU hydrate nhưng TRƯỚC khi trình duyệt paint. Nhờ vậy màn desktop paint thẳng
- * layout desktop, KHÔNG nháy mobile→desktop như khi dùng useSyncExternalStore
- * (re-sync của nó xảy ra sau paint → nháy). Mobile giữ nguyên (false → false).
+ * SAU hydrate nhưng TRƯỚC khi trình duyệt paint. Nhờ vậy MÀN CLIENT-SIDE NAV
+ * paint thẳng layout đúng, KHÔNG nháy mobile→desktop như khi dùng
+ * useSyncExternalStore (re-sync của nó xảy ra sau paint → nháy). Mobile giữ
+ * nguyên (false → false).
+ *
+ * ⚠️ Giới hạn: trên HARD-LOAD (refresh / vào thẳng URL), trình duyệt paint HTML
+ * server (matches=false) TRƯỚC khi bất kỳ JS nào — kể cả useLayoutEffect — chạy.
+ * Nghĩa là `matches` một mình KHÔNG phân biệt được "đang là mobile thật" với
+ * "chưa kịp đo viewport". Component cần render layout khác hẳn giữa 2 breakpoint
+ * (vd master-detail split desktop vs card list mobile) PHẢI dùng
+ * `useMediaQueryState().resolved` để hoãn nhánh tới khi đo xong viewport, tránh
+ * nháy layout-sai (card-mobile → bảng-desktop) lúc hard-load.
  */
 
 import { useEffect, useLayoutEffect, useState } from "react";
@@ -20,21 +29,46 @@ import { useEffect, useLayoutEffect, useState } from "react";
 const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
-export function useMediaQuery(query: string): boolean {
-  // false ở SSR + lần render client đầu (hydrate) → khớp, không mismatch.
-  const [matches, setMatches] = useState(false);
+interface MediaQueryState {
+  /** Query có khớp không. `false` ở SSR + lần render client đầu (chưa đo). */
+  matches: boolean;
+  /**
+   * Đã đo viewport thật chưa. `false` ở SSR + render đầu, `true` sau khi
+   * useLayoutEffect chạy. Gate nhánh layout khác-hẳn-nhau bằng cờ này để
+   * KHÔNG commit mobile/desktop trước khi biết viewport thật (chống nháy
+   * layout-sai lúc hard-load — xem chú thích trên).
+   */
+  resolved: boolean;
+}
+
+/**
+ * Như `useMediaQuery` nhưng trả kèm cờ `resolved` để phân biệt "mobile thật"
+ * với "chưa đo viewport". Dùng khi 2 breakpoint render CÂY ELEMENT khác hẳn
+ * nhau và nháy layout-sai lúc hard-load là không chấp nhận được.
+ */
+export function useMediaQueryState(query: string): MediaQueryState {
+  // resolved=false ở SSR + lần render client đầu (hydrate) → khớp, không mismatch.
+  const [state, setState] = useState<MediaQueryState>({
+    matches: false,
+    resolved: false,
+  });
 
   useIsomorphicLayoutEffect(() => {
     const mediaQuery = window.matchMedia(query);
-    // Set giá trị THẬT trước paint đầu tiên → không flash.
-    setMatches(mediaQuery.matches);
+    // Set giá trị THẬT + đánh dấu resolved trước paint đầu (client-side nav).
+    setState({ matches: mediaQuery.matches, resolved: true });
 
-    const onChange = () => setMatches(mediaQuery.matches);
+    const onChange = () =>
+      setState({ matches: mediaQuery.matches, resolved: true });
     mediaQuery.addEventListener("change", onChange);
     return () => mediaQuery.removeEventListener("change", onChange);
   }, [query]);
 
-  return matches;
+  return state;
+}
+
+export function useMediaQuery(query: string): boolean {
+  return useMediaQueryState(query).matches;
 }
 
 // Convenience hooks for common breakpoints (Tailwind defaults)


### PR DESCRIPTION
## Bảng Lead command-center linh hoạt hóa

Fix 2 vấn đề: ô dữ liệu đầy làm **lệch bố cục** + **cột không resize được**.

### Nguyên nhân gốc (1 gốc cho cả 2)
`LeadsTable` chạy `table-layout: auto` → nội dung dài nong cột, `getSize()` chỉ là gợi ý, kéo resize "nảy về" theo nội dung.

### Thay đổi
- **T1** `table-layout: fixed` + `width = table.getTotalSize()` → resize authoritative, tràn cuộn ngang; truncate đồng bộ (min-w-0 + ellipsis + title).
- **T2** `minSize/maxSize` mỗi cột + persist `columnSizing` localStorage + nút "Đặt lại cột".
- **T3** double-click mép = **auto-fit** (đo scrollWidth thật); kéo **grip** đổi thứ tự cột (@dnd-kit, pin `select`/`actions` 2 đầu) + persist `columnOrder`.
- **Detail panel** `/leads` thu gọn 25% mặc định (table 75%).
- **Menu ẩn/hiện cột** dẫn xuất từ `table.getAllLeafColumns()` (single source, hết lệch contract).
- **Chống nháy layout** mobile→desktop khi hard-load (gate content trên `useMediaQueryState().resolved`).

### Đã qua 2 vòng /code-review max
15+ finding: auto-fit đo natural width · grip overlay không nuốt click sort (gutter `pl-4`) · minSize riêng select/actions · persist chờ resize-end · hydration guard · SortableContext memo...

### Verify (CI-local xanh)
- FE: type-check 0 · lint 0-error · **vitest 1844 pass** · `next build` ✅
- Smoke admin `/leads` ALL GREEN (resize/reorder/auto-fit/persist/menu cột/chống nháy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)