### PR TITLE
fix(security): R1 — chặn CỨNG assign/reassign lead consultation-terminal (né ping-pong)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -254,6 +254,8 @@ jobs:
           tests/api/test_admission_workflow_api.py
           tests/api/test_lead_assignment_api.py::test_lead_assignment_lifecycle_end_to_end
           tests/services/test_assignment.py
+          tests/unit/test_lead_action_permissions.py
+          tests/integration/test_reassign_terminal_guard.py
           tests/services/test_assignment_self_sourced.py
           tests/unit/test_admission_state_machine.py
           tests/unit/test_b2_1_admission_milestone_events.py

--- a/Backend_FastAPI/app/core/status_mapping.py
+++ b/Backend_FastAPI/app/core/status_mapping.py
@@ -34,7 +34,7 @@ import structlog
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
-    from ..models import ConsultationStatus
+    from ..models import ConsultationStatus, Lead
 
 log = structlog.get_logger(__name__)
 
@@ -75,6 +75,24 @@ def is_consultation_terminal_status(cs: "Optional[ConsultationStatus]") -> bool:
     (sts16/sts08/...). Xem Documents/LEAD_REOPEN_WORKFLOW_PLAN.md.
     """
     return cs is not None and bool(cs.is_final) and cs.phase == "consultation"
+
+
+async def is_lead_consultation_terminal(
+    db: "AsyncSession", lead: "Lead"
+) -> bool:
+    """Async: nạp ConsultationStatus của lead rồi kiểm tra consultation-terminal
+    (sts20). Dùng cho guard chỉ có sẵn ``lead`` + ``db`` (chưa load status). Dùng
+    ``db.get`` theo PK (identity-map friendly), KHÔNG chạm lazy relationship
+    (tránh MissingGreenlet). Trả False nếu lead chưa có consultation status.
+
+    Nơi ĐÃ có status load sẵn (vd ``TerminalGuardResult.current_status``) gọi
+    thẳng ``is_consultation_terminal_status`` để khỏi nạp lại.
+    """
+    if not lead.consultation_status_id:
+        return False
+    from .. import models  # local: giữ module import-light + tránh vòng import
+    cs = await db.get(models.ConsultationStatus, lead.consultation_status_id)
+    return is_consultation_terminal_status(cs)
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/core/task_constants.py
+++ b/Backend_FastAPI/app/core/task_constants.py
@@ -19,6 +19,9 @@ class AssignmentFailureReason:
     LEAD_NOT_FOUND = "lead_not_found"
     LEAD_DELETED = "lead_deleted"
     ALREADY_ASSIGNED = "already_assigned"
+    # R1: lead consultation-terminal (đã đóng, vd sts20) — auto-assign KHÔNG
+    # BAO GIỜ vớ lead đóng; phải reopen trước.
+    LEAD_TERMINAL = "lead_terminal"
 
 
 class AssignmentSkipReason:

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import models
 from ..core.constants import UserRole
 from ..core.events import SystemEvents
-from ..core.status_mapping import is_consultation_terminal_status
+from ..core.status_mapping import is_lead_consultation_terminal
 from ..core.task_constants import AssignmentResult, AssignmentFailureReason
 from ..utils.exceptions import LockContentionError
 from .assignment_reason import SELF_SOURCED_REASON_TOKEN
@@ -340,14 +340,7 @@ async def automatically_assign_lead(
                 # terminal = no-op có log (KHÔNG raise). sts20 vốn đã bị
                 # _non_final_status_filter loại khỏi khâu QUÉT workload, nhưng
                 # auto-assign per-id vẫn tới đây nếu bị enqueue → chặn tại đây.
-                _cs = (
-                    await db.get(
-                        models.ConsultationStatus, lead.consultation_status_id
-                    )
-                    if lead.consultation_status_id
-                    else None
-                )
-                if is_consultation_terminal_status(_cs):
+                if await is_lead_consultation_terminal(db, lead):
                     log.info(
                         f"[Lead ID: {lead_id}] Lead consultation-terminal (đã "
                         f"đóng), skip auto-assign."

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import models
 from ..core.constants import UserRole
 from ..core.events import SystemEvents
+from ..core.status_mapping import is_consultation_terminal_status
 from ..core.task_constants import AssignmentResult, AssignmentFailureReason
 from ..utils.exceptions import LockContentionError
 from .assignment_reason import SELF_SOURCED_REASON_TOKEN
@@ -334,6 +335,29 @@ async def automatically_assign_lead(
                 )
                 return {"status": AssignmentResult.SKIPPED, "reason": AssignmentFailureReason.ALREADY_ASSIGNED, "lead_id": lead_id, "officer_id": lead.assigned_officer_id}, _post_commit_callbacks
             else:
+                # ✅ R1: auto-assign KHÔNG BAO GIỜ vớ lead consultation-terminal
+                # (đã đóng, vd sts20) — phải reopen trước. Chạy per-lead-id nên
+                # terminal = no-op có log (KHÔNG raise). sts20 vốn đã bị
+                # _non_final_status_filter loại khỏi khâu QUÉT workload, nhưng
+                # auto-assign per-id vẫn tới đây nếu bị enqueue → chặn tại đây.
+                _cs = (
+                    await db.get(
+                        models.ConsultationStatus, lead.consultation_status_id
+                    )
+                    if lead.consultation_status_id
+                    else None
+                )
+                if is_consultation_terminal_status(_cs):
+                    log.info(
+                        f"[Lead ID: {lead_id}] Lead consultation-terminal (đã "
+                        f"đóng), skip auto-assign."
+                    )
+                    return {
+                        "status": AssignmentResult.SKIPPED,
+                        "reason": AssignmentFailureReason.LEAD_TERMINAL,
+                        "lead_id": lead_id,
+                    }, _post_commit_callbacks
+
                 lead_unit_id = lead.unit_id
                 # Get blacklisted officers for this lead
                 blacklisted_officer_ids = lead.rejected_by_officer_ids or []

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -767,7 +767,15 @@ async def get_leads(
     # truyền None nên bỏ qua. Không truy vấn DB thêm (đọc role + assigned_officer_id).
     if current_user is not None:
         for _lead in leads:
-            _lead.permissions = compute_lead_action_permissions(_lead, current_user)
+            # R1: cờ terminal lấy từ consultation_status (get_filtered eager-load
+            # sẵn → không query thêm) để tắt giao/đổi officer trên lead đã đóng.
+            _lead.permissions = compute_lead_action_permissions(
+                _lead,
+                current_user,
+                is_terminal=is_consultation_terminal_status(
+                    _lead.consultation_status
+                ),
+            )
 
     return total_count, leads, summary
 
@@ -2310,6 +2318,21 @@ async def assign_lead_manually(
             # ✅ FIX: Explicit deleted check (get_lead_by_id may not always exclude)
             if lead.deleted_at is not None:
                 raise BadRequest(detail="Cannot assign a deleted lead.")
+
+            # ✅ R1: Lead đã đóng (consultation-terminal, vd sts20) KHÔNG được
+            # giao/đổi officer bằng đường thủ công (kể cả bulk, đi qua đây) — phải
+            # reopen trước. Chặn CỨNG (check_terminal_status_guard chỉ hard-block
+            # 'enrolled', để soft cho sts20 nên không đủ ở đây).
+            current_cs = (
+                await db.get(models.ConsultationStatus, lead.consultation_status_id)
+                if lead.consultation_status_id
+                else None
+            )
+            if is_consultation_terminal_status(current_cs):
+                raise BusinessRuleViolation(
+                    detail="Lead đã đóng (ngừng tư vấn) — cần mở lại trước khi "
+                    "giao cho người khác."
+                )
             
             officer = await db.get(models.User, officer_id)
 
@@ -3443,6 +3466,22 @@ async def process_officer_action(
             terminal_guard = await check_terminal_status_guard(db, lead)
             if terminal_guard.hard_block:
                 raise BusinessRuleViolation(detail=terminal_guard.reason)
+
+            # ✅ R1: reassign trên lead consultation-terminal (sts20) — chặn CỨNG.
+            # check_terminal_status_guard chỉ hard-block 'enrolled' (soft cho
+            # sts20) nên officer/manager vẫn nhả được officer → lead ping-pong né
+            # reopen. Phải reopen trước. (reject vẫn cho qua — chỉ khóa đổi người.)
+            if action == "reassign":
+                _reassign_cs = (
+                    await db.get(models.ConsultationStatus, lead.consultation_status_id)
+                    if lead.consultation_status_id
+                    else None
+                )
+                if is_consultation_terminal_status(_reassign_cs):
+                    raise BusinessRuleViolation(
+                        detail="Lead đã đóng (ngừng tư vấn) — cần mở lại trước khi "
+                        "đổi người phụ trách."
+                    )
 
             # ✅ FIX: Admin/Manager can reassign ANY lead, Officers can only reassign their own
             if not is_admin_or_manager and lead.assigned_officer_id != officer_id:
@@ -4905,6 +4944,7 @@ def _lead_role_context(
 def compute_lead_action_permissions(
     lead: models.Lead,
     current_user: Optional[models.User],
+    is_terminal: bool = False,
 ) -> dict[str, bool]:
     """Query-free lead action flags (transfer / reassign) from role + assignment
     state only.
@@ -4914,6 +4954,13 @@ def compute_lead_action_permissions(
     "Chuyển giao lead" / "Yêu cầu đổi người phụ trách" WITHOUT a per-row detail
     fetch — and WITHOUT the FE reading ``user.role`` (thin-client rule). No DB
     access → safe to call per list item. Returns ``{}`` for system contexts.
+
+    ``is_terminal`` (R1): lead consultation-terminal (đã đóng, vd sts20) KHÔNG
+    được giao/đổi/xin-đổi officer — phải reopen trước (khớp guard BE ở
+    ``assign_lead_manually`` / ``process_officer_action``). Caller tính từ
+    consultation status đã eager-load (list) hoặc ``cs_terminal`` (detail) rồi
+    truyền vào để giữ hàm pure-sync. Nút hợp lệ còn lại trên lead đóng chỉ là
+    ``can_reopen``.
     """
     if current_user is None:
         return {}
@@ -4923,11 +4970,11 @@ def compute_lead_action_permissions(
     return {
         # manager/admin gán lead CHƯA có người phụ trách (endpoint /assign =
         # "Admin/Manager only") → thin-client gate nút "Gán cho cán bộ".
-        "can_assign_lead": is_manager_admin,
+        "can_assign_lead": is_manager_admin and not is_terminal,
         # manager/admin đổi trực tiếp; chỉ khi lead đã có người phụ trách
-        "can_transfer_lead": is_manager_admin and lead_assigned,
+        "can_transfer_lead": is_manager_admin and lead_assigned and not is_terminal,
         # officer ĐƯỢC GIAO lead → xin đổi
-        "can_request_reassign": is_officer_assigned,
+        "can_request_reassign": is_officer_assigned and not is_terminal,
     }
 
 
@@ -5020,7 +5067,9 @@ async def _populate_lead_detail_fields(
     # Backend là nơi role-gate duy nhất. Chỉ áp khi lead đã có người phụ trách;
     # lead chưa gán dùng luồng "Gán cho cán bộ" riêng. Cùng nguồn với list
     # serializer qua compute_lead_action_permissions() (single source of truth).
-    permissions.update(compute_lead_action_permissions(lead, current_user))
+    permissions.update(
+        compute_lead_action_permissions(lead, current_user, is_terminal=cs_terminal)
+    )
 
     lead.permissions = permissions
     lead.available_actions = [k for k, v in permissions.items() if v]

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -26,6 +26,7 @@ from ..services import pipeline_service, distribution_service, audit_service
 from ..core.status_mapping import (
     sync_lead_status_from_consultation,
     is_consultation_terminal_status,
+    is_lead_consultation_terminal,
 )
 from ..core.constants import UserRole
 from .status_helper import StatusHelper, AssignmentStatus
@@ -772,7 +773,7 @@ async def get_leads(
             _lead.permissions = compute_lead_action_permissions(
                 _lead,
                 current_user,
-                is_terminal=is_consultation_terminal_status(
+                is_consultation_terminal=is_consultation_terminal_status(
                     _lead.consultation_status
                 ),
             )
@@ -2323,12 +2324,7 @@ async def assign_lead_manually(
             # giao/đổi officer bằng đường thủ công (kể cả bulk, đi qua đây) — phải
             # reopen trước. Chặn CỨNG (check_terminal_status_guard chỉ hard-block
             # 'enrolled', để soft cho sts20 nên không đủ ở đây).
-            current_cs = (
-                await db.get(models.ConsultationStatus, lead.consultation_status_id)
-                if lead.consultation_status_id
-                else None
-            )
-            if is_consultation_terminal_status(current_cs):
+            if await is_lead_consultation_terminal(db, lead):
                 raise BusinessRuleViolation(
                     detail="Lead đã đóng (ngừng tư vấn) — cần mở lại trước khi "
                     "giao cho người khác."
@@ -2411,6 +2407,24 @@ async def assign_lead_manually(
             )
             # Commit nested transaction (auto-commits on context exit)
 
+        except (
+            BusinessRuleViolation,
+            BadRequest,
+            ResourceNotFoundError,
+            PermissionDeniedError,
+        ) as e:
+            # 400/404/403 kỳ vọng (vd lead đã đóng R1 / đã xóa / officer sai) →
+            # WARNING, KHÔNG ERROR+traceback. BusinessRuleViolation là anh em với
+            # BadRequest dưới ValidationError nên phải liệt kê tường minh, nếu
+            # không rơi except Exception. begin_nested tự rollback savepoint khi
+            # raise thoát ra.
+            log.warning(
+                "Manual assign rejected (expected business/validation error)",
+                lead_id=lead_id,
+                officer_id=officer_id,
+                detail=getattr(e, "detail", str(e)),
+            )
+            raise e
         except Exception as e:
             # Rollback tự động
             log.error(
@@ -3471,17 +3485,14 @@ async def process_officer_action(
             # check_terminal_status_guard chỉ hard-block 'enrolled' (soft cho
             # sts20) nên officer/manager vẫn nhả được officer → lead ping-pong né
             # reopen. Phải reopen trước. (reject vẫn cho qua — chỉ khóa đổi người.)
-            if action == "reassign":
-                _reassign_cs = (
-                    await db.get(models.ConsultationStatus, lead.consultation_status_id)
-                    if lead.consultation_status_id
-                    else None
+            # Tái dùng status đã load ở terminal_guard.current_status (khỏi re-fetch).
+            if action == "reassign" and is_consultation_terminal_status(
+                terminal_guard.current_status
+            ):
+                raise BusinessRuleViolation(
+                    detail="Lead đã đóng (ngừng tư vấn) — cần mở lại trước khi "
+                    "đổi người phụ trách."
                 )
-                if is_consultation_terminal_status(_reassign_cs):
-                    raise BusinessRuleViolation(
-                        detail="Lead đã đóng (ngừng tư vấn) — cần mở lại trước khi "
-                        "đổi người phụ trách."
-                    )
 
             # ✅ FIX: Admin/Manager can reassign ANY lead, Officers can only reassign their own
             if not is_admin_or_manager and lead.assigned_officer_id != officer_id:
@@ -3624,9 +3635,13 @@ async def process_officer_action(
     except (
         PermissionDeniedError,
         BadRequest,
+        BusinessRuleViolation,
         ResourceNotFoundError,
     ) as e:  # Thêm ResourceNotFoundError
-        # Rollback nếu lỗi validation hoặc không tìm thấy
+        # Rollback nếu lỗi validation hoặc không tìm thấy (400/404 kỳ vọng —
+        # WARNING, KHÔNG phải ERROR+traceback). BusinessRuleViolation là anh em
+        # với BadRequest dưới ValidationError nên phải liệt kê tường minh (vd
+        # guard terminal R1 / enrolled) — nếu không rơi except Exception ở dưới.
         await db.rollback()
         log.warning(
             "Officer action failed validation or resource not found",
@@ -4944,7 +4959,7 @@ def _lead_role_context(
 def compute_lead_action_permissions(
     lead: models.Lead,
     current_user: Optional[models.User],
-    is_terminal: bool = False,
+    is_consultation_terminal: bool = False,
 ) -> dict[str, bool]:
     """Query-free lead action flags (transfer / reassign) from role + assignment
     state only.
@@ -4955,12 +4970,14 @@ def compute_lead_action_permissions(
     fetch — and WITHOUT the FE reading ``user.role`` (thin-client rule). No DB
     access → safe to call per list item. Returns ``{}`` for system contexts.
 
-    ``is_terminal`` (R1): lead consultation-terminal (đã đóng, vd sts20) KHÔNG
-    được giao/đổi/xin-đổi officer — phải reopen trước (khớp guard BE ở
-    ``assign_lead_manually`` / ``process_officer_action``). Caller tính từ
-    consultation status đã eager-load (list) hoặc ``cs_terminal`` (detail) rồi
-    truyền vào để giữ hàm pure-sync. Nút hợp lệ còn lại trên lead đóng chỉ là
-    ``can_reopen``.
+    ``is_consultation_terminal`` (R1): lead consultation-terminal (đã đóng, vd
+    sts20) KHÔNG được giao/đổi/xin-đổi officer — phải reopen trước (khớp guard BE
+    ở ``assign_lead_manually`` / ``process_officer_action``). Caller tính từ
+    ``is_consultation_terminal_status`` trên consultation status đã eager-load
+    (list) hoặc ``cs_terminal`` (detail) rồi truyền vào để giữ hàm pure-sync.
+    ⚠️ KHÔNG truyền ``TerminalGuardResult.is_terminal`` (là is_final MỌI phase,
+    gồm enrolled) — sẽ tắt nhầm nút trên lead final phase khác. Nút hợp lệ còn
+    lại trên lead đóng chỉ là ``can_reopen``.
     """
     if current_user is None:
         return {}
@@ -4970,11 +4987,13 @@ def compute_lead_action_permissions(
     return {
         # manager/admin gán lead CHƯA có người phụ trách (endpoint /assign =
         # "Admin/Manager only") → thin-client gate nút "Gán cho cán bộ".
-        "can_assign_lead": is_manager_admin and not is_terminal,
+        "can_assign_lead": is_manager_admin and not is_consultation_terminal,
         # manager/admin đổi trực tiếp; chỉ khi lead đã có người phụ trách
-        "can_transfer_lead": is_manager_admin and lead_assigned and not is_terminal,
+        "can_transfer_lead": (
+            is_manager_admin and lead_assigned and not is_consultation_terminal
+        ),
         # officer ĐƯỢC GIAO lead → xin đổi
-        "can_request_reassign": is_officer_assigned and not is_terminal,
+        "can_request_reassign": is_officer_assigned and not is_consultation_terminal,
     }
 
 
@@ -5068,7 +5087,9 @@ async def _populate_lead_detail_fields(
     # lead chưa gán dùng luồng "Gán cho cán bộ" riêng. Cùng nguồn với list
     # serializer qua compute_lead_action_permissions() (single source of truth).
     permissions.update(
-        compute_lead_action_permissions(lead, current_user, is_terminal=cs_terminal)
+        compute_lead_action_permissions(
+            lead, current_user, is_consultation_terminal=cs_terminal
+        )
     )
 
     lead.permissions = permissions

--- a/Backend_FastAPI/tests/integration/test_reassign_terminal_guard.py
+++ b/Backend_FastAPI/tests/integration/test_reassign_terminal_guard.py
@@ -1,0 +1,90 @@
+"""Integration tests (R1) — chặn assign/reassign trên lead consultation-terminal.
+
+Lead đã đóng (sts20: ``is_final`` + ``phase=='consultation'``) KHÔNG được giao/đổi
+officer bằng đường thủ công hay officer-reassign — phải reopen trước. Guard mềm
+``check_terminal_status_guard`` chỉ hard-block ``enrolled`` nên R1 chặn CỨNG riêng
+ở đường assign. Xem plan ``spicy-rolling-whistle.md`` §R1.
+
+Đường hợp lệ (reopen→assign) + non-terminal vẫn giao được đã có test hiện hữu
+phủ (``test_assignment.py`` + assign flow), nên file này chỉ khoá 2 lỗ mới.
+"""
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.services import lead_service
+from app.utils.exceptions import BusinessRuleViolation
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+@pytest_asyncio.fixture
+async def terminal_status(
+    db: AsyncSession, seeded_dependencies: dict
+) -> models.ConsultationStatus:
+    """Consultation status CUỐI phase tư vấn (giống sts20 prod)."""
+    cs = models.ConsultationStatus(
+        id="STS20_TEST",
+        name="Ngừng tư vấn (test)",
+        color_code="#CC0000",
+        stage_id=seeded_dependencies["stage_id"],
+        is_final=True,
+        phase="consultation",
+    )
+    db.add(cs)
+    await db.flush()
+    return cs
+
+
+@pytest_asyncio.fixture
+async def terminal_lead(
+    db: AsyncSession,
+    seeded_dependencies: dict,
+    terminal_status: models.ConsultationStatus,
+    officer_user: models.User,
+) -> models.Lead:
+    """Lead đã đóng (terminal), đang gán cho officer_user."""
+    lead = models.Lead(
+        full_name="Terminal Lead",
+        phone="0900111222",
+        email="terminal_lead@test.com",
+        source="website",
+        unit_id=seeded_dependencies["unit_id"],
+        assigned_officer_id=officer_user.id,
+        consultation_status_id=terminal_status.id,
+        consultation_count=0,
+        status="rejected",
+    )
+    db.add(lead)
+    await db.flush()
+    await db.refresh(lead)
+    return lead
+
+
+async def test_assign_lead_manually_blocks_terminal(
+    db: AsyncSession,
+    terminal_lead: models.Lead,
+    officer_user: models.User,
+    manager_user: models.User,
+):
+    """Manager giao lead đã đóng cho officer khác → BusinessRuleViolation."""
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await lead_service.assign_lead_manually(
+            db, terminal_lead.id, officer_user.id, manager_user
+        )
+    assert "mở lại" in str(exc.value.detail).lower()
+
+
+async def test_officer_reassign_blocks_terminal(
+    db: AsyncSession,
+    terminal_lead: models.Lead,
+    officer_user: models.User,
+):
+    """Officer tự xin đổi người (reassign) trên lead đã đóng → chặn CỨNG
+    (né ping-pong bỏ qua reopen)."""
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await lead_service.process_officer_action(
+            db, terminal_lead.id, officer_user, "reassign", "muốn đổi người"
+        )
+    assert "mở lại" in str(exc.value.detail).lower()

--- a/Backend_FastAPI/tests/services/test_assignment.py
+++ b/Backend_FastAPI/tests/services/test_assignment.py
@@ -16,7 +16,8 @@ independent flags on ``settings``:
     ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT  → add historical-share fairness term
 """
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
@@ -245,6 +246,28 @@ async def test_assign_skip_lead_already_assigned(mock_db_session, lead_new):
     await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
 
     assert lead_new.assigned_officer_id == 999
+    assert mock_db_session.add.call_count == 0
+    assert mock_db_session.add_all.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_assign_skip_lead_consultation_terminal(mock_db_session, lead_new):
+    """R1: lead consultation-terminal (đã đóng, vd sts20) chưa gán ⇒ auto-assign
+    SKIPPED (no-op), KHÔNG chọn officer, KHÔNG add gì. Đường hợp lệ = reopen
+    trước rồi mới assign."""
+    lead_new.consultation_status_id = "sts20"
+    mock_db_session.execute.side_effect = [_lead_result(lead_new)]
+    # db.get(ConsultationStatus, ...) trả status terminal (is_final + phase tư vấn)
+    mock_db_session.get = AsyncMock(
+        return_value=SimpleNamespace(is_final=True, phase="consultation")
+    )
+
+    result, _ = await assignment_service.automatically_assign_lead(
+        lead_new.id, mock_db_session
+    )
+
+    assert result["reason"] == AssignmentFailureReason.LEAD_TERMINAL
+    assert lead_new.assigned_officer_id is None
     assert mock_db_session.add.call_count == 0
     assert mock_db_session.add_all.call_count == 0
 

--- a/Backend_FastAPI/tests/unit/test_lead_action_permissions.py
+++ b/Backend_FastAPI/tests/unit/test_lead_action_permissions.py
@@ -74,7 +74,9 @@ def test_terminal_lead_disables_transfer_and_assign_for_manager():
     # Lead đã đóng → manager/admin KHÔNG được gán/đổi trực tiếp; đường hợp lệ
     # duy nhất là reopen (cờ can_reopen tính ở _populate_lead_detail_fields).
     p = compute_lead_action_permissions(
-        _lead(assigned_officer_id=5), _user(UserRole.MANAGER), is_terminal=True
+        _lead(assigned_officer_id=5),
+        _user(UserRole.MANAGER),
+        is_consultation_terminal=True,
     )
     assert p["can_transfer_lead"] is False
     assert p["can_assign_lead"] is False
@@ -85,7 +87,7 @@ def test_terminal_lead_disables_request_reassign_for_officer():
     p = compute_lead_action_permissions(
         _lead(assigned_officer_id=7),
         _user(UserRole.OFFICER, uid=7),
-        is_terminal=True,
+        is_consultation_terminal=True,
     )
     assert p["can_request_reassign"] is False
     assert p["can_transfer_lead"] is False

--- a/Backend_FastAPI/tests/unit/test_lead_action_permissions.py
+++ b/Backend_FastAPI/tests/unit/test_lead_action_permissions.py
@@ -65,3 +65,37 @@ def test_officer_not_assigned_no_flags():
 
 def test_system_context_none_user_returns_empty():
     assert compute_lead_action_permissions(_lead(assigned_officer_id=5), None) == {}
+
+
+# --- R1: lead consultation-terminal (đã đóng) tắt mọi cờ giao/đổi officer ---
+
+
+def test_terminal_lead_disables_transfer_and_assign_for_manager():
+    # Lead đã đóng → manager/admin KHÔNG được gán/đổi trực tiếp; đường hợp lệ
+    # duy nhất là reopen (cờ can_reopen tính ở _populate_lead_detail_fields).
+    p = compute_lead_action_permissions(
+        _lead(assigned_officer_id=5), _user(UserRole.MANAGER), is_terminal=True
+    )
+    assert p["can_transfer_lead"] is False
+    assert p["can_assign_lead"] is False
+    assert p["can_request_reassign"] is False
+
+
+def test_terminal_lead_disables_request_reassign_for_officer():
+    p = compute_lead_action_permissions(
+        _lead(assigned_officer_id=7),
+        _user(UserRole.OFFICER, uid=7),
+        is_terminal=True,
+    )
+    assert p["can_request_reassign"] is False
+    assert p["can_transfer_lead"] is False
+    assert p["can_assign_lead"] is False
+
+
+def test_is_terminal_defaults_false_preserves_prior_behavior():
+    # Không truyền is_terminal → hành vi cũ giữ nguyên (không hồi quy).
+    p = compute_lead_action_permissions(
+        _lead(assigned_officer_id=5), _user(UserRole.MANAGER)
+    )
+    assert p["can_transfer_lead"] is True
+    assert p["can_assign_lead"] is True


### PR DESCRIPTION
## Bối cảnh
Lead đã đóng (consultation-terminal sts20: `is_final` + `phase=='consultation'`) trước đây vẫn **đổi được officer qua CẢ 4 đường** — không đường nào chặn terminal (`check_terminal_status_guard` cố ý chỉ hard-block `enrolled`, soft cho sts20 để cho phép GHI consultation). Officer tự reassign lead sts20 → **ping-pong đổi chủ né reopen**, bỏ qua `lead_reopen_service` (đường hợp lệ duy nhất đưa terminal về vòng làm việc).

**Owner chốt (16-07):** (1) lead đóng KHÔNG đổi officer bằng BẤT KỲ đường nào — phải reopen trước; (2) auto-assign KHÔNG BAO GIỜ vớ lead đóng.

## Fix — chặn CỨNG mọi đường (BE-only)
| Đường | Chặn |
|---|---|
| `assign_lead_manually` (thủ công, **bịt luôn bulk** đi qua đây) | → `BusinessRuleViolation` |
| `process_officer_action` `action=='reassign'` (reject vẫn qua) | → `BusinessRuleViolation` |
| `automatically_assign_lead` (auto-assign) | → SKIPPED `reason=lead_terminal` (no-op có log, không raise) |
| `compute_lead_action_permissions(is_consultation_terminal=…)` | FE tự ẩn nút giao/đổi; lead đóng chỉ còn `can_reopen` |

Dùng helper sẵn có `is_consultation_terminal_status` + helper mới `status_mapping.is_lead_consultation_terminal(db, lead)` (async load-then-check, `db.get` theo PK né MissingGreenlet). **KHÔNG đụng** `check_terminal_status_guard` (giữ soft-block cho luồng ghi consultation). **KHÔNG migration, KHÔNG data-fix** (chỉ chặn forward).

## Đã chạy `/code-review max` + áp 5 finding
0 bug correctness. Áp toàn bộ quality finding:
- Trích helper chung (hết copy-paste 3 nơi).
- Đổi tên param `is_consultation_terminal` (chống trùng nghĩa `TerminalGuardResult.is_terminal` = is_final mọi phase → wiring nhầm sẽ tắt nút trên enrolled).
- `process_officer_action` reuse `terminal_guard.current_status` (bỏ re-fetch).
- Thêm `BusinessRuleViolation` vào nhánh WARNING except (BRV là anh em `BadRequest` dưới `ValidationError` → trước đây rơi `except Exception` → log ERROR+traceback cho rejection 400 kỳ vọng; prod không Sentry nên nhiễu log che lỗi thật).

## Test & verify
- **36 pass**: unit cờ (`test_lead_action_permissions`) + mock auto-assign (`test_assignment`) + integration manual/reassign (`test_reassign_terminal_guard`). +2 file mới vào CI allowlist Tier 4.
- flake8 net-zero dòng mới.
- **Smoke qua app thật + auth + CSRF** (×2, trước & sau review-fix — hành vi identical): lead đóng `available_actions=["can_reopen"]`, menu mất nút "Chuyển giao lead"; assign+reassign lead đóng → 400 đúng message, không mutation; lead thường vẫn giao/đổi được.

## Deploy
BE-only (FE thin-client gate theo cờ). KHÔNG migration/data-fix. Độc lập consultation-hardening.
⚠️ Lịch: PR-2 Nhóm4 cũng sửa `compute_lead_action_permissions` → R1 nên merge TRƯỚC PR-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)