### PR TITLE
feat(assignment): giảm trừ tải học phí khỏi phân công lead (Option A, cờ OFF mặc định)

### DIFF
--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -586,6 +586,17 @@ class Settings(BaseSettings):
     # is_officer_at_threshold (referral fast-path) VẪN dùng TỔNG workload —
     # self-tuyển không phá trần quá tải thật. Default False ⇒ 0 đổi hành vi + 0
     # query phụ cho tới khi bật.
+    ENABLE_FINANCE_WORKLOAD_DISCOUNT: bool = Field(
+        default=False,
+        validation_alias="ENABLE_FINANCE_WORKLOAD_DISCOUNT",
+    )  # Khi ON: lead ở giai đoạn HỌC PHÍ non-final (sts14 Chưa hoàn tất học phí +
+    # sts10 Đã hoàn tất học phí — xem TUITION_HOLD_STATUS_IDS) được GIẢM TRỪ khỏi
+    # cơ sở sắp xếp (eff_util/dist_load), khỏi cổng `overloaded`, VÀ khỏi
+    # is_officer_at_threshold (referral fast-path) — vì đây là khách đã chuyển đổi
+    # đang chờ xác nhận nhập học, không còn là tải tư vấn. Gate cứng
+    # `workload < capacity` VẪN theo TỔNG workload (không ôm quá capacity học sinh
+    # thật). Loại trừ sts18 (TUITION_REFUNDED, is_final). Default False ⇒ 0 đổi
+    # hành vi + 0 aggregate/audit-shape phụ cho tới khi bật.
 
     # -- Lead Lifecycle SLA: auto-close stale rejected consultations --
     # A lead in sts04 (CONSULT_REJECTED, is_final=false for re-engagement) that

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -227,10 +227,23 @@ async def is_officer_at_threshold(
     row = (await db.execute(workload_stmt)).one()
     workload = row.workload or 0
     tuition_cnt = (row.tuition_cnt or 0) if finance_on else 0
+    cap = _safe_capacity(officer)
+
+    # ⚠️ TRẦN CỨNG cho referral fast-path: đường referral (lead_service, gán
+    # THẲNG cho managing officer) CHỈ có guard duy nhất là hàm này — KHÔNG có gate
+    # `workload < capacity` riêng như auto-assign BƯỚC 4. Nếu chỉ trả theo tải
+    # HIỆU DỤNG (đã trừ học phí), officer đầy toàn lead học phí (raw workload ≥
+    # cap) sẽ "thoát ngưỡng" → bị bơm thêm referral → VƯỢT capacity, phá bất biến
+    # config "không ôm quá capacity". Vì thế: khi cờ ON, raw workload ≥ cap LUÔN
+    # coi là quá tải (chặn referral), discount chỉ áp KHI CÒN dưới trần.
+    # finance_on=False ⇒ nhánh này no-op (raw ≥ cap ⇒ raw/cap ≥ 1 ≥ threshold vẫn
+    # True) → OFF y hệt hôm nay.
+    if finance_on and workload >= cap:
+        return True
 
     # Option A: ngưỡng referral theo TẢI HIỆU DỤNG (trừ học phí) khi cờ ON.
     # tuition_cnt ⊆ workload ⇒ (workload - tuition_cnt) ≥ 0.
-    return ((workload - tuition_cnt) / _safe_capacity(officer)) >= threshold
+    return ((workload - tuition_cnt) / cap) >= threshold
 
 
 async def _log_assignment_decision(
@@ -436,6 +449,14 @@ async def automatically_assign_lead(
                 if exclude_active and finance_on:
                     # Phần GIAO self-tuyển ∩ học phí — chống trừ HAI LẦN khi tính
                     # dist_load = workload − |self ∪ tuition|.
+                    # ⚠️ EFFICIENCY (chấp nhận có chủ đích): filter này nhúng LẠI
+                    # `_self_sourced_subquery()` (correlated LIMIT-1 trên
+                    # assignment_log) nên khi CẢ HAI cờ ON, subquery chạy 2 lần/dòng
+                    # (self_cnt + đây). KHÔNG refactor thành 1 cột `is_self` chung ở
+                    # đây vì sẽ đụng path self-sourced HIỆN CÓ (MockWorkloadRow +
+                    # test_assignment_self_sourced đã ghim self_cnt). Chỉ phát sinh
+                    # khi member/fairness + finance đều ON; auto-assign không siêu
+                    # nóng (chạy lúc tạo lead) ⇒ chi phí chấp nhận được.
                     _wl_cols.append(
                         func.count(models.Lead.id)
                         .filter(
@@ -476,10 +497,15 @@ async def automatically_assign_lead(
                         self_and_tuition_map[row.assigned_officer_id] = (
                             row.self_and_tuition_cnt
                         )
-                log.debug(
+                # ⚠️ Parity khi OFF: hậu tố tuition-hold CHỈ nối khi finance_on ⇒
+                # cờ OFF giữ nguyên chuỗi log cũ (byte-identical, không chỉ audit).
+                _dbg_load = (
                     f"[Lead ID: {lead_id}] Workloads={workload_map} "
-                    f"self-sourced={self_map} tuition-hold={tuition_map}"
+                    f"self-sourced={self_map}"
                 )
+                if finance_on:
+                    _dbg_load += f" tuition-hold={tuition_map}"
+                log.debug(_dbg_load)
 
                 # === BƯỚC 4: Xây dựng Danh sách Officer Hợp lệ (còn capacity) ===
                 officer_loads = []

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -8,7 +8,7 @@ This ensures notifications are persisted to database AND sent via Socket.IO/Emai
 import logging
 from datetime import datetime, timezone
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.exc import OperationalError  # Dùng để bắt LockNotAvailableError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -42,6 +42,25 @@ def _non_final_status_filter():
         (models.ConsultationStatus.is_final == False) |  # noqa: E712
         (models.ConsultationStatus.is_final.is_(None))
     )
+
+
+# Non-final tuition fee statuses (stg05 "Xử lý học phí" — tuition-hold). Khách
+# đã chuyển đổi, đang chờ đóng đủ / xác nhận nhập học ⇒ KHÔNG còn là tải tư vấn.
+# Được GIẢM TRỪ khỏi cơ sở sắp xếp + cổng quá tải + referral fast-path khi
+# ``ENABLE_FINANCE_WORKLOAD_DISCOUNT`` ON. Excludes sts18 (TUITION_REFUNDED,
+# is_final) — trạng thái final KHÔNG BAO GIỜ tính tải nên không cần liệt kê.
+# ⚠️ Hardcode có chủ đích (KHÔNG derive theo stage_id='stg05') để sts18 không
+# lọt vào; ghim bởi test_tuition_hold_status_ids_documented.
+TUITION_HOLD_STATUS_IDS = ("sts14", "sts10")
+
+
+def _tuition_hold_filter():
+    """SQL condition: lead ở trạng thái học phí non-final (``TUITION_HOLD_STATUS_IDS``).
+
+    Dùng làm FILTER aggregate trong workload_stmt (và referral fast-path) để đếm
+    riêng phần tải học phí — chỉ khi ``ENABLE_FINANCE_WORKLOAD_DISCOUNT`` ON.
+    """
+    return models.ConsultationStatus.id.in_(TUITION_HOLD_STATUS_IDS)
 
 
 # _ASSIGNMENT_SOURCE_METHODS = method của SỰ KIỆN (RE-)PHÂN CÔNG (cách officer CÓ
@@ -177,8 +196,21 @@ async def is_officer_at_threshold(
     đó fallback sang auto-assign cân bằng. Giữ cùng định nghĩa workload với thuật
     toán né officer, nên kết luận ở đây khớp với việc officer có bị auto-assign né.
     """
+    from ..config import settings
+
+    finance_on = settings.ENABLE_FINANCE_WORKLOAD_DISCOUNT
+    _cols = [func.count(models.Lead.id).label("workload")]
+    if finance_on:
+        # Đếm riêng tải HỌC PHÍ để GIẢM TRỪ khỏi ngưỡng referral (Option A) —
+        # cùng discount với auto-assign, tránh referral fast-path né officer mà
+        # balancer đã coi là KHÔNG quá tải (chỉ thêm cột khi cờ ON ⇒ OFF y hệt).
+        _cols.append(
+            func.count(models.Lead.id)
+            .filter(_tuition_hold_filter())
+            .label("tuition_cnt")
+        )
     workload_stmt = (
-        select(func.count(models.Lead.id))
+        select(*_cols)
         .join(
             models.ConsultationStatus,
             models.Lead.consultation_status_id == models.ConsultationStatus.id,
@@ -190,9 +222,15 @@ async def is_officer_at_threshold(
             _non_final_status_filter(),
         )
     )
-    workload = (await db.execute(workload_stmt)).scalar_one() or 0
+    # COUNT không GROUP BY ⇒ luôn đúng 1 dòng (kể cả khi 0) → .one() an toàn,
+    # giữ nguyên kết quả với path .scalar_one() cũ khi cờ OFF.
+    row = (await db.execute(workload_stmt)).one()
+    workload = row.workload or 0
+    tuition_cnt = (row.tuition_cnt or 0) if finance_on else 0
 
-    return (workload / _safe_capacity(officer)) >= threshold
+    # Option A: ngưỡng referral theo TẢI HIỆU DỤNG (trừ học phí) khi cờ ON.
+    # tuition_cnt ⊆ workload ⇒ (workload - tuition_cnt) ≥ 0.
+    return ((workload - tuition_cnt) / _safe_capacity(officer)) >= threshold
 
 
 async def _log_assignment_decision(
@@ -371,6 +409,11 @@ async def automatically_assign_lead(
                     settings.ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED
                     and (member_on or fairness_on)
                 )
+                # Option A finance discount (cờ ĐỘC LẬP — KHÔNG gate theo member/
+                # fairness vì overloaded/threshold áp mọi chế độ). Khi ON: lead học
+                # phí non-final giảm trừ khỏi dist_load (eff_util) + cổng overloaded.
+                # OFF ⇒ 0 aggregate phụ + audit-shape y hệt hôm nay.
+                finance_on = settings.ENABLE_FINANCE_WORKLOAD_DISCOUNT
 
                 officer_ids = [o.id for o in available_officers]
                 _wl_cols = [
@@ -382,6 +425,26 @@ async def automatically_assign_lead(
                         func.count(models.Lead.id)
                         .filter(_self_sourced_subquery())
                         .label("self_cnt")
+                    )
+                if finance_on:
+                    # Tải HỌC PHÍ (sts14/sts10) — giảm trừ ở dist_load + overloaded.
+                    _wl_cols.append(
+                        func.count(models.Lead.id)
+                        .filter(_tuition_hold_filter())
+                        .label("tuition_cnt")
+                    )
+                if exclude_active and finance_on:
+                    # Phần GIAO self-tuyển ∩ học phí — chống trừ HAI LẦN khi tính
+                    # dist_load = workload − |self ∪ tuition|.
+                    _wl_cols.append(
+                        func.count(models.Lead.id)
+                        .filter(
+                            and_(
+                                _self_sourced_subquery(),
+                                _tuition_hold_filter(),
+                            )
+                        )
+                        .label("self_and_tuition_cnt")
                     )
                 workload_stmt = (
                     select(*_wl_cols)
@@ -401,12 +464,21 @@ async def automatically_assign_lead(
                 )
                 workload_map: dict = {}
                 self_map: dict = {}
+                tuition_map: dict = {}
+                self_and_tuition_map: dict = {}
                 for row in await db.execute(workload_stmt):
                     workload_map[row.assigned_officer_id] = row.workload
                     if exclude_active:
                         self_map[row.assigned_officer_id] = row.self_cnt
+                    if finance_on:
+                        tuition_map[row.assigned_officer_id] = row.tuition_cnt
+                    if exclude_active and finance_on:
+                        self_and_tuition_map[row.assigned_officer_id] = (
+                            row.self_and_tuition_cnt
+                        )
                 log.debug(
-                    f"[Lead ID: {lead_id}] Workloads={workload_map} self-sourced={self_map}"
+                    f"[Lead ID: {lead_id}] Workloads={workload_map} "
+                    f"self-sourced={self_map} tuition-hold={tuition_map}"
                 )
 
                 # === BƯỚC 4: Xây dựng Danh sách Officer Hợp lệ (còn capacity) ===
@@ -421,16 +493,25 @@ async def automatically_assign_lead(
                     # self-tuyển/weight KHÔNG BAO GIỜ nới trần này.
                     if workload < capacity:
                         weight = _safe_weight(officer)
-                        # balance_load = CƠ SỞ SẮP XẾP. Khi exclude_active, trừ phần
-                        # officer tự tuyển ⇒ lead tự tuyển không làm giảm suất nhận
-                        # lead-chia. self_cnt = COUNT FILTER trên cùng tập dòng ⇒
-                        # self_cnt ≤ workload (bất biến CẤU TRÚC) ⇒ balance_load ≥ 0,
-                        # KHÔNG cần max(0).
-                        balance_load = (
-                            workload - self_map.get(officer.id, 0)
-                            if exclude_active
-                            else workload
+                        # balance_load = CƠ SỞ SẮP XẾP = workload − |self ∪ tuition|.
+                        # - self (exclude_active): lead tự tuyển không làm giảm suất.
+                        # - tuition (finance_on): khách HỌC PHÍ đã chuyển đổi, không
+                        #   còn là tải tư vấn (Option A).
+                        # Mỗi phần = 0 khi cờ tương ứng OFF; trừ `overlap` (self ∩
+                        # tuition) để KHÔNG trừ hai lần. Cả hai ⊆ workload ⇒
+                        # balance_load ≥ 0 (khỏi max(0)).
+                        self_cnt = (
+                            self_map.get(officer.id, 0) if exclude_active else 0
                         )
+                        tuition_cnt = (
+                            tuition_map.get(officer.id, 0) if finance_on else 0
+                        )
+                        overlap = (
+                            self_and_tuition_map.get(officer.id, 0)
+                            if (exclude_active and finance_on)
+                            else 0
+                        )
+                        balance_load = workload - self_cnt - tuition_cnt + overlap
                         # real_util/eff_util tính trên balance_load (đầu vào SẮP
                         # XẾP ở BƯỚC 5). eff_util có nhân weight: weight cao ⇒
                         # eff_util thấp ⇒ officer "được coi là vơi hơn" ⇒ nhận
@@ -445,10 +526,17 @@ async def automatically_assign_lead(
                                 "real_util": real_util,
                                 "eff_util": eff_util,
                                 "weight": weight,
-                                # ⚠️ Cổng an toàn theo TỔNG tải (workload/capacity),
-                                # TÁCH khỏi real_util (dist-based khi exclude_active).
-                                # weight/self-tuyển KHÔNG phá trần. Đặt sẵn ở đây.
-                                "overloaded": (workload / capacity) >= SAFETY_THRESHOLD,
+                                # ⚠️ Cổng an toàn TÁCH khỏi real_util (dist-based khi
+                                # exclude_active). weight/self-tuyển KHÔNG phá trần.
+                                # Option A: chỉ trừ HỌC PHÍ (tuition_cnt) khi
+                                # finance_on — self KHÔNG trừ ở cổng này (giữ như hôm
+                                # nay). tuition_cnt ⊆ workload ⇒ ≥ 0.
+                                "overloaded": (
+                                    (workload - tuition_cnt) / capacity
+                                )
+                                >= SAFETY_THRESHOLD,
+                                # tải học phí (audit; chỉ emit vào snapshot khi ON).
+                                "tuition_hold": tuition_cnt,
                                 # score = giá trị dùng để SẮP XẾP; mặc định real_util,
                                 # các nhánh weighted ở BƯỚC 5 ghi đè. Ở nhánh legacy/
                                 # fallback score GIỮ real_util nhưng KHÔNG quyết định thứ
@@ -497,8 +585,15 @@ async def automatically_assign_lead(
                         eligible_officer_ids=officer_ids, unit_id=lead_unit_id,
                         channel="auto", reason="at_capacity",
                         capacity_snapshot={
-                            str(o.id): {"current": workload_map.get(o.id, 0),
-                                        "max": o.max_capacity or 100}
+                            str(o.id): {
+                                "current": workload_map.get(o.id, 0),
+                                "max": o.max_capacity or 100,
+                                **(
+                                    {"tuition_hold": tuition_map.get(o.id, 0)}
+                                    if finance_on
+                                    else {}
+                                ),
+                            }
                             for o in available_officers
                         }, log=log,
                     )
@@ -659,6 +754,13 @@ async def automatically_assign_lead(
                                 "eff_util": round(ol["eff_util"], 4),
                                 "weight": ol["weight"],
                                 "score": round(ol["score"], 4),
+                                # Option A: chỉ thêm khi finance_on ⇒ OFF giữ nguyên
+                                # audit-shape (byte-identical).
+                                **(
+                                    {"tuition_hold": ol["tuition_hold"]}
+                                    if finance_on
+                                    else {}
+                                ),
                             }
                             for ol in officer_loads
                         }
@@ -667,6 +769,11 @@ async def automatically_assign_lead(
                         str(ol["officer"].id): {
                             "current": ol["workload"],
                             "max": ol["officer"].max_capacity or 100,
+                            **(
+                                {"tuition_hold": ol["tuition_hold"]}
+                                if finance_on
+                                else {}
+                            ),
                         }
                         for ol in officer_loads
                     }, log=log,

--- a/Backend_FastAPI/requirements.txt
+++ b/Backend_FastAPI/requirements.txt
@@ -91,7 +91,7 @@ regex==2025.11.3
 requests==2.33.0
 rsa==4.9.1
 sentry-sdk==2.22.0
-setuptools==80.9.0
+setuptools==83.0.0
 simple-websocket==1.1.0
 simpleeval==1.0.5
 six==1.17.0

--- a/Backend_FastAPI/tests/services/conftest.py
+++ b/Backend_FastAPI/tests/services/conftest.py
@@ -618,13 +618,24 @@ async def deleted_lead_with_phone(
 
 class MockWorkloadRow:
     """Row shape returned by the BƯỚC 3 workload GROUP BY query. ``self_cnt`` chỉ
-    có mặt khi exclude_active (COUNT FILTER tự-tuyển gộp vào cùng query); default 0
-    để test không dùng exclude giữ nguyên."""
+    có mặt khi exclude_active; ``tuition_cnt`` chỉ khi finance_on;
+    ``self_and_tuition_cnt`` chỉ khi CẢ HAI (COUNT FILTER gộp vào cùng query).
+    Default 0 ⇒ test không bật cờ tương ứng giữ nguyên (service chỉ đọc cột khi
+    cờ đã ON, xem BƯỚC 3)."""
 
-    def __init__(self, assigned_officer_id, workload, self_cnt=0):
+    def __init__(
+        self,
+        assigned_officer_id,
+        workload,
+        self_cnt=0,
+        tuition_cnt=0,
+        self_and_tuition_cnt=0,
+    ):
         self.assigned_officer_id = assigned_officer_id
         self.workload = workload
         self.self_cnt = self_cnt
+        self.tuition_cnt = tuition_cnt
+        self.self_and_tuition_cnt = self_and_tuition_cnt
 
 
 @pytest.fixture

--- a/Backend_FastAPI/tests/services/test_assignment.py
+++ b/Backend_FastAPI/tests/services/test_assignment.py
@@ -387,6 +387,113 @@ async def test_matrix_member_on_safety_gate_not_bent(
     assert _decision_log(mock_db_session).reason == "member_weighted"
 
 
+# =====================================================================
+# Finance workload discount (ENABLE_FINANCE_WORKLOAD_DISCOUNT — Option A)
+# Drive the discount END-TO-END qua automatically_assign_lead (không phải query
+# viết tay): ranking flip, cổng overloaded, dedup union, và audit-shape khi OFF.
+# =====================================================================
+@pytest.mark.asyncio
+async def test_finance_discount_on_flips_ranking_and_adds_audit_key(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """member ON + finance ON: officer_1 tải TỔNG cao hơn (8) nhưng 6/8 là lead
+    HỌC PHÍ (sts14/sts10) ⇒ dist_load 8−6=2 < officer_2 (4) ⇒ officer_1 THẮNG
+    (đảo thứ hạng). Cổng overloaded officer_1 = (8−6)/10=0.2 < 0.8 (KHÔNG bị đẩy
+    sau dù raw 0.8). scores_snapshot thêm key 'tuition_hold'."""
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    monkeypatch.setattr(settings, "ENABLE_FINANCE_WORKLOAD_DISCOUNT", True)
+    officer_1.assignment_weight = 1
+    officer_2.assignment_weight = 1
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([
+            MockWorkloadRow(101, 8, tuition_cnt=6),
+            MockWorkloadRow(102, 4, tuition_cnt=0),
+        ]),
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    assert lead_new.assigned_officer_id == officer_1.id
+    decision = _decision_log(mock_db_session)
+    assert decision.reason == "member_weighted"
+    snap = decision.scores_snapshot
+    assert snap["101"]["tuition_hold"] == 6
+    assert snap["102"]["tuition_hold"] == 0
+    # dist_load = workload − tuition (exclude_active OFF ⇒ self=0)
+    assert snap["101"]["dist_load"] == 2
+    assert snap["102"]["dist_load"] == 4
+
+
+@pytest.mark.asyncio
+async def test_finance_discount_off_no_flip_and_no_audit_key(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """CÙNG tải như test ON nhưng finance OFF: officer_1 raw 8/10=0.8 ⇒ overloaded
+    ⇒ bị đẩy sau ⇒ officer_2 THẮNG (không đảo). scores_snapshot KHÔNG có key
+    'tuition_hold' — chốt audit-shape byte-identical khi cờ OFF."""
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    monkeypatch.setattr(settings, "ENABLE_FINANCE_WORKLOAD_DISCOUNT", False)
+    officer_1.assignment_weight = 1
+    officer_2.assignment_weight = 1
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([
+            MockWorkloadRow(101, 8, tuition_cnt=6),
+            MockWorkloadRow(102, 4, tuition_cnt=0),
+        ]),
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    assert lead_new.assigned_officer_id == officer_2.id
+    snap = _decision_log(mock_db_session).scores_snapshot
+    assert "tuition_hold" not in snap["101"]
+    assert "tuition_hold" not in snap["102"]
+
+
+@pytest.mark.asyncio
+async def test_finance_discount_union_dedup_through_service(
+    monkeypatch, mock_db_session, lead_new, officer_1, officer_2
+):
+    """exclude_active + finance ON: dist_load = workload − |self ∪ tuition|.
+    officer_1: workload 8, self 3, tuition 6, giao 2 ⇒ 8−3−6+2 = 1 (phần giao chỉ
+    trừ 1 LẦN). Kiểm dedup CHẠY QUA service (BƯỚC 3-4), không phải query viết tay."""
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    monkeypatch.setattr(settings, "ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED", True)
+    monkeypatch.setattr(settings, "ENABLE_FINANCE_WORKLOAD_DISCOUNT", True)
+    officer_1.assignment_weight = 1
+    officer_2.assignment_weight = 1
+
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([officer_1, officer_2]),
+        _workload_result([
+            MockWorkloadRow(
+                101, 8, self_cnt=3, tuition_cnt=6, self_and_tuition_cnt=2
+            ),
+            MockWorkloadRow(102, 5),
+        ]),
+    ]
+
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+
+    snap = _decision_log(mock_db_session).scores_snapshot
+    # union-dedup: 8 − 3 − 6 + 2 = 1 (giao trừ 1 lần); officer_2 = 5.
+    assert snap["101"]["dist_load"] == 1
+    assert snap["101"]["tuition_hold"] == 6
+    assert snap["102"]["dist_load"] == 5
+    # officer_1 dist_load 1 < officer_2 5 ⇒ officer_1 thắng.
+    assert lead_new.assigned_officer_id == officer_1.id
+
+
 @pytest.mark.asyncio
 async def test_matrix_fairness_on_member_off_raw_share(
     monkeypatch, mock_db_session, lead_new, officer_1, officer_2

--- a/Backend_FastAPI/tests/services/test_assignment_finance_discount.py
+++ b/Backend_FastAPI/tests/services/test_assignment_finance_discount.py
@@ -1,0 +1,197 @@
+# tests/services/test_assignment_finance_discount.py
+# -*- coding: utf-8 -*-
+"""Real-DB test cho GIẢM TRỪ TẢI HỌC PHÍ (Option A, ENABLE_FINANCE_WORKLOAD_DISCOUNT).
+
+Bọc sau cờ ``ENABLE_FINANCE_WORKLOAD_DISCOUNT`` (default OFF). Khi ON: lead ở
+trạng thái học phí non-final (``TUITION_HOLD_STATUS_IDS`` = sts14/sts10) được
+giảm trừ khỏi:
+  - cơ sở sắp xếp ``dist_load`` (eff_util) — GỘP với self-tuyển, chống trừ 2 lần
+    qua phần giao S∩T,
+  - cổng ``overloaded`` = ((workload − tuition)/capacity) >= SAFETY_THRESHOLD,
+  - ``is_officer_at_threshold`` (referral fast-path).
+Trần cứng ``workload < capacity`` VẪN theo TỔNG workload (không test ở đây).
+
+Seed lead + consultation_status THẬT rồi execute production path
+(``COUNT(id) FILTER(_tuition_hold_filter())`` + union self∩tuition) và gọi thẳng
+``is_officer_at_threshold``. Chạy one-off container (CLAUDE.md) — seed DB thật.
+"""
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import and_, func, select
+
+from app import models
+from app.config import settings
+from app.security import get_password_hash
+from app.services.assignment_reason import build_assignment_reason
+from app.services.assignment_service import (
+    TUITION_HOLD_STATUS_IDS,
+    _non_final_status_filter,
+    _self_sourced_subquery,
+    _tuition_hold_filter,
+    is_officer_at_threshold,
+)
+
+# asyncio_mode=auto (pytest.ini) ⇒ async test tự chạy, KHÔNG cần mark asyncio
+# (mark asyncio ở module-level sẽ dính nhầm vào test đồng bộ documented → warning).
+pytestmark = pytest.mark.integration
+
+
+async def _ensure_status(db, sid, is_final):
+    """get-or-create ConsultationStatus (test DB không seed sẵn sts14/10/18/06;
+    get-or-create để idempotent giữa các test cùng schema)."""
+    st = await db.get(models.ConsultationStatus, sid)
+    if st is None:
+        db.add(
+            models.ConsultationStatus(
+                id=sid,
+                name=f"FD {sid}",
+                color_code="#123456",
+                is_final=is_final,
+            )
+        )
+    else:
+        st.is_final = is_final
+    await db.flush()
+
+
+async def _mk_officer(db, unit_id, tag, cap=100):
+    u = models.User(
+        username=f"fd_{tag}",
+        email=f"fd_{tag}@test.com",
+        password_hash=get_password_hash("OfficerPass123!"),
+        role="officer",
+        status="active",
+        availability_status="available",
+        full_name=f"Finance Officer {tag}",
+        unit_id=unit_id,
+        max_capacity=cap,
+    )
+    db.add(u)
+    await db.flush()
+    await db.refresh(u)
+    return u
+
+
+async def _mk_lead(db, deps, officer, status_id, phone):
+    lead = models.Lead(
+        full_name="FD Lead",
+        phone=phone,
+        source="website",
+        unit_id=deps["unit_id"],
+        status="qualified",
+        consultation_status_id=status_id,
+        pipeline_stage_id=deps["stage_id"],
+        assigned_officer_id=officer.id,
+        assigned_at=datetime.now(timezone.utc),
+    )
+    db.add(lead)
+    await db.flush()
+    await db.refresh(lead)
+    return lead
+
+
+async def _self_log(db, lead, officer):
+    """AssignmentLog manual + reason DO CHÍNH officer ⇒ latest self-sourced."""
+    db.add(
+        models.AssignmentLog(
+            lead_id=lead.id,
+            officer_id=officer.id,
+            method="manual",
+            reason=build_assignment_reason("Assigned during lead creation", officer),
+            timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+    )
+    await db.flush()
+
+
+def test_tuition_hold_status_ids_documented():
+    """Ghim danh sách trạng thái học phí non-final được giảm trừ. Hardcode CÓ CHỦ
+    ĐÍCH (KHÔNG derive theo stage_id='stg05') để sts18 (TUITION_REFUNDED, final)
+    không lọt vào discount."""
+    assert TUITION_HOLD_STATUS_IDS == ("sts14", "sts10")
+
+
+async def test_tuition_hold_filter_and_union_dedup(db, seeded_dependencies):
+    """production path: workload (non-final) / tuition_cnt / self_cnt / (self∩tuition).
+
+    5 lead: sts14, sts10 (tuition), sts18 (FINAL → rớt workload), sts06 (non-final
+    non-tuition), sts14+self-sourced. Chốt: sts18 KHÔNG vào workload lẫn tuition;
+    dist_load = workload − |self ∪ tuition| dedup đúng qua phần giao."""
+    deps = seeded_dependencies
+    await _ensure_status(db, "sts14", False)  # Chưa hoàn tất học phí (non-final)
+    await _ensure_status(db, "sts10", False)  # Đã hoàn tất học phí (non-final)
+    await _ensure_status(db, "sts18", True)   # Đã hoàn học phí / refund (FINAL)
+    await _ensure_status(db, "sts06", False)  # Đồng ý tư vấn (non-final, non-tuition)
+    o = await _mk_officer(db, deps["unit_id"], "flt")
+
+    await _mk_lead(db, deps, o, "sts14", "0961000001")           # tuition
+    await _mk_lead(db, deps, o, "sts10", "0961000002")           # tuition
+    await _mk_lead(db, deps, o, "sts18", "0961000003")           # FINAL → excluded
+    await _mk_lead(db, deps, o, "sts06", "0961000004")           # non-final non-tuition
+    l5 = await _mk_lead(db, deps, o, "sts14", "0961000005")  # tuition + self-sourced
+    await _self_log(db, l5, o)
+
+    stmt = (
+        select(
+            func.count(models.Lead.id).label("workload"),
+            func.count(models.Lead.id)
+            .filter(_self_sourced_subquery())
+            .label("self_cnt"),
+            func.count(models.Lead.id)
+            .filter(_tuition_hold_filter())
+            .label("tuition_cnt"),
+            func.count(models.Lead.id)
+            .filter(and_(_self_sourced_subquery(), _tuition_hold_filter()))
+            .label("both_cnt"),
+        )
+        .join(
+            models.ConsultationStatus,
+            models.Lead.consultation_status_id == models.ConsultationStatus.id,
+            isouter=True,
+        )
+        .where(
+            models.Lead.assigned_officer_id == o.id,
+            models.Lead.deleted_at.is_(None),
+            _non_final_status_filter(),
+        )
+    )
+    row = (await db.execute(stmt)).one()
+
+    # sts18 (final) rớt khỏi workload ⇒ còn L1,L2,L4,L5 = 4
+    assert row.workload == 4
+    assert row.tuition_cnt == 3   # L1(sts14), L2(sts10), L5(sts14)
+    assert row.self_cnt == 1      # L5
+    assert row.both_cnt == 1      # L5 = tuition ∩ self
+    # dist_load = workload − |self ∪ tuition| = 4 − 1 − 3 + 1 = 1 (chỉ còn L4)
+    assert row.workload - row.self_cnt - row.tuition_cnt + row.both_cnt == 1
+    # bất biến subset cấu trúc: mỗi discount ⊆ workload
+    assert row.tuition_cnt <= row.workload
+    assert row.self_cnt <= row.workload
+
+
+async def test_is_officer_at_threshold_finance_discount(
+    db, seeded_dependencies, monkeypatch
+):
+    """Referral fast-path (Option A yêu cầu #1): cờ ON trừ tải học phí khỏi ngưỡng.
+
+    cap=10; 7 lead sts06 + 2 lead sts14 = workload 9, tuition 2.
+      - OFF: 9/10 = 0.90 ≥ 0.8  → at threshold (True)
+      - ON:  (9−2)/10 = 0.70 < 0.8 → KHÔNG at threshold (False)
+    """
+    deps = seeded_dependencies
+    await _ensure_status(db, "sts14", False)
+    await _ensure_status(db, "sts06", False)
+    o = await _mk_officer(db, deps["unit_id"], "thr", cap=10)
+    for i in range(7):
+        await _mk_lead(db, deps, o, "sts06", f"09620001{i:02d}")
+    for i in range(2):
+        await _mk_lead(db, deps, o, "sts14", f"09620002{i:02d}")
+
+    # Cờ OFF ⇒ ngưỡng theo TỔNG workload (y hệt hôm nay).
+    monkeypatch.setattr(settings, "ENABLE_FINANCE_WORKLOAD_DISCOUNT", False)
+    assert await is_officer_at_threshold(db, o) is True
+
+    # Cờ ON ⇒ trừ tải học phí ⇒ dưới ngưỡng ⇒ referral vẫn gán thẳng được.
+    monkeypatch.setattr(settings, "ENABLE_FINANCE_WORKLOAD_DISCOUNT", True)
+    assert await is_officer_at_threshold(db, o) is False

--- a/Backend_FastAPI/tests/services/test_assignment_finance_discount.py
+++ b/Backend_FastAPI/tests/services/test_assignment_finance_discount.py
@@ -38,8 +38,12 @@ pytestmark = pytest.mark.integration
 
 
 async def _ensure_status(db, sid, is_final):
-    """get-or-create ConsultationStatus (test DB không seed sẵn sts14/10/18/06;
-    get-or-create để idempotent giữa các test cùng schema)."""
+    """create-if-absent ConsultationStatus (test DB không seed sẵn sts14/10/18/06).
+
+    ⚠️ KHÔNG ghi đè ``is_final`` của row ĐÃ tồn tại: đây là row lookup dùng chung,
+    ghi đè sẽ rewrite semantics cho test khác trong cùng session. Nếu gặp seed sẵn
+    mâu thuẫn → FAIL rõ ràng thay vì âm thầm sửa bảng tra cứu.
+    """
     st = await db.get(models.ConsultationStatus, sid)
     if st is None:
         db.add(
@@ -50,9 +54,12 @@ async def _ensure_status(db, sid, is_final):
                 is_final=is_final,
             )
         )
-    else:
-        st.is_final = is_final
-    await db.flush()
+        await db.flush()
+    elif st.is_final != is_final:
+        pytest.fail(
+            f"ConsultationStatus {sid} đã tồn tại với is_final={st.is_final}, "
+            f"test cần {is_final} — KHÔNG ghi đè row lookup dùng chung."
+        )
 
 
 async def _mk_officer(db, unit_id, tag, cap=100):
@@ -106,10 +113,19 @@ async def _self_log(db, lead, officer):
 
 
 def test_tuition_hold_status_ids_documented():
-    """Ghim danh sách trạng thái học phí non-final được giảm trừ. Hardcode CÓ CHỦ
-    ĐÍCH (KHÔNG derive theo stage_id='stg05') để sts18 (TUITION_REFUNDED, final)
-    không lọt vào discount."""
+    """Ghim danh sách trạng thái học phí non-final được giảm trừ + NEO vào nguồn
+    taxonomy chính ``phase_manager.PHASE_STATUSES[FEE]`` để BẮT DRIFT: thêm/đổi
+    trạng thái fee mà quên cập nhật đây → test gãy. Hardcode CÓ CHỦ ĐÍCH (KHÔNG
+    derive theo stage_id='stg05') để sts18 (TUITION_REFUNDED, final) không lọt."""
+    from app.services.phase_manager import LeadPhase, PHASE_STATUSES
+
     assert TUITION_HOLD_STATUS_IDS == ("sts14", "sts10")
+    fee = PHASE_STATUSES[LeadPhase.FEE]
+    # Là tập con của nhóm FEE chính thức, và đúng bằng FEE trừ sts18 (fee status
+    # FINAL duy nhất, bị loại có chủ đích khỏi discount tải).
+    assert set(TUITION_HOLD_STATUS_IDS) <= fee
+    assert set(TUITION_HOLD_STATUS_IDS) == fee - {"sts18"}
+    assert "sts18" in fee  # neo: nếu sts18 rời nhóm FEE, xem lại giả định loại trừ
 
 
 async def test_tuition_hold_filter_and_union_dedup(db, seeded_dependencies):


### PR DESCRIPTION
## Mục tiêu
Lead ở giai đoạn **học phí non-final** (`sts14` Chưa hoàn tất học phí + `sts10` Đã hoàn tất học phí) là khách **đã chuyển đổi**, đang chờ xác nhận nhập học — không còn là tải tư vấn nhưng vẫn đẩy officer qua ngưỡng `overloaded`, làm họ nhận ít lead tư vấn mới hơn mức đáng có. Ví dụ thật (Phòng TS): Hiệu 324/400=81% **đã** qua `SAFETY_THRESHOLD=0.8`; trừ 64 lead học phí còn 260/400=0.65 → thoát.

## Thiết kế — Option A (bọc sau cờ `ENABLE_FINANCE_WORKLOAD_DISCOUNT`, **default OFF** ⇒ 0 đổi hành vi + audit khi tắt)
Khi ON, lead học phí được giảm trừ khỏi:
- **Cơ sở xếp hạng** `dist_load = workload − |self ∪ tuition|` (gộp với discount self-tuyển sẵn có, dedup phần giao) → `eff_util`.
- **Cổng `overloaded`** = `((workload − tuition)/capacity) ≥ SAFETY_THRESHOLD`.
- **`is_officer_at_threshold`** (referral fast-path).
- **Trần cứng `workload < capacity` GIỮ tải TỔNG** — không ôm quá capacity học sinh thật. `TUITION_HOLD_STATUS_IDS=("sts14","sts10")` (loại `sts18` refunded/final). **Không migration.**

## Đã qua /code-review max — patch toàn bộ 8 finding
- **#1 (bug thật)**: referral fast-path (`lead_service.py:1065-1074`, guard tải DUY NHẤT) có thể đẩy officer **vượt** `max_capacity` khi cờ ON → vá: cờ ON + raw `workload ≥ capacity` LUÔN coi quá tải.
- **#2/#7**: thêm 3 test service-level qua `automatically_assign_lead` (đảo thứ hạng khi ON · không đảo + không key audit khi OFF · dedup union) + mở rộng `MockWorkloadRow`.
- **#3**: test neo `TUITION_HOLD_STATUS_IDS` vào `phase_manager.PHASE_STATUSES[LeadPhase.FEE]` (bắt drift).
- **#4** double-eval subquery: ghi comment (không rewrite core). **#6** parity log OFF. **#8** `_ensure_status` fail-loud.

## Kiểm chứng
- **80/80 test PASS** (3 finance + 24 mock-suite gồm 3 service-level mới + self-sourced + full 52 `test_sts20`).
- flake8 net-zero E501/W293 mới. Không migration, revert = tắt cờ.

## Rollout sau merge
Deploy ship code với cờ **OFF** (0 đổi hành vi). Bật: set `ENABLE_FINANCE_WORKLOAD_DISCOUNT=true` trong `.env.production` + `up -d --force-recreate --no-deps backend celery-worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)