### PR TITLE
fix(security): consultation hardening PR-1 — deleted-items IDOR + oracle 404 + accountant deny (S1–S5)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -214,6 +214,7 @@ jobs:
           tests/security/test_ratelimit_order_guard.py
           tests/security/test_ip_rate_limit.py
           tests/security/test_ratelimit_per_user_key.py
+          tests/api/test_consultation_security.py
           -q --tb=short --timeout=60
 
       # =====================================================================

--- a/Backend_FastAPI/alembic/versions/consultacctdeny20260716_accountant_consultation_write_deny.py
+++ b/Backend_FastAPI/alembic/versions/consultacctdeny20260716_accountant_consultation_write_deny.py
@@ -1,0 +1,83 @@
+"""deny accountant POST/PUT/DELETE consultations (separation-of-duties)
+
+OFFICER_TEMPLATE grants the consultation write paths to role:officer:
+    POST   /api/leads/{id}/consultations
+    PUT    /api/leads/{id}/consultations/{consultation_id}
+    DELETE /api/leads/{id}/consultations/{consultation_id}
+
+Because role:accountant inherits role:officer (g, role:accountant, role:officer),
+those three allow-rows ALSO reach accountant. Only the GET counterpart was ever
+denied (migration seeding `/api/leads/{id}/consultations` GET), which left
+finance staff able to CREATE / EDIT / DELETE consultations while being unable to
+read the list — an asymmetry, not a policy decision. Consultations drive lead
+status transitions, so writing them lets accountant move leads through the
+pipeline.
+
+Fix: insert explicit accountant DENY rows. Casbin's effect policy (deny
+overrides allow) bounces the inherited officer allows → clean 403 at the Casbin
+gateway, mirroring the existing /api/leads POST/PUT denies.
+
+Insert WITH v3='deny' — every existing p-row carries an eft; a NULL eft makes
+Casbin `load_policy` crash on next reload (memory casbin-insert-must-include-eft).
+Idempotent (WHERE NOT EXISTS) so re-runs are safe.
+
+NOTE: editing policy_templates.py alone ships nothing — AUTO_SYNC_TEMPLATES is
+False by default and only honoured in development/test (main.py), and
+docker-entrypoint.sh has no casbin template-sync step. This migration is the
+only automatic write path into casbin_rule. The backend container must be
+RESTARTED after upgrade: the enforcer loads policy once per process at lifespan
+(load_policy), so a running multi-worker Gunicorn fleet keeps the stale policy
+in memory and would enforce the deny on only some workers.
+
+Revision ID: consultacctdeny20260716
+Revises: apptacctdeny20260713
+Create Date: 2026-07-16
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "consultacctdeny20260716"
+down_revision = "apptacctdeny20260713"
+branch_labels = None
+depends_on = None
+
+
+# (object, action) pairs mirroring the OFFICER_TEMPLATE consultation grants.
+_DENY_TARGETS = [
+    ("/api/leads/{id}/consultations", "POST"),
+    ("/api/leads/{id}/consultations/{consultation_id}", "PUT"),
+    ("/api/leads/{id}/consultations/{consultation_id}", "DELETE"),
+]
+
+
+def upgrade() -> None:
+    # template_id='_legacy' khớp các row deny accountant cùng khối
+    # (apptacctdeny20260713) → không bị coi orphan bởi logic tracking template.
+    for obj, act in _DENY_TARGETS:
+        op.execute(
+            f"""
+            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id)
+            SELECT 'p', 'role:accountant', '{obj}', '{act}', 'deny', '_legacy'
+            WHERE NOT EXISTS (
+                SELECT 1 FROM casbin_rule
+                WHERE ptype = 'p'
+                  AND v0 = 'role:accountant'
+                  AND v1 = '{obj}'
+                  AND v2 = '{act}'
+            )
+            """
+        )
+
+
+def downgrade() -> None:
+    for obj, act in _DENY_TARGETS:
+        op.execute(
+            f"""
+            DELETE FROM casbin_rule
+            WHERE ptype = 'p'
+              AND v0 = 'role:accountant'
+              AND v1 = '{obj}'
+              AND v2 = '{act}'
+              AND v3 = 'deny'
+            """
+        )

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -530,6 +530,16 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/leads/{id}/insights",       "action": "GET",  "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads/{id}/audit-logs",     "action": "GET",  "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads/{id}/consultations",  "action": "GET",  "eft": "deny"},
+        # Consultation WRITE paths — OFFICER_TEMPLATE grants POST/PUT/DELETE
+        # (see the consultations block above) and accountant inherits them via
+        # `g, role:accountant, role:officer`. The GET deny right above was the
+        # only one seeded, leaving accountant able to CREATE/EDIT/DELETE
+        # consultations while unable to read the list — an asymmetry, not a
+        # policy. Same separation-of-duties rationale as /api/leads PUT/POST.
+        # Migration: consultacctdeny20260716.
+        {"subject": "{role}", "object": "/api/leads/{id}/consultations",  "action": "POST", "eft": "deny"},
+        {"subject": "{role}", "object": "/api/leads/{id}/consultations/{consultation_id}", "action": "PUT",    "eft": "deny"},
+        {"subject": "{role}", "object": "/api/leads/{id}/consultations/{consultation_id}", "action": "DELETE", "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads/check-duplicate",     "action": "GET",  "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads/import",              "action": "POST", "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads/import/template",     "action": "GET",  "eft": "deny"},

--- a/Backend_FastAPI/app/routers/admin/deleted_items.py
+++ b/Backend_FastAPI/app/routers/admin/deleted_items.py
@@ -25,9 +25,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app import database, models, schemas
-from app.core.deps import CasbinAuth, require_admin_or_manager
+from app.core.constants import UserRole
+from app.core.deps import get_lead_for_user, require_admin_or_manager
 from app.core.events import SystemEvents
 from app.core.rate_limits import limiter, RateLimits
+from app.repositories.organization_repository import OrganizationRepository
 from app.services import lead_service
 from app.services.notification_dispatcher import rooms_for_lead, safe_dispatch
 from app.services.notification_payloads import EventPayload
@@ -35,6 +37,29 @@ from app.services.notification_payloads import EventPayload
 log = structlog.get_logger(__name__)
 
 router = APIRouter(tags=["Admin - Deleted Items"])
+
+
+async def _resolve_deleted_items_unit_scope(
+    db: AsyncSession,
+    current_user: models.User,
+) -> Optional[List[int]]:
+    """Đơn vị mà user được phép thấy trong màn "Deleted Items".
+
+    Returns:
+        None  -> toàn hệ thống (admin).
+        list  -> giới hạn theo cây đơn vị (manager). Rỗng = không thấy gì.
+
+    Manager chưa gán đơn vị (``unit_id`` NULL) trả ``[]`` — fail-closed, cùng
+    hướng với ``get_lead_for_user`` (deps.py: manager không unit_id -> 404).
+    """
+    if current_user.role == UserRole.ADMIN:
+        return None
+
+    if current_user.unit_id is None:
+        return []
+
+    org_repo = OrganizationRepository(db)
+    return await org_repo.get_descendant_unit_ids(current_user.unit_id)
 
 
 # ============================================================================
@@ -99,10 +124,32 @@ async def list_deleted_items(
     """
     List all soft-deleted leads and consultations.
 
-    Admin/Manager only. Returns most recently deleted items first.
+    Admin: toàn hệ thống. Manager: CHỈ trong cây đơn vị của mình.
+
+    Unit-scope phải áp cho MỌI phần (rows + counts + search) — lọc rows mà
+    bỏ counts thì manager vẫn suy ra được SỐ LƯỢNG lead/consultation của
+    đơn vị khác.
     """
+    allowed_unit_ids = await _resolve_deleted_items_unit_scope(db, current_user)
+
+    def _scope_leads(stmt):
+        """Giới hạn theo unit của Lead. None = admin, không giới hạn."""
+        if allowed_unit_ids is None:
+            return stmt
+        return stmt.where(models.Lead.unit_id.in_(allowed_unit_ids))
+
+    def _scope_consultations(stmt):
+        """Giới hạn theo unit của Lead mà consultation thuộc về."""
+        if allowed_unit_ids is None:
+            return stmt
+        return stmt.where(
+            models.Consultation.lead.has(
+                models.Lead.unit_id.in_(allowed_unit_ids)
+            )
+        )
+
     # ========== DELETED LEADS ==========
-    leads_query = (
+    leads_query = _scope_leads(
         select(models.Lead)
         .where(models.Lead.deleted_at.isnot(None))
         .order_by(models.Lead.deleted_at.desc())
@@ -122,7 +169,10 @@ async def list_deleted_items(
 
     # Count total deleted leads
     total_leads_result = await db.execute(
-        select(func.count(models.Lead.id)).where(models.Lead.deleted_at.isnot(None))
+        _scope_leads(
+            select(func.count(models.Lead.id))
+            .where(models.Lead.deleted_at.isnot(None))
+        )
     )
     total_leads = total_leads_result.scalar() or 0
 
@@ -147,7 +197,7 @@ async def list_deleted_items(
         ))
 
     # ========== DELETED CONSULTATIONS ==========
-    consultations_query = (
+    consultations_query = _scope_consultations(
         select(models.Consultation)
         .options(
             selectinload(models.Consultation.lead),
@@ -174,10 +224,12 @@ async def list_deleted_items(
 
     # Count total deleted consultations (from active leads only)
     total_consultations_result = await db.execute(
-        select(func.count(models.Consultation.id))
-        .where(
-            models.Consultation.deleted_at.isnot(None),
-            models.Consultation.lead.has(models.Lead.deleted_at.is_(None)),
+        _scope_consultations(
+            select(func.count(models.Consultation.id))
+            .where(
+                models.Consultation.deleted_at.isnot(None),
+                models.Consultation.lead.has(models.Lead.deleted_at.is_(None)),
+            )
         )
     )
     total_consultations = total_consultations_result.scalar() or 0
@@ -286,7 +338,16 @@ async def restore_deleted_consultation(
     """
     Restore a soft-deleted consultation.
 
-    Admin/Manager only. Updates lead status if restored consultation is the most recent.
+    Admin: mọi consultation. Manager: CHỈ trong cây đơn vị của mình.
+
+    Updates lead status if restored consultation is the most recent.
+
+    Thu hẹp có chủ đích: consultation thuộc lead ĐÃ BỊ XÓA nay trả 404
+    (get_lead_for_user bỏ qua lead soft-deleted) — trước đây admin restore
+    được. Không luồng nào vỡ: list ở trên chỉ trả consultation của lead còn
+    sống, nên UI không có đường dẫn tới chúng; và restore lẻ một consultation
+    của lead đã xóa là vô nghĩa vì lead vẫn ẩn. Đường đúng để khôi phục là
+    restore LEAD — nó tự kéo consultation theo (lead_service.restore_lead).
     """
     # First find the consultation to get lead_id
     consultation_result = await db.execute(
@@ -305,6 +366,13 @@ async def restore_deleted_consultation(
         )
 
     lead_id = consultation.lead_id
+
+    # Ép unit-scope: lead_id lấy TỪ CHÍNH row người gọi chỉ định, nên filter
+    # lead_id bên trong restore_consultation luôn khớp và không cản được gì.
+    # get_lead_for_user là chốt IDOR duy nhất ở đây (manager ngoài cây đơn vị
+    # -> 404; manager chưa gán đơn vị -> fail-closed 404).
+    # Phải gọi bằng KEYWORD: các tham số có Path()/Depends() làm default.
+    await get_lead_for_user(lead_id=lead_id, db=db, current_user=current_user)
 
     # Restore it
     await lead_service.restore_consultation(

--- a/Backend_FastAPI/app/routers/admin/deleted_items.py
+++ b/Backend_FastAPI/app/routers/admin/deleted_items.py
@@ -380,7 +380,12 @@ async def restore_deleted_consultation(
     )
     await db.commit()
 
-    # Re-fetch with eager loading to avoid lazy load issues
+    # Re-fetch with eager loading to avoid lazy load issues.
+    # ``officer`` PHẢI eager-load: response_model schemas.Consultation có
+    # ``officer: Optional[User]``; khi người restore KHÁC officer tạo
+    # consultation (vd manager restore cuộc do officer ghi — đúng ca S1 mở),
+    # officer không nằm sẵn identity-map → serialize lazy-load → MissingGreenlet
+    # (500). Trước đây lọt vì không test nào chạy success-path này.
     result = await db.execute(
         select(models.Consultation)
         .where(models.Consultation.id == consultation_id)
@@ -388,6 +393,7 @@ async def restore_deleted_consultation(
             selectinload(models.Consultation.consultation_status)
             .selectinload(models.ConsultationStatus.stage),
             selectinload(models.Consultation.lead),
+            selectinload(models.Consultation.officer),
         )
     )
     restored = result.scalar_one()

--- a/Backend_FastAPI/app/routers/admin/deleted_items.py
+++ b/Backend_FastAPI/app/routers/admin/deleted_items.py
@@ -17,7 +17,6 @@ from fastapi import (
     Depends,
     Request,
     Query,
-    status,
 )
 from pydantic import BaseModel
 from sqlalchemy import select, func

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -1247,9 +1247,13 @@ async def restore_a_consultation(
     """
     Restore a soft-deleted consultation.
 
-    Permission Rules:
-    - Admin/Manager: Can restore any consultation
-    - Officer: Can only restore if assigned to the lead
+    Permission Rules (contract THẬT):
+    - ADMIN ONLY. Route gác CasbinAuth và KHÔNG template nào cấp allow cho
+      path này — keyMatch4 không match segment /restore thêm vào sau
+      /api/leads/{id}/consultations/{consultation_id}. Chỉ admin đi lọt nhờ
+      wildcard ADMIN_TEMPLATE.
+    - Manager/Officer: 403 tại Casbin gateway. Manager muốn restore thì dùng
+      POST /api/admin/deleted-items/consultations/{cid}/restore (có unit-scope).
 
     Business Logic:
     - Restores the consultation by clearing deleted_at

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -1266,7 +1266,11 @@ async def restore_a_consultation(
     # Commit the transaction
     await db.commit()
 
-    # Re-fetch with eager loading to avoid lazy load issues
+    # Re-fetch with eager loading to avoid lazy load issues.
+    # ``officer`` PHẢI eager-load: response_model schemas.Consultation có
+    # ``officer: Optional[User]``; admin restore cuộc do officer KHÁC tạo →
+    # officer không nằm sẵn identity-map → serialize lazy-load →
+    # MissingGreenlet (500). Song song với fix ở deleted_items.restore.
     from sqlalchemy import select
     from sqlalchemy.orm import selectinload
 
@@ -1277,6 +1281,7 @@ async def restore_a_consultation(
             selectinload(models.Consultation.consultation_status)
             .selectinload(models.ConsultationStatus.stage),
             selectinload(models.Consultation.lead),
+            selectinload(models.Consultation.officer),
         )
     )
     consultation = result.scalar_one()

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -2541,10 +2541,16 @@ async def delete_consultation(
             # Lấy Consultation cần xóa với row-level lock
             # ✅ FIX: Use FOR UPDATE to prevent concurrent modification
             # ✅ FIX: Filter out already soft-deleted consultations
+            # ✅ SECURITY: lead_id nằm TRONG WHERE — "không tồn tại" và "thuộc
+            # lead khác" phải cùng trả 404. Tách 2 nhánh (404 vs 400) biến
+            # endpoint thành oracle: caller chỉ cần 1 lead hợp lệ của mình rồi
+            # dò consultation_id toàn hệ thống (400 = tồn tại, 404 = không).
+            # Noi theo restore_consultation vốn đã lọc đúng.
             consultation_result = await db.execute(
                 select(models.Consultation)
                 .where(
                     models.Consultation.id == consultation_id,
+                    models.Consultation.lead_id == lead_id,
                     models.Consultation.deleted_at.is_(None),  # Not already deleted
                 )
                 .with_for_update()
@@ -2553,11 +2559,6 @@ async def delete_consultation(
             if not consultation:
                 raise ResourceNotFoundError(
                     detail=f"Consultation with id {consultation_id} not found or already deleted."
-                )
-            # Kiểm tra consultation thuộc đúng Lead
-            if consultation.lead_id != lead_id:
-                raise BadRequest(
-                    detail="Consultation does not belong to the specified lead."
                 )
 
             # Kiểm tra quyền
@@ -2742,9 +2743,18 @@ async def restore_consultation(
     """
     Restore a soft-deleted consultation and update Lead status accordingly.
 
-    Permission Rules:
-    - Admin/Manager: Can restore any consultation
-    - Officer: Can only restore if assigned to the lead
+    Permission Rules (contract THẬT, đã đối chiếu Casbin + routes):
+    - Admin: đường duy nhất còn sống.
+        * POST /api/leads/{id}/consultations/{cid}/restore — gác CasbinAuth,
+          và KHÔNG template nào cấp allow cho path này (keyMatch4 không match
+          thêm segment /restore). Chỉ admin lọt qua wildcard ADMIN_TEMPLATE.
+        * POST /api/admin/deleted-items/consultations/{cid}/restore — gác
+          require_admin_or_manager + get_lead_for_user (unit-scope).
+    - Manager: CHỈ qua đường /api/admin/deleted-items/... ở trên, và chỉ trong
+      cây đơn vị của mình. Bị Casbin chặn ở route /api/leads/... .
+    - Officer: KHÔNG có đường nào — nhánh officer bên dưới là DEAD CODE
+      (fail-closed ở tầng Casbin trước khi tới đây). Giữ lại làm defense in
+      depth; ĐỪNG suy ra cờ quyền `can_restore` từ nó, sẽ sai.
 
     Business Logic:
     - Clears deleted_at timestamp to restore the consultation
@@ -2927,7 +2937,18 @@ async def update_consultation(
                 raise BadRequest(detail="Cannot modify consultations for a deleted lead.")
 
             # Lấy Consultation cần update
-            consultation = await db.get(models.Consultation, consultation_id)
+            # ✅ SECURITY: lead_id nằm TRONG WHERE thay vì db.get() theo PK rồi
+            # so lead_id sau — "không tồn tại" và "thuộc lead khác" phải cùng
+            # trả 404. Tách 2 nhánh (404 vs 400) biến endpoint thành oracle:
+            # caller chỉ cần 1 lead hợp lệ của mình rồi dò consultation_id toàn
+            # hệ thống (400 = tồn tại, 404 = không).
+            consultation_result = await db.execute(
+                select(models.Consultation).where(
+                    models.Consultation.id == consultation_id,
+                    models.Consultation.lead_id == lead_id,
+                )
+            )
+            consultation = consultation_result.scalar_one_or_none()
             if not consultation:
                 raise ResourceNotFoundError(
                     detail=f"Consultation with id {consultation_id} not found."
@@ -2936,11 +2957,6 @@ async def update_consultation(
             if consultation.deleted_at is not None:
                 raise ResourceNotFoundError(
                     detail=f"Consultation with id {consultation_id} not found or already deleted."
-                )
-            # Kiểm tra consultation thuộc đúng Lead
-            if consultation.lead_id != lead_id:
-                raise BadRequest(
-                    detail="Consultation does not belong to the specified lead."
                 )
 
             # ✅ FIX: Single check for latest consultation (eliminates TOCTOU vulnerability)

--- a/Backend_FastAPI/tests/api/test_consultation_security.py
+++ b/Backend_FastAPI/tests/api/test_consultation_security.py
@@ -45,6 +45,10 @@ def _lead_consult_url(lead_id: int, consultation_id: int) -> str:
     return f"/api/leads/{lead_id}/consultations/{consultation_id}"
 
 
+def _restore_via_leads_route(lead_id: int, consultation_id: int) -> str:
+    return f"/api/leads/{lead_id}/consultations/{consultation_id}/restore"
+
+
 # ===========================================================================
 # FIXTURES
 # ===========================================================================
@@ -207,6 +211,50 @@ async def consultation_cross_lead_dataset(
             data = {
                 "lead_a": lead_a.id, "lead_b": lead_b.id,
                 "consult_b": consult_b.id,
+            }
+    return data
+
+
+@pytest_asyncio.fixture(scope="function")
+async def officer_authored_deleted_consultation(
+    seed_lead_dependencies: dict,
+    officer_user_in_db: dict,
+) -> dict:
+    """Lead còn sống + 1 consultation ĐÃ XÓA do OFFICER (≠ admin) tạo.
+
+    Cho route admin-only leads.py restore: người restore (admin) KHÁC officer
+    tạo cuộc → officer không nằm sẵn identity-map → serialize officer phải
+    eager-load, nếu không → MissingGreenlet 500.
+    """
+    unit1 = seed_lead_dependencies["unit_id"]
+    status_id = seed_lead_dependencies["initial_status_id"]
+    officer_id = officer_user_in_db["id"]
+    now = datetime.now(timezone.utc)
+
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            lead = models.Lead(
+                full_name="Officer Authored Lead", phone="0900000021",
+                email="officerauthored@test.com", source="website",
+                unit_id=unit1, assigned_officer_id=officer_id,
+                consultation_status_id=status_id, consultation_count=0,
+                status="new",
+            )
+            session.add(lead)
+            await session.flush()
+
+            consult = models.Consultation(
+                lead_id=lead.id, officer_id=officer_id,
+                consultation_date=now, method="phone",
+                notes="created by officer, soft-deleted",
+                consultation_status_id=status_id, deleted_at=now,
+            )
+            session.add(consult)
+            await session.flush()
+
+            data = {
+                "lead_id": lead.id, "consult_id": consult.id,
+                "officer_id": officer_id,
             }
     return data
 
@@ -407,3 +455,30 @@ async def test_s3_delete_consultation_correct_lead_still_works(
         _lead_consult_url(lead_b, consult_b), headers=admin_token_headers
     )
     assert r.status_code == 204, r.text
+
+
+# ===========================================================================
+# Route anh em leads.py restore — officer eager-load (chống 500 MissingGreenlet)
+# ===========================================================================
+
+
+async def test_leads_route_restore_officer_authored_consultation_no_500(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_authored_deleted_consultation: dict,
+):
+    """POST /api/leads/{id}/consultations/{cid}/restore (admin-only): admin
+    restore cuộc do OFFICER tạo → 200, KHÔNG 500 MissingGreenlet.
+
+    Route dùng response_model schemas.Consultation (có ``officer``); khi người
+    restore ≠ officer tạo cuộc, officer phải được eager-load ở re-fetch.
+    """
+    lead_id = officer_authored_deleted_consultation["lead_id"]
+    cid = officer_authored_deleted_consultation["consult_id"]
+    r = await client.post(
+        _restore_via_leads_route(lead_id, cid), headers=admin_token_headers
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["id"] == cid
+    assert body["officer_id"] == officer_authored_deleted_consultation["officer_id"]

--- a/Backend_FastAPI/tests/api/test_consultation_security.py
+++ b/Backend_FastAPI/tests/api/test_consultation_security.py
@@ -1,0 +1,409 @@
+# tests/api/test_consultation_security.py
+# -*- coding: utf-8 -*-
+"""Security regression tests cho PR consultation-security (2026-07-16).
+
+Phủ 3 lỗ hổng đã vá (S5 accountant-deny nằm ở
+``tests/integration/test_casbin_b1_4x14_matrix.py``):
+
+- **S1** — Manager restore consultation CROSS-UNIT (IDOR ghi). Guard cũ chỉ
+  check role → manager restore được consultation của mọi đơn vị. Fix: gọi
+  ``get_lead_for_user`` ép unit-scope trước ``restore_consultation``.
+- **S2** — Manager xem + search PII deleted-items TOÀN HỆ THỐNG (IDOR đọc).
+  Rows/counts/search đều không lọc unit → manager gõ chuỗi bất kỳ ra
+  tên/phone/email lead mọi đơn vị. Fix: unit-scope cho MỌI phần.
+- **S3** — Oracle 400-vs-404 khi dò ``consultation_id``. ``delete``/``update``
+  trả 400 "does not belong" khi consultation thuộc lead khác (400=tồn tại,
+  404=không) → enumerate toàn hệ thống. Fix: đưa ``lead_id`` vào WHERE → 404
+  đồng nhất.
+
+Router-level behavior (unit-scope trong ``deleted_items.py`` + mã lỗi HTTP mà
+attacker thực sự thấy) → test qua API, không phải service.
+"""
+import logging
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from app import models
+from app.database import AsyncSessionLocal
+from tests.fixtures.constants import AuthURLs
+
+log = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.security]
+
+DELETED_ITEMS_URL = "/api/admin/deleted-items"
+
+
+def _restore_consult_url(consultation_id: int) -> str:
+    return f"{DELETED_ITEMS_URL}/consultations/{consultation_id}/restore"
+
+
+def _lead_consult_url(lead_id: int, consultation_id: int) -> str:
+    return f"/api/leads/{lead_id}/consultations/{consultation_id}"
+
+
+# ===========================================================================
+# FIXTURES
+# ===========================================================================
+
+
+@pytest_asyncio.fixture(scope="function")
+async def manager_no_unit_token_headers(client: AsyncClient) -> dict:
+    """Manager CHƯA gán đơn vị (``unit_id=None``) — kiểm chứng fail-closed.
+
+    Không tái dùng ``manager_user_in_db`` (đã gán UNIT_1). Username riêng để
+    coexist trong cùng DB session.
+    """
+    from tests.fixtures.users import create_user_with_role, get_auth_headers
+    from app.main import fastapi_app
+    from app.security import get_password_hash
+
+    try:
+        from casbin_async_sqlalchemy_adapter.adapter import CasbinRule
+    except ImportError:  # pragma: no cover
+        CasbinRule = None
+
+    user_data = {
+        "username": "testmanager_nounit",
+        "email": "manager_nounit@example.com",
+        "password": "ManagerPassword!789",
+        "role": "manager",
+        "status": "active",
+    }
+    user_info = await create_user_with_role(
+        session_factory=AsyncSessionLocal,
+        user_data=user_data,
+        casbin_role="role:manager",
+        unit_id=None,
+        models=models,
+        get_password_hash=get_password_hash,
+        CasbinRule=CasbinRule,
+        app=fastapi_app,
+    )
+    return await get_auth_headers(client, user_info, AuthURLs.LOGIN)
+
+
+@pytest_asyncio.fixture(scope="function")
+async def deleted_items_dataset(
+    seed_lead_dependencies: dict,
+    seed_other_unit: dict,
+    admin_user_in_db: dict,
+) -> dict:
+    """Dữ liệu soft-deleted trải 2 đơn vị cho S1/S2.
+
+    UNIT_1 (đơn vị manager):
+      - ``lead_a2`` — lead đã xóa (hiện ở danh sách deleted-leads).
+      - ``lead_a1`` — lead còn sống + ``consult_a1`` đã xóa (hiện ở
+        deleted-consultations; list chỉ trả consultation của lead còn sống).
+    UNIT_2 (đơn vị khác): ``lead_b2`` (đã xóa) + ``lead_b1``/``consult_b1``.
+
+    Tên lead mang token ``ZZUNIT1``/``ZZUNIT2`` để test search không lộ chéo.
+    """
+    unit1 = seed_lead_dependencies["unit_id"]
+    unit2 = seed_other_unit["unit_id"]
+    status_id = seed_lead_dependencies["initial_status_id"]
+    officer_id = admin_user_in_db["id"]
+    now = datetime.now(timezone.utc)
+
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            lead_a2 = models.Lead(
+                full_name="ZZUNIT1 Deleted Lead", phone="0900000001",
+                email="zzunit1lead@test.com", source="website",
+                unit_id=unit1, assigned_officer_id=officer_id,
+                consultation_status_id=status_id, consultation_count=0,
+                status="new", deleted_at=now,
+            )
+            lead_a1 = models.Lead(
+                full_name="ZZUNIT1 Active Lead", phone="0900000002",
+                email="zzunit1active@test.com", source="website",
+                unit_id=unit1, assigned_officer_id=officer_id,
+                consultation_status_id=status_id, consultation_count=0,
+                status="new",
+            )
+            lead_b2 = models.Lead(
+                full_name="ZZUNIT2 Deleted Lead", phone="0900000003",
+                email="zzunit2lead@test.com", source="website",
+                unit_id=unit2, assigned_officer_id=officer_id,
+                consultation_status_id=status_id, consultation_count=0,
+                status="new", deleted_at=now,
+            )
+            lead_b1 = models.Lead(
+                full_name="ZZUNIT2 Active Lead", phone="0900000004",
+                email="zzunit2active@test.com", source="website",
+                unit_id=unit2, assigned_officer_id=officer_id,
+                consultation_status_id=status_id, consultation_count=0,
+                status="new",
+            )
+            session.add_all([lead_a2, lead_a1, lead_b2, lead_b1])
+            await session.flush()
+
+            consult_a1 = models.Consultation(
+                lead_id=lead_a1.id, officer_id=officer_id,
+                consultation_date=now, method="phone",
+                notes="unit1 deleted consult",
+                consultation_status_id=status_id, deleted_at=now,
+            )
+            consult_b1 = models.Consultation(
+                lead_id=lead_b1.id, officer_id=officer_id,
+                consultation_date=now, method="phone",
+                notes="unit2 deleted consult",
+                consultation_status_id=status_id, deleted_at=now,
+            )
+            session.add_all([consult_a1, consult_b1])
+            await session.flush()
+
+            data = {
+                "unit1": unit1, "unit2": unit2,
+                "lead_a2": lead_a2.id, "lead_a1": lead_a1.id,
+                "lead_b2": lead_b2.id, "lead_b1": lead_b1.id,
+                "consult_a1": consult_a1.id, "consult_b1": consult_b1.id,
+            }
+    return data
+
+
+@pytest_asyncio.fixture(scope="function")
+async def consultation_cross_lead_dataset(
+    seed_lead_dependencies: dict,
+    admin_user_in_db: dict,
+) -> dict:
+    """2 lead còn sống + 1 consultation (còn sống) thuộc ``lead_b`` — cho S3."""
+    unit1 = seed_lead_dependencies["unit_id"]
+    status_id = seed_lead_dependencies["initial_status_id"]
+    officer_id = admin_user_in_db["id"]
+    now = datetime.now(timezone.utc)
+
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            lead_a = models.Lead(
+                full_name="S3 Lead A", phone="0900000011",
+                email="s3leada@test.com", source="website",
+                unit_id=unit1, assigned_officer_id=officer_id,
+                consultation_status_id=status_id, consultation_count=0,
+                status="new",
+            )
+            lead_b = models.Lead(
+                full_name="S3 Lead B", phone="0900000012",
+                email="s3leadb@test.com", source="website",
+                unit_id=unit1, assigned_officer_id=officer_id,
+                consultation_status_id=status_id, consultation_count=0,
+                status="new",
+            )
+            session.add_all([lead_a, lead_b])
+            await session.flush()
+
+            consult_b = models.Consultation(
+                lead_id=lead_b.id, officer_id=officer_id,
+                consultation_date=now, method="phone",
+                notes="belongs to lead_b",
+                consultation_status_id=status_id,
+            )
+            session.add(consult_b)
+            await session.flush()
+
+            data = {
+                "lead_a": lead_a.id, "lead_b": lead_b.id,
+                "consult_b": consult_b.id,
+            }
+    return data
+
+
+# ===========================================================================
+# S2 — deleted-items list/count/search unit-scope (IDOR đọc)
+# ===========================================================================
+
+
+async def test_s2_admin_sees_all_units(
+    client: AsyncClient, admin_token_headers: dict, deleted_items_dataset: dict
+):
+    r = await client.get(DELETED_ITEMS_URL, headers=admin_token_headers)
+    assert r.status_code == 200, r.text
+    data = r.json()
+
+    assert data["total_leads"] == 2
+    assert data["total_consultations"] == 2
+    lead_ids = {row["id"] for row in data["deleted_leads"]}
+    assert deleted_items_dataset["lead_a2"] in lead_ids
+    assert deleted_items_dataset["lead_b2"] in lead_ids
+    consult_ids = {row["id"] for row in data["deleted_consultations"]}
+    assert deleted_items_dataset["consult_a1"] in consult_ids
+    assert deleted_items_dataset["consult_b1"] in consult_ids
+
+
+async def test_s2_manager_scoped_to_own_unit(
+    client: AsyncClient, manager_token_headers: dict, deleted_items_dataset: dict
+):
+    r = await client.get(DELETED_ITEMS_URL, headers=manager_token_headers)
+    assert r.status_code == 200, r.text
+    data = r.json()
+
+    # Counts CŨNG phải unit-scope (không chỉ rows) — nếu không manager suy ra
+    # được số lượng lead/consultation của đơn vị khác.
+    assert data["total_leads"] == 1
+    assert data["total_consultations"] == 1
+
+    lead_ids = {row["id"] for row in data["deleted_leads"]}
+    assert deleted_items_dataset["lead_a2"] in lead_ids
+    assert deleted_items_dataset["lead_b2"] not in lead_ids
+
+    consult_ids = {row["id"] for row in data["deleted_consultations"]}
+    assert deleted_items_dataset["consult_a1"] in consult_ids
+    assert deleted_items_dataset["consult_b1"] not in consult_ids
+
+
+async def test_s2_manager_search_cannot_enumerate_cross_unit(
+    client: AsyncClient, manager_token_headers: dict, deleted_items_dataset: dict
+):
+    # Search token của đơn vị KHÁC → manager UNIT_1 không được thấy gì.
+    r = await client.get(
+        DELETED_ITEMS_URL, headers=manager_token_headers,
+        params={"search": "ZZUNIT2"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    lead_ids = {row["id"] for row in data["deleted_leads"]}
+    assert deleted_items_dataset["lead_b2"] not in lead_ids
+    assert data["deleted_leads"] == []
+    assert data["deleted_consultations"] == []
+
+    # Sanity: search chính đơn vị mình vẫn ra.
+    r2 = await client.get(
+        DELETED_ITEMS_URL, headers=manager_token_headers,
+        params={"search": "ZZUNIT1"},
+    )
+    assert r2.status_code == 200, r2.text
+    own_ids = {row["id"] for row in r2.json()["deleted_leads"]}
+    assert deleted_items_dataset["lead_a2"] in own_ids
+
+
+async def test_s2_manager_without_unit_sees_nothing(
+    client: AsyncClient,
+    manager_no_unit_token_headers: dict,
+    deleted_items_dataset: dict,
+):
+    r = await client.get(
+        DELETED_ITEMS_URL, headers=manager_no_unit_token_headers
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["total_leads"] == 0
+    assert data["total_consultations"] == 0
+    assert data["deleted_leads"] == []
+    assert data["deleted_consultations"] == []
+
+
+# ===========================================================================
+# S1 — restore consultation cross-unit (IDOR ghi)
+# ===========================================================================
+
+
+async def test_s1_manager_cannot_restore_cross_unit_consultation(
+    client: AsyncClient, manager_token_headers: dict, deleted_items_dataset: dict
+):
+    # consult_b1 thuộc UNIT_2 → manager UNIT_1 phải bị 404 (không lộ tồn tại).
+    r = await client.post(
+        _restore_consult_url(deleted_items_dataset["consult_b1"]),
+        headers=manager_token_headers,
+    )
+    assert r.status_code == 404, r.text
+
+
+async def test_s1_manager_can_restore_own_unit_consultation(
+    client: AsyncClient, manager_token_headers: dict, deleted_items_dataset: dict
+):
+    r = await client.post(
+        _restore_consult_url(deleted_items_dataset["consult_a1"]),
+        headers=manager_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == deleted_items_dataset["consult_a1"]
+
+
+async def test_s1_manager_without_unit_cannot_restore(
+    client: AsyncClient,
+    manager_no_unit_token_headers: dict,
+    deleted_items_dataset: dict,
+):
+    r = await client.post(
+        _restore_consult_url(deleted_items_dataset["consult_a1"]),
+        headers=manager_no_unit_token_headers,
+    )
+    assert r.status_code == 404, r.text
+
+
+async def test_s1_admin_can_restore_any_unit_consultation(
+    client: AsyncClient, admin_token_headers: dict, deleted_items_dataset: dict
+):
+    r = await client.post(
+        _restore_consult_url(deleted_items_dataset["consult_b1"]),
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == deleted_items_dataset["consult_b1"]
+
+
+# ===========================================================================
+# S3 — oracle 400-vs-404 khi dò consultation_id (enumeration)
+# ===========================================================================
+
+
+async def test_s3_delete_consultation_wrong_lead_is_404_not_400(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    consultation_cross_lead_dataset: dict,
+):
+    lead_a = consultation_cross_lead_dataset["lead_a"]
+    consult_b = consultation_cross_lead_dataset["consult_b"]  # thuộc lead_b
+
+    # Tồn tại nhưng thuộc lead khác → PHẢI 404 (trước fix: 400 "does not belong").
+    r_mismatch = await client.delete(
+        _lead_consult_url(lead_a, consult_b), headers=admin_token_headers
+    )
+    assert r_mismatch.status_code == 404, r_mismatch.text
+
+    # Không tồn tại → cũng 404. Hai trường hợp KHÔNG phân biệt được (hết oracle).
+    r_missing = await client.delete(
+        _lead_consult_url(lead_a, 999_999_999), headers=admin_token_headers
+    )
+    assert r_missing.status_code == 404, r_missing.text
+    assert r_mismatch.status_code == r_missing.status_code
+
+
+async def test_s3_update_consultation_wrong_lead_is_404_not_400(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    consultation_cross_lead_dataset: dict,
+):
+    lead_a = consultation_cross_lead_dataset["lead_a"]
+    consult_b = consultation_cross_lead_dataset["consult_b"]
+
+    r_mismatch = await client.put(
+        _lead_consult_url(lead_a, consult_b),
+        json={"notes": "tries to touch another lead's consultation"},
+        headers=admin_token_headers,
+    )
+    assert r_mismatch.status_code == 404, r_mismatch.text
+
+    r_missing = await client.put(
+        _lead_consult_url(lead_a, 999_999_999),
+        json={"notes": "x"},
+        headers=admin_token_headers,
+    )
+    assert r_missing.status_code == 404, r_missing.text
+
+
+async def test_s3_delete_consultation_correct_lead_still_works(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    consultation_cross_lead_dataset: dict,
+):
+    # Control: đúng chủ sở hữu vẫn xóa được (fix không chặn nhầm đường hợp lệ).
+    lead_b = consultation_cross_lead_dataset["lead_b"]
+    consult_b = consultation_cross_lead_dataset["consult_b"]
+    r = await client.delete(
+        _lead_consult_url(lead_b, consult_b), headers=admin_token_headers
+    )
+    assert r.status_code == 204, r.text

--- a/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
+++ b/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
@@ -456,6 +456,14 @@ async def test_accountant_deny_rows_seeded(setup_test_database):
             ("/api/leads/{id}/insights",              "GET"),
             ("/api/leads/{id}/audit-logs",            "GET"),
             ("/api/leads/{id}/consultations",         "GET"),
+            # PR consultation-security (2026-07-16) — accountant inherits the
+            # officer consultation WRITE grants; only GET was denied, so finance
+            # staff could create/edit/delete consultations (and thereby move lead
+            # status) while unable to read the list. Migration
+            # `consultacctdeny20260716` seeds these 3.
+            ("/api/leads/{id}/consultations",         "POST"),
+            ("/api/leads/{id}/consultations/{consultation_id}", "PUT"),
+            ("/api/leads/{id}/consultations/{consultation_id}", "DELETE"),
             ("/api/leads/check-duplicate",            "GET"),
             ("/api/leads/import",                     "POST"),
             ("/api/leads/import/template",            "GET"),


### PR DESCRIPTION
## Bối cảnh
PR-1 của kế hoạch hardening luồng consultation. Độc lập, **không đổi contract FE** (BE-only). Vá 5 lỗ hổng bảo mật (S1–S5) + test hồi quy + 1 fix 500 ẩn.

## Các lỗ hổng đã vá

| # | Lỗ hổng | Fix |
|---|---------|-----|
| **S1** | Manager restore consultation **cross-unit** (IDOR ghi) — guard chỉ check role | Gọi `get_lead_for_user` ép unit-scope trước `restore_consultation`; manager không unit → fail-closed 404 |
| **S2** | Manager xem + **search PII deleted-items TOÀN HỆ THỐNG** (IDOR đọc) — rows/counts/search đều không lọc unit → enumerate tên/phone/email mọi đơn vị | Unit-scope cho **mọi phần** (rows + `total_leads`/`total_consultations` + search); admin giữ toàn hệ thống |
| **S3** | **Oracle 400-vs-404** — `delete`/`update` consultation thuộc lead khác trả 400 "does not belong" (400=tồn tại, 404=không) → dò `consultation_id` toàn hệ thống | Đưa `lead_id` vào WHERE → 404 đồng nhất (theo `restore_consultation`) |
| **S4** | Docstring sai contract quyền route restore (nhánh officer = dead code) | Sửa docstring cho đúng; **không mở thêm quyền** |
| **S5** | **Accountant ghi/sửa/xóa được consultation** (kế thừa officer; chỉ GET bị deny) — viết consultation = đẩy được lead qua pipeline | Thêm 3 deny row POST/PUT/DELETE vào `ACCOUNTANT_TEMPLATE` + **migration** `consultacctdeny20260716` (seed `casbin_rule` với `v3='deny'`) |

## Fix kèm (phát hiện bởi test)
- **500 ẩn ở `restore_deleted_consultation`**: re-fetch thiếu eager-load `Consultation.officer`; khi người restore ≠ officer tạo cuộc (đúng ca S1 mở cho manager) → serialize `schemas.Consultation.officer` lazy-load → `MissingGreenlet`. Thêm `selectinload(Consultation.officer)`. Success-path này trước đây không test nào chạy.

## Test
- `tests/api/test_consultation_security.py` (mới, marker `security`) — S1/S2/S3 đầy đủ (admin/manager/manager-no-unit).
- `tests/integration/test_casbin_b1_4x14_matrix.py` — cập nhật exact-set cho 3 deny row S5.
- **12 passed** (one-off container). Đã thêm test file mới vào allowlist CI Tier 2 `backend-test.yml`.
- flake8 code mới sạch; alembic single head `consultacctdeny20260716`.

## ⚠️ Lưu ý DEPLOY (S5)
- Migration seed `casbin_rule` (Alembic = đường ghi tự động DUY NHẤT; sửa `policy_templates.py` một mình = 0 row trên prod).
- **PHẢI RESTART container backend** sau upgrade — KHÔNG dùng `POST /api/v2/admin/casbin/reload` (enforcer build per-process, Gunicorn multi-worker → deny áp một phần).
- Verify: `SELECT v1,v2 FROM casbin_rule WHERE ptype='p' AND v0='role:accountant' AND v3='deny' AND v1 LIKE '%consultations%'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)