### PR TITLE
fix(leads): hết 500 ở list/search do phone2==phone + data legacy; search theo phone2

### DIFF
--- a/Backend_FastAPI/app/repositories/lead_repository.py
+++ b/Backend_FastAPI/app/repositories/lead_repository.py
@@ -258,7 +258,9 @@ class LeadRepository(BaseRepository[models.Lead]):
         # ✅ FIX: Normalize Unicode to NFC format for Vietnamese diacritics
         # Windows/browsers may send NFD (decomposed) but DB stores NFC (composed)
         # Example: "Hùng" NFD = "Hu" + combining accent vs NFC = single char "ù"
-        if search:
+        # `.strip()` trong điều kiện: search chỉ toàn khoảng trắng → search_term
+        # thành "%%" → ilike match MỌI row (trả cả tập lead theo RBAC). Bỏ qua.
+        if search and search.strip():
             normalized_search = unicodedata.normalize('NFC', search.strip())
             # Escape LIKE wildcards so a literal % / _ typed by the user matches
             # literally instead of acting as a wildcard (mirror vn_school_service
@@ -279,6 +281,9 @@ class LeadRepository(BaseRepository[models.Lead]):
                 ),
                 models.Lead.email.ilike(search_term),
                 models.Lead.phone.ilike(search_term),
+                # Số phụ cũng tìm được (nhất quán với get_by_phone/check_phone_conflict
+                # vốn đã cross-slot). phone2 lưu đã normalize giống phone.
+                models.Lead.phone2.ilike(search_term),
             )
             filters.append(search_conditions)
 

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -257,7 +257,7 @@ async def get_all_leads(
         None, description="Filter by source (comma-separated)"
     ),
     search: Optional[str] = Query(
-        None, description="Search term for name, email, phone"
+        None, description="Search term for name, email, phone, phone2"
     ),
     sort_by: Literal[
         "created_at", "updated_at", "full_name", "email", "phone",
@@ -416,7 +416,7 @@ async def export_leads(
         None, description="Filter by source (comma-separated)"
     ),
     search: Optional[str] = Query(
-        None, description="Search term for name, email, phone"
+        None, description="Search term for name, email, phone, phone2"
     ),
     sort_by: Literal[
         "created_at", "updated_at", "full_name", "email", "phone",

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -191,56 +191,11 @@ class LeadBase(BaseModel):
             return None
         return v
 
-    @field_validator("phone", "phone2", mode="before")
-    @classmethod
-    def normalize_and_validate_phone(cls, v, info):
-        """
-        Normalize and validate Vietnam phone numbers.
-        
-        - Normalizes +84/84 prefix to 0
-        - Validates against Vietnam phone regex: ^0(3|5|7|8|9|2)\\d{8,9}$
-        - Allows None/empty for phone2 (optional field)
-        """
-        from app.utils.phone_helpers import normalize_vietnam_phone, validate_vietnam_phone
-        
-        # Allow None for optional fields (phone2)
-        if v is None:
-            return None
-        
-        # Allow empty string for phone2, convert to None
-        if isinstance(v, str) and v.strip() == "":
-            if info.field_name == "phone2":
-                return None
-            # phone is required, empty string will fail min_length validation
-            return v
-        
-        # Normalize the phone number
-        normalized = normalize_vietnam_phone(v)
-        if normalized is None:
-            return v  # Let min_length validation handle it
-        
-        # Validate against Vietnam format
-        if not validate_vietnam_phone(normalized, normalize=False):
-            raise ValueError(
-                f"Số điện thoại không hợp lệ. Vui lòng nhập số điện thoại Việt Nam "
-                f"(VD: 0901234567, +84901234567)"
-            )
-        
-        return normalized
-
-    @field_validator("phone2", mode="after")
-    @classmethod
-    def phone2_must_differ_from_phone(cls, v, info):
-        """Ensure phone2 is different from phone."""
-        if v is None:
-            return v
-        
-        # Access phone from data (already validated)
-        phone = info.data.get("phone")
-        if phone and v == phone:
-            raise ValueError("Số điện thoại phụ phải khác số điện thoại chính")
-        
-        return v
+    # ⚠️ Validator SĐT (normalize + phone2≠phone) đặt ở LeadCreate (write) — KHÔNG
+    # ở LeadBase. Nếu ở base thì response Lead(LeadBase)/LeadListItem/LeadDetail kế
+    # thừa → serialize lead LEGACY (phone sai format hoặc phone2==phone) sẽ raise
+    # ResponseValidationError → HTTP 500 (sập list/search). LeadUpdate đã có validator
+    # write riêng. Bài học: pydantic-validator-on-base-hits-response-schema.
 
 
 class LeadCreate(LeadBase):
@@ -271,6 +226,58 @@ class LeadCreate(LeadBase):
     location_proximity: int = Field(0, ge=0, le=2, description="0=Xa, 1=Lân cận, 2=Gần")
     occupation_relevance: int = Field(0, ge=0, le=2, description="0=Không liên quan, 1=Gián tiếp, 2=Trực tiếp")
     academic_performance: int = Field(0, ge=0, le=3, description="0=Yếu, 1=TB, 2=Khá, 3=Giỏi")
+
+    # Validator SĐT write-side (dời từ LeadBase — xem ghi chú ở LeadBase).
+    @field_validator("phone", "phone2", mode="before")
+    @classmethod
+    def normalize_and_validate_phone(cls, v, info):
+        """
+        Normalize and validate Vietnam phone numbers.
+
+        - Normalizes +84/84 prefix to 0
+        - Validates against Vietnam phone regex: ^0(3|5|7|8|9|2)\\d{8,9}$
+        - Allows None/empty for phone2 (optional field)
+        """
+        from app.utils.phone_helpers import normalize_vietnam_phone, validate_vietnam_phone
+
+        # Allow None for optional fields (phone2)
+        if v is None:
+            return None
+
+        # Allow empty string for phone2, convert to None
+        if isinstance(v, str) and v.strip() == "":
+            if info.field_name == "phone2":
+                return None
+            # phone is required, empty string will fail min_length validation
+            return v
+
+        # Normalize the phone number
+        normalized = normalize_vietnam_phone(v)
+        if normalized is None:
+            return v  # Let min_length validation handle it
+
+        # Validate against Vietnam format
+        if not validate_vietnam_phone(normalized, normalize=False):
+            raise ValueError(
+                f"Số điện thoại không hợp lệ. Vui lòng nhập số điện thoại Việt Nam "
+                f"(VD: 0901234567, +84901234567)"
+            )
+
+        return normalized
+
+    @field_validator("phone2", mode="after")
+    @classmethod
+    def phone2_must_differ_from_phone(cls, v, info):
+        """Ensure phone2 is different from phone."""
+        if v is None:
+            return v
+
+        # Access phone from data (already validated)
+        phone = info.data.get("phone")
+        if phone and v == phone:
+            raise ValueError("Số điện thoại phụ phải khác số điện thoại chính")
+
+        return v
 
 
 class LeadUpdate(BaseModel):
@@ -388,6 +395,17 @@ class LeadStatusUpdate(BaseModel):
 
 
 class Lead(LeadBase):
+    # ── READ-TOLERANCE: response đọc THẲNG từ DB (nguồn thật) nên KHÔNG được
+    # re-validate ràng buộc WRITE của LeadBase (EmailStr / min_length / required-
+    # non-null). Data legacy xấu (email không hợp RFC, phone/full_name rỗng, source
+    # NULL) sẽ raise ResponseValidationError → HTTP 500 khi serialize ở GET /leads
+    # (list) và /leads/{id} (detail). Override sang kiểu lenient; strict validation
+    # GIỮ NGUYÊN ở LeadCreate / LeadUpdate (write). Cùng lớp bug với validator phone
+    # đã dời — ref pydantic-validator-on-base-hits-response-schema.
+    full_name: str = ""
+    email: Optional[str] = None       # KHÔNG EmailStr ở response
+    phone: str = ""
+    source: Optional[str] = None
     id: int
     status: str
     # Assignment workflow status: pending, assigned, failed, reassign_pending

--- a/Backend_FastAPI/tests/services/test_lead.py
+++ b/Backend_FastAPI/tests/services/test_lead.py
@@ -136,7 +136,39 @@ class TestGetLeads:
         # Assert
         assert total_count >= 5  # At least our 5 seeded leads
         assert len(leads) == 3  # Respects limit
-    
+
+    async def test_get_leads_search_matches_phone2(
+        self,
+        db: AsyncSession,
+        seeded_dependencies: dict,
+        officer_user: models.User,
+    ):
+        """Hotfix: search PHẢI tìm được lead theo SỐ PHỤ (phone2), không chỉ phone."""
+        lead = models.Lead(
+            full_name="Search Phone2 Lead",
+            phone="0900000055",
+            phone2="0988887766",  # số phụ distinctive
+            email="search_phone2@test.com",
+            source="Website",
+            unit_id=seeded_dependencies["unit_id"],
+            status=seeded_dependencies["initial_status_id"],
+            consultation_status_id=seeded_dependencies["initial_status_id"],
+            pipeline_stage_id=seeded_dependencies["stage_id"],
+            assigned_officer_id=officer_user.id,
+            assigned_at=datetime.now(timezone.utc),
+        )
+        db.add(lead)
+        await db.flush()
+        await db.refresh(lead)
+
+        # Tìm theo SỐ PHỤ → phải ra (trước fix: sót vì OR-clause thiếu phone2)
+        _, by_phone2, _ = await lead_service.get_leads(db, search="0988887766")
+        assert lead.id in {ld.id for ld in by_phone2}
+
+        # Số chính vẫn tìm được (không regression)
+        _, by_phone, _ = await lead_service.get_leads(db, search="0900000055")
+        assert lead.id in {ld.id for ld in by_phone}
+
     async def test_get_leads_with_skip(
         self, 
         db: AsyncSession, 

--- a/Backend_FastAPI/tests/unit/test_lead_phone_schema.py
+++ b/Backend_FastAPI/tests/unit/test_lead_phone_schema.py
@@ -1,0 +1,95 @@
+"""Hotfix (2026-07-14): validator SĐT (normalize + phone2≠phone) dời khỏi LeadBase
+→ response Lead/LeadListItem/LeadDetail KHÔNG còn 500 khi serialize lead legacy
+(phone2==phone hoặc phone sai format); LeadCreate (write) VẪN enforce.
+
+Khóa bug prod: GET /api/leads trả 500 ResponseValidationError trên lead có
+phone2 == phone (validator write lọt vào response schema qua kế thừa LeadBase).
+Ref memory: pydantic-validator-on-base-hits-response-schema.
+"""
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from app.schemas.lead import Lead, LeadCreate, LeadListItem
+
+
+def _lead_row(**over):
+    """Row response tối thiểu hợp lệ, mặc định phone2 == phone (data legacy)."""
+    row = dict(
+        id=1,
+        full_name="Lưu Hoàng Gia Khang",
+        phone="0395219628",
+        phone2="0395219628",  # == phone → TRƯỚC ĐÂY 500 khi serialize
+        source="website",
+        status="new",
+        lead_score=50,
+        created_at=datetime(2026, 7, 12, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 7, 12, tzinfo=timezone.utc),
+    )
+    row.update(over)
+    return row
+
+
+class TestPhoneValidatorMovedOffResponseSchema:
+    def test_response_lead_serializes_phone2_equals_phone(self):
+        """Response Lead KHÔNG raise khi phone2 == phone (từng là HTTP 500)."""
+        lead = Lead.model_validate(_lead_row())
+        assert lead.phone == lead.phone2 == "0395219628"
+
+    def test_response_leadlistitem_serializes_phone2_equals_phone(self):
+        """Endpoint list dùng LeadListItem — cũng phải miễn nhiễm."""
+        item = LeadListItem.model_validate(_lead_row())
+        assert item.phone2 == item.phone
+
+    def test_response_lead_serializes_bad_format_phone(self):
+        """Lead legacy phone sai format cũng KHÔNG được 500 khi đọc."""
+        lead = Lead.model_validate(_lead_row(phone="123", phone2=None))
+        assert lead.phone == "123"
+
+    def test_leadcreate_still_rejects_phone2_equals_phone(self):
+        """Write schema VẪN chặn phone2 == phone."""
+        with pytest.raises(PydanticValidationError):
+            LeadCreate(
+                full_name="X",
+                phone="0901234567",
+                phone2="0901234567",
+                source="website",
+            )
+
+    def test_leadcreate_still_normalizes_and_validates_phone(self):
+        """Write schema VẪN normalize +84 và loại SĐT VN sai."""
+        lc = LeadCreate(full_name="X", phone="+84901234567", source="website")
+        assert lc.phone == "0901234567"
+        with pytest.raises(PydanticValidationError):
+            LeadCreate(full_name="X", phone="123", source="website")
+
+
+class TestResponseReadTolerance:
+    """Response Lead/LeadListItem read-tolerant với data legacy XẤU (email không
+    hợp RFC, phone/full_name rỗng, source NULL) → KHÔNG 500 khi serialize; write
+    schema (LeadCreate) VẪN strict. Đóng gap: LeadBase giữ EmailStr/min_length/
+    required nên response kế thừa vẫn 500 dù đã dời validator phone."""
+
+    def test_response_tolerates_invalid_email(self):
+        lead = Lead.model_validate(_lead_row(email="n/a"))  # non-RFC
+        assert lead.email == "n/a"  # giữ nguyên, KHÔNG raise (trước: EmailStr → 500)
+
+    def test_response_tolerates_empty_phone_and_fullname(self):
+        lead = Lead.model_validate(_lead_row(phone="", full_name=""))
+        assert lead.phone == "" and lead.full_name == ""  # min_length cũ → 500
+
+    def test_response_tolerates_null_source(self):
+        lead = Lead.model_validate(_lead_row(source=None))
+        assert lead.source is None  # source required cũ → 500
+
+    def test_response_listitem_tolerates_invalid_email(self):
+        item = LeadListItem.model_validate(_lead_row(email="not-an-email"))
+        assert item.email == "not-an-email"
+
+    def test_leadcreate_still_rejects_invalid_email(self):
+        """Write VẪN chặn email không hợp lệ (EmailStr giữ ở LeadBase→LeadCreate)."""
+        with pytest.raises(PydanticValidationError):
+            LeadCreate(
+                full_name="X", phone="0901234567", source="website", email="n/a"
+            )


### PR DESCRIPTION
@
## Bối cảnh (sự cố PROD 14-07)

`GET /api/leads` (list) và `/leads/{id}` (search) trả **HTTP 500** trên lead có `phone2 == phone`: `field_validator` SĐT (write) đặt trên `LeadBase` → response `Lead`/`LeadListItem`/`LeadDetail` kế thừa → `ResponseValidationError` khi serialize data legacy. Prod đã vá tạm bằng data (lead 2101 `phone2→NULL`); PR này vá tận gốc ở tầng schema.

Ref bài học: `pydantic-validator-on-base-hits-response-schema`.

## A — dứt điểm 500 (P0)

- Dời validator SĐT (normalize `+84/84→0` + `phone2≠phone`) `LeadBase` → **`LeadCreate`** (write-side).
- `Lead` (response) override lenient các field strict của `LeadBase`: `email→Optional[str]` (bỏ `EmailStr`), `phone`/`full_name` bỏ `min_length`, `source→Optional[str]`. `LeadListItem`/`LeadDetail` kế thừa nên hưởng theo.
- Response giờ đọc thẳng DB → **miễn nhiễm mọi data legacy xấu** (email không hợp RFC, phone/tên rỗng, source NULL). Strict validation **giữ nguyên** ở `LeadCreate`/`LeadUpdate`.

## C — search (P1)

- Thêm `Lead.phone2` vào OR-clause của search (tìm theo số phụ ra lead) + cập nhật mô tả param 2 route.
- Vá edge pre-existing: `search="   "` (toàn whitespace) → guard `if search and search.strip()` (tránh `%%` ilike quét cả tập RBAC).

## Kiểm chứng

- `tests/unit/test_lead_phone_schema.py`: **10 test** (serialize `phone2==phone` / email-xấu / phone-rỗng / source-NULL không raise; `LeadCreate` vẫn strict) — pass.
- `tests/services/test_lead.py`: +1 test search phone2, **110 regression pass**.
- flake8 2 file đã sửa: **net ≤ 0** (schema 37→29, repo 84→84 — không phát sinh vi phạm mới).

## Ngoài phạm vi PR này

**Guard B** (đồng bộ SĐT sang admission profile) đã **tách khỏi hotfix** theo `/code-review max`: bản copy-tay bỏ 2 khóa bảo mật (identity-lock + terminal-status lock §9.1 B-2) và xử lý `IntegrityError` sai tầng. Sẽ làm đúng ở PR riêng (trích `lead_service._apply_lead_phone_change()` dùng chung). Không khẩn vì A đã làm response miễn nhiễm + prod đã vá data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@