### PR TITLE
fix(leads): đồng bộ Profile→Lead identity qua guard chung (bịt nguyên nhân gốc 500/drift)

### DIFF
--- a/Backend_FastAPI/app/repositories/lead_repository.py
+++ b/Backend_FastAPI/app/repositories/lead_repository.py
@@ -1752,3 +1752,42 @@ class LeadRepository(BaseRepository[models.Lead]):
         # Insert new identity rows
         await self.register_phone_identities(lead_id, phone, phone2)
 
+    async def update_phone_slot_identity(
+        self,
+        lead_id: int,
+        phone: Optional[str],
+    ) -> None:
+        """
+        Replace ONLY the ``slot='phone'`` identity row(s) for a lead, leaving
+        the ``slot='phone2'`` row untouched.
+
+        Dùng khi CHỈ số chính đổi (vd đường sửa-hồ-sơ Profile→Lead) — KHÔNG
+        rewrite slot ``phone2`` bằng ``lead.phone2`` có thể đã STALE (lead
+        eager-loaded, không lock/refresh) → tránh clobber một thay đổi phone2
+        đồng thời của đường sửa-lead. Ràng buộc phone2 == phone vẫn được index
+        toàn cục ``uq_lead_phone_active`` bắt ở INSERT (fail-safe).
+
+        Args:
+            lead_id: Lead ID
+            phone: New primary phone (normalized)
+        """
+        from sqlalchemy import delete
+        from app.utils.phone_helpers import normalize_vietnam_phone
+
+        await self.db.execute(
+            delete(models.LeadPhoneIdentity).where(
+                models.LeadPhoneIdentity.lead_id == lead_id,
+                models.LeadPhoneIdentity.slot == "phone",
+            )
+        )
+        if phone:
+            normalized = normalize_vietnam_phone(phone) or phone
+            self.db.add(
+                models.LeadPhoneIdentity(
+                    lead_id=lead_id,
+                    phone_normalized=normalized,
+                    slot="phone",
+                    deleted_at=None,
+                )
+            )
+

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -707,9 +707,15 @@ class AdmissionProfileUpdate(BaseModel):
     # Personal Info Fields
     full_name: Optional[str] = Field(None, max_length=255)
     phone: Optional[str] = Field(
-        None, 
-        pattern=r"^0\d{9,10}$",
-        description="Phone number (10-11 digits starting with 0)"
+        None,
+        # MIRROR CHÍNH XÁC VIETNAM_PHONE_REGEX (phone_helpers.py) để chặn số
+        # 04x/06x/01x ngay ở 422 thay vì lọt xuống service rồi 400.
+        # ⚠ Dùng [0-9] ASCII, KHÔNG \d: Pydantic \d khớp cả Unicode digit
+        # (full-width ０-９) → '090１２３４５６７' lọt schema nhưng service reject
+        # → vẫn "422-miss → 400". Đầu số hợp lệ: 03/05/07/08/09/02 (gồm cố định
+        # 02x — KHÔNG mobile-only, khớp validate_vietnam_phone).
+        pattern=r"^0(3|5|7|8|9|2)[0-9]{8,9}$",
+        description="Số điện thoại Việt Nam hợp lệ (VD: 0901234567)"
     )
     email: Optional[EmailStr] = Field(None, max_length=255)
     dob: Optional[date] = Field(None, description="Date of birth")

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -5178,24 +5178,28 @@ async def update_profile(
             from app.utils.exceptions import ValidationError as _ValidationError
             raise _ValidationError(str(exc))
 
-    # ✅ Sync with Lead: Full Name
+    # Set identity fields TRÊN PROFILE (bản ghi riêng). Chiều đẩy xuống Lead
+    # KHÔNG còn ghi thẳng ``profile.lead.* = ...`` (đường cũ bỏ qua normalize /
+    # check_phone_conflict / update_phone_identities / phone2≠phone / bump
+    # version / audit → gốc sự cố leads list/search 500 do ``phone2 == phone`` +
+    # drift bảng ``lead_phone_identity``). Nay đi qua ``sync_lead_from_profile``
+    # với ĐẦY ĐỦ guard (parity với ``lead_service.update_lead``).
     if "full_name" in data and data["full_name"] is not None:
         profile.full_name = data["full_name"]
-        if profile.lead and data["full_name"].strip():
-            profile.lead.full_name = data["full_name"]
 
-    # ✅ Sync with Lead: Phone
     if "phone" in data and data["phone"] is not None:
         profile.phone = data["phone"]
-        if profile.lead and data["phone"].strip():
-            profile.lead.phone = data["phone"]
 
-    # ✅ Sync with Lead: Email
     if "email" in data and data["email"] is not None:
         profile.email = data["email"]
-        if profile.lead:
-            profile.lead.email = data["email"]
-    
+
+    # Lưu ý: chiều đẩy identity xuống Lead (sync_lead_from_profile) đặt SAU
+    # db.flush() + handler IntegrityError citizen_id bên dưới — để lỗi unique
+    # citizen_id của CHÍNH profile được map ConflictError 409 tại đó. Vì session
+    # autoflush=False, flush ĐẦU TIÊN là savepoint bên trong helper; nếu gọi
+    # helper Ở ĐÂY, một IntegrityError citizen_id (race TOCTOU) sẽ bị savepoint
+    # nuốt rồi _handle_lead_integrity_error re-raise THÔ → 500 thay vì 409.
+
     # Other fields
     if "dob" in data and data["dob"] is not None:
         profile.dob = data["dob"]
@@ -5335,7 +5339,24 @@ async def update_profile(
             raise ConflictError("Dữ liệu trùng lặp (CCCD hoặc thông tin đã tồn tại)")
         else:
             raise ConflictError(f"Vi phạm ràng buộc dữ liệu: {error_msg}")
-    
+
+    # ── Đẩy identity (full_name/phone/email) xuống Lead qua module chung có
+    # guard (parity update_lead). Đặt SAU flush profile ở trên: citizen_id của
+    # profile đã flush + map 409 nếu trùng; helper chỉ còn lo ghi Lead/identity
+    # trong savepoint riêng của nó (map race unique phone/email sạch).
+    identity_changed = [
+        f for f in ("full_name", "phone", "email")
+        if f in data and data[f] is not None
+    ]
+    if identity_changed and profile.lead:
+        from .lead_profile_sync import sync_lead_from_profile
+        await sync_lead_from_profile(
+            db,
+            profile,
+            changed_fields=identity_changed,
+            changed_by_user_id=current_user.id,
+        )
+
     # ✅ Fix: Fetch fresh scores but do NOT assign to profile.subject_scores (avoid SA error)
     fresh_scores = await admission_repo.get_profile_scores(profile.id)
 

--- a/Backend_FastAPI/app/services/lead_profile_sync.py
+++ b/Backend_FastAPI/app/services/lead_profile_sync.py
@@ -11,13 +11,18 @@ Architecture Philosophy (V3.0):
 
 Sync Rules Matrix:
 ------------------
-| Profile Status | Lead → Profile | Profile → Lead | Lead Identity Edit |
-|----------------|----------------|----------------|-------------------|
-| draft          | ✅ Sync        | ✅ Sync        | ✅ Allowed        |
-| submitted      | ✅ Sync        | ❌ Can't edit  | ✅ Allowed        |
-| rejected       | ❌ Snapshot    | ✅ Sync (fix)  | ✅ Allowed        |
-| approved       | ❌ Snapshot    | ❌ Locked      | ❌ BLOCKED        |
-| enrolled       | ❌ Snapshot    | ❌ Locked      | ❌ BLOCKED        |
+| Profile Status     | Lead → Profile | Profile → Lead | Lead Identity Edit |
+|--------------------|----------------|----------------|--------------------|
+| draft              | ✅ Sync        | ✅ Sync (guard)| ✅ Allowed         |
+| submitted          | ✅ Sync        | ❌ Can't edit  | ✅ Allowed         |
+| rejected           | ❌ Snapshot    | ✅ Sync (guard)| ✅ Allowed         |
+| revision_requested | ❌ Snapshot    | ✅ Sync (guard)| ✅ Allowed         |
+| approved           | ❌ Snapshot    | ❌ Locked      | ❌ BLOCKED         |
+| enrolled           | ❌ Snapshot    | ❌ Locked      | ❌ BLOCKED         |
+
+Note: chiều Profile → Lead nay đi qua ``sync_lead_from_profile`` với ĐẦY ĐỦ
+guard (identity-lock + terminal-lock + normalize/validate phone + phone2≠phone +
+phone/email conflict + identity-registry + version + audit). "Sync (guard)".
 
 Why Conditional Sync?
 ---------------------
@@ -97,8 +102,13 @@ SYNCABLE_FIELDS: List[str] = list(IDENTITY_FIELDS)
 EDITABLE_PROFILE_STATUSES: Set[str] = frozenset({"draft", "submitted"})
 
 # AdmissionProfile statuses that allow Profile UPDATE (and Profile → Lead sync)
-# Note: "submitted" cannot be edited (waiting for decision), only draft/rejected
-PROFILE_UPDATE_ALLOWED_STATUSES: Set[str] = frozenset({"draft", "rejected"})
+# Note: "submitted" cannot be edited (waiting for decision). Must mirror the
+# function-level gate in admission_service.update_profile
+# ({draft, rejected, revision_requested}); nếu lệch, profile
+# ``revision_requested`` sẽ sửa được nhưng KHÔNG sync xuống Lead → drift.
+PROFILE_UPDATE_ALLOWED_STATUSES: Set[str] = frozenset(
+    {"draft", "rejected", "revision_requested"}
+)
 
 # AdmissionProfile statuses that LOCK identity fields on Lead
 # These are "legal snapshots" - data is frozen for official records.
@@ -289,6 +299,24 @@ async def sync_profile_from_lead(
 # SYNC: ADMISSION PROFILE → LEAD (Conditional)
 # =============================================================================
 
+def _format_lead_conflict_detail(dup: models.Lead, kind: str) -> str:
+    """Message xung đột phone/email — GIỮ CÙNG format với ``lead_service.
+    update_lead`` để 2 đường sửa identity không trả câu lỗi khác nhau."""
+    officer_name = (
+        dup.assigned_officer.full_name if dup.assigned_officer else "Chưa phân công"
+    )
+    if kind == "email":
+        return (
+            f"Email này đã được sử dụng. Lead: {dup.full_name} "
+            f"(SĐT: {dup.phone}) - Đang được quản lý bởi: {officer_name}"
+        )
+    unit_name = dup.unit.name if getattr(dup, "unit", None) else "N/A"
+    return (
+        f"Số điện thoại này đã được sử dụng. Lead: {dup.full_name} "
+        f"(SĐT: {dup.phone}) - Đơn vị: {unit_name} - Quản lý bởi: {officer_name}"
+    )
+
+
 async def sync_lead_from_profile(
     db: AsyncSession,
     profile: models.AdmissionProfile,
@@ -296,60 +324,80 @@ async def sync_lead_from_profile(
     changed_by_user_id: Optional[int] = None,
 ) -> bool:
     """
-    Sync personal info from AdmissionProfile back to its Lead (CONDITIONAL).
+    Sync identity info (full_name/phone/email) from AdmissionProfile → Lead.
 
-    ⚠️ IMPORTANT: Only syncs when profile is in EDITABLE state (draft/submitted).
-    When profile is LOCKED (approved/rejected/enrolled), sync is BLOCKED to
-    preserve the Lead's operational data integrity.
+    Đây là ĐƯỜNG DUY NHẤT hợp lệ cho chiều Profile → Lead — thay thế việc ghi
+    thẳng ``profile.lead.<field> = ...`` trong admission_service.update_profile
+    (đã bỏ qua toàn bộ guard, là nguyên nhân gốc sự cố list/search 500 do
+    ``phone2 == phone`` + drift bảng ``lead_phone_identity``).
 
-    Use Case:
-        - Lead created with partial name: "anh A"
-        - Officer creates Profile with full name: "Nguyễn Văn A"
-        - Sync updates Lead so officer sees correct name in Lead list
-
-    Security:
-        - draft/submitted: ✅ Sync allowed (data entry phase)
-        - approved/rejected/enrolled: ❌ Sync blocked (legal snapshot)
+    Áp CÙNG guard với ``lead_service.update_lead`` (parity đầy đủ):
+      1. Status gate: chỉ profile ∈ PROFILE_UPDATE_ALLOWED_STATUSES.
+      2. Identity-lock: chặn nếu Lead có profile khác ở trạng thái locked
+         (approved/admitted/enrolled) — ``check_lead_identity_update_allowed``.
+      3. phone: normalize → VALIDATE (normalize KHÔNG phải validator) →
+         terminal-lock (không đổi số khi lead đã ngừng tư vấn) → phone2 ≠ phone
+         → ``check_phone_conflict`` (global).
+      4. email: ``check_email_conflict`` (scope theo unit — KHÁC phone global).
+      5. Ghi Lead + ``update_phone_identities`` + bump version, bọc trong
+         ``begin_nested()`` để race unique (``uq_lead_phone_active`` /
+         ``uq_lead_email_unit_active``) được map sạch qua
+         ``_handle_lead_integrity_error`` mà KHÔNG poison outer transaction của
+         update_profile (vốn không dùng savepoint riêng). Cuối cùng audit "Lead".
 
     Args:
         db: Database session (same transaction as caller)
-        profile: AdmissionProfile model with updated personal info
-        changed_fields: List of field names that changed (optional, syncs all if None)
-        changed_by_user_id: User who triggered the change (for audit)
+        profile: AdmissionProfile với identity đã set (full_name/phone/email)
+        changed_fields: Field đã đổi (mặc định SYNCABLE_FIELDS)
+        changed_by_user_id: User trigger (audit)
 
     Returns:
-        bool: True if sync was performed, False if skipped/blocked
+        bool: True nếu có ghi xuống Lead, False nếu skip.
+
+    Raises:
+        BusinessRuleViolation: identity-lock / terminal-lock.
+        ValidationError: phone sai format sau normalize / phone2 == phone.
+        DuplicateResourceError: phone (global) hoặc email (cùng unit) trùng lead khác.
     """
-    # Check if profile is in updatable state (draft or rejected)
-    # Note: "submitted" profiles can't be edited (waiting for decision)
+    from sqlalchemy.exc import IntegrityError
+
+    from app.repositories.lead_repository import LeadRepository
+    from app.utils.phone_helpers import (
+        normalize_vietnam_phone,
+        validate_vietnam_phone,
+    )
+    from app.core.status_mapping import is_consultation_terminal_status
+    from app.utils.exceptions import (
+        BusinessRuleViolation,
+        DuplicateResourceError,
+        ValidationError,
+    )
+    from . import audit_service
+    from .lead_service import _get_lead_audit_state, _handle_lead_integrity_error
+
+    # ── Status gate ──────────────────────────────────────────────────────────
     if profile.status not in PROFILE_UPDATE_ALLOWED_STATUSES:
         log.info(
             "sync_lead_from_profile: Blocked - Profile in locked state",
             profile_id=profile.id,
             profile_status=profile.status,
             lead_id=profile.lead_id,
-            message="Profile → Lead sync blocked for locked profiles to preserve data integrity",
         )
         return False
 
-    fields_to_sync = changed_fields or SYNCABLE_FIELDS
-
-    # Filter to only syncable fields
-    fields_to_sync = [f for f in fields_to_sync if f in SYNCABLE_FIELDS]
-
+    fields_to_sync = [
+        f for f in (changed_fields or SYNCABLE_FIELDS) if f in SYNCABLE_FIELDS
+    ]
     if not fields_to_sync:
         return False
 
     # Ensure lead is loaded
     lead = profile.lead
     if not lead:
-        # Try to load lead
         result = await db.execute(
-            select(models.Lead)
-            .where(models.Lead.id == profile.lead_id)
+            select(models.Lead).where(models.Lead.id == profile.lead_id)
         )
         lead = result.scalar_one_or_none()
-
         if not lead:
             log.warning(
                 "sync_lead_from_profile: Lead not found",
@@ -358,37 +406,177 @@ async def sync_lead_from_profile(
             )
             return False
 
-    changes_made = False
+    repo = LeadRepository(db)
 
-    for field in fields_to_sync:
-        profile_value = getattr(profile, field, None)
-        lead_value = getattr(lead, field, None)
+    # ── Phòng tuyến 1: xác định DELTA thật (field identity ĐỔI so với lead),
+    # rồi identity-lock + validate + conflict CHỈ áp cho field đổi. Tính delta
+    # TRƯỚC guard để tránh chặn oan khi FE echo lại identity không đổi (vd chỉ
+    # sửa dob nhưng gửi kèm full_name/phone/email cũ). Chạy NGOÀI savepoint.
+    new_full_name = None
+    new_email = None
+    new_phone = None
 
-        if profile_value != lead_value:
-            setattr(lead, field, profile_value)
-            changes_made = True
+    _pf_phone = profile.phone
+    if "phone" in fields_to_sync and _pf_phone is not None and str(_pf_phone).strip():
+        normalized = normalize_vietnam_phone(_pf_phone)
+        # Đồng nhất profile.phone về dạng chuẩn (nếu parse được) để 2 bảng khớp.
+        if normalized is not None:
+            profile.phone = normalized
+        # So delta trên GIÁ TRỊ ĐÃ NORMALIZE CẢ 2 PHÍA: lead.phone legacy có thể
+        # chưa chuẩn hóa (vd '84…') — so với raw sẽ báo "đổi" oan cho số echo
+        # không đổi, kích terminal-lock/conflict/version-churn thừa (giống lỗi
+        # phone2 đã vá bên dưới). CHỈ coi là đổi (và validate) khi khác thật.
+        existing_phone = normalize_vietnam_phone(lead.phone) if lead.phone else lead.phone
+        if normalized != existing_phone:
+            if normalized is None or not validate_vietnam_phone(
+                normalized, normalize=False
+            ):
+                raise ValidationError(
+                    detail=(
+                        "Số điện thoại không hợp lệ. Vui lòng nhập số điện thoại "
+                        "Việt Nam (VD: 0901234567)."
+                    )
+                )
+            new_phone = normalized
 
-            log.info(
-                "sync_lead_from_profile: Field synced",
-                profile_id=profile.id,
-                lead_id=lead.id,
-                field=field,
-                old_value=lead_value,
-                new_value=profile_value,
+    if "email" in fields_to_sync and profile.email:
+        if not lead.email or profile.email.lower() != lead.email.lower():
+            new_email = profile.email
+
+    if (
+        "full_name" in fields_to_sync
+        and profile.full_name is not None
+        and str(profile.full_name).strip()
+        and profile.full_name != lead.full_name
+    ):
+        new_full_name = profile.full_name
+
+    changed_fields = [
+        name for name, val in (
+            ("full_name", new_full_name),
+            ("email", new_email),
+            ("phone", new_phone),
+        ) if val is not None
+    ]
+    if not changed_fields:
+        return False
+
+    # ── GUARD: identity-lock — Lead có profile khác ở trạng thái locked
+    # (approved/admitted/enrolled) → identity là snapshot pháp lý. KHÁC
+    # update_lead (raise 400 chặn): ở đường SỬA-HỒ-SƠ ta SKIP đẩy identity xuống
+    # Lead (hồ sơ vẫn lưu các field khác, Lead giữ snapshot) thay vì abort toàn
+    # bộ edit — tránh khóa cứng luồng returning-student. Chỉ xét field THẬT đổi.
+    allowed, block_reason, _ = await check_lead_identity_update_allowed(
+        db=db, lead_id=lead.id, fields_to_update=changed_fields
+    )
+    if not allowed:
+        log.info(
+            "sync_lead_from_profile: identity locked — SKIP Lead sync "
+            "(hồ sơ giữ giá trị, Lead giữ snapshot)",
+            lead_id=lead.id,
+            profile_id=profile.id,
+            changed_fields=changed_fields,
+            reason=block_reason,
+        )
+        return False
+
+    # Snapshot audit state TRƯỚC mọi mutation lead (khớp pattern update_lead).
+    old_audit_state = _get_lead_audit_state(lead)
+
+    if new_phone is not None:
+        # Terminal-lock: không đổi SĐT khi lead đã ngừng tư vấn (mirror §9.1 B-2).
+        if lead.consultation_status_id:
+            term_cs = await db.get(
+                models.ConsultationStatus, lead.consultation_status_id
+            )
+            if is_consultation_terminal_status(term_cs):
+                raise BusinessRuleViolation(
+                    detail=(
+                        "Lead đang ở trạng thái đã ngừng tư vấn — không thể đổi "
+                        "số điện thoại. Vui lòng mở lại tư vấn (reopen) trước khi "
+                        "chỉnh sửa."
+                    )
+                )
+        # phone2 ≠ phone — NORMALIZE lead.phone2 trước khi so (phone2 legacy có
+        # thể chưa chuẩn hóa, vd '84…' — so raw sẽ lọt guard rồi đụng unique).
+        existing_phone2 = normalize_vietnam_phone(lead.phone2) if lead.phone2 else None
+        if existing_phone2 and new_phone == existing_phone2:
+            raise ValidationError(
+                detail="Số điện thoại phụ không thể trùng với số điện thoại chính."
+            )
+        # Conflict GLOBAL (cross-slot).
+        dup = await repo.check_phone_conflict(
+            phone=new_phone, phone2=lead.phone2, exclude_id=lead.id
+        )
+        if dup:
+            raise DuplicateResourceError(
+                detail=_format_lead_conflict_detail(dup, "phone")
             )
 
-    if changes_made:
-        await db.flush()
+    if new_email is not None:
+        # Conflict scope theo UNIT (khác phone global) — mirror update_lead.
+        dup = await repo.check_email_conflict(
+            email=new_email, unit_id=lead.unit_id, exclude_id=lead.id
+        )
+        if dup:
+            raise DuplicateResourceError(
+                detail=_format_lead_conflict_detail(dup, "email")
+            )
 
-        log.info(
-            "sync_lead_from_profile: Sync completed",
-            profile_id=profile.id,
-            lead_id=lead.id,
-            fields=fields_to_sync,
-            changed_by_user_id=changed_by_user_id,
+    # ── Write: Lead + phone-identity, bọc savepoint để map race unique sạch ──
+    # Chỉ phần này nằm trong savepoint (KHÔNG phải mọi write của update_profile).
+    # Mục tiêu: Lead/identity write + IntegrityError (uq_lead_phone_active /
+    # uq_lead_email_unit_active) được map thành domain error mà không poison
+    # outer transaction. Phòng tuyến 1 ở trên đã chặn phần lớn xung đột.
+    try:
+        async with db.begin_nested():
+            if new_full_name is not None:
+                lead.full_name = new_full_name
+            if new_email is not None:
+                lead.email = new_email
+            if new_phone is not None:
+                lead.phone = new_phone  # đã normalized
+                # CHỈ thay slot 'phone' (đường này KHÔNG đổi phone2). KHÔNG
+                # rewrite slot phone2 bằng lead.phone2 có thể STALE (lead
+                # eager-loaded, không lock) → tránh clobber thay đổi phone2 đồng
+                # thời của update_lead. phone2==phone vẫn được uq_lead_phone_active
+                # bắt ở INSERT. (Tránh lock lead → không gây deadlock lock-order.)
+                await repo.update_phone_slot_identity(
+                    lead_id=lead.id, phone=lead.phone
+                )
+            # Optimistic-lock: bump version của Lead (đường inline cũ đã bỏ sót).
+            lead.version = (lead.version or 1) + 1
+            await db.flush()
+    except IntegrityError as exc:
+        # Map uq_lead_phone_active → SĐT, uq_lead_email_unit_active → email;
+        # re-raise constraint lạ. Savepoint đã rollback → session sạch.
+        _handle_lead_integrity_error(exc)
+
+    # Audit "Lead" (khớp pattern update_lead; đường inline cũ KHÔNG audit).
+    audit_changes = audit_service.detect_changes(
+        old_audit_state,
+        _get_lead_audit_state(lead),
+        exclude_fields=["_sa_instance_state", "updated_at", "created_at"],
+    )
+    if audit_changes:
+        await audit_service.log_changes(
+            db,
+            entity_type="Lead",
+            entity_id=lead.id,
+            action="updated",
+            changes=audit_changes,
+            actor_user_id=changed_by_user_id,
+            source="api",
         )
 
-    return changes_made
+    log.info(
+        "sync_lead_from_profile: Sync completed (guarded)",
+        profile_id=profile.id,
+        lead_id=lead.id,
+        changed_fields=changed_fields,
+        changed_by_user_id=changed_by_user_id,
+    )
+    return True
 
 
 # =============================================================================

--- a/Backend_FastAPI/tests/services/test_admission_profile_identity_sync.py
+++ b/Backend_FastAPI/tests/services/test_admission_profile_identity_sync.py
@@ -1,0 +1,432 @@
+"""Guard parity cho chiều Profile → Lead (``sync_lead_from_profile``).
+
+Nâng cấp Fix B (mở rộng): đường sửa hồ sơ tuyển sinh (admission_service.
+update_profile) KHÔNG còn ghi thẳng ``profile.lead.phone/full_name/email`` —
+mọi thay đổi identity đẩy xuống Lead qua ``sync_lead_from_profile`` với ĐẦY ĐỦ
+guard (parity với ``lead_service.update_lead``):
+
+  - normalize + VALIDATE phone (normalize KHÔNG phải validator)
+  - phone2 ≠ phone
+  - check_phone_conflict (GLOBAL, cross-slot)
+  - check_email_conflict (scope theo UNIT)
+  - identity-lock (Lead có profile locked) + terminal-lock (đã ngừng tư vấn)
+  - update_phone_identities (đồng bộ ``lead_phone_identity`` — hết drift)
+  - bump lead.version + audit "Lead"
+  - race unique map sạch trong ``begin_nested`` (không poison outer transaction)
+
+Ref: sự cố PROD 14-07 (leads list/search 500 do ``phone2 == phone``).
+"""
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app import models
+from app.models.lead_phone import LeadPhoneIdentity
+from app.repositories.lead_repository import LeadRepository
+from app.services.lead_profile_sync import sync_lead_from_profile
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    DuplicateResourceError,
+    ValidationError,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+async def _make_lead(db, deps, *, phone, email=None, phone2=None, unit_id=None,
+                     full_name="Lead X", cs_id=None, register_identity=True):
+    lead = models.Lead(
+        full_name=full_name,
+        phone=phone,
+        phone2=phone2,
+        email=email,
+        source="website",
+        unit_id=unit_id if unit_id is not None else deps["unit_id"],
+        consultation_status_id=cs_id or deps["initial_status_id"],
+        status="new",
+    )
+    db.add(lead)
+    await db.flush()
+    await db.refresh(lead)
+    # Sinh lead_phone_identity như create_lead thật → để đường update_phone_identities
+    # (hard-delete row cũ + register mới) thực sự được test (chống drift prod).
+    if register_identity:
+        await LeadRepository(db).register_phone_identities(lead.id, phone, phone2)
+        await db.flush()
+    return lead
+
+
+async def _make_draft_profile(db, lead, *, status="draft", cid_prefix="9",
+                              academic_year=2025):
+    ts = datetime.now(timezone.utc).timestamp()
+    profile = models.AdmissionProfile(
+        lead_id=lead.id,
+        status=status,
+        citizen_id=f"{cid_prefix}{ts:.0f}"[:12],
+        version=1,
+        applied_rules={},
+        academic_year=academic_year,  # uq_admission_profile_lead_year: 1 profile/năm
+        full_name=lead.full_name,
+        phone=lead.phone,
+        email=lead.email,
+    )
+    db.add(profile)
+    await db.flush()
+    # Reload với lead eager-loaded (mirror update_profile L5049 selectinload) →
+    # tránh lazy-load profile.lead trong sync context (MissingGreenlet).
+    result = await db.execute(
+        select(models.AdmissionProfile)
+        .where(models.AdmissionProfile.id == profile.id)
+        .options(selectinload(models.AdmissionProfile.lead))
+    )
+    return result.scalar_one()
+
+
+# =============================================================================
+# PHONE — normalize / validate / conflict / phone2
+# =============================================================================
+
+class TestPhoneGuards:
+    async def test_duplicate_phone_global_raises(self, db, seeded_dependencies, officer_user):
+        deps = seeded_dependencies
+        other = await _make_lead(db, deps, phone="0388888888", full_name="Owner")
+        lead = await _make_lead(db, deps, phone="0901111111")
+        profile = await _make_draft_profile(db, lead)
+
+        profile.phone = other.phone  # 0388888888 đã thuộc lead khác
+        with pytest.raises(DuplicateResourceError):
+            await sync_lead_from_profile(
+                db, profile, changed_fields=["phone"], changed_by_user_id=officer_user.id
+            )
+
+    async def test_invalid_phone_after_normalize_raises(self, db, seeded_dependencies, officer_user):
+        lead = await _make_lead(db, seeded_dependencies, phone="0901111111")
+        profile = await _make_draft_profile(db, lead)
+
+        profile.phone = "0123"  # sai format VN (validate sau normalize)
+        with pytest.raises(ValidationError):
+            await sync_lead_from_profile(
+                db, profile, changed_fields=["phone"], changed_by_user_id=officer_user.id
+            )
+
+    async def test_phone2_equals_phone_raises(self, db, seeded_dependencies, officer_user):
+        lead = await _make_lead(
+            db, seeded_dependencies, phone="0901111111", phone2="0977777777"
+        )
+        profile = await _make_draft_profile(db, lead)
+
+        profile.phone = "0977777777"  # trùng phone2 của chính lead
+        with pytest.raises(ValidationError):
+            await sync_lead_from_profile(
+                db, profile, changed_fields=["phone"], changed_by_user_id=officer_user.id
+            )
+
+    async def test_phone_change_syncs_identity_registry(self, db, seeded_dependencies, officer_user):
+        lead = await _make_lead(db, seeded_dependencies, phone="0901111111")
+        profile = await _make_draft_profile(db, lead)
+
+        profile.phone = "0909999999"
+        ok = await sync_lead_from_profile(
+            db, profile, changed_fields=["phone"], changed_by_user_id=officer_user.id
+        )
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.phone == "0909999999"
+
+        rows = (await db.execute(
+            select(LeadPhoneIdentity).where(
+                LeadPhoneIdentity.lead_id == lead.id,
+                LeadPhoneIdentity.deleted_at.is_(None),
+            )
+        )).scalars().all()
+        actives = {r.phone_normalized for r in rows}
+        assert "0909999999" in actives          # số mới đã đăng ký
+        assert "0901111111" not in actives      # số CŨ đã bị dọn (hết drift — đường hard-delete chạy thật)
+
+    async def test_phone_change_preserves_phone2_identity_row(
+        self, db, seeded_dependencies, officer_user
+    ):
+        """Chỉ đổi phone qua hồ sơ → slot 'phone2' identity GIỮ NGUYÊN (không bị
+        rewrite bằng lead.phone2 stale → chống clobber thay đổi phone2 đồng thời)."""
+        lead = await _make_lead(
+            db, seeded_dependencies, phone="0901111111", phone2="0977777777"
+        )
+        profile = await _make_draft_profile(db, lead)
+
+        profile.phone = "0909999999"
+        ok = await sync_lead_from_profile(
+            db, profile, changed_fields=["phone"], changed_by_user_id=officer_user.id
+        )
+        assert ok is True
+
+        rows = (await db.execute(
+            select(LeadPhoneIdentity).where(
+                LeadPhoneIdentity.lead_id == lead.id,
+                LeadPhoneIdentity.deleted_at.is_(None),
+            )
+        )).scalars().all()
+        by_slot = {r.slot: r.phone_normalized for r in rows}
+        assert by_slot.get("phone") == "0909999999"     # slot phone cập nhật
+        assert by_slot.get("phone2") == "0977777777"    # slot phone2 GIỮ NGUYÊN
+
+    async def test_legacy_unnormalized_lead_phone_echoed_is_noop(
+        self, db, seeded_dependencies, officer_user
+    ):
+        """lead.phone legacy CHƯA chuẩn hóa ('84…') + profile echo số canonical
+        tương đương → KHÔNG coi là đổi (so delta normalize CẢ 2 phía). Không
+        version-bump / churn / terminal-lock oan."""
+        lead = await _make_lead(
+            db, seeded_dependencies, phone="84901234567", register_identity=False,
+        )
+        v0 = lead.version
+        profile = await _make_draft_profile(db, lead)
+
+        profile.phone = "0901234567"  # cùng số, dạng canonical
+        ok = await sync_lead_from_profile(
+            db, profile, changed_fields=["phone"], changed_by_user_id=officer_user.id
+        )
+        assert ok is False            # đồng nhất sau normalize → no-op
+        await db.refresh(lead)
+        assert lead.version == v0      # KHÔNG bump version oan
+
+    async def test_phone_normalizes_plus84(self, db, seeded_dependencies, officer_user):
+        """+84 → 0 (normalize) khi đẩy xuống lead + ghi lại profile.phone chuẩn."""
+        lead = await _make_lead(db, seeded_dependencies, phone="0901111111")
+        profile = await _make_draft_profile(db, lead)
+
+        profile.phone = "+84907654321"
+        ok = await sync_lead_from_profile(
+            db, profile, changed_fields=["phone"], changed_by_user_id=officer_user.id
+        )
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.phone == "0907654321"      # đã normalize +84→0
+        assert profile.phone == "0907654321"   # profile cũng được ghi lại chuẩn
+
+
+# =============================================================================
+# EMAIL — conflict theo UNIT
+# =============================================================================
+
+class TestEmailGuards:
+    async def test_duplicate_email_same_unit_raises(self, db, seeded_dependencies, officer_user):
+        deps = seeded_dependencies
+        await _make_lead(db, deps, phone="0388888888", email="dup@test.com")
+        lead = await _make_lead(db, deps, phone="0901111111", email="orig@test.com")
+        profile = await _make_draft_profile(db, lead)
+
+        profile.email = "dup@test.com"
+        with pytest.raises(DuplicateResourceError):
+            await sync_lead_from_profile(
+                db, profile, changed_fields=["email"], changed_by_user_id=officer_user.id
+            )
+
+    async def test_duplicate_email_other_unit_allowed(self, db, seeded_dependencies, officer_user):
+        deps = seeded_dependencies
+        other_unit = models.OrganizationUnit(name="Other Unit", type="department")
+        db.add(other_unit)
+        await db.flush()
+        # email E thuộc lead ở UNIT KHÁC → không tính trùng (scope unit)
+        await _make_lead(db, deps, phone="0388888888", email="e@test.com",
+                         unit_id=other_unit.id)
+        lead = await _make_lead(db, deps, phone="0901111111", email="orig@test.com")
+        profile = await _make_draft_profile(db, lead)
+
+        profile.email = "e@test.com"
+        ok = await sync_lead_from_profile(
+            db, profile, changed_fields=["email"], changed_by_user_id=officer_user.id
+        )
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.email == "e@test.com"
+
+
+# =============================================================================
+# STATE LOCKS — identity-lock / terminal-lock
+# =============================================================================
+
+class TestStateLocks:
+    async def test_identity_lock_skips_sync_when_sibling_locked(self, db, seeded_dependencies, officer_user):
+        """Lead có sibling profile approved (identity đóng băng) → SKIP đẩy
+        identity xuống Lead (KHÔNG raise): hồ sơ giữ giá trị mới, Lead giữ
+        snapshot. (Quyết định nghiệp vụ: đường sửa-hồ-sơ nới hơn update_lead.)"""
+        lead = await _make_lead(db, seeded_dependencies, phone="0901111111",
+                                full_name="Tên Gốc")
+        # profile năm 2024 approved (locked) + profile năm 2025 draft đang sửa
+        # (uq_admission_profile_lead_year: mỗi năm chỉ 1 profile/lead).
+        await _make_draft_profile(db, lead, status="approved", cid_prefix="1",
+                                  academic_year=2024)
+        draft = await _make_draft_profile(db, lead, status="draft", cid_prefix="2",
+                                          academic_year=2025)
+
+        draft.full_name = "Tên Mới"
+        ok = await sync_lead_from_profile(
+            db, draft, changed_fields=["full_name"], changed_by_user_id=officer_user.id
+        )
+        assert ok is False                    # SKIP — không đẩy xuống lead
+        await db.refresh(lead)
+        assert lead.full_name == "Tên Gốc"    # Lead giữ snapshot pháp lý
+        assert draft.full_name == "Tên Mới"   # hồ sơ vẫn giữ giá trị đã sửa
+
+    async def test_terminal_lock_blocks_phone_change(self, db, seeded_dependencies, officer_user):
+        deps = seeded_dependencies
+        term = models.ConsultationStatus(
+            id="sts_term_test",
+            name="Đã ngừng tư vấn (Test)",
+            color_code="#000000",
+            stage_id=deps["stage_id"],
+            phase="consultation",
+            is_final=True,
+        )
+        db.add(term)
+        await db.flush()
+
+        lead = await _make_lead(db, deps, phone="0901111111", cs_id="sts_term_test")
+        profile = await _make_draft_profile(db, lead)
+
+        profile.phone = "0909999999"
+        with pytest.raises(BusinessRuleViolation):
+            await sync_lead_from_profile(
+                db, profile, changed_fields=["phone"], changed_by_user_id=officer_user.id
+            )
+
+
+# =============================================================================
+# VERSION + AUDIT + RACE
+# =============================================================================
+
+class TestVersionAuditRace:
+    async def test_version_bumped_and_audit_logged(self, db, seeded_dependencies, officer_user):
+        lead = await _make_lead(db, seeded_dependencies, phone="0901111111",
+                                full_name="Cũ")
+        v0 = lead.version
+        profile = await _make_draft_profile(db, lead)
+
+        profile.full_name = "Nguyễn Văn Mới"
+        ok = await sync_lead_from_profile(
+            db, profile, changed_fields=["full_name"], changed_by_user_id=officer_user.id
+        )
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.full_name == "Nguyễn Văn Mới"
+        assert lead.version == (v0 or 1) + 1
+
+        # Audit ghi ĐÚNG NỘI DUNG: full_name cũ→mới + đúng actor.
+        audit = (await db.execute(
+            select(models.EntityAuditLog).where(
+                models.EntityAuditLog.entity_type == "Lead",
+                models.EntityAuditLog.entity_id == lead.id,
+            )
+        )).scalars().all()
+        assert len(audit) == 1
+        entry = audit[0]
+        assert entry.actor_user_id == officer_user.id
+        changes = entry.changes or {}
+        assert "full_name" in changes
+        assert changes["full_name"]["new"] == "Nguyễn Văn Mới"
+        assert changes["full_name"]["old"] == "Cũ"
+
+    async def test_race_unique_maps_to_duplicate_not_raw(self, db, seeded_dependencies, officer_user):
+        """Race unique: check_phone_conflict (đọc bảng lead) LỌT nhưng identity
+        INSERT đụng uq_lead_phone_active. Savepoint bắt IntegrityError →
+        _handle_lead_integrity_error map thành DuplicateResourceError (SĐT) —
+        KHÔNG lọt IntegrityError thô (500) cũng KHÔNG map nhầm 'CCCD'."""
+        deps = seeded_dependencies
+        repo = LeadRepository(db)
+        # decoy: lead.phone KHÁC (check_phone_conflict trên bảng lead không thấy)
+        # nhưng chiếm identity 0909999999 → đụng uq_lead_phone_active khi register.
+        decoy = await _make_lead(db, deps, phone="0366666666")
+        await repo.register_phone_identities(decoy.id, "0909999999", None)
+        await db.flush()
+
+        lead = await _make_lead(db, deps, phone="0901111111")
+        profile = await _make_draft_profile(db, lead)
+
+        profile.phone = "0909999999"
+        with pytest.raises(DuplicateResourceError) as exc_info:
+            await sync_lead_from_profile(
+                db, profile, changed_fields=["phone"], changed_by_user_id=officer_user.id
+            )
+        # Đúng lỗi SĐT (savepoint + _handle_lead_integrity_error), không phải CCCD.
+        msg = str(exc_info.value).lower()
+        assert "điện thoại" in msg or "sử dụng" in msg
+        assert "cccd" not in msg
+
+
+# =============================================================================
+# END-TO-END qua admission_service.update_profile (wiring thật — chỗ từng vỡ prod)
+# =============================================================================
+
+class TestUpdateProfileEndToEnd:
+    async def test_update_profile_syncs_identity_to_lead_through_guards(
+        self, db, seeded_dependencies, admin_user
+    ):
+        """update_profile (đường HTTP thật) phải đẩy identity xuống lead QUA
+        sync_lead_from_profile — không còn ghi thẳng profile.lead.* (bug prod)."""
+        from app.services import admission_service
+
+        lead = await _make_lead(
+            db, seeded_dependencies, phone="0901111111", full_name="Tên Cũ",
+            email="old@test.com",
+        )
+        profile = await _make_draft_profile(db, lead)
+        await db.flush()
+
+        updated = await admission_service.update_profile(
+            db=db,
+            profile_id=profile.id,
+            data={"phone": "0909999999", "full_name": "Tên Mới"},
+            current_user=admin_user,
+        )
+
+        await db.refresh(lead)
+        assert lead.phone == "0909999999"        # đồng bộ xuống lead
+        assert lead.full_name == "Tên Mới"
+        assert updated.phone == "0909999999"     # profile giữ dạng chuẩn
+
+        rows = (await db.execute(
+            select(LeadPhoneIdentity).where(
+                LeadPhoneIdentity.lead_id == lead.id,
+                LeadPhoneIdentity.deleted_at.is_(None),
+            )
+        )).scalars().all()
+        actives = {r.phone_normalized for r in rows}
+        assert "0909999999" in actives
+        assert "0901111111" not in actives       # số cũ dọn qua đường thật
+
+
+# =============================================================================
+# SCHEMA: AdmissionProfileUpdate.phone mirror validate_vietnam_phone (chặn 422)
+# =============================================================================
+
+class TestAdmissionPhoneSchema:
+    """Pattern schema phải MIRROR VIETNAM_PHONE_REGEX ([0-9] ASCII) để số xấu bị
+    chặn ở 422, KHÔNG lọt xuống service rồi 400."""
+
+    async def test_schema_accepts_valid_vn_phone(self):
+        from app.schemas.admission import AdmissionProfileUpdate
+        assert AdmissionProfileUpdate(phone="0901234567", version=1).phone == "0901234567"
+        # 02x cố định hợp lệ (mirror VIETNAM_PHONE_REGEX, KHÔNG mobile-only)
+        assert AdmissionProfileUpdate(phone="0212345678", version=1).phone == "0212345678"
+
+    async def test_schema_rejects_fullwidth_unicode_digit(self):
+        """'090１２３４５６７' (full-width): \\d cũ khớp Unicode digit → lọt; [0-9]
+        ASCII phải reject ở 422 (khớp validate_vietnam_phone)."""
+        from pydantic import ValidationError as PydanticValidationError
+        from app.schemas.admission import AdmissionProfileUpdate
+        with pytest.raises(PydanticValidationError) as exc:
+            AdmissionProfileUpdate(phone="090１２３４５６７", version=1)
+        assert "phone" in str(exc.value)   # fail ĐÚNG do phone, không phải field khác
+
+    async def test_schema_rejects_landline_04x(self):
+        from pydantic import ValidationError as PydanticValidationError
+        from app.schemas.admission import AdmissionProfileUpdate
+        with pytest.raises(PydanticValidationError) as exc:
+            AdmissionProfileUpdate(phone="0412345678", version=1)
+        assert "phone" in str(exc.value)


### PR DESCRIPTION
@
## Bối cảnh

Nối tiếp hotfix #479 (vá response 500 do `phone2==phone`). PR này bịt **nguyên nhân gốc**: khi officer sửa **hồ sơ tuyển sinh** (`admission_service.update_profile`), identity (full_name/phone/email) bị ghi **thẳng** `profile.lead.* = data[...]`, **bỏ qua toàn bộ guard** của đường sửa-lead chuẩn (`lead_service.update_lead`) → tạo dữ liệu xấu (`phone2==phone`) + **drift bảng `lead_phone_identity`**.

## Thay đổi

- **`update_profile`**: bỏ ghi thẳng `profile.lead.*`, đẩy identity xuống Lead qua **`sync_lead_from_profile`** (hồi sinh + nâng cấp hàm dead-code) với **đầy đủ guard parity `update_lead`**: normalize + validate phone · `phone2≠phone` · `check_phone_conflict` (global) · `check_email_conflict` (unit-scope) · identity-lock (**SKIP** khi lead có sibling profile locked — nới hơn update_lead, tránh khóa cứng returning-student) · terminal-lock · bump `lead.version` · audit "Lead". Bọc write trong `begin_nested` → map IntegrityError sạch.
- Lời gọi sync đặt **sau** `db.flush()` + handler IntegrityError citizen_id → giữ map `ConflictError` 409 cho CCCD (không bị savepoint nuốt thành 500).
- **Schema** `AdmissionProfileUpdate.phone` siết `^0(3|5|7|8|9|2)[0-9]{8,9}$` khớp `VIETNAM_PHONE_REGEX` — chặn số 04x/06x + **full-width Unicode digit** ở 422 (thay vì lọt schema rồi 400 sâu trong service).
- **Repo** `update_phone_slot_identity`: chỉ thay slot `phone` (không rewrite slot `phone2` bằng `lead.phone2` có thể stale → không clobber; tránh lock lead → không deadlock lock-order `update_lead`↔`update_profile`).

## Kiểm chứng

- Unit/integration: **17 guard test** mới (conflict/registry/lock/race/e2e update_profile/schema) + regression `test_admission_service` 29 · `test_admissions_partial_update_invariants` 10 · `test_lead` 110 · `test_bidirectional_sync` 11 (2 fail PRE-EXISTING) · flake8 net ≤ 0.
- 2 vòng `/code-review max` (nội bộ diff + impact cross-subsystem: finance/notification/audit/permission CLEARED).
- **Chrome smoke (dev)**: login → leads list 200 → search SĐT 200 → sửa phone hồ sơ → `PUT /api/admissions/{id}` 200 → DB verify lead synced, **phone2 giữ nguyên**, version bump, identity slot đúng, audit ghi.

## ⚠️ Audit prod (kèm để lên kế hoạch deploy)

Fix chặn drift MỚI nhưng KHÔNG dọn drift CŨ. Audit `qlts_production` (read-only): `phone2==phone` = **0** (sạch), nhưng **19 lead drift phone + 1 drift phone2** — `lead_phone_identity` trỏ số KHÁC HẲN `lead.phone` hiện tại (hệ quả các lần sửa hồ sơ qua đường bug). **Cần task data-cleanup riêng** (re-register identity từ `lead.phone/phone2` hiện tại) sau khi deploy — sẽ làm ở PR/script riêng, cần duyệt (prod mutation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@