### PR TITLE
fix(sla): reopen không còn bị recalc cache 00:05 vô hiệu hoá — hotfix prod

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -261,6 +261,7 @@ jobs:
           tests/unit/test_admission_report_helpers.py
           tests/repositories/test_admission_report_integration.py
           tests/api/test_admission_report_api.py
+          tests/integration/test_sts20_consult_giveup.py
           -q --tb=short --timeout=60
 
       # =====================================================================

--- a/Backend_FastAPI/app/services/lead_reopen_service.py
+++ b/Backend_FastAPI/app/services/lead_reopen_service.py
@@ -104,11 +104,18 @@ async def _apply_reopen(
 
     now = datetime.now(timezone.utc)
     await StatusHelper.sync_lead_status(lead, target_cs)
+    # Reset đồng hồ SLA: close_stale đọc GREATEST(consultation_reengaged_at,
+    # last_consultation_at) nên CHỈ cần set mốc re-engage này.
+    #
+    # KHÔNG ghi lead.last_consultation_at ở đây (trước đây có). Field đó là
+    # cache DẪN XUẤT từ MAX(consultation_date), do update_lead_cache sở hữu và
+    # ghi đè VÔ ĐIỀU KIỆN — recalculate_lead_caches_task quét mọi lead lúc
+    # 00:05 nên mốc reset thủ công bị xóa sau đúng một đêm, rồi beat 03:30 đóng
+    # lại lead vừa reopen. Ghi mốc thủ công vào field cache là sai chủ sở hữu;
+    # consultation_reengaged_at mới là nơi đúng (không job nào đụng).
     lead.consultation_reengaged_at = now
     lead.updated_at = now
-    # Reset đồng hồ SLA (close_stale dùng coalesce(last_consultation_at,...)) + bump
-    # version (optimistic-lock — mọi thay đổi trạng thái phải tăng version).
-    lead.last_consultation_at = now
+    # Bump version (optimistic-lock — mọi thay đổi trạng thái phải tăng version).
     lead.version = (lead.version or 1) + 1
 
     new_state = _get_current_lead_state(lead)

--- a/Backend_FastAPI/app/tasks/sla_tasks.py
+++ b/Backend_FastAPI/app/tasks/sla_tasks.py
@@ -61,11 +61,29 @@ async def close_stale_rejected_leads(
     result = {"checked": 0, "transitioned": 0, "skipped": 0, "errors": 0}
 
     def _stale_predicate(stmt):
+        # Mốc "còn sống" = hoạt động MUỘN NHẤT giữa:
+        #   - consultation_reengaged_at: mốc re-engage THỦ CÔNG (reopen sts20→
+        #     sts04) — không ai ghi đè, kể cả recalc cache nightly;
+        #   - last_consultation_at: recency tư vấn, do update_lead_cache dẫn
+        #     xuất từ MAX(consultation_date).
+        #
+        # GREATEST chứ KHÔNG phải COALESCE: COALESCE lấy giá trị non-null ĐẦU
+        # TIÊN, nên reengaged (cố định tại lúc reopen) sẽ luôn thắng
+        # last_consultation_at mới hơn → lead được reopen rồi tư vấn tích cực
+        # vẫn bị đóng sau đúng `days` kể từ ngày reopen. GREATEST bỏ qua NULL
+        # (Postgres) nên mọi tổ hợp NULL đều đúng:
+        #   chưa reopen        -> GREATEST(NULL, last) = last  (hồi quy: y hệt cũ)
+        #   reopen, chưa tư vấn -> GREATEST(reengaged, NULL) = reengaged
+        #   reopen rồi tư vấn   -> mốc muộn hơn thắng
+        #   cả hai NULL        -> NULL -> COALESCE rơi về updated_at/created_at
         return stmt.where(
             models.Lead.consultation_status_id == "sts04",
             models.Lead.deleted_at.is_(None),
             func.coalesce(
-                models.Lead.last_consultation_at,
+                func.greatest(
+                    models.Lead.consultation_reengaged_at,
+                    models.Lead.last_consultation_at,
+                ),
                 models.Lead.updated_at,
                 models.Lead.created_at,
             ) < cutoff,

--- a/Backend_FastAPI/app/tasks/sla_tasks.py
+++ b/Backend_FastAPI/app/tasks/sla_tasks.py
@@ -23,6 +23,50 @@ from .utils import task_db_session, run_async_task
 _default_log = logging.getLogger(__name__)
 
 
+def stale_sts04_predicate(stmt, cutoff: datetime):
+    """NGUỒN SỰ THẬT DUY NHẤT của "lead sts04 đã stale" — beat + test dùng CHUNG.
+
+    Module-level (không phải closure trong close_stale_rejected_leads) để test
+    import được thay vì chép tay lại điều kiện: hai bản chép đã từng lệch khỏi
+    production mà suite vẫn xanh.
+
+    Mốc "còn sống" = hoạt động MUỘN NHẤT giữa:
+      - consultation_reengaged_at: mốc re-engage THỦ CÔNG (reopen sts20→sts04)
+        — không ai ghi đè, kể cả recalc cache nightly;
+      - last_consultation_at: recency tư vấn, do update_lead_cache dẫn xuất từ
+        MAX(consultation_date).
+
+    GREATEST chứ KHÔNG phải COALESCE: COALESCE lấy giá trị non-null ĐẦU TIÊN,
+    nên reengaged (cố định tại lúc reopen) sẽ luôn thắng last_consultation_at
+    mới hơn → lead được reopen rồi tư vấn tích cực vẫn bị đóng sau đúng `days`
+    kể từ ngày reopen. GREATEST bỏ qua NULL (Postgres):
+      chưa reopen         -> GREATEST(NULL, last) = last  (hồi quy: y hệt cũ)
+      reopen, chưa tư vấn -> GREATEST(reengaged, NULL) = reengaged
+      reopen rồi tư vấn   -> mốc muộn hơn thắng
+
+    ⚠️ Fallback updated_at/created_at CHỈ với lead CHƯA từng reopen. Khi
+    consultation_reengaged_at non-NULL (write-once, không ai clear) thì GREATEST
+    luôn non-NULL nên COALESCE dừng ngay và KHÔNG bao giờ đọc updated_at nữa —
+    có chủ đích: sửa vu vơ một field của lead không phải "hoạt động tư vấn" nên
+    không được gia hạn SLA. Khoá bởi test_reopened_lead_ignores_updated_at_bump.
+    """
+    from sqlalchemy import func
+    from .. import models
+
+    return stmt.where(
+        models.Lead.consultation_status_id == "sts04",
+        models.Lead.deleted_at.is_(None),
+        func.coalesce(
+            func.greatest(
+                models.Lead.consultation_reengaged_at,
+                models.Lead.last_consultation_at,
+            ),
+            models.Lead.updated_at,
+            models.Lead.created_at,
+        ) < cutoff,
+    )
+
+
 async def close_stale_rejected_leads(
     session,
     *,
@@ -54,40 +98,16 @@ async def close_stale_rejected_leads(
     Returns {checked, transitioned, skipped, errors} with the invariant
     checked == transitioned + skipped + errors.
     """
-    from sqlalchemy import select, func
+    from sqlalchemy import select
     from .. import models
     from ..services.fsm_engine import execute_system_transition
 
     result = {"checked": 0, "transitioned": 0, "skipped": 0, "errors": 0}
 
     def _stale_predicate(stmt):
-        # Mốc "còn sống" = hoạt động MUỘN NHẤT giữa:
-        #   - consultation_reengaged_at: mốc re-engage THỦ CÔNG (reopen sts20→
-        #     sts04) — không ai ghi đè, kể cả recalc cache nightly;
-        #   - last_consultation_at: recency tư vấn, do update_lead_cache dẫn
-        #     xuất từ MAX(consultation_date).
-        #
-        # GREATEST chứ KHÔNG phải COALESCE: COALESCE lấy giá trị non-null ĐẦU
-        # TIÊN, nên reengaged (cố định tại lúc reopen) sẽ luôn thắng
-        # last_consultation_at mới hơn → lead được reopen rồi tư vấn tích cực
-        # vẫn bị đóng sau đúng `days` kể từ ngày reopen. GREATEST bỏ qua NULL
-        # (Postgres) nên mọi tổ hợp NULL đều đúng:
-        #   chưa reopen        -> GREATEST(NULL, last) = last  (hồi quy: y hệt cũ)
-        #   reopen, chưa tư vấn -> GREATEST(reengaged, NULL) = reengaged
-        #   reopen rồi tư vấn   -> mốc muộn hơn thắng
-        #   cả hai NULL        -> NULL -> COALESCE rơi về updated_at/created_at
-        return stmt.where(
-            models.Lead.consultation_status_id == "sts04",
-            models.Lead.deleted_at.is_(None),
-            func.coalesce(
-                func.greatest(
-                    models.Lead.consultation_reengaged_at,
-                    models.Lead.last_consultation_at,
-                ),
-                models.Lead.updated_at,
-                models.Lead.created_at,
-            ) < cutoff,
-        )
+        # Delegate: giữ shim này để 2 call site dưới khỏi phải truyền cutoff.
+        # Logic THẬT ở module-level stale_sts04_predicate (test import trực tiếp).
+        return stale_sts04_predicate(stmt, cutoff)
 
     ids_result = await session.execute(
         _stale_predicate(select(models.Lead.id)).order_by(models.Lead.id)

--- a/Backend_FastAPI/scripts/backfill_sts20_giveup.py
+++ b/Backend_FastAPI/scripts/backfill_sts20_giveup.py
@@ -7,9 +7,13 @@ non-destructive; run THIS script deliberately — once the reopen workflow /
 observation window is ready — to close existing stale rejections.
 
 Predicate matches the daily beat exactly: consultation_status_id='sts04',
-deleted_at IS NULL, COALESCE(last_consultation_at, updated_at, created_at) older
-than SLA_CONSULT_GIVEUP_DAYS. Idempotent: a re-run matches zero rows because
+deleted_at IS NULL, COALESCE(GREATEST(consultation_reengaged_at,
+last_consultation_at), updated_at, created_at) older than
+SLA_CONSULT_GIVEUP_DAYS. Idempotent: a re-run matches zero rows because
 moved leads are no longer in sts04.
+
+Phải giữ ĐỒNG BỘ với ``sla_tasks._stale_predicate`` — lệch nhau thì dry-run
+đếm một tập, beat đóng một tập khác.
 
 Usage:
     python scripts/backfill_sts20_giveup.py            # DRY-RUN (count only)
@@ -29,10 +33,14 @@ from app.config import settings  # noqa: E402
 from app.database import AsyncSessionLocal  # noqa: E402
 
 # Strict SLA predicate (same rows as the runtime beat). :days bound at call time.
+# GREATEST (không phải COALESCE) giữa mốc re-engage thủ công và recency tư vấn —
+# xem giải thích đầy đủ ở ``sla_tasks._stale_predicate``. Hai nơi PHẢI khớp nhau.
 _STALE_STS04_PREDICATE = (
     "consultation_status_id = 'sts04' "
     "AND deleted_at IS NULL "
-    "AND COALESCE(last_consultation_at, updated_at, created_at) "
+    "AND COALESCE("
+    "      GREATEST(consultation_reengaged_at, last_consultation_at), "
+    "      updated_at, created_at) "
     "    < NOW() - (:days * INTERVAL '1 day')"
 )
 

--- a/Backend_FastAPI/scripts/backfill_sts20_giveup.py
+++ b/Backend_FastAPI/scripts/backfill_sts20_giveup.py
@@ -83,6 +83,21 @@ async def main() -> int:
             print("❌ sts20 not found — run 'alembic upgrade head' first.")
             return 1
 
+        # Guard: the predicate reads consultation_reengaged_at, added by a LATER
+        # revision (leadreopen_a_20260609) than the one seeding sts20. Standing
+        # at the sts20 revision — the runbook's "downgrade -1" rollback point —
+        # the query would die with an opaque UndefinedColumn instead of this.
+        has_col = (await db.execute(text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = 'lead' AND column_name = 'consultation_reengaged_at'"
+        ))).scalar()
+        if not has_col:
+            print(
+                "❌ lead.consultation_reengaged_at not found — run "
+                "'alembic upgrade head' first (revision leadreopen_a_20260609)."
+            )
+            return 1
+
         n = await count_stale_sts04(db, days)
         print(f"Stale sts04 leads (≥ {days} days): {n}")
 

--- a/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
+++ b/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy import func, select, text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models, schemas
@@ -35,7 +35,7 @@ from app.services.lead_reopen_service import (
     reopen_lead,
     request_reopen,
 )
-from app.tasks.sla_tasks import close_stale_rejected_leads
+from app.tasks.sla_tasks import close_stale_rejected_leads, stale_sts04_predicate
 
 pytestmark = pytest.mark.asyncio
 
@@ -102,6 +102,7 @@ async def _make_lead(
     consultation_status_id: str = "sts04",
     status: str = "contacted",
     last_consultation_at=None,
+    consultation_reengaged_at=None,
     officer_id=None,
     offering_id=None,
 ) -> models.Lead:
@@ -115,6 +116,7 @@ async def _make_lead(
         pipeline_stage_id="stg02",
         status=status,
         last_consultation_at=last_consultation_at,
+        consultation_reengaged_at=consultation_reengaged_at,
         assigned_officer_id=officer_id,
         offering_id=offering_id,
     )
@@ -340,16 +342,10 @@ async def test_stale_predicate_selects_only_stale_sts04(db: AsyncSession):
     )
 
     cutoff = now - timedelta(days=30)
+    # Dùng CHÍNH predicate của beat (không chép tay lại — bản chép sẽ lệch
+    # production mà test vẫn xanh, đúng thứ đã xảy ra với bản COALESCE cũ).
     matched = (await db.execute(
-        select(models.Lead.id).where(
-            models.Lead.consultation_status_id == "sts04",
-            models.Lead.deleted_at.is_(None),
-            func.coalesce(
-                models.Lead.last_consultation_at,
-                models.Lead.updated_at,
-                models.Lead.created_at,
-            ) < cutoff,
-        )
+        stale_sts04_predicate(select(models.Lead.id), cutoff)
     )).scalars().all()
 
     assert stale.id in matched
@@ -527,21 +523,19 @@ async def test_beat_recheck_drops_touched_or_deleted_lead(db: AsyncSession):
     snapshot_ids = [touched.id, deleted.id, still_stale.id]
 
     # Mutations AFTER the id snapshot, BEFORE the batch is processed.
+    # 'touched' mô phỏng officer vừa ghi consultation mới (update_lead_cache đẩy
+    # last_consultation_at lên) — KHÔNG phải reopen; reopen ghi
+    # consultation_reengaged_at và được phủ ở test_reopen_* bên dưới.
     touched.last_consultation_at = now  # re-engaged
     deleted.deleted_at = now            # soft-deleted
     await db.flush()
 
     cutoff = now - timedelta(days=30)
+    # Dùng CHÍNH predicate của beat (xem ghi chú ở test stale-predicate trên).
     rechecked = (await db.execute(
-        select(models.Lead.id).where(
-            models.Lead.id.in_(snapshot_ids),
-            models.Lead.consultation_status_id == "sts04",
-            models.Lead.deleted_at.is_(None),
-            func.coalesce(
-                models.Lead.last_consultation_at,
-                models.Lead.updated_at,
-                models.Lead.created_at,
-            ) < cutoff,
+        stale_sts04_predicate(
+            select(models.Lead.id).where(models.Lead.id.in_(snapshot_ids)),
+            cutoff,
         )
     )).scalars().all()
 
@@ -1028,9 +1022,14 @@ async def test_reopen_sts20_to_sts04_sets_reengaged_and_history(db: AsyncSession
     unit = await _make_unit(db)
     manager = await _make_manager(db, unit.id)
     officer = await _make_officer(db, unit.id, cap=10)
+    # Seed last_consultation_at KHÁC None: bất biến cần khoá là reopen phải
+    # BẢO TOÀN mốc cache này. Nếu để mặc định None thì assert dưới thành
+    # tautology (None trước = None sau) và vẫn xanh kể cả khi _apply_reopen bị
+    # xoá sạch hoặc bị đổi thành `last_consultation_at = None`.
+    d_last = datetime.now(timezone.utc) - timedelta(days=90)
     lead = await _make_lead(
         db, unit.id, consultation_status_id="sts20", status="rejected",
-        officer_id=officer.id,
+        officer_id=officer.id, last_consultation_at=d_last,
     )
     v_before = lead.version
 
@@ -1050,7 +1049,8 @@ async def test_reopen_sts20_to_sts04_sets_reengaged_and_history(db: AsyncSession
     # được) ghi vào last_consultation_at: đó là cache dẫn xuất do
     # update_lead_cache sở hữu, ghi vào sẽ bị recalc nightly xóa sau 1 đêm.
     assert reopened.consultation_reengaged_at is not None
-    assert reopened.last_consultation_at is None  # reopen KHÔNG đụng field cache
+    # Khoá CẢ HAI chiều: không ghi đè bằng now (bug cũ), cũng không xoá về None.
+    assert reopened.last_consultation_at == d_last
     # #3: bump version (optimistic-lock) — mọi thay đổi trạng thái phải tăng version.
     assert reopened.version == (v_before or 1) + 1
     # assigned_officer giữ nguyên (reopen KHÔNG đụng assignment) — C1.
@@ -1178,8 +1178,9 @@ async def test_reopen_then_beat_can_close_again(db: AsyncSession):
 async def test_reopen_resets_sla_clock_so_beat_does_not_immediately_reclose(
     db: AsyncSession,
 ):
-    """#1: reopen reset last_consultation_at = now → lead KHÔNG còn stale → beat
-    auto-close KHÔNG đóng lại NGAY sau reopen (cho officer cửa sổ SLA mới)."""
+    """#1: reopen reset đồng hồ SLA qua consultation_reengaged_at → lead KHÔNG
+    còn stale → beat auto-close KHÔNG đóng lại NGAY sau reopen (cho officer cửa
+    sổ SLA mới). Reopen KHÔNG ghi last_consultation_at (cache dẫn xuất)."""
     await _seed_fsm(db)
     unit = await _make_unit(db)
     officer = await _make_officer(db, unit.id, cap=10)
@@ -1274,32 +1275,62 @@ async def test_reopen_survives_nightly_cache_recalc_then_beat(db: AsyncSession):
 async def test_reopen_without_human_consultation_is_not_closed(db: AsyncSession):
     """Ca owner chốt: lead reopen mà SAU ĐÓ không có tư vấn thật nào.
 
-    Đây là hình dạng của 4/5 lead bị hại trên prod (tư vấn thật sau reopen = 0).
-    last_consultation_at rất cũ (hoặc NULL sau khi B8b loại 'system'), nhưng mốc
-    re-engage phải giữ lead sống trọn cửa sổ SLA.
+    Hình dạng của 4/5 lead bị hại trên prod (tư vấn thật sau reopen = 0).
+
+    ⚠️ PHẢI chạy update_lead_cache sau reopen, nếu không test VÔ GIÁ TRỊ: bản
+    pre-fix ghi last_consultation_at = now lúc reopen nên không có recalc thì
+    predicate cũ cũng thấy lead "tươi" và test xanh ở CẢ HAI phía. Chính recalc
+    mới là bước kéo mốc về quá khứ (bite-verified: ca A đỏ trên origin/main).
     """
+    from app.services.lead_cache_service import update_lead_cache
+
     await _seed_fsm(db)
     unit = await _make_unit(db)
     officer = await _make_officer(db, unit.id, cap=10)
     manager = await _make_manager(db, unit.id)
     now = datetime.now(timezone.utc)
+    d_old = now - timedelta(days=90)
 
-    for last_at in (now - timedelta(days=90), None):  # 'system' rất cũ | NULL
-        lead = await _make_lead(
-            db, unit.id, consultation_status_id="sts20", status="rejected",
-            officer_id=officer.id, last_consultation_at=last_at,
-        )
+    # Ca A — có Consultation 'system' cũ (beat ghi lúc auto-close). Chính nó ghim
+    # MAX(consultation_date) ở mốc cũ để recalc bơm ngược vào cache.
+    lead_a = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+        officer_id=officer.id, last_consultation_at=d_old,
+    )
+    db.add(models.Consultation(
+        lead_id=lead_a.id, officer_id=officer.id, method="system",
+        consultation_status_id="sts20", consultation_date=d_old,
+        notes="auto-close SLA",
+    ))
+    # Ca B — chưa từng có consultation nào (lead chưa gán officer lúc auto-close:
+    # sla_tasks bỏ qua tạo Consultation) → last_consultation_at NULL.
+    lead_b = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+        officer_id=officer.id, last_consultation_at=None,
+    )
+    await db.flush()
+
+    for lead in (lead_a, lead_b):
         _, cb = await reopen_lead(
             db, lead.id, reviewer=manager, reason="khách quay lại",
         )
         if cb:
             await cb()
         await db.flush()
+        # ⚡ recalc 00:05 — bước giết reopen trước khi vá.
+        await update_lead_cache(db, lead.id)
+    await db.flush()
 
-        result = await close_stale_rejected_leads(
-            db, cutoff=now - timedelta(days=5), days=5,
-        )
-        assert result["transitioned"] == 0, f"đóng nhầm lead (last={last_at})"
+    await db.refresh(lead_a)
+    assert lead_a.last_consultation_at == d_old  # recalc kéo mốc về quá khứ
+    await db.refresh(lead_b)
+    assert lead_b.last_consultation_at is None
+
+    result = await close_stale_rejected_leads(
+        db, cutoff=now - timedelta(days=5), days=5,
+    )
+    assert result["transitioned"] == 0, "đóng nhầm lead vừa reopen"
+    for lead in (lead_a, lead_b):
         await db.refresh(lead)
         assert lead.consultation_status_id == "sts04"
 
@@ -1337,6 +1368,80 @@ async def test_reopen_then_active_consulting_is_not_closed(db: AsyncSession):
     assert result["transitioned"] == 0, "COALESCE-bug: đóng nhầm lead vừa được tư vấn"
     await db.refresh(lead)
     assert lead.consultation_status_id == "sts04"
+
+
+async def test_reopened_lead_ignores_updated_at_bump(db: AsyncSession):
+    """Khoá Ý ĐỊNH: với lead ĐÃ reopen, fallback updated_at không còn tác dụng.
+
+    consultation_reengaged_at là write-once (không ai clear) nên GREATEST luôn
+    non-NULL → COALESCE dừng ngay, KHÔNG bao giờ đọc updated_at nữa. Hệ quả:
+    sửa vu vơ một field của lead (bump updated_at) KHÔNG gia hạn SLA — đúng
+    spec của module ("no consultation activity"), và khác hành vi cũ (lead
+    không consultation sống vô hạn nhờ updated_at được recalc bump mỗi đêm).
+
+    Đây là behavior change CÓ CHỦ ĐÍCH; test này tồn tại để lần sau ai đổi thì
+    phải đổi có ý thức.
+    """
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    manager = await _make_manager(db, unit.id)
+    now = datetime.now(timezone.utc)
+
+    lead = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+        officer_id=officer.id, last_consultation_at=None,
+    )
+    _, cb = await reopen_lead(db, lead.id, reviewer=manager, reason="quay lại")
+    if cb:
+        await cb()
+
+    # Reopen 10 ngày trước, không tư vấn lần nào, nhưng lead bị sửa field HÔM QUA.
+    lead.consultation_reengaged_at = now - timedelta(days=10)
+    lead.updated_at = now - timedelta(days=1)
+    await db.flush()
+
+    result = await close_stale_rejected_leads(
+        db, cutoff=now - timedelta(days=5), days=5,
+    )
+    assert result["transitioned"] == 1, "updated_at KHÔNG được gia hạn SLA"
+    await db.refresh(lead)
+    assert lead.consultation_status_id == "sts20"
+
+
+async def test_backfill_predicate_matches_beat_for_reopened_lead(db: AsyncSession):
+    """Khoá đồng bộ predicate raw-SQL (backfill/dry-run) vs ORM (beat).
+
+    Nhánh GREATEST của _STALE_STS04_PREDICATE trước đây KHÔNG test nào chạm:
+    mọi test count_stale_sts04 đều dùng lead có consultation_reengaged_at NULL.
+    Revert string về COALESCE-only sẽ làm dry-run đếm lead reopened mà beat
+    không đóng — đúng drift mà docstring script cảnh báo.
+    """
+    from scripts.backfill_sts20_giveup import count_stale_sts04
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    now = datetime.now(timezone.utc)
+
+    # Lead reopen HÔM NAY nhưng tư vấn cuối từ 90 ngày trước: beat KHÔNG đóng
+    # (GREATEST lấy mốc reopen). Predicate raw-SQL phải nói ĐÚNG như vậy.
+    await _make_lead(
+        db, unit.id, consultation_status_id="sts04", status="contacted",
+        officer_id=officer.id, last_consultation_at=now - timedelta(days=90),
+        consultation_reengaged_at=now,
+    )
+    await db.flush()
+
+    beat_ids = (await db.execute(
+        stale_sts04_predicate(select(models.Lead.id), now - timedelta(days=5))
+    )).scalars().all()
+    script_count = await count_stale_sts04(db, days=5)
+
+    assert len(beat_ids) == 0, "beat không được đóng lead vừa reopen"
+    assert script_count == len(beat_ids), (
+        f"dry-run script ({script_count}) lệch beat ({len(beat_ids)})"
+    )
 
 
 async def test_never_reopened_lead_sla_behaviour_unchanged(db: AsyncSession):

--- a/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
+++ b/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
@@ -1045,10 +1045,12 @@ async def test_reopen_sts20_to_sts04_sets_reengaged_and_history(db: AsyncSession
     # status suy từ sts04 qua sync_lead_status (Rule 4: stg02 non-final) -> 'contacted'.
     assert reopened.status == "contacted"
     assert reopened.status != "rejected"  # đã rời khỏi trạng thái give-up
+    # #1: reopen reset đồng hồ SLA bằng CHÍNH consultation_reengaged_at — beat
+    # đọc GREATEST(reengaged, last_consultation_at) nên không cần (và không
+    # được) ghi vào last_consultation_at: đó là cache dẫn xuất do
+    # update_lead_cache sở hữu, ghi vào sẽ bị recalc nightly xóa sau 1 đêm.
     assert reopened.consultation_reengaged_at is not None
-    # #1: reopen reset đồng hồ SLA (last_consultation_at = now == reengaged_at) để beat
-    # KHÔNG đóng lại ngay.
-    assert reopened.last_consultation_at == reopened.consultation_reengaged_at
+    assert reopened.last_consultation_at is None  # reopen KHÔNG đụng field cache
     # #3: bump version (optimistic-lock) — mọi thay đổi trạng thái phải tăng version.
     assert reopened.version == (v_before or 1) + 1
     # assigned_officer giữ nguyên (reopen KHÔNG đụng assignment) — C1.
@@ -1147,8 +1149,11 @@ async def test_reopen_then_beat_can_close_again(db: AsyncSession):
     assert reopened.consultation_status_id == "sts04"
     assert reopened.consultation_reengaged_at is not None
 
-    # Reopen reset last_consultation_at = now (#1). Mô phỏng officer tư vấn lại rồi im
-    # lặng tiếp quá SLA: đẩy last_consultation_at về quá khứ SAU reopen -> stale LẠI.
+    # Mô phỏng officer tư vấn lại rồi im lặng tiếp quá SLA -> stale LẠI.
+    # Beat đọc GREATEST(consultation_reengaged_at, last_consultation_at) nên
+    # phải đẩy CẢ HAI mốc về quá khứ; chỉ đẩy last là chưa đủ (reengaged ~ now
+    # vừa set lúc reopen sẽ thắng và giữ lead sống — đúng như thiết kế).
+    lead.consultation_reengaged_at = now - timedelta(days=40)
     lead.last_consultation_at = now - timedelta(days=40)
     await db.flush()
 
@@ -1193,13 +1198,177 @@ async def test_reopen_resets_sla_clock_so_beat_does_not_immediately_reclose(
     if cb:
         await cb()
 
-    # Beat chạy NGAY (cutoff 30d). Vì last_consultation_at đã = now, lead KHÔNG stale.
+    # Beat chạy NGAY (cutoff 30d). GREATEST(reengaged=now, last=-40d) = now
+    # -> lead KHÔNG stale.
     cutoff = now - timedelta(days=30)
     result = await close_stale_rejected_leads(db, cutoff=cutoff, days=15)
     assert result["checked"] == 0  # không khớp stale-predicate
     assert result["transitioned"] == 0
     await db.refresh(lead)
     assert lead.consultation_status_id == "sts04"  # vẫn mở, không bị đóng lại
+
+
+async def test_reopen_survives_nightly_cache_recalc_then_beat(db: AsyncSession):
+    """🔴 HỒI QUY cho bug PROD: reopen bị recalc cache 00:05 vô hiệu hoá.
+
+    Chuỗi hỏng có thật (prod 16-07: SLA_AUTO_GIVEUP_ENABLED=true, DAYS=5 —
+    13 lead từng reopen, 5 nằm sts20, 0 còn sống ở sts04; 4/5 bị đóng lại khi
+    officer chưa gọi được cuộc nào, 3 ca chết < 1 ngày):
+
+      1. beat auto-close lead -> tạo Consultation(method='system', date=D)
+      2. D+20 manager reopen (trước đây: last_consultation_at = now)
+      3. 00:05 recalculate_lead_caches_task quét MỌI lead, update_lead_cache
+         ghi đè last_consultation_at = MAX(consultation_date) = D  <-- lùi 20 ngày
+      4. 03:30 beat: coalesce(D,...) < cutoff -> ĐÓNG LẠI
+
+    Không test nào từng phủ giao thoa reopen × update_lead_cache, nên suite cũ
+    xanh dù chuỗi trên hỏng. Test này khoá đúng điểm đó: chạy recalc THẬT giữa
+    reopen và beat.
+    """
+    from app.services.lead_cache_service import update_lead_cache
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    manager = await _make_manager(db, unit.id)
+    now = datetime.now(timezone.utc)
+    d_close = now - timedelta(days=20)  # ngày lead bị auto-close lần đầu
+
+    lead = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+        officer_id=officer.id, last_consultation_at=d_close,
+    )
+    # Consultation 'system' mà beat tạo lúc auto-close — chính nó ghim
+    # MAX(consultation_date) ở mốc cũ (sla_tasks.py: method="system").
+    db.add(models.Consultation(
+        lead_id=lead.id, officer_id=officer.id, method="system",
+        consultation_status_id="sts20", consultation_date=d_close,
+        notes="auto-close SLA",
+    ))
+    await db.flush()
+
+    reopened, cb = await reopen_lead(
+        db, lead.id, reviewer=manager, reason="khách quay lại",
+    )
+    if cb:
+        await cb()
+    assert reopened.consultation_status_id == "sts04"
+
+    # ⚡ Nightly recalc chạy giữa reopen và beat — ĐÂY là bước giết reopen
+    # trước khi vá. Nó ghi đè last_consultation_at = MAX(date) = d_close.
+    await update_lead_cache(db, lead.id)
+    await db.flush()
+    await db.refresh(lead)
+    assert lead.last_consultation_at == d_close  # recalc VẪN ghi đè (đúng vai trò)
+
+    # Beat 03:30 cùng đêm. Mốc re-engage KHÔNG bị recalc đụng nên lead sống.
+    result = await close_stale_rejected_leads(
+        db, cutoff=now - timedelta(days=5), days=5,
+    )
+    assert result["checked"] == 0, "recalc vẫn giết được reopen -> bug còn sống"
+    assert result["transitioned"] == 0
+    await db.refresh(lead)
+    assert lead.consultation_status_id == "sts04"
+
+
+async def test_reopen_without_human_consultation_is_not_closed(db: AsyncSession):
+    """Ca owner chốt: lead reopen mà SAU ĐÓ không có tư vấn thật nào.
+
+    Đây là hình dạng của 4/5 lead bị hại trên prod (tư vấn thật sau reopen = 0).
+    last_consultation_at rất cũ (hoặc NULL sau khi B8b loại 'system'), nhưng mốc
+    re-engage phải giữ lead sống trọn cửa sổ SLA.
+    """
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    manager = await _make_manager(db, unit.id)
+    now = datetime.now(timezone.utc)
+
+    for last_at in (now - timedelta(days=90), None):  # 'system' rất cũ | NULL
+        lead = await _make_lead(
+            db, unit.id, consultation_status_id="sts20", status="rejected",
+            officer_id=officer.id, last_consultation_at=last_at,
+        )
+        _, cb = await reopen_lead(
+            db, lead.id, reviewer=manager, reason="khách quay lại",
+        )
+        if cb:
+            await cb()
+        await db.flush()
+
+        result = await close_stale_rejected_leads(
+            db, cutoff=now - timedelta(days=5), days=5,
+        )
+        assert result["transitioned"] == 0, f"đóng nhầm lead (last={last_at})"
+        await db.refresh(lead)
+        assert lead.consultation_status_id == "sts04"
+
+
+async def test_reopen_then_active_consulting_is_not_closed(db: AsyncSession):
+    """🔴 Chống REGRESSION NGƯỢC: COALESCE thay GREATEST -> đóng nhầm lead active.
+
+    COALESCE lấy giá trị non-null ĐẦU TIÊN, nên consultation_reengaged_at (cố
+    định tại lúc reopen) sẽ luôn thắng last_consultation_at mới hơn -> lead được
+    reopen rồi tư vấn tích cực vẫn bị đóng sau đúng `days` kể từ NGÀY REOPEN.
+    GREATEST lấy mốc muộn nhất -> tư vấn thật gia hạn được đồng hồ.
+    """
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    manager = await _make_manager(db, unit.id)
+    now = datetime.now(timezone.utc)
+
+    lead = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+        officer_id=officer.id, last_consultation_at=now - timedelta(days=90),
+    )
+    _, cb = await reopen_lead(db, lead.id, reviewer=manager, reason="quay lại")
+    if cb:
+        await cb()
+
+    # Reopen 10 ngày trước; officer tư vấn thật HÔM QUA -> lead rõ ràng đang sống.
+    lead.consultation_reengaged_at = now - timedelta(days=10)
+    lead.last_consultation_at = now - timedelta(days=1)
+    await db.flush()
+
+    result = await close_stale_rejected_leads(
+        db, cutoff=now - timedelta(days=5), days=5,
+    )
+    assert result["transitioned"] == 0, "COALESCE-bug: đóng nhầm lead vừa được tư vấn"
+    await db.refresh(lead)
+    assert lead.consultation_status_id == "sts04"
+
+
+async def test_never_reopened_lead_sla_behaviour_unchanged(db: AsyncSession):
+    """Hồi quy: lead CHƯA từng reopen (reengaged NULL) phải hành xử y hệt trước.
+
+    GREATEST(NULL, last) = last (Postgres bỏ qua NULL) -> predicate không đổi.
+    """
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    now = datetime.now(timezone.utc)
+
+    stale = await _make_lead(
+        db, unit.id, consultation_status_id="sts04", status="contacted",
+        officer_id=officer.id, last_consultation_at=now - timedelta(days=40),
+    )
+    fresh = await _make_lead(
+        db, unit.id, consultation_status_id="sts04", status="contacted",
+        officer_id=officer.id, last_consultation_at=now - timedelta(days=1),
+    )
+    await db.flush()
+    assert stale.consultation_reengaged_at is None
+    assert fresh.consultation_reengaged_at is None
+
+    result = await close_stale_rejected_leads(
+        db, cutoff=now - timedelta(days=5), days=5,
+    )
+    assert result["transitioned"] == 1  # chỉ lead cũ bị đóng
+    await db.refresh(stale)
+    await db.refresh(fresh)
+    assert stale.consultation_status_id == "sts20"
+    assert fresh.consultation_status_id == "sts04"
 
 
 async def test_can_reopen_flag_thin_client(db: AsyncSession):

--- a/Documents/STS20_DEPLOY_RUNBOOK.md
+++ b/Documents/STS20_DEPLOY_RUNBOOK.md
@@ -81,6 +81,13 @@ có thể phát triển song song.
 - Lead sts20 = terminal: chưa có đường mở lại tới khi ship
   `Documents/LEAD_REOPEN_WORKFLOW_PLAN.md`. Vì vậy backfill + bật beat nên SAU khi
   reopen lên (hoặc chấp nhận tường minh).
-- Quy mô: predicate backfill/beat seq-scan trên `lead` (~vài chục–trăm row hiện
-  tại). Nếu bảng lead lớn về sau, cân nhắc partial index
-  `(consultation_status_id, last_consultation_at) WHERE deleted_at IS NULL`.
+- Quy mô: predicate backfill/beat **KHÔNG seq-scan** — `EXPLAIN` (2026-07-16,
+  2013 row) cho Bitmap Index Scan qua `ix_lead_consultation_status_id` rồi mới
+  apply biểu thức thời gian làm Filter. Đừng thêm index
+  `(consultation_status_id, last_consultation_at)`: vế thời gian bị bọc trong
+  `COALESCE(GREATEST(consultation_reengaged_at, last_consultation_at), ...)` nên
+  index thường trên cột đó **không bao giờ** được planner chọn (bản COALESCE cũ
+  cũng vậy — index `ix_lead_last_consultation_at` chưa từng phục vụ query này).
+  Nếu bảng lead lớn về sau và Filter trở thành nút cổ chai, cách đúng là
+  **expression index** khớp đúng biểu thức, hoặc partial index chỉ trên
+  `consultation_status_id WHERE deleted_at IS NULL`.


### PR DESCRIPTION
## Bug đang chạy prod — tính năng reopen (#390) về cơ bản không hoạt động

`SLA_AUTO_GIVEUP_ENABLED=true`, `SLA_CONSULT_GIVEUP_DAYS=5` trên prod.

**Chuỗi hỏng** (thứ tự beat là mấu chốt):
1. Ngày D: beat auto-close lead → tạo `Consultation(method='system', date=D)` → `MAX(consultation_date)` bị ghim ở D.
2. D+20: manager reopen → ghi `last_consultation_at = now`. Lead về sts04, màn hình hiển thị đúng.
3. **00:05** đêm đó: `recalculate_lead_caches_task` quét **mọi** lead (không cờ gate) → `update_lead_cache` ghi đè `last_consultation_at = MAX = D`, **lùi 20 ngày**.
4. **03:30**: beat thấy `coalesce(D,...) < now-5d` → **đóng lại**.

Reopen chỉ sống đến 00:05 kế tiếp.

**Gốc rễ:** `last_consultation_at` bị dùng cho **hai mục đích xung đột** — cache dẫn xuất `MAX(consultation_date)` (do `update_lead_cache` sở hữu, ghi đè vô điều kiện) và đồng hồ SLA reset thủ công (reopen ghi). Ghi mốc thủ công vào field cache là sai chủ sở hữu.

### Bằng chứng data prod (16-07)

| | |
|---|---|
| Lead đã từng reopen | 13 |
| Đang nằm lại `sts20` (bị đóng lần nữa) | 5 |
| **Còn sống ở `sts04`** | **0** |

| lead | reopen | sống được | tư vấn THẬT sau reopen |
|---|---|---|---|
| 291 | 14-07 | **0.4 ngày** (~10h) | **0** |
| 625 | 01-07 | **0.5 ngày** | **0** |
| 534 | 24-06 | **0.8 ngày** | **0** |
| 361 | 01-07 | 3.5 ngày | **0** |
| 58 | 17-06 | 15.5 ngày | 2 ✅ *(hợp lệ — đóng đúng luật)* |

4/5 lead bị đóng khi officer **chưa gọi được cuộc nào**, dù cutoff là 5 ngày.

> ⚠️ **Bug tự phi tang bằng chứng:** khi đóng lại, SLA tạo consultation `system` mới → `MAX` nhảy lên ngày đóng → `last > reengaged`. Đừng đo bằng `last_consultation_at < consultation_reengaged_at` (trả 0 giả). Đo bằng `sts20 + consultation_reengaged_at IS NOT NULL`.

## Fix — tách nghĩa 2 field (KHÔNG migration)

`consultation_reengaged_at` đã tồn tại từ `leadreopen_a_20260609`; reopen vốn đã ghi nó cho RULE #13.2.

| Field | Nghĩa | Ai ghi |
|---|---|---|
| `last_consultation_at` | **thuần** recency tư vấn | CHỈ `update_lead_cache` |
| `consultation_reengaged_at` | mốc re-engage thủ công | CHỈ reopen (không job nào đụng) |
| SLA predicate | `COALESCE(GREATEST(reengaged, last), updated_at, created_at)` | — |

**`GREATEST` chứ không `COALESCE`:** coalesce lấy non-null ĐẦU TIÊN → `reengaged` (cố định lúc reopen) luôn thắng `last` mới hơn → lead reopen rồi **tư vấn tích cực vẫn bị đóng** sau `days` kể từ ngày reopen = vá bug này đẻ bug ngược. `GREATEST` bỏ qua NULL (Postgres) nên lead chưa reopen giữ **nguyên** hành vi cũ.

| Tình huống | Trước | Sau |
|---|---|---|
| Reopen, officer chưa kịp gọi | đóng lại sau vài giờ | sống trọn 5 ngày |
| Reopen rồi tư vấn tích cực | đóng lại sau vài giờ | sống, mỗi lần tư vấn gia hạn |
| Reopen rồi bỏ bê quá 5 ngày | đóng | đóng (không tạo lead bất tử) |
| Chưa từng reopen | theo luật cũ | **y hệt** |

## Thay đổi hành vi có chủ đích

Với lead **đã reopen**, fallback `updated_at` không còn tác dụng (`GREATEST` luôn non-NULL → `COALESCE` dừng ngay). Sửa vu vơ một field không phải "hoạt động tư vấn" nên không gia hạn SLA — đúng spec module. Khoá bởi `test_reopened_lead_ignores_updated_at_bump`.

## Test — bite-verified trên `origin/main` thật

Commit 2 áp findings `/code-review max`. Đáng nói nhất: **bite-verify ban đầu là giả** — nó chỉ revert predicate mà giữ `lead_reopen_service` đã sửa, một tổ hợp chưa từng tồn tại. Chạy lại đúng cách: chỉ 1/4 test mới đỏ; `without_human_consultation` xanh cả hai phía vì thiếu `update_lead_cache` — đúng bước gây án.

Sau khi sửa, **5 test đỏ trên `origin/main`** (trước 1):
- `reopen_sts20_to_sts04_sets_reengaged_and_history` — assert cũ là tautology (`None == None`), xanh kể cả khi xoá sạch `_apply_reopen`
- `reopen_survives_nightly_cache_recalc_then_beat` — chạy recalc **thật** giữa reopen và beat
- `reopen_without_human_consultation_is_not_closed` — hình dạng 4/5 lead bị hại
- `reopened_lead_ignores_updated_at_bump`
- `backfill_predicate_matches_beat_for_reopened_lead`

(`active_consulting` đỏ trên biến thể COALESCE; `never_reopened` xanh hai phía = hồi quy đúng.)

**Sửa cấu trúc:** predicate từng có **4 bản chép tay** (closure, raw SQL, 2 bản trong test) — chép vì closure nội bộ nên test *không thể* gọi. Trích ra module-level `stale_sts04_predicate(stmt, cutoff)` = nguồn sự thật duy nhất.

**CI:** file test này **không nằm trong allowlist** (`grep sts20|giveup|sla_tasks` toàn workflows = 0 hit) → 5 test hồi quy chưa từng chạy trên PR gate. Đã thêm vào Tier 4.

Verify: **58/58 pass** · flake8 net-zero (E501 còn lại pre-existing).

## Deploy

Không migration, BE-only. Sau merge: `SLA_AUTO_GIVEUP_ENABLED` đang bật + cutoff 5 ngày → **03:30 mỗi đêm vẫn chạy code cũ cho tới khi deploy**.

**Còn nợ (cần approval riêng):** 4 lead bị đóng oan (291/625/534/361) vẫn nằm `sts20` — fix code không tự kéo về; cứu thì phải reopen lại qua đường nghiệp vụ. Lead 58 **không** đụng.

## Ngoài scope (pre-existing, ghi nhận)

backfill dry-run `NOW()` vs apply `datetime.now()` lệch qua prompt · `days`/`cutoff` độc lập làm audit khai sai ngưỡng · `updated_at` bị recalc re-arm mỗi đêm · `consultation_reengaged_at` chưa expose ra FE (reopen vô hình với officer) · `sla_tasks` thiếu `populate_existing` ở batch re-select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)