### PR TITLE
feat(officer): bảng "Điểm bận" — giải trình phân phối lead cho officer

### DIFF
--- a/Backend_FastAPI/alembic/versions/distpanelcasbin20260719_officer_distribution_panel_policy.py
+++ b/Backend_FastAPI/alembic/versions/distpanelcasbin20260719_officer_distribution_panel_policy.py
@@ -13,9 +13,11 @@ này lộ TÊN + TẢI của toàn phòng tư vấn nên cần 2 row:
    nằm ngoài phạm vi kế toán ⇒ deny tường minh ngay ở policy layer.
    (Cùng khuôn với consultacctdeny20260716.)
 
-Insert WITH v3 (eft) — mọi p-row hiện có đều mang eft; NULL eft làm Casbin
+Ghi WITH v3 (eft) — mọi p-row hiện có đều mang eft; NULL eft làm Casbin
 ``load_policy`` crash ở lần reload kế tiếp (memory casbin-insert-must-include-eft).
-Idempotent (WHERE NOT EXISTS) nên chạy lại an toàn.
+Idempotent theo kiểu UPSERT (UPDATE sửa eft drift rồi mới INSERT nếu thiếu), KHÔNG
+chỉ ``WHERE NOT EXISTS`` — vì row đã tồn tại với eft sai/NULL sẽ khiến INSERT bị bỏ
+qua mà policy vẫn hỏng.
 
 Revision ID: distpanelcasbin20260719
 Revises: consultacctdeny20260716
@@ -32,35 +34,46 @@ depends_on = None
 _OBJ = "/api/officer/distribution-panel"
 
 
+def _upsert(subject: str, eft: str) -> None:
+    """Đảm bảo tồn tại ĐÚNG 1 row (subject, _OBJ, GET) với eft mong muốn.
+
+    Hai bước, vì `WHERE NOT EXISTS` một mình KHÔNG đủ idempotent: nếu môi trường
+    đã có row cùng (ptype,v0,v1,v2) nhưng eft sai/NULL (drift do seed tay hoặc
+    template cũ), INSERT sẽ bị bỏ qua và policy vẫn sai — đúng thứ mà
+    memory casbin-insert-must-include-eft cảnh báo (NULL eft làm load_policy crash).
+    → UPDATE sửa drift TRƯỚC, rồi INSERT nếu thực sự chưa có.
+    """
+    op.execute(
+        f"""
+        UPDATE casbin_rule
+        SET v3 = '{eft}'
+        WHERE ptype = 'p'
+          AND v0 = '{subject}'
+          AND v1 = '{_OBJ}'
+          AND v2 = 'GET'
+          AND (v3 IS DISTINCT FROM '{eft}')
+        """
+    )
+    op.execute(
+        f"""
+        INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id)
+        SELECT 'p', '{subject}', '{_OBJ}', 'GET', '{eft}', '_legacy'
+        WHERE NOT EXISTS (
+            SELECT 1 FROM casbin_rule
+            WHERE ptype = 'p'
+              AND v0 = '{subject}'
+              AND v1 = '{_OBJ}'
+              AND v2 = 'GET'
+        )
+        """
+    )
+
+
 def upgrade() -> None:
     # template_id='_legacy' khớp các row role:officer/role:accountant hiện có
     # → row mới không bị logic quản-lý-template coi là orphan.
-    op.execute(
-        f"""
-        INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id)
-        SELECT 'p', 'role:officer', '{_OBJ}', 'GET', 'allow', '_legacy'
-        WHERE NOT EXISTS (
-            SELECT 1 FROM casbin_rule
-            WHERE ptype = 'p'
-              AND v0 = 'role:officer'
-              AND v1 = '{_OBJ}'
-              AND v2 = 'GET'
-        )
-        """
-    )
-    op.execute(
-        f"""
-        INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id)
-        SELECT 'p', 'role:accountant', '{_OBJ}', 'GET', 'deny', '_legacy'
-        WHERE NOT EXISTS (
-            SELECT 1 FROM casbin_rule
-            WHERE ptype = 'p'
-              AND v0 = 'role:accountant'
-              AND v1 = '{_OBJ}'
-              AND v2 = 'GET'
-        )
-        """
-    )
+    _upsert("role:officer", "allow")
+    _upsert("role:accountant", "deny")
 
 
 def downgrade() -> None:

--- a/Backend_FastAPI/alembic/versions/distpanelcasbin20260719_officer_distribution_panel_policy.py
+++ b/Backend_FastAPI/alembic/versions/distpanelcasbin20260719_officer_distribution_panel_policy.py
@@ -20,14 +20,20 @@ chỉ ``WHERE NOT EXISTS`` — vì row đã tồn tại với eft sai/NULL sẽ 
 qua mà policy vẫn hỏng.
 
 Revision ID: distpanelcasbin20260719
-Revises: consultacctdeny20260716
+Revises: elcurrentunique20260720
 Create Date: 2026-07-19
+
+⚠️ down_revision đổi từ ``consultacctdeny20260716`` sang ``elcurrentunique20260720``
+khi rebase lên main sau khi PR #486 (Giấy báo nhập học) merge: nhánh đó cũng phân
+nhánh từ ``consultacctdeny20260716``, để nguyên sẽ thành HAI HEAD và
+``alembic upgrade head`` (chạy trong entrypoint mỗi lần container khởi động) sẽ
+lỗi ambiguous ⇒ deploy hỏng.
 """
 from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "distpanelcasbin20260719"
-down_revision = "consultacctdeny20260716"
+down_revision = "elcurrentunique20260720"
 branch_labels = None
 depends_on = None
 

--- a/Backend_FastAPI/alembic/versions/distpanelcasbin20260719_officer_distribution_panel_policy.py
+++ b/Backend_FastAPI/alembic/versions/distpanelcasbin20260719_officer_distribution_panel_policy.py
@@ -1,0 +1,75 @@
+"""add casbin policy: officer ALLOW + accountant DENY /api/officer/distribution-panel
+
+Bảng "điểm bận" (`GET /api/officer/distribution-panel`) giải trình cách engine
+chia lead cho CẢ ĐƠN VỊ. Khác các widget officer khác (chỉ xem của mình), endpoint
+này lộ TÊN + TẢI của toàn phòng tư vấn nên cần 2 row:
+
+1. ``role:officer`` **allow** — officer là người dùng chính (xem vị trí của mình
+   giữa cả phòng). role:manager kế thừa role:officer qua g-policy nên cũng được;
+   role:admin đã có wildcard.
+2. ``role:accountant`` **deny** — accountant CŨNG kế thừa role:officer
+   (diamond inheritance), nên nếu chỉ thêm row allow ở trên thì Casbin sẽ cho
+   accountant qua, chỉ còn dependency chặn. Dữ liệu nhân sự/tải của phòng tư vấn
+   nằm ngoài phạm vi kế toán ⇒ deny tường minh ngay ở policy layer.
+   (Cùng khuôn với consultacctdeny20260716.)
+
+Insert WITH v3 (eft) — mọi p-row hiện có đều mang eft; NULL eft làm Casbin
+``load_policy`` crash ở lần reload kế tiếp (memory casbin-insert-must-include-eft).
+Idempotent (WHERE NOT EXISTS) nên chạy lại an toàn.
+
+Revision ID: distpanelcasbin20260719
+Revises: consultacctdeny20260716
+Create Date: 2026-07-19
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "distpanelcasbin20260719"
+down_revision = "consultacctdeny20260716"
+branch_labels = None
+depends_on = None
+
+_OBJ = "/api/officer/distribution-panel"
+
+
+def upgrade() -> None:
+    # template_id='_legacy' khớp các row role:officer/role:accountant hiện có
+    # → row mới không bị logic quản-lý-template coi là orphan.
+    op.execute(
+        f"""
+        INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id)
+        SELECT 'p', 'role:officer', '{_OBJ}', 'GET', 'allow', '_legacy'
+        WHERE NOT EXISTS (
+            SELECT 1 FROM casbin_rule
+            WHERE ptype = 'p'
+              AND v0 = 'role:officer'
+              AND v1 = '{_OBJ}'
+              AND v2 = 'GET'
+        )
+        """
+    )
+    op.execute(
+        f"""
+        INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id)
+        SELECT 'p', 'role:accountant', '{_OBJ}', 'GET', 'deny', '_legacy'
+        WHERE NOT EXISTS (
+            SELECT 1 FROM casbin_rule
+            WHERE ptype = 'p'
+              AND v0 = 'role:accountant'
+              AND v1 = '{_OBJ}'
+              AND v2 = 'GET'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        f"""
+        DELETE FROM casbin_rule
+        WHERE ptype = 'p'
+          AND v1 = '{_OBJ}'
+          AND v2 = 'GET'
+          AND v0 IN ('role:officer', 'role:accountant')
+        """
+    )

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -159,6 +159,9 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/officer/availability", "action": "POST"},
         {"subject": "{role}", "object": "/api/officer/my-kpi-plan", "action": "GET"},  # Gap 2
         {"subject": "{role}", "object": "/api/officer/recommendations", "action": "GET"},  # Phase 7
+        # Bảng "điểm bận" — officer xem được CẢ ĐƠN VỊ mình (minh bạch cách chia
+        # lead). Accountant kế thừa officer nên có DENY riêng ở ACCOUNTANT_TEMPLATE.
+        {"subject": "{role}", "object": "/api/officer/distribution-panel", "action": "GET"},  # noqa: E501
         # Admissions access (Admission Profile workflow)
         {"subject": "{role}", "object": "/api/admissions", "action": "GET"},   # List profiles
         {"subject": "{role}", "object": "/api/admissions", "action": "POST"},  # Create profile
@@ -338,6 +341,10 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         # These are ADDITIONAL accountant-only permissions (Finance operations)
         # Accountant does NOT inherit Manager (separation of duties)
         # =========================================================================
+        # DENY bảng "điểm bận": kế thừa officer sẽ allow, nhưng endpoint này lộ
+        # TÊN + TẢI của cả phòng tư vấn — ngoài phạm vi kế toán. Deny tường minh ở
+        # policy layer (không chỉ dựa dependency fail-close).
+        {"subject": "{role}", "object": "/api/officer/distribution-panel", "action": "GET", "eft": "deny"},  # noqa: E501
         # Profile access (SELF only)
         {"subject": "{role}", "object": "/api/profile", "action": "GET"},
         {"subject": "{role}", "object": "/api/profile", "action": "PUT"},

--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -49,6 +49,7 @@ __all__ = [
     "get_kpi_plan_for_user",  # Phase A6: KPI Planning IDOR
     "get_kpi_plan_month_for_user",  # Phase A6: KPI Planning IDOR
     "get_officer_dashboard_scope",
+    "get_officer_distribution_scope",
     "get_criteria_access",
     "get_config_filter",
     "get_lead_list_filter",  # Phase 2.1
@@ -948,6 +949,74 @@ async def get_officer_dashboard_scope(
     # =====================================================================
     raise PermissionDeniedError(
         detail="Your role is not allowed to access officer dashboard"
+    )
+
+
+async def get_officer_distribution_scope(
+    scope: str | None = None,
+    officer_id: int | None = None,
+    unit_id: int | None = None,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(get_current_active_user),
+) -> DashboardScopeContext:
+    """Scope resolver cho bảng "điểm bận" (`GET /api/officer/distribution-panel`).
+
+    KHÁC DUY NHẤT so với :func:`get_officer_dashboard_scope`: **officer được xem
+    TOÀN BỘ đơn vị của chính mình** (không chỉ personal), vì bảng này có mục đích
+    giải trình minh bạch cách engine chia lead cho cả phòng. Lời khuyên cá nhân
+    (``boost``) vẫn chỉ hiện trên dòng của chính người xem — do service quyết định.
+
+    Manager / admin / mọi role khác **ủy quyền nguyên vẹn** cho
+    :func:`get_officer_dashboard_scope` (một nguồn sự thật cho IDOR + fail-close,
+    tránh nhân bản logic descendants). Chỉ mặc định ``scope`` theo role để caller
+    không phải truyền.
+
+    Bảo mật nhánh officer:
+    - ``unit_id`` / ``officer_id`` khác của mình ⇒ **404** (không lộ tồn tại).
+    - Đơn vị LUÔN lấy từ ``current_user.unit_id`` (không nhận từ query).
+    - KHÔNG mở rộng sang đơn vị con (khác manager).
+    """
+    from ..repositories.officer_repository import OfficerRepository
+
+    user_role = current_user.role
+
+    if user_role == UserRole.OFFICER:
+        # IDOR: officer không được trỏ sang người/đơn vị khác.
+        if officer_id is not None and officer_id != current_user.id:
+            raise ResourceNotFoundError(detail="Officer not found")
+        if unit_id is not None and unit_id != current_user.unit_id:
+            raise ResourceNotFoundError(detail="Unit not found")
+        if current_user.unit_id is None:
+            raise BusinessRuleViolation(detail="Officer chưa được gán đơn vị")
+
+        officer_repo = OfficerRepository(db)
+        pool = await officer_repo.get_active_officer_ids(
+            scope="unit", unit_id=current_user.unit_id
+        )
+        return DashboardScopeContext(
+            scope_kind="unit",
+            requested_officer_id=None,
+            requested_unit_id=current_user.unit_id,
+            effective_officer_ids=pool,
+            effective_unit_root_id=current_user.unit_id,
+            effective_unit_ids=[current_user.unit_id],
+            includes_descendants=False,
+            forced_by_role=True,
+            label="Đơn vị của tôi",
+            requesting_user=current_user,
+        )
+
+    # Manager → 'unit', admin → 'organization'; role khác rơi vào fail-close
+    # của get_officer_dashboard_scope (accountant/user bị chặn).
+    if scope is None:
+        scope = "unit" if user_role == UserRole.MANAGER else "organization"
+
+    return await get_officer_dashboard_scope(
+        scope=scope,
+        officer_id=officer_id,
+        unit_id=unit_id,
+        db=db,
+        current_user=current_user,
     )
 
 

--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -975,6 +975,13 @@ async def get_officer_distribution_scope(
     - ``unit_id`` / ``officer_id`` khác của mình ⇒ **404** (không lộ tồn tại).
     - Đơn vị LUÔN lấy từ ``current_user.unit_id`` (không nhận từ query).
     - KHÔNG mở rộng sang đơn vị con (khác manager).
+
+    ⚠️ Manager/admin KẾ THỪA nguyên hành vi của ``get_officer_dashboard_scope``,
+    KHÔNG đồng nhất với nhánh officer ở trên: manager truyền ``unit_id`` ngoài
+    đơn vị mình nhận **403** (``PermissionDeniedError``), còn drill-down
+    ``officer_id`` ngoài phạm vi mới là 404 (qua ``_validate_officer_target``).
+    Đây là hành vi sẵn có của cả họ endpoint dashboard — cố ý giữ nguyên để một
+    nguồn sự thật, KHÔNG bịa 404 riêng cho endpoint này.
     """
     from ..repositories.officer_repository import OfficerRepository
 

--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -1013,6 +1013,37 @@ async def get_officer_distribution_scope(
             requesting_user=current_user,
         )
 
+    # ⚠️ officer_id ở endpoint này nghĩa là "TIÊU ĐIỂM", KHÔNG phải "thu hẹp".
+    # Nếu chuyển thẳng xuống resolver chung, nó thu `effective_officer_ids` còn
+    # [officer_id] ⇒ panel chấm điểm trên pool MỘT NGƯỜI: ở chế độ
+    # member_fairness thì actual_share == target_share ⇒ thành phần fairness ≡ 0,
+    # và `scoring_mode` bị quyết bởi ngưỡng history ≥10 của riêng người đó. Kết
+    # quả là API trả `score`/`scoring_mode` mà engine KHÔNG BAO GIỜ sinh ra, dưới
+    # danh nghĩa "điểm sắp xếp thực tế của engine". Vì vậy: xác thực quyền xem
+    # người đó (404 nếu ngoài phạm vi) rồi MỞ RỘNG ra đơn vị của họ.
+    if officer_id is not None and user_role in (UserRole.MANAGER, UserRole.ADMIN):
+        target = await _validate_officer_target(db, officer_id, current_user)
+        if target.unit_id is None:
+            raise BusinessRuleViolation(
+                detail="Nhân viên này chưa được gán đơn vị nên không có bảng so sánh"
+            )
+        officer_repo = OfficerRepository(db)
+        pool = await officer_repo.get_active_officer_ids(
+            scope="unit", unit_id=target.unit_id
+        )
+        return DashboardScopeContext(
+            scope_kind="unit",
+            requested_officer_id=officer_id,
+            requested_unit_id=target.unit_id,
+            effective_officer_ids=pool,
+            effective_unit_root_id=target.unit_id,
+            effective_unit_ids=[target.unit_id],
+            includes_descendants=False,
+            forced_by_role=False,
+            label=f"Đơn vị của {target.full_name or officer_id}",
+            requesting_user=current_user,
+        )
+
     # Manager → 'unit', admin → 'organization'; role khác rơi vào fail-close
     # của get_officer_dashboard_scope (accountant/user bị chặn).
     if scope is None:
@@ -1020,7 +1051,7 @@ async def get_officer_distribution_scope(
 
     return await get_officer_dashboard_scope(
         scope=scope,
-        officer_id=officer_id,
+        officer_id=None,
         unit_id=unit_id,
         db=db,
         current_user=current_user,

--- a/Backend_FastAPI/app/repositories/officer_repository.py
+++ b/Backend_FastAPI/app/repositories/officer_repository.py
@@ -1435,6 +1435,22 @@ class OfficerRepository(BaseRepository[models.User]):
         result = await self.db.execute(query)
         return [row[0] for row in result.fetchall()]
 
+    async def get_officers_by_ids(self, officer_ids: List[int]) -> List[models.User]:
+        """Load full User rows cho danh sách officer id (KHÔNG lock).
+
+        Dùng cho distribution panel: cần ``max_capacity`` / ``assignment_weight`` /
+        ``last_assigned_at`` / ``availability_status`` để tính tải.
+        ⚠️ CỐ Ý KHÔNG lọc ``availability_status`` — officer đang offline/busy vẫn
+        phải hiển thị trên bảng (được đánh dấu không eligible), việc lọc pool
+        chấm điểm do caller quyết định.
+        """
+        if not officer_ids:
+            return []
+        result = await self.db.execute(
+            select(models.User).where(models.User.id.in_(officer_ids))
+        )
+        return list(result.scalars().all())
+
     async def get_officers_total_capacity(self, officer_ids: List[int]) -> int:
         """Sum actual max_capacity for given officers. NULL defaults to 100."""
         if not officer_ids:

--- a/Backend_FastAPI/app/repositories/officer_repository.py
+++ b/Backend_FastAPI/app/repositories/officer_repository.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy import select, func, or_, and_, case, literal_column
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload, joinedload
+from sqlalchemy.orm import selectinload, joinedload, load_only
 
 from app import models
 from app.core.constants import UserRole, SYSTEM_CONSULTATION_METHOD
@@ -1423,31 +1423,65 @@ class OfficerRepository(BaseRepository[models.User]):
         Returns:
             List of officer user IDs
         """
+        # FAIL-CLOSED: scope='unit' mà không có đơn vị thì KHÔNG được âm thầm
+        # rơi về phạm vi toàn tổ chức — trả rỗng để caller lộ lỗi sớm.
+        if scope == "unit" and unit_id is None:
+            return []
+
         conditions = [
             models.User.role == UserRole.OFFICER,
             models.User.status == "active",
         ]
-        
-        if unit_id:
+
+        # ⚠️ `is not None`, KHÔNG dùng truthiness: `unit_id=0` lọt qua `if unit_id:`
+        # sẽ bỏ hẳn mệnh đề lọc đơn vị ⇒ trả về TOÀN BỘ officer của tổ chức. Với
+        # caller mới (distribution panel, officer tự xem đơn vị mình) đó là đường
+        # lộ danh sách nhân sự toàn công ty.
+        if unit_id is not None:
             conditions.append(models.User.unit_id == unit_id)
-        
-        query = select(models.User.id).where(*conditions)
+
+        query = select(models.User.id).where(*conditions).order_by(models.User.id)
         result = await self.db.execute(query)
         return [row[0] for row in result.fetchall()]
 
     async def get_officers_by_ids(self, officer_ids: List[int]) -> List[models.User]:
-        """Load full User rows cho danh sách officer id (KHÔNG lock).
+        """Load User rows cho danh sách officer id (KHÔNG lock).
 
         Dùng cho distribution panel: cần ``max_capacity`` / ``assignment_weight`` /
         ``last_assigned_at`` / ``availability_status`` để tính tải.
         ⚠️ CỐ Ý KHÔNG lọc ``availability_status`` — officer đang offline/busy vẫn
         phải hiển thị trên bảng (được đánh dấu không eligible), việc lọc pool
         chấm điểm do caller quyết định.
+
+        ⚠️ ``order_by(id)``: hạ nguồn dùng sort ỔN ĐỊNH theo
+        ``(overloaded, score, last_assigned)``; khi hoà hoàn toàn (đơn vị mới,
+        ai cũng ``last_assigned=NULL``) thứ tự đầu vào QUYẾT ĐỊNH thứ hạng. Không
+        có ORDER BY thì thứ hạng đổi giữa các lần poll và có thể lệch engine.
+
+        ⚠️ ``load_only``: đây là đường ĐỌC hiển thị, không được kéo
+        ``password_hash`` / ``totp_secret_encrypted`` / ``backup_codes_hashed``
+        vào bộ nhớ chỉ để in tên và tải. ``unit`` eager-load để lấy tên đơn vị
+        mà không cần query rời (Anti-N+1 theo CLAUDE.md).
         """
         if not officer_ids:
             return []
         result = await self.db.execute(
-            select(models.User).where(models.User.id.in_(officer_ids))
+            select(models.User)
+            .options(
+                load_only(
+                    models.User.id,
+                    models.User.username,
+                    models.User.full_name,
+                    models.User.unit_id,
+                    models.User.max_capacity,
+                    models.User.assignment_weight,
+                    models.User.last_assigned_at,
+                    models.User.availability_status,
+                ),
+                selectinload(models.User.unit),
+            )
+            .where(models.User.id.in_(officer_ids))
+            .order_by(models.User.id)
         )
         return list(result.scalars().all())
 

--- a/Backend_FastAPI/app/routers/officer.py
+++ b/Backend_FastAPI/app/routers/officer.py
@@ -8,6 +8,7 @@ from ..core.deps import (
     CasbinAuth,
     DashboardScopeContext,
     get_officer_dashboard_scope,
+    get_officer_distribution_scope,
     resolve_kpi_plan_officer_id,
 )
 from ..services import officer_service
@@ -149,6 +150,34 @@ async def get_leaderboard(
         end_date=parsed_end,
     )
     return leaderboard
+
+
+# =============================================================================
+# Distribution Panel ("Điểm bận") — giải trình phân phối lead
+# =============================================================================
+
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "/distribution-panel",
+    response_model=schemas.OfficerDistributionPanel,
+    summary="Bảng điểm bận — giải trình engine chia lead cho cả đơn vị",
+)
+async def get_distribution_panel(
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[models.User, CasbinAuth],
+    ctx: Annotated[
+        DashboardScopeContext, Depends(get_officer_distribution_scope)
+    ],
+):
+    """Bảng điểm bận của đơn vị.
+
+    Khác các widget officer khác: **officer xem được cả đơn vị của mình** (minh
+    bạch cách chia lead), nên gate 2 lớp — Casbin cho path + scope dependency
+    resolve pool. Lời khuyên cá nhân (``boost``) chỉ trả cho chính người xem.
+    GET thuần đọc ⇒ KHÔNG commit.
+    """
+    return await officer_service.get_officer_distribution_panel(db=db, ctx=ctx)
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/routers/officer.py
+++ b/Backend_FastAPI/app/routers/officer.py
@@ -156,12 +156,18 @@ async def get_leaderboard(
 # Distribution Panel ("Điểm bận") — giải trình phân phối lead
 # =============================================================================
 
-@limiter.limit(RateLimits.DATA_READ)
+# ⚠️ THỨ TỰ DECORATOR: @router.get PHẢI ở TRÊN @limiter.limit.
+# Decorator áp từ dưới lên — nếu đảo lại, router đăng ký hàm CHƯA bọc và
+# limiter chỉ bọc một tham chiếu không ai dùng ⇒ rate limit vô hiệu. Endpoint
+# này là read đắt nhất router và trả cả roster đơn vị nên bắt buộc có trần.
+# (Các endpoint còn lại trong file vẫn sai thứ tự — nợ
+#  `slowapi-limiter-decorator-order-debt`.)
 @router.get(
     "/distribution-panel",
     response_model=schemas.OfficerDistributionPanel,
     summary="Bảng điểm bận — giải trình engine chia lead cho cả đơn vị",
 )
+@limiter.limit(RateLimits.DATA_READ)
 async def get_distribution_panel(
     request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -425,6 +425,10 @@ from .officer import (
     # Phase 4: Leaderboard
     LeaderboardEntry,
     WeeklyLeaderboard,
+    # Distribution panel ("điểm bận")
+    OfficerArchetype,
+    OfficerDistributionEntry,
+    OfficerDistributionPanel,
     # Phase 6: Team Stats + Annual Progress
     TeamStats,
     AnnualProgressInfo,

--- a/Backend_FastAPI/app/schemas/officer.py
+++ b/Backend_FastAPI/app/schemas/officer.py
@@ -433,7 +433,8 @@ class OfficerDistributionEntry(BaseModel):
     """
     rank: int
     user_id: int
-    username: str
+    # ⚠️ KHÔNG expose `username`: endpoint này trả cả roster đơn vị, FE chỉ render
+    # `full_name` — đưa login-id đồng nghiệp lên wire là bề mặt PII vô ích.
     full_name: str
     unit_id: Optional[int] = None
     unit_name: Optional[str] = None
@@ -448,8 +449,12 @@ class OfficerDistributionEntry(BaseModel):
     weight: int                    # Ưu tiên kỳ cựu (×N)
     self_sourced: int              # Lead tự tìm
     tuition_hold: int              # Hồ sơ đã đóng tiền
+    # Phần GIAO (vừa tự tìm vừa đã đóng tiền) — chỉ bị trừ MỘT lần.
+    # ⚠️ deducted = self_sourced + tuition_hold − overlap. Thiếu trường này thì
+    # client sẽ trình bày self+tuition như một phép cộng KHÔNG bằng deducted.
+    overlap: int = 0
     dist_load: int                 # Lead hệ thống tính
-    deducted: int                  # Không tính = workload - dist_load
+    deducted: int                  # Không tính = self + tuition − overlap
     real_util_pct: float           # dist_load/cap  (cơ sở sắp xếp, %)
     fill_pct: float                # workload/cap   (chỗ đầy thật, %)
     eff_util_pct: float            # ĐIỂM BẬN = dist_load/(cap*weight), %

--- a/Backend_FastAPI/app/schemas/officer.py
+++ b/Backend_FastAPI/app/schemas/officer.py
@@ -437,6 +437,10 @@ class OfficerDistributionEntry(BaseModel):
     full_name: str
     unit_id: Optional[int] = None
     unit_name: Optional[str] = None
+    # Chế độ chấm điểm engine áp cho ĐƠN VỊ của dòng này (per-unit, vì ngưỡng
+    # history fairness tính riêng từng đơn vị). Đây mới là giá trị chính xác;
+    # trường cùng tên ở cấp panel chỉ là tóm tắt.
+    scoring_mode: Optional[str] = None
 
     # --- Số liệu tải (nguyên bản từ engine) ---
     workload: int                  # Lead đang giữ (tổng non-final)
@@ -469,7 +473,11 @@ class OfficerDistributionPanel(BaseModel):
     """Bảng điểm bận của (các) đơn vị trong phạm vi người xem."""
     unit_id: Optional[int] = None
     total_officers: int
-    scoring_mode: Optional[str] = None      # legacy | member | fairness | member_fairness
+    # legacy | member | fairness | member_fairness | "mixed" | None.
+    # ⚠️ Chỉ là TÓM TẮT: chấm điểm chạy per-unit, nên khi phạm vi trải nhiều đơn
+    # vị có mode khác nhau giá trị này = "mixed"; muốn chính xác đọc
+    # ``entries[].scoring_mode``. None = không đơn vị nào có pool chấm điểm.
+    scoring_mode: Optional[str] = None
     flags_snapshot: Dict[str, bool]
     entries: List[OfficerDistributionEntry]
 

--- a/Backend_FastAPI/app/schemas/officer.py
+++ b/Backend_FastAPI/app/schemas/officer.py
@@ -416,6 +416,65 @@ class WeeklyLeaderboard(BaseModel):
 
 
 # =============================================================================
+# Distribution Panel ("Điểm bận") — giải trình phân phối lead của đơn vị
+# =============================================================================
+
+class OfficerArchetype(BaseModel):
+    """Nhãn kiểu officer suy ra từ tỉ lệ các đòn bẩy tải."""
+    key: str
+    label: str
+
+
+class OfficerDistributionEntry(BaseModel):
+    """Một dòng trong bảng điểm bận.
+
+    Mọi con số tải đến TRỰC TIẾP từ ``assignment_service.compute_unit_officer_loads``
+    — cùng hàm engine chia lead dùng, nên KHÔNG thể lệch.
+    """
+    rank: int
+    user_id: int
+    username: str
+    full_name: str
+    unit_id: Optional[int] = None
+    unit_name: Optional[str] = None
+
+    # --- Số liệu tải (nguyên bản từ engine) ---
+    workload: int                  # Lead đang giữ (tổng non-final)
+    max_capacity: int              # Khả năng nhận
+    weight: int                    # Ưu tiên kỳ cựu (×N)
+    self_sourced: int              # Lead tự tìm
+    tuition_hold: int              # Hồ sơ đã đóng tiền
+    dist_load: int                 # Lead hệ thống tính
+    deducted: int                  # Không tính = workload - dist_load
+    real_util_pct: float           # dist_load/cap  (cơ sở sắp xếp, %)
+    fill_pct: float                # workload/cap   (chỗ đầy thật, %)
+    eff_util_pct: float            # ĐIỂM BẬN = dist_load/(cap*weight), %
+    score: float                   # điểm sắp xếp thực tế của engine
+    overload_gate_pct: float       # (workload-tuition)/cap, ngưỡng dừng 80%
+
+    # --- Cờ trạng thái ---
+    overloaded: bool
+    at_capacity: bool
+    eligible_for_assignment: bool  # False = offline/busy/đầy tải ⇒ ngoài luồng chia
+    availability_status: str
+
+    # --- Diễn giải (backend tính, thin-client) ---
+    archetype: OfficerArchetype
+    diagnosis: str
+    boost: Optional[str] = None    # 🔒 CHỈ set cho chính người đang xem
+    is_current_user: bool = False
+
+
+class OfficerDistributionPanel(BaseModel):
+    """Bảng điểm bận của (các) đơn vị trong phạm vi người xem."""
+    unit_id: Optional[int] = None
+    total_officers: int
+    scoring_mode: Optional[str] = None      # legacy | member | fairness | member_fairness
+    flags_snapshot: Dict[str, bool]
+    entries: List[OfficerDistributionEntry]
+
+
+# =============================================================================
 # PHASE 6: Team Stats for Performance Comparison
 # =============================================================================
 

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -6,7 +6,9 @@ Lead Assignment Service - Automatic lead distribution logic.
 This ensures notifications are persisted to database AND sent via Socket.IO/Email.
 """
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import NamedTuple
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.exc import OperationalError  # Dùng để bắt LockNotAvailableError
@@ -280,6 +282,292 @@ async def _log_assignment_decision(
 
 
 # Thêm tham số logger=None
+class AssignmentFlags(NamedTuple):
+    """Anh chup 4 co dieu khien cach cham diem phan phoi (doc 1 lan/quyet dinh)."""
+
+    member_on: bool
+    fairness_on: bool
+    exclude_active: bool
+    finance_on: bool
+
+
+def read_assignment_flags() -> AssignmentFlags:
+    """Doc co tu settings - BYTE-IDENTICAL voi logic goc o BUOC 3.
+
+    ``exclude_active`` bi GATE KEP: co loai-self chi co tac dung o che do
+    member/fairness (legacy sap xep thuan last_assigned => dist_load vo nghia).
+    ``finance_on`` DOC LAP (overloaded/threshold ap moi che do).
+    """
+    from ..config import settings
+
+    member_on = settings.ENABLE_MEMBER_WEIGHTED_ASSIGNMENT
+    fairness_on = settings.ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT
+    exclude_active = (
+        settings.ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED
+        and (member_on or fairness_on)
+    )
+    finance_on = settings.ENABLE_FINANCE_WORKLOAD_DISCOUNT
+    return AssignmentFlags(member_on, fairness_on, exclude_active, finance_on)
+
+
+@dataclass
+class UnitOfficerLoads:
+    """Ket qua cham diem tai cua MOT don vi.
+
+    ``loads``: TAT CA officer duoc truyen vao (ke ca day tai / khong eligible),
+    da sap xep: nhom eligible (sort theo engine) truoc, phan con lai noi sau.
+    Caller loc ``eligible_for_assignment`` de lay pool chon nguoi.
+    """
+
+    loads: list
+    scoring: str | None
+    assign_reason: str | None
+    flags: AssignmentFlags
+
+
+async def compute_unit_officer_loads(
+    db: AsyncSession,
+    officers,
+    *,
+    include_at_capacity: bool = True,
+    eligible_officer_ids=None,
+    lead_unit_id: int = None,
+    flags: AssignmentFlags = None,
+    log: logging.Logger = None,
+) -> UnitOfficerLoads:
+    """Tinh tai + cham diem + sap xep officer cua mot don vi (HAM THUAN).
+
+    NGUON SU THAT DUY NHAT cho bo so phan phoi. ``automatically_assign_lead``
+    va dashboard "diem ban" deu goi ham nay => KHONG THE lech nhau. Moi thay doi
+    cong thuc phai sua o day.
+
+    Args:
+        officers: pool HIEN THI - moi officer can tinh metric.
+        include_at_capacity: False => loai han officer day tai khoi ``loads``.
+        eligible_officer_ids: pool CHAM DIEM. ``None`` => moi officer truyen vao
+            deu eligible (duong engine: BUOC 2 da loc availability + blacklist).
+            Dashboard truyen tap officer ``availability_status == 'available'``
+            de officer offline/busy van co metric hien thi nhung KHONG tham gia
+            cham diem/sap xep => diem cua nguoi eligible y het engine.
+            Ham nay KHONG tu doc ``availability_status`` - loc la viec cua caller.
+    """
+    _log = log or default_log
+    flags = flags or read_assignment_flags()
+    member_on, fairness_on = flags.member_on, flags.fairness_on
+    exclude_active, finance_on = flags.exclude_active, flags.finance_on
+
+    officer_ids = [o.id for o in officers]
+    eligible_set = (
+        set(eligible_officer_ids)
+        if eligible_officer_ids is not None
+        else set(officer_ids)
+    )
+
+    # --- Dem tai (+ tu tuyen / hoc phi theo co) - 1 round-trip ---
+    _wl_cols = [
+        models.Lead.assigned_officer_id,
+        func.count(models.Lead.id).label("workload"),
+    ]
+    if exclude_active:
+        _wl_cols.append(
+            func.count(models.Lead.id)
+            .filter(_self_sourced_subquery())
+            .label("self_cnt")
+        )
+    if finance_on:
+        _wl_cols.append(
+            func.count(models.Lead.id)
+            .filter(_tuition_hold_filter())
+            .label("tuition_cnt")
+        )
+    if exclude_active and finance_on:
+        _wl_cols.append(
+            func.count(models.Lead.id)
+            .filter(
+                and_(
+                    _self_sourced_subquery(),
+                    _tuition_hold_filter(),
+                )
+            )
+            .label("self_and_tuition_cnt")
+        )
+    workload_stmt = (
+        select(*_wl_cols)
+        .join(
+            models.ConsultationStatus,
+            models.Lead.consultation_status_id == models.ConsultationStatus.id,
+            isouter=True,
+        )
+        .where(
+            models.Lead.assigned_officer_id.in_(officer_ids),
+            models.Lead.deleted_at.is_(None),
+            _non_final_status_filter(),
+        )
+        .group_by(models.Lead.assigned_officer_id)
+    )
+    workload_map: dict = {}
+    self_map: dict = {}
+    tuition_map: dict = {}
+    self_and_tuition_map: dict = {}
+    for row in await db.execute(workload_stmt):
+        workload_map[row.assigned_officer_id] = row.workload
+        if exclude_active:
+            self_map[row.assigned_officer_id] = row.self_cnt
+        if finance_on:
+            tuition_map[row.assigned_officer_id] = row.tuition_cnt
+        if exclude_active and finance_on:
+            self_and_tuition_map[row.assigned_officer_id] = (
+                row.self_and_tuition_cnt
+            )
+    _dbg_load = (
+        f"[Unit: {lead_unit_id}] Workloads={workload_map} "
+        f"self-sourced={self_map}"
+    )
+    if finance_on:
+        _dbg_load += f" tuition-hold={tuition_map}"
+    _log.debug(_dbg_load)
+
+    # --- Dung metric per-officer (pool-independent) ---
+    loads = []
+    for officer in officers:
+        workload = workload_map.get(officer.id, 0)
+        capacity = _safe_capacity(officer)
+        at_capacity = workload >= capacity
+        if at_capacity and not include_at_capacity:
+            _log.debug(
+                f"Officer {officer.id} skipped (at full capacity: "
+                f"{workload}/{capacity})"
+            )
+            continue
+        weight = _safe_weight(officer)
+        self_cnt = self_map.get(officer.id, 0) if exclude_active else 0
+        tuition_cnt = tuition_map.get(officer.id, 0) if finance_on else 0
+        overlap = (
+            self_and_tuition_map.get(officer.id, 0)
+            if (exclude_active and finance_on)
+            else 0
+        )
+        balance_load = workload - self_cnt - tuition_cnt + overlap
+        real_util = balance_load / capacity
+        eff_util = balance_load / (capacity * weight)
+        loads.append(
+            {
+                "officer": officer,
+                "workload": workload,
+                "dist_load": balance_load,
+                "real_util": real_util,
+                "eff_util": eff_util,
+                "weight": weight,
+                "overloaded": ((workload - tuition_cnt) / capacity)
+                >= SAFETY_THRESHOLD,
+                "tuition_hold": tuition_cnt,
+                # Surface cho dashboard (da tinh san, khong ton query them).
+                # capacity = _safe_capacity(officer) -> dashboard doc thang, khong
+                # goi lai helper => khong the lech mau so voi engine.
+                "capacity": capacity,
+                "self_cnt": self_cnt,
+                "at_capacity": at_capacity,
+                "eligible_for_assignment": (
+                    officer.id in eligible_set and not at_capacity
+                ),
+                "score": real_util,
+                "last_assigned": officer.last_assigned_at
+                or datetime.min.replace(tzinfo=timezone.utc),
+            }
+        )
+
+    scoring_pool = [ol for ol in loads if ol["eligible_for_assignment"]]
+    others = [ol for ol in loads if not ol["eligible_for_assignment"]]
+    if not scoring_pool:
+        # Khong ai du dieu kien => BO QUA han khau cham diem (giu dung hanh vi
+        # cu: engine return som o nhanh at_capacity, KHONG query lich su).
+        return UnitOfficerLoads(
+            loads=loads, scoring=None, assign_reason=None, flags=flags
+        )
+
+    # --- Lich su phan cong (chi khi fairness bat) ---
+    hist_counts: dict = {}
+    if fairness_on:
+        try:
+            from sqlalchemy import select as sel, func as fn
+            hist_q = await db.execute(
+                sel(
+                    models.AssignmentDecisionLog.assigned_officer_id,
+                    fn.count(models.AssignmentDecisionLog.id).label("cnt"),
+                )
+                .where(
+                    models.AssignmentDecisionLog.unit_id == lead_unit_id,
+                    models.AssignmentDecisionLog.assigned_officer_id.isnot(None),
+                )
+                .group_by(models.AssignmentDecisionLog.assigned_officer_id)
+            )
+            hist_counts = {r.assigned_officer_id: r.cnt for r in hist_q.all()}
+        except Exception as e:
+            _log.warning(
+                f"[Unit: {lead_unit_id}] Fairness history query failed, "
+                f"falling back: {e}"
+            )
+
+    # --- Quyet dinh CHE DO cham diem (pool = scoring_pool) ---
+    if member_on and fairness_on:
+        eligible_hist_total = sum(
+            hist_counts.get(e["officer"].id, 0) for e in scoring_pool
+        )
+        scoring = "member_fairness" if eligible_hist_total >= 10 else "member"
+    elif fairness_on:
+        total_hist = sum(hist_counts.values())
+        scoring = "fairness" if total_hist >= 10 else "legacy"
+    elif member_on:
+        scoring = "member"
+    else:
+        scoring = "legacy"
+
+    if scoring == "member_fairness":
+        total_weight = sum(e["weight"] for e in scoring_pool)
+        for e in scoring_pool:
+            target_share = e["weight"] / total_weight
+            actual_share = (
+                hist_counts.get(e["officer"].id, 0) / eligible_hist_total
+            )
+            e["score"] = 0.6 * e["eff_util"] + 0.4 * (actual_share - target_share)
+        assign_reason = "member_fairness_weighted"
+        _log.info(
+            f"[Unit: {lead_unit_id}] Member+fairness weighted "
+            f"(pool_hist={eligible_hist_total})"
+        )
+    elif scoring == "fairness":
+        for e in scoring_pool:
+            share = hist_counts.get(e["officer"].id, 0) / total_hist
+            e["score"] = 0.6 * e["real_util"] + 0.4 * share
+        assign_reason = "fairness_weighted"
+        _log.info(
+            f"[Unit: {lead_unit_id}] Using fairness-weighted scoring "
+            f"(history={total_hist})"
+        )
+    elif scoring == "member":
+        for e in scoring_pool:
+            e["score"] = e["eff_util"]
+        assign_reason = "member_weighted"
+        _log.info(f"[Unit: {lead_unit_id}] Using member-weighted scoring")
+    else:
+        assign_reason = "lowest_workload"
+        _log.info(f"[Unit: {lead_unit_id}] Using legacy round-robin")
+
+    if scoring == "legacy":
+        scoring_pool.sort(key=lambda x: (x["overloaded"], x["last_assigned"]))
+    else:
+        scoring_pool.sort(
+            key=lambda x: (x["overloaded"], x["score"], x["last_assigned"])
+        )
+
+    return UnitOfficerLoads(
+        loads=scoring_pool + others,
+        scoring=scoring,
+        assign_reason=assign_reason,
+        flags=flags,
+    )
+
+
 async def automatically_assign_lead(
     lead_id: int, db: AsyncSession, logger: logging.Logger = None
 ) -> tuple[dict, list]:
@@ -423,178 +711,25 @@ async def automatically_assign_lead(
                     f"[Lead ID: {lead_id}] Found {len(available_officers)} available officers for unit {lead_unit_id}."
                 )
 
-                # === BƯỚC 3: TÍNH TOÁN WORKLOAD (+ tải TỰ TUYỂN nếu exclude_active) ===
-                # `exclude_active` = flag loại-self CHỈ có tác dụng ở chế độ member/
-                # fairness (legacy sắp xếp thuần last_assigned → dist_load vô nghĩa;
-                # gate ở đây tránh query thừa + không bẩn legacy snapshot). Khi active
-                # thêm 1 aggregate self_cnt = COUNT(...) FILTER(tự tuyển) NGAY trên
-                # workload_stmt ⇒ 1 round-trip, và bất biến self_cnt ≤ workload là CẤU
-                # TRÚC (subset của FILTER trên cùng tập dòng) ⇒ balance_load ≥ 0 khỏi
-                # cần max(0). Flags đọc 1 lần ở đây, tái dùng ở BƯỚC 5.
-                from ..config import settings
-
-                member_on = settings.ENABLE_MEMBER_WEIGHTED_ASSIGNMENT
-                fairness_on = settings.ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT
-                exclude_active = (
-                    settings.ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED
-                    and (member_on or fairness_on)
-                )
-                # Option A finance discount (cờ ĐỘC LẬP — KHÔNG gate theo member/
-                # fairness vì overloaded/threshold áp mọi chế độ). Khi ON: lead học
-                # phí non-final giảm trừ khỏi dist_load (eff_util) + cổng overloaded.
-                # OFF ⇒ 0 aggregate phụ + audit-shape y hệt hôm nay.
-                finance_on = settings.ENABLE_FINANCE_WORKLOAD_DISCOUNT
-
+                # === BUOC 3-5: TINH TAI + CHAM DIEM + SAP XEP ===
+                # Dung HAM CHUNG compute_unit_officer_loads - cung duong code voi
+                # dashboard "diem ban" nen hai ben KHONG THE lech so. O day pool da
+                # duoc BUOC 2 loc availability + blacklist nen KHONG truyen
+                # eligible_officer_ids (mac dinh: moi officer deu eligible) => hanh
+                # vi y het truoc refactor.
                 officer_ids = [o.id for o in available_officers]
-                _wl_cols = [
-                    models.Lead.assigned_officer_id,
-                    func.count(models.Lead.id).label("workload"),
+                _loads_res = await compute_unit_officer_loads(
+                    db,
+                    available_officers,
+                    include_at_capacity=True,
+                    lead_unit_id=lead_unit_id,
+                    log=log,
+                )
+                finance_on = _loads_res.flags.finance_on
+                # officer_loads = pool CHON NGUOI (con capacity), da sort theo engine.
+                officer_loads = [
+                    ol for ol in _loads_res.loads if ol["eligible_for_assignment"]
                 ]
-                if exclude_active:
-                    _wl_cols.append(
-                        func.count(models.Lead.id)
-                        .filter(_self_sourced_subquery())
-                        .label("self_cnt")
-                    )
-                if finance_on:
-                    # Tải HỌC PHÍ (sts14/sts10) — giảm trừ ở dist_load + overloaded.
-                    _wl_cols.append(
-                        func.count(models.Lead.id)
-                        .filter(_tuition_hold_filter())
-                        .label("tuition_cnt")
-                    )
-                if exclude_active and finance_on:
-                    # Phần GIAO self-tuyển ∩ học phí — chống trừ HAI LẦN khi tính
-                    # dist_load = workload − |self ∪ tuition|.
-                    # ⚠️ EFFICIENCY (chấp nhận có chủ đích): filter này nhúng LẠI
-                    # `_self_sourced_subquery()` (correlated LIMIT-1 trên
-                    # assignment_log) nên khi CẢ HAI cờ ON, subquery chạy 2 lần/dòng
-                    # (self_cnt + đây). KHÔNG refactor thành 1 cột `is_self` chung ở
-                    # đây vì sẽ đụng path self-sourced HIỆN CÓ (MockWorkloadRow +
-                    # test_assignment_self_sourced đã ghim self_cnt). Chỉ phát sinh
-                    # khi member/fairness + finance đều ON; auto-assign không siêu
-                    # nóng (chạy lúc tạo lead) ⇒ chi phí chấp nhận được.
-                    _wl_cols.append(
-                        func.count(models.Lead.id)
-                        .filter(
-                            and_(
-                                _self_sourced_subquery(),
-                                _tuition_hold_filter(),
-                            )
-                        )
-                        .label("self_and_tuition_cnt")
-                    )
-                workload_stmt = (
-                    select(*_wl_cols)
-                    .join(
-                        models.ConsultationStatus,
-                        models.Lead.consultation_status_id == models.ConsultationStatus.id,
-                        isouter=True,  # LEFT JOIN để bao gồm cả lead chưa có status
-                    )
-                    .where(
-                        models.Lead.assigned_officer_id.in_(officer_ids),
-                        models.Lead.deleted_at.is_(None),  # lead đã xóa không tính tải
-                        # Chỉ đếm lead chưa kết thúc — cùng định nghĩa với
-                        # is_officer_at_threshold (referral fast-path).
-                        _non_final_status_filter(),
-                    )
-                    .group_by(models.Lead.assigned_officer_id)
-                )
-                workload_map: dict = {}
-                self_map: dict = {}
-                tuition_map: dict = {}
-                self_and_tuition_map: dict = {}
-                for row in await db.execute(workload_stmt):
-                    workload_map[row.assigned_officer_id] = row.workload
-                    if exclude_active:
-                        self_map[row.assigned_officer_id] = row.self_cnt
-                    if finance_on:
-                        tuition_map[row.assigned_officer_id] = row.tuition_cnt
-                    if exclude_active and finance_on:
-                        self_and_tuition_map[row.assigned_officer_id] = (
-                            row.self_and_tuition_cnt
-                        )
-                # ⚠️ Parity khi OFF: hậu tố tuition-hold CHỈ nối khi finance_on ⇒
-                # cờ OFF giữ nguyên chuỗi log cũ (byte-identical, không chỉ audit).
-                _dbg_load = (
-                    f"[Lead ID: {lead_id}] Workloads={workload_map} "
-                    f"self-sourced={self_map}"
-                )
-                if finance_on:
-                    _dbg_load += f" tuition-hold={tuition_map}"
-                log.debug(_dbg_load)
-
-                # === BƯỚC 4: Xây dựng Danh sách Officer Hợp lệ (còn capacity) ===
-                officer_loads = []
-                for officer in available_officers:
-                    workload = workload_map.get(officer.id, 0)
-                    # Capacity an toàn (mặc định 100, không bao giờ <= 0) —
-                    # cùng helper với is_officer_at_threshold.
-                    capacity = _safe_capacity(officer)
-
-                    # Gate còn-capacity LUÔN theo TỔNG workload (trần cứng) —
-                    # self-tuyển/weight KHÔNG BAO GIỜ nới trần này.
-                    if workload < capacity:
-                        weight = _safe_weight(officer)
-                        # balance_load = CƠ SỞ SẮP XẾP = workload − |self ∪ tuition|.
-                        # - self (exclude_active): lead tự tuyển không làm giảm suất.
-                        # - tuition (finance_on): khách HỌC PHÍ đã chuyển đổi, không
-                        #   còn là tải tư vấn (Option A).
-                        # Mỗi phần = 0 khi cờ tương ứng OFF; trừ `overlap` (self ∩
-                        # tuition) để KHÔNG trừ hai lần. Cả hai ⊆ workload ⇒
-                        # balance_load ≥ 0 (khỏi max(0)).
-                        self_cnt = (
-                            self_map.get(officer.id, 0) if exclude_active else 0
-                        )
-                        tuition_cnt = (
-                            tuition_map.get(officer.id, 0) if finance_on else 0
-                        )
-                        overlap = (
-                            self_and_tuition_map.get(officer.id, 0)
-                            if (exclude_active and finance_on)
-                            else 0
-                        )
-                        balance_load = workload - self_cnt - tuition_cnt + overlap
-                        # real_util/eff_util tính trên balance_load (đầu vào SẮP
-                        # XẾP ở BƯỚC 5). eff_util có nhân weight: weight cao ⇒
-                        # eff_util thấp ⇒ officer "được coi là vơi hơn" ⇒ nhận
-                        # nhiều lead hơn (member ON).
-                        real_util = balance_load / capacity
-                        eff_util = balance_load / (capacity * weight)
-                        officer_loads.append(
-                            {
-                                "officer": officer,
-                                "workload": workload,  # TỔNG tải (audit + gate)
-                                "dist_load": balance_load,  # cơ sở SẮP XẾP
-                                "real_util": real_util,
-                                "eff_util": eff_util,
-                                "weight": weight,
-                                # ⚠️ Cổng an toàn TÁCH khỏi real_util (dist-based khi
-                                # exclude_active). weight/self-tuyển KHÔNG phá trần.
-                                # Option A: chỉ trừ HỌC PHÍ (tuition_cnt) khi
-                                # finance_on — self KHÔNG trừ ở cổng này (giữ như hôm
-                                # nay). tuition_cnt ⊆ workload ⇒ ≥ 0.
-                                "overloaded": (
-                                    (workload - tuition_cnt) / capacity
-                                )
-                                >= SAFETY_THRESHOLD,
-                                # tải học phí (audit; chỉ emit vào snapshot khi ON).
-                                "tuition_hold": tuition_cnt,
-                                # score = giá trị dùng để SẮP XẾP; mặc định real_util,
-                                # các nhánh weighted ở BƯỚC 5 ghi đè. Ở nhánh legacy/
-                                # fallback score GIỮ real_util nhưng KHÔNG quyết định thứ
-                                # tự (sort chỉ theo overloaded+last_assigned) — chỉ mang
-                                # tính thông tin cho snapshot.
-                                "score": real_util,
-                                # Xử lý last_assigned_at là None (coalesce)
-                                "last_assigned": officer.last_assigned_at
-                                or datetime.min.replace(tzinfo=timezone.utc),
-                            }
-                        )
-                    else:
-                        log.debug(
-                            f"[Lead ID: {lead_id}] Officer {officer.id} skipped (at full capacity: {workload}/{capacity})"
-                        )
 
                 # --- Xử lý khi tất cả Officer đã đầy tải ---
                 if not officer_loads:
@@ -628,113 +763,23 @@ async def automatically_assign_lead(
                         eligible_officer_ids=officer_ids, unit_id=lead_unit_id,
                         channel="auto", reason="at_capacity",
                         capacity_snapshot={
-                            str(o.id): {
-                                "current": workload_map.get(o.id, 0),
-                                "max": o.max_capacity or 100,
+                            str(ol["officer"].id): {
+                                "current": ol["workload"],
+                                "max": ol["officer"].max_capacity or 100,
                                 **(
-                                    {"tuition_hold": tuition_map.get(o.id, 0)}
+                                    {"tuition_hold": ol["tuition_hold"]}
                                     if finance_on
                                     else {}
                                 ),
                             }
-                            for o in available_officers
+                            for ol in _loads_res.loads
                         }, log=log,
                     )
                     return {"status": AssignmentResult.FAILED, "reason": AssignmentFailureReason.AT_CAPACITY, "lead_id": lead_id, "unit_id": lead_unit_id}, _post_commit_callbacks
 
-                # === BƯỚC 5: Sắp xếp và Chọn Officer ===
-                # Hai flag ĐỘC LẬP chồng lên logic gốc (KHÔNG thay thế nhánh):
-                #   ENABLE_MEMBER_WEIGHTED_ASSIGNMENT   → order theo eff_util (nhân weight)
-                #   ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT → thêm thành phần fairness share
-                # order_util = eff_util nếu member ON, ngược lại real_util (=== hôm nay).
-                # overloaded = (workload/capacity) >= SAFETY_THRESHOLD — LUÔN theo
-                # TỔNG tải; weight/self-tuyển KHÔNG BAO GIỜ phá cổng an toàn (không
-                # dồn quá tải thật). (member_on/fairness_on/settings đã đọc ở BƯỚC 3.)
-
-                # `overloaded` (cổng an toàn theo tải THẬT) đã đặt sẵn ở BƯỚC 4 —
-                # SAFETY_THRESHOLD là hằng module (chia sẻ với referral fast-path qua
-                # is_officer_at_threshold). weight KHÔNG BAO GIỜ phá cổng này.
-
-                # Lịch sử phân công của đơn vị — chỉ truy vấn khi fairness bật.
-                hist_counts: dict = {}
-                if fairness_on:
-                    try:
-                        from sqlalchemy import select as sel, func as fn
-                        hist_q = await db.execute(
-                            sel(
-                                models.AssignmentDecisionLog.assigned_officer_id,
-                                fn.count(models.AssignmentDecisionLog.id).label("cnt"),
-                            )
-                            .where(
-                                models.AssignmentDecisionLog.unit_id == lead_unit_id,
-                                models.AssignmentDecisionLog.assigned_officer_id.isnot(None),
-                            )
-                            .group_by(models.AssignmentDecisionLog.assigned_officer_id)
-                        )
-                        hist_counts = {r.assigned_officer_id: r.cnt for r in hist_q.all()}
-                    except Exception as e:
-                        log.warning(f"[Lead ID: {lead_id}] Fairness history query failed, falling back: {e}")
-
-                # --- Quyết định CHẾ ĐỘ chấm điểm theo 2 flag độc lập + đủ history ---
-                #   member_fairness: fairness ON + member ON + đủ pool-history (>=10)
-                #   fairness:        fairness ON + member OFF + đủ unit-history (>=10) — Y HỆT P2-2 cũ
-                #   member:          member ON (gồm cả fallback fairness+member thiếu history)
-                #   legacy:          cả 2 OFF, HOẶC fairness ON + member OFF + thiếu history — Y HỆT hôm nay
-                # (member scoring viết ở MỘT nơi duy nhất bên dưới, tránh trùng lặp.)
-                if member_on and fairness_on:
-                    # Target & actual PHẢI cùng pool = officer_loads (sau lọc capacity).
-                    # KHÔNG dùng total_hist toàn unit: history officer offline/đầy tải sẽ
-                    # loãng mẫu số ⇒ officer đã vượt share trong pool vẫn bị coi là dưới
-                    # target. Pool đồng đều weight ⇒ pressure = actual − 1/N.
-                    eligible_hist_total = sum(hist_counts.get(e["officer"].id, 0) for e in officer_loads)
-                    scoring = "member_fairness" if eligible_hist_total >= 10 else "member"
-                elif fairness_on:
-                    total_hist = sum(hist_counts.values())
-                    scoring = "fairness" if total_hist >= 10 else "legacy"
-                elif member_on:
-                    scoring = "member"
-                else:
-                    scoring = "legacy"
-
-                # --- Áp chế độ: đặt score + reason. Mỗi weight >= 1 và các ngưỡng
-                # history >= 10 đã đảm bảo mọi mẫu số dưới đây đều > 0 (không div-0). ---
-                if scoring == "member_fairness":
-                    total_weight = sum(e["weight"] for e in officer_loads)
-                    for e in officer_loads:
-                        target_share = e["weight"] / total_weight
-                        actual_share = hist_counts.get(e["officer"].id, 0) / eligible_hist_total
-                        # pressure = actual − target (<0 ⇒ dưới target ⇒ đẩy lên; >0 ⇒ phạt)
-                        e["score"] = 0.6 * e["eff_util"] + 0.4 * (actual_share - target_share)
-                    assign_reason = "member_fairness_weighted"
-                    log.info(f"[Lead ID: {lead_id}] Member+fairness weighted (pool_hist={eligible_hist_total})")
-                elif scoring == "fairness":
-                    # ⚠️ Khi exclude_active, real_util là DIST-based ⇒ score fairness
-                    # KHÁC P2-2 gốc (officer thắng có thể lật). Chủ đích (spec §5).
-                    for e in officer_loads:
-                        share = hist_counts.get(e["officer"].id, 0) / total_hist
-                        e["score"] = 0.6 * e["real_util"] + 0.4 * share
-                    assign_reason = "fairness_weighted"
-                    log.info(f"[Lead ID: {lead_id}] Using fairness-weighted scoring (history={total_hist})")
-                elif scoring == "member":
-                    # Tie-break đầu là eff_util (weight cao ⇒ eff_util thấp ⇒ ưu tiên),
-                    # rồi last_assigned. Weight ĐỒNG ĐỀU (đều =1) ⇒ eff_util == real_util
-                    # ⇒ order theo TẢI (proportional), KHÁC round-robin thuần legacy —
-                    # chủ đích member mode. ⚠️ Khi exclude_active, "TẢI" ở đây là
-                    # DIST-based (đã trừ tự tuyển), KHÔNG phải tổng workload.
-                    for e in officer_loads:
-                        e["score"] = e["eff_util"]
-                    assign_reason = "member_weighted"
-                    log.info(f"[Lead ID: {lead_id}] Using member-weighted scoring")
-                else:  # legacy — Y HỆT hôm nay
-                    assign_reason = "lowest_workload"
-                    log.info(f"[Lead ID: {lead_id}] Using legacy round-robin")
-
-                # Legacy sắp xếp KHÔNG dùng score (round-robin thuần theo last_assigned);
-                # các chế độ weighted chèn score làm tie-break thứ 2 (sau cổng overloaded).
-                if scoring == "legacy":
-                    officer_loads.sort(key=lambda x: (x["overloaded"], x["last_assigned"]))
-                else:
-                    officer_loads.sort(key=lambda x: (x["overloaded"], x["score"], x["last_assigned"]))
+                # === BUOC 5: da tinh trong compute_unit_officer_loads ===
+                scoring = _loads_res.scoring
+                assign_reason = _loads_res.assign_reason
 
                 chosen_officer_data = officer_loads[0]
                 chosen_one = chosen_officer_data["officer"]

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -466,6 +466,10 @@ async def compute_unit_officer_loads(
                 # goi lai helper => khong the lech mau so voi engine.
                 "capacity": capacity,
                 "self_cnt": self_cnt,
+                # BAT BUOC surface: deducted = self + tuition - overlap. Neu chi
+                # tra self/tuition, moi UI hien thi chung se ngam hieu la phep
+                # CONG va sai bang dung phan giao (lead vua tu tim vua da dong tien).
+                "overlap": overlap,
                 "at_capacity": at_capacity,
                 "eligible_for_assignment": (
                     officer.id in eligible_set and not at_capacity
@@ -478,11 +482,16 @@ async def compute_unit_officer_loads(
 
     scoring_pool = [ol for ol in loads if ol["eligible_for_assignment"]]
     others = [ol for ol in loads if not ol["eligible_for_assignment"]]
+    # ``others`` KHONG BAO GIO di qua khau cham diem, nen phai co thu tu on dinh
+    # RIENG. Neu de nguyen thu tu DB, caller (dashboard) enumerate ra `rank` se
+    # xuat ban mot thu tu tuy y duoi dang bang xep hang.
+    others.sort(key=lambda x: (x["at_capacity"], x["eff_util"], x["officer"].id))
     if not scoring_pool:
         # Khong ai du dieu kien => BO QUA han khau cham diem (giu dung hanh vi
         # cu: engine return som o nhanh at_capacity, KHONG query lich su).
+        # Van tra ve theo thu tu on dinh (khong phai thu tu DB).
         return UnitOfficerLoads(
-            loads=loads, scoring=None, assign_reason=None, flags=flags
+            loads=others, scoring=None, assign_reason=None, flags=flags
         )
 
     # --- Lich su phan cong (chi khi fairness bat) ---

--- a/Backend_FastAPI/app/services/officer_service.py
+++ b/Backend_FastAPI/app/services/officer_service.py
@@ -1884,6 +1884,7 @@ def _map_load_to_entry(
     unit_name,
     requesting_user_id: int,
     finance_on: bool,
+    scoring_mode,
 ) -> Dict[str, Any]:
     """Đổi 1 OfficerLoad của engine thành 1 dòng bảng (KHÔNG tính lại số nào)."""
     officer = load["officer"]
@@ -1901,6 +1902,8 @@ def _map_load_to_entry(
         "full_name": officer.full_name or officer.username,
         "unit_id": unit_id,
         "unit_name": unit_name,
+        # Chế độ chấm điểm là PER-UNIT ⇒ gắn vào từng dòng mới chính xác.
+        "scoring_mode": scoring_mode,
         "workload": workload,
         "max_capacity": capacity,
         "weight": load["weight"],
@@ -1970,7 +1973,7 @@ async def get_officer_distribution_panel(db: AsyncSession, ctx) -> Dict[str, Any
 
     requesting_user_id = ctx.requesting_user.id
     entries: List[Dict[str, Any]] = []
-    scoring_mode = None
+    modes_seen = set()
 
     for unit_id, unit_officers in by_unit.items():
         # Pool CHẤM ĐIỂM = đúng tập engine sẽ xét (đang sẵn sàng). Người còn lại
@@ -1986,8 +1989,7 @@ async def get_officer_distribution_panel(db: AsyncSession, ctx) -> Dict[str, Any
             lead_unit_id=unit_id,
             flags=flags,
         )
-        if scoring_mode is None:
-            scoring_mode = res.scoring
+        modes_seen.add(res.scoring)
         # res.loads đã sort: nhóm eligible (thứ tự ưu tiên nhận của engine) trước.
         for rank, load in enumerate(res.loads, 1):
             entries.append(
@@ -1998,13 +2000,27 @@ async def get_officer_distribution_panel(db: AsyncSession, ctx) -> Dict[str, Any
                     unit_name=unit_name_map.get(unit_id),
                     requesting_user_id=requesting_user_id,
                     finance_on=flags.finance_on,
+                    scoring_mode=res.scoring,
                 )
             )
+
+    # ⚠️ Chế độ chấm điểm là PER-UNIT (ngưỡng history fairness tính riêng từng
+    # đơn vị). Manager/admin có thể trải NHIỀU đơn vị ⇒ giá trị top-level chỉ có
+    # nghĩa khi mọi đơn vị cùng mode; khác nhau ⇒ "mixed" (đọc mode chính xác ở
+    # ``entries[].scoring_mode``). Không bao giờ lấy mode của unit đầu tiên làm
+    # đại diện — sẽ giải thích SAI cho phần entries còn lại.
+    real_modes = {m for m in modes_seen if m is not None}
+    if len(real_modes) == 1:
+        panel_mode = next(iter(real_modes))
+    elif len(real_modes) > 1:
+        panel_mode = "mixed"
+    else:
+        panel_mode = None
 
     return {
         "unit_id": ctx.effective_unit_root_id,
         "total_officers": len(entries),
-        "scoring_mode": scoring_mode,
+        "scoring_mode": panel_mode,
         "flags_snapshot": flags_snapshot,
         "entries": entries,
     }

--- a/Backend_FastAPI/app/services/officer_service.py
+++ b/Backend_FastAPI/app/services/officer_service.py
@@ -1,8 +1,9 @@
+import logging as _logging
+
 import structlog
 from datetime import datetime, timedelta, timezone, date
 from typing import List, Dict, Any, Callable, Tuple
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models, schemas
@@ -1772,6 +1773,10 @@ async def get_officer_kpi_plan(
 # dùng để chọn người. Service này CHỈ diễn giải (nhãn/câu chữ), TUYỆT ĐỐI không
 # tự tính lại workload/dist_load/eff_util (sẽ lệch khi engine đổi công thức).
 
+# Logger riêng cho đường ĐỌC. Dùng chung logger của assignment_service sẽ khiến
+# log của dashboard trông y hệt log của một quyết định phân công thật.
+_panel_log = _logging.getLogger("app.services.officer_distribution_panel")
+
 
 def classify_archetype(load: Dict[str, Any], finance_on: bool) -> Dict[str, str]:
     """Nhãn kiểu officer, suy ra từ tỉ lệ các đòn bẩy tải. Hàm THUẦN."""
@@ -1793,15 +1798,24 @@ def classify_archetype(load: Dict[str, Any], finance_on: bool) -> Dict[str, str]
     return {"key": "balanced", "label": "Cân bằng"}
 
 
-def build_diagnosis(load: Dict[str, Any], archetype_key: str) -> str:
-    """Câu chẩn đoán 1 dòng, điền số thật. Hàm THUẦN (dùng nhãn đã chốt)."""
+def build_diagnosis(
+    load: Dict[str, Any], archetype_key: str, *, fill_pct: float
+) -> str:
+    """Câu chẩn đoán 1 dòng, điền số thật. Hàm THUẦN (dùng nhãn đã chốt).
+
+    ⚠️ NGÔI THỨ BA: chuỗi này render trên MỌI dòng, kể cả dòng đồng nghiệp —
+    tuyệt đối không xưng "bạn" (chỉ ``build_boost`` mới được, vì nó chỉ gắn cho
+    chính người xem).
+    ⚠️ ``fill_pct`` nhận từ caller, KHÔNG tự tính lại: dùng ``round()`` không
+    ndigits sẽ ra banker's rounding (round(80.5) == 80) và mâu thuẫn với
+    ``fill_pct`` in ngay cạnh trong cùng tooltip.
+    """
     workload = load["workload"]
     capacity = load["capacity"]
     dist = load["dist_load"]
     self_cnt = load["self_cnt"]
     tuition = load["tuition_hold"]
     deducted = workload - dist
-    fill = round(workload / capacity * 100) if capacity else 0
 
     if archetype_key == "paused":
         return (
@@ -1810,7 +1824,7 @@ def build_diagnosis(load: Dict[str, Any], archetype_key: str) -> str:
         )
     if archetype_key == "overloaded":
         return (
-            f"Đang giữ {workload}/{capacity} lead ({fill}% khả năng nhận) — "
+            f"Đang giữ {workload}/{capacity} lead ({fill_pct}% khả năng nhận) — "
             f"chạm ngưỡng tạm dừng nên hệ thống ưu tiên người khác."
         )
     if archetype_key == "available":
@@ -1820,7 +1834,7 @@ def build_diagnosis(load: Dict[str, Any], archetype_key: str) -> str:
         )
     if archetype_key == "self_driven":
         return (
-            f"{self_cnt}/{workload} lead là bạn tự tìm nên không bị tính; "
+            f"{self_cnt}/{workload} lead là tự tìm nên không bị tính; "
             f"hệ thống chỉ tính {dist} lead."
         )
     if archetype_key == "tuition_heavy":
@@ -1864,11 +1878,19 @@ def build_boost(load: Dict[str, Any], archetype_key: str) -> str:
         )
     if dist == 0:
         return "Hệ thống đang thấy bạn hoàn toàn rảnh — bạn được ưu tiên chia trước."
-    if (self_cnt + tuition) > dist:
+    deducted = workload - dist
+    if deducted > dist:
+        # ⚠️ KHÔNG viết "{self} tự tìm và {tuition} đã đóng tiền" như một phép
+        # cộng: phần giao (lead vừa tự tìm vừa đã đóng tiền) chỉ được trừ MỘT
+        # lần, nên self + tuition > deducted. Nêu tổng thật, rồi mới tách chi tiết.
+        overlap = load.get("overlap", 0)
+        detail = f"{self_cnt} lead tự tìm và {tuition} hồ sơ đã đóng tiền"
+        if overlap:
+            detail += f" (trong đó {overlap} lead thuộc cả hai)"
         return (
-            f"Điểm bận thấp của bạn đến từ {self_cnt} lead tự tìm và {tuition} "
-            f"hồ sơ đã đóng tiền (không bị tính). Phần bạn chủ động giảm được là "
-            f"{dist} lead hệ thống đang tính."
+            f"Điểm bận thấp của bạn nhờ {deducted} lead không bị tính — gồm "
+            f"{detail}. Phần bạn chủ động giảm được là {dist} lead hệ thống "
+            f"đang tính."
         )
     return (
         f"Muốn được chia thêm: giảm {dist} lead hệ thống đang tính bằng cách "
@@ -1894,12 +1916,15 @@ def _map_load_to_entry(
     tuition = load["tuition_hold"]
     archetype = classify_archetype(load, finance_on)
     is_me = officer.id == requesting_user_id
+    fill_pct = round(workload / capacity * 100, 1) if capacity else 0.0
 
     return {
         "rank": rank,
         "user_id": officer.id,
-        "username": officer.username,
-        "full_name": officer.full_name or officer.username,
+        # ⚠️ KHÔNG trả `username`: đây là endpoint duy nhất lộ cả roster đơn vị,
+        # FE chỉ render `full_name`, nên đưa login-id của đồng nghiệp lên wire là
+        # bề mặt PII không đổi lấy gì.
+        "full_name": officer.full_name or f"NV #{officer.id}",
         "unit_id": unit_id,
         "unit_name": unit_name,
         # Chế độ chấm điểm là PER-UNIT ⇒ gắn vào từng dòng mới chính xác.
@@ -1909,10 +1934,14 @@ def _map_load_to_entry(
         "weight": load["weight"],
         "self_sourced": load["self_cnt"],
         "tuition_hold": tuition,
+        # Phần GIAO self ∩ tuition. BẮT BUỘC có trên wire: thiếu nó thì
+        # self_sourced + tuition_hold ≠ deducted và mọi UI hiển thị chung sẽ
+        # trình bày một phép cộng không đúng tổng của chính nó.
+        "overlap": load.get("overlap", 0),
         "dist_load": dist,
         "deducted": workload - dist,
         "real_util_pct": round(load["real_util"] * 100, 1),
-        "fill_pct": round(workload / capacity * 100, 1) if capacity else 0.0,
+        "fill_pct": fill_pct,
         "eff_util_pct": round(load["eff_util"] * 100, 1),
         "score": round(load["score"], 4),
         "overload_gate_pct": (
@@ -1923,7 +1952,7 @@ def _map_load_to_entry(
         "eligible_for_assignment": load["eligible_for_assignment"],
         "availability_status": officer.availability_status or "offline",
         "archetype": archetype,
-        "diagnosis": build_diagnosis(load, archetype["key"]),
+        "diagnosis": build_diagnosis(load, archetype["key"], fill_pct=fill_pct),
         # 🔒 Lời khuyên CHỈ hiện trên dòng của chính người đang xem.
         "boost": build_boost(load, archetype["key"]) if is_me else None,
         "is_current_user": is_me,
@@ -1962,14 +1991,14 @@ async def get_officer_distribution_panel(db: AsyncSession, ctx) -> Dict[str, Any
     for officer in officers:
         by_unit.setdefault(officer.unit_id, []).append(officer)
 
-    unit_name_map: Dict[int, str] = {}
-    real_unit_ids = [uid for uid in by_unit if uid is not None]
-    if real_unit_ids:
-        rows = await db.execute(
-            select(models.OrganizationUnit.id, models.OrganizationUnit.name)
-            .where(models.OrganizationUnit.id.in_(real_unit_ids))
-        )
-        unit_name_map = {row.id: row.name for row in rows}
+    # Tên đơn vị lấy từ quan hệ đã eager-load (`selectinload(User.unit)` trong
+    # repo) — KHÔNG query rời trong service (giữ đúng Repository pattern và bớt
+    # một round-trip).
+    unit_name_map: Dict[int, str] = {
+        o.unit_id: o.unit.name
+        for o in officers
+        if o.unit_id is not None and o.unit is not None
+    }
 
     requesting_user_id = ctx.requesting_user.id
     entries: List[Dict[str, Any]] = []
@@ -1988,6 +2017,11 @@ async def get_officer_distribution_panel(db: AsyncSession, ctx) -> Dict[str, Any
             eligible_officer_ids=eligible_ids,
             lead_unit_id=unit_id,
             flags=flags,
+            # ⚠️ Logger RIÊNG: nếu để mặc định, mỗi lần poll dashboard sẽ ghi
+            # "Using <mode> scoring" ở mức INFO vào logger của assignment_service
+            # — trước đây một dòng như thế nghĩa là ĐÚNG MỘT lead vừa được gán,
+            # nên mọi audit đếm quyết định phân công theo log sẽ bị thổi phồng.
+            log=_panel_log,
         )
         modes_seen.add(res.scoring)
         # res.loads đã sort: nhóm eligible (thứ tự ưu tiên nhận của engine) trước.

--- a/Backend_FastAPI/app/services/officer_service.py
+++ b/Backend_FastAPI/app/services/officer_service.py
@@ -2,6 +2,7 @@ import structlog
 from datetime import datetime, timedelta, timezone, date
 from typing import List, Dict, Any, Callable, Tuple
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models, schemas
@@ -1760,4 +1761,250 @@ async def get_officer_kpi_plan(
         "progress_pct": round(progress_pct, 1),
         "months": month_summaries,
         "source": source,
+    }
+
+
+# =============================================================================
+# Distribution Panel ("Điểm bận") — giải trình phân phối lead của đơn vị
+# =============================================================================
+# ⚠️ MỌI con số tải ở đây đến TRỰC TIẾP từ
+# ``assignment_service.compute_unit_officer_loads`` — đúng hàm engine chia lead
+# dùng để chọn người. Service này CHỈ diễn giải (nhãn/câu chữ), TUYỆT ĐỐI không
+# tự tính lại workload/dist_load/eff_util (sẽ lệch khi engine đổi công thức).
+
+
+def classify_archetype(load: Dict[str, Any], finance_on: bool) -> Dict[str, str]:
+    """Nhãn kiểu officer, suy ra từ tỉ lệ các đòn bẩy tải. Hàm THUẦN."""
+    officer = load["officer"]
+    workload = load["workload"]
+    capacity = load["capacity"]
+    fill = workload / capacity if capacity else 0.0
+
+    if (officer.availability_status or "offline") != "available":
+        return {"key": "paused", "label": "Đang tắt nhận lead"}
+    if load["at_capacity"] or load["overloaded"]:
+        return {"key": "overloaded", "label": "Quá tải"}
+    if fill < 0.30:
+        return {"key": "available", "label": "Còn nhiều chỗ trống"}
+    if workload > 0 and load["self_cnt"] / workload >= 0.50:
+        return {"key": "self_driven", "label": "Tự tìm khách là chính"}
+    if finance_on and workload > 0 and load["tuition_hold"] / workload >= 0.50:
+        return {"key": "tuition_heavy", "label": "Chủ yếu chờ học phí"}
+    return {"key": "balanced", "label": "Cân bằng"}
+
+
+def build_diagnosis(load: Dict[str, Any], archetype_key: str) -> str:
+    """Câu chẩn đoán 1 dòng, điền số thật. Hàm THUẦN (dùng nhãn đã chốt)."""
+    workload = load["workload"]
+    capacity = load["capacity"]
+    dist = load["dist_load"]
+    self_cnt = load["self_cnt"]
+    tuition = load["tuition_hold"]
+    deducted = workload - dist
+    fill = round(workload / capacity * 100) if capacity else 0
+
+    if archetype_key == "paused":
+        return (
+            f"Đang tắt sẵn sàng nên hệ thống không chia lead mới; "
+            f"vẫn giữ {workload} lead."
+        )
+    if archetype_key == "overloaded":
+        return (
+            f"Đang giữ {workload}/{capacity} lead ({fill}% khả năng nhận) — "
+            f"chạm ngưỡng tạm dừng nên hệ thống ưu tiên người khác."
+        )
+    if archetype_key == "available":
+        return (
+            f"Mới dùng {workload}/{capacity} khả năng nhận — "
+            f"hệ thống thấy còn rất rảnh nên ưu tiên chia thêm."
+        )
+    if archetype_key == "self_driven":
+        return (
+            f"{self_cnt}/{workload} lead là bạn tự tìm nên không bị tính; "
+            f"hệ thống chỉ tính {dist} lead."
+        )
+    if archetype_key == "tuition_heavy":
+        return (
+            f"{tuition}/{workload} lead đã đóng tiền nên không bị tính; "
+            f"hệ thống chỉ tính {dist} lead."
+        )
+    if deducted > 0:
+        return (
+            f"Giữ {workload} lead, được trừ {deducted} (tự tìm + đã đóng tiền) "
+            f"nên hệ thống tính {dist}."
+        )
+    return (
+        f"Gần như toàn bộ {workload} lead là do hệ thống chia — "
+        f"không có phần được trừ."
+    )
+
+
+def build_boost(load: Dict[str, Any], archetype_key: str) -> str:
+    """Lời khuyên hành động. 🔒 Chỉ gắn cho CHÍNH người đang xem (caller gate).
+
+    Bám đúng cơ chế engine: chỉ ``dist_load`` (lead hệ thống tính) mới kéo điểm
+    bận xuống. Lead tự tìm / hồ sơ đã đóng tiền ĐÃ được trừ sẵn nên xử lý chúng
+    KHÔNG làm được chia thêm — tuyệt đối không khuyên sai điều này.
+    """
+    workload = load["workload"]
+    capacity = load["capacity"]
+    dist = load["dist_load"]
+    self_cnt = load["self_cnt"]
+    tuition = load["tuition_hold"]
+
+    if archetype_key == "paused":
+        return (
+            "Bạn đang tắt sẵn sàng nên hệ thống bỏ qua khi chia. "
+            "Bật lại khi muốn nhận tiếp."
+        )
+    if archetype_key == "overloaded":
+        return (
+            f"Bạn đang giữ {workload}/{capacity} lead nên hệ thống tạm giảm chia. "
+            f"Chốt bớt lead đang mở để hạ điểm bận."
+        )
+    if dist == 0:
+        return "Hệ thống đang thấy bạn hoàn toàn rảnh — bạn được ưu tiên chia trước."
+    if (self_cnt + tuition) > dist:
+        return (
+            f"Điểm bận thấp của bạn đến từ {self_cnt} lead tự tìm và {tuition} "
+            f"hồ sơ đã đóng tiền (không bị tính). Phần bạn chủ động giảm được là "
+            f"{dist} lead hệ thống đang tính."
+        )
+    return (
+        f"Muốn được chia thêm: giảm {dist} lead hệ thống đang tính bằng cách "
+        f"chốt bớt lead đang mở — điểm bận sẽ hạ xuống."
+    )
+
+
+def _map_load_to_entry(
+    load: Dict[str, Any],
+    *,
+    rank: int,
+    unit_id,
+    unit_name,
+    requesting_user_id: int,
+    finance_on: bool,
+) -> Dict[str, Any]:
+    """Đổi 1 OfficerLoad của engine thành 1 dòng bảng (KHÔNG tính lại số nào)."""
+    officer = load["officer"]
+    workload = load["workload"]
+    capacity = load["capacity"]
+    dist = load["dist_load"]
+    tuition = load["tuition_hold"]
+    archetype = classify_archetype(load, finance_on)
+    is_me = officer.id == requesting_user_id
+
+    return {
+        "rank": rank,
+        "user_id": officer.id,
+        "username": officer.username,
+        "full_name": officer.full_name or officer.username,
+        "unit_id": unit_id,
+        "unit_name": unit_name,
+        "workload": workload,
+        "max_capacity": capacity,
+        "weight": load["weight"],
+        "self_sourced": load["self_cnt"],
+        "tuition_hold": tuition,
+        "dist_load": dist,
+        "deducted": workload - dist,
+        "real_util_pct": round(load["real_util"] * 100, 1),
+        "fill_pct": round(workload / capacity * 100, 1) if capacity else 0.0,
+        "eff_util_pct": round(load["eff_util"] * 100, 1),
+        "score": round(load["score"], 4),
+        "overload_gate_pct": (
+            round((workload - tuition) / capacity * 100, 1) if capacity else 0.0
+        ),
+        "overloaded": load["overloaded"],
+        "at_capacity": load["at_capacity"],
+        "eligible_for_assignment": load["eligible_for_assignment"],
+        "availability_status": officer.availability_status or "offline",
+        "archetype": archetype,
+        "diagnosis": build_diagnosis(load, archetype["key"]),
+        # 🔒 Lời khuyên CHỈ hiện trên dòng của chính người đang xem.
+        "boost": build_boost(load, archetype["key"]) if is_me else None,
+        "is_current_user": is_me,
+    }
+
+
+async def get_officer_distribution_panel(db: AsyncSession, ctx) -> Dict[str, Any]:
+    """Bảng "điểm bận" — giải trình engine chia lead cho từng officer.
+
+    Chấm điểm THEO TỪNG ĐƠN VỊ (giống engine, vì pool fairness là per-unit).
+    Officer offline/busy vẫn được tính metric để hiển thị nhưng KHÔNG vào pool
+    chấm điểm ⇒ điểm của người eligible y hệt con số engine dùng.
+    """
+    from . import assignment_service
+
+    repo = OfficerRepository(db)
+    flags = assignment_service.read_assignment_flags()
+    flags_snapshot = {
+        "member_weighted": flags.member_on,
+        "fairness_weighted": flags.fairness_on,
+        "exclude_self_sourced": flags.exclude_active,
+        "finance_discount": flags.finance_on,
+    }
+
+    officers = await repo.get_officers_by_ids(ctx.effective_officer_ids)
+    if not officers:
+        return {
+            "unit_id": ctx.effective_unit_root_id,
+            "total_officers": 0,
+            "scoring_mode": None,
+            "flags_snapshot": flags_snapshot,
+            "entries": [],
+        }
+
+    by_unit: Dict[Any, List[Any]] = {}
+    for officer in officers:
+        by_unit.setdefault(officer.unit_id, []).append(officer)
+
+    unit_name_map: Dict[int, str] = {}
+    real_unit_ids = [uid for uid in by_unit if uid is not None]
+    if real_unit_ids:
+        rows = await db.execute(
+            select(models.OrganizationUnit.id, models.OrganizationUnit.name)
+            .where(models.OrganizationUnit.id.in_(real_unit_ids))
+        )
+        unit_name_map = {row.id: row.name for row in rows}
+
+    requesting_user_id = ctx.requesting_user.id
+    entries: List[Dict[str, Any]] = []
+    scoring_mode = None
+
+    for unit_id, unit_officers in by_unit.items():
+        # Pool CHẤM ĐIỂM = đúng tập engine sẽ xét (đang sẵn sàng). Người còn lại
+        # vẫn có metric hiển thị nhưng đứng ngoài luồng chia.
+        eligible_ids = {
+            o.id for o in unit_officers if o.availability_status == "available"
+        }
+        res = await assignment_service.compute_unit_officer_loads(
+            db,
+            unit_officers,
+            include_at_capacity=True,
+            eligible_officer_ids=eligible_ids,
+            lead_unit_id=unit_id,
+            flags=flags,
+        )
+        if scoring_mode is None:
+            scoring_mode = res.scoring
+        # res.loads đã sort: nhóm eligible (thứ tự ưu tiên nhận của engine) trước.
+        for rank, load in enumerate(res.loads, 1):
+            entries.append(
+                _map_load_to_entry(
+                    load,
+                    rank=rank,
+                    unit_id=unit_id,
+                    unit_name=unit_name_map.get(unit_id),
+                    requesting_user_id=requesting_user_id,
+                    finance_on=flags.finance_on,
+                )
+            )
+
+    return {
+        "unit_id": ctx.effective_unit_root_id,
+        "total_officers": len(entries),
+        "scoring_mode": scoring_mode,
+        "flags_snapshot": flags_snapshot,
+        "entries": entries,
     }

--- a/Backend_FastAPI/tests/api/test_officer_dashboard_scope.py
+++ b/Backend_FastAPI/tests/api/test_officer_dashboard_scope.py
@@ -1215,3 +1215,100 @@ class TestDistributionPanelDenies:
             assert body["scoring_mode"] == next(iter(real_modes))
         else:
             assert body["scoring_mode"] is None
+
+
+# ===========================================================================
+# Distribution Panel — CHẾ ĐỘ ĐANG CHẠY PROD (cờ BẬT)
+# ===========================================================================
+# ⚠️ `.env.test` không set cờ nào ⇒ mặc định TẮT HẾT. Khi tắt thì
+# self_sourced = tuition_hold = deducted = 0, dist_load == workload, weight == 1,
+# và eff_util_pct == real_util_pct == fill_pct — nghĩa là mọi assert về số liệu
+# trở thành hằng đúng (0 == 0, x == x) và TOÀN BỘ chủ đề của tính năng (giảm
+# trừ, trọng số, "điểm bận vs chỗ đầy") KHÔNG được test. Prod unit 14 đang chạy
+# member + exclude-self + finance ⇒ phải test đúng cấu hình đó.
+
+
+@pytest.fixture
+def prod_flags(monkeypatch):
+    """Bật đúng bộ cờ đang chạy prod cho các test dưới đây."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "ENABLE_MEMBER_WEIGHTED_ASSIGNMENT", True)
+    monkeypatch.setattr(settings, "ENABLE_DISTRIBUTION_EXCLUDE_SELF_SOURCED", True)
+    monkeypatch.setattr(settings, "ENABLE_FINANCE_WORKLOAD_DISCOUNT", True)
+    monkeypatch.setattr(settings, "ENABLE_FAIRNESS_WEIGHTED_ASSIGNMENT", False)
+    return settings
+
+
+class TestDistributionPanelProdFlags:
+    """Ghim bộ số ở ĐÚNG cấu hình prod — nơi các phép trừ/trọng số mới có tác dụng."""
+
+    @pytest.mark.asyncio
+    async def test_scoring_mode_is_member_when_flags_on(
+        self, client: AsyncClient, officer_token_headers, prod_flags,
+    ):
+        resp = await client.get(DISTRIBUTION_URL, headers=officer_token_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        # Với cờ TẮT giá trị này là "legacy" — assert dưới đây chỉ đúng khi cờ BẬT,
+        # nên nó cũng là canary phát hiện test lại rơi về chế độ mặc định.
+        assert body["scoring_mode"] == "member"
+        for e in body["entries"]:
+            assert e["scoring_mode"] == "member"
+
+    @pytest.mark.asyncio
+    async def test_deducted_equals_self_plus_tuition_minus_overlap(
+        self, client: AsyncClient, officer_token_headers, prod_flags,
+    ):
+        """Bất biến then chốt: overlap PHẢI có trên wire và khớp phép trừ.
+
+        Thiếu `overlap`, client sẽ trình bày `self + tuition` như một phép cộng
+        không bằng `deducted` (phần giao bị trừ hai lần trong đầu người đọc).
+        """
+        resp = await client.get(DISTRIBUTION_URL, headers=officer_token_headers)
+        assert resp.status_code == 200
+        for e in resp.json()["entries"]:
+            assert "overlap" in e
+            assert e["deducted"] == e["self_sourced"] + e["tuition_hold"] - e["overlap"]
+            assert e["overlap"] <= min(e["self_sourced"], e["tuition_hold"])
+            assert e["dist_load"] == e["workload"] - e["deducted"]
+
+    @pytest.mark.asyncio
+    async def test_weight_actually_divides_eff_util(
+        self, client: AsyncClient, officer_token_headers, prod_flags,
+    ):
+        """Với cờ TẮT thì weight luôn = 1 nên phép chia này vô nghĩa."""
+        resp = await client.get(DISTRIBUTION_URL, headers=officer_token_headers)
+        assert resp.status_code == 200
+        for e in resp.json()["entries"]:
+            expected = round(
+                e["dist_load"] / (e["max_capacity"] * e["weight"]) * 100, 1
+            )
+            assert e["eff_util_pct"] == expected
+            # real_util_pct KHÔNG chia trọng số
+            assert e["real_util_pct"] == round(
+                e["dist_load"] / e["max_capacity"] * 100, 1
+            )
+
+    @pytest.mark.asyncio
+    async def test_username_not_exposed(
+        self, client: AsyncClient, officer_token_headers, prod_flags,
+    ):
+        """Endpoint trả cả roster đơn vị ⇒ không được kèm login-id đồng nghiệp."""
+        resp = await client.get(DISTRIBUTION_URL, headers=officer_token_headers)
+        assert resp.status_code == 200
+        for e in resp.json()["entries"]:
+            assert "username" not in e
+            assert "email" not in e
+
+    @pytest.mark.asyncio
+    async def test_diagnosis_never_addresses_reader_on_peer_rows(
+        self, client: AsyncClient, officer_user_in_db, officer_token_headers,
+        officer2_in_unit1, prod_flags,
+    ):
+        """`diagnosis` render ở MỌI dòng nên không được xưng "bạn"."""
+        resp = await client.get(DISTRIBUTION_URL, headers=officer_token_headers)
+        assert resp.status_code == 200
+        for e in resp.json()["entries"]:
+            if e["user_id"] != officer_user_in_db["id"]:
+                assert "bạn" not in e["diagnosis"].lower(), e["diagnosis"]

--- a/Backend_FastAPI/tests/api/test_officer_dashboard_scope.py
+++ b/Backend_FastAPI/tests/api/test_officer_dashboard_scope.py
@@ -1123,3 +1123,95 @@ class TestDistributionPanelScope:
                 e["dist_load"] / (e["max_capacity"] * e["weight"]) * 100, 1
             )
             assert e["eff_util_pct"] == expected_eff
+
+
+# --- Bổ sung sau review: accountant deny + manager ngoài scope + scoring_mode ---
+ACCOUNTANT_DIST_DATA = {
+    "username": "accountant_dist",
+    "email": "accountant_dist@example.com",
+    "password": "AccountantDist!321",
+    "role": "accountant",
+    "status": "active",
+}
+
+
+@pytest_asyncio.fixture
+async def accountant_in_unit1(seed_lead_dependencies):
+    """Accountant cùng UNIT_1 — dùng để ghim Casbin DENY của endpoint này."""
+    return await _create_user_and_role(
+        ACCOUNTANT_DIST_DATA, "role:accountant", unit_id=1
+    )
+
+
+class TestDistributionPanelDenies:
+    """Các nhánh CHẶN + ngữ nghĩa scoring_mode (bổ sung sau review)."""
+
+    @pytest.mark.asyncio
+    async def test_accountant_denied(
+        self, client: AsyncClient, accountant_in_unit1,
+    ):
+        """Accountant kế thừa role:officer nhưng PHẢI bị DENY tường minh.
+
+        Endpoint lộ tên + tải của cả phòng tư vấn ⇒ ngoài phạm vi kế toán.
+        Nếu row deny trong ACCOUNTANT_TEMPLATE bị mất, test này đỏ.
+        """
+        headers = await _get_token_headers(client, ACCOUNTANT_DIST_DATA)
+        resp = await client.get(DISTRIBUTION_URL, headers=headers)
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_manager_other_unit_denied(
+        self, client: AsyncClient, manager_user_in_db, manager_token_headers,
+        unrelated_unit,
+    ):
+        """Manager trỏ unit ngoài phạm vi ⇒ CHẶN.
+
+        ⚠️ Ghi nhận hành vi THẬT: nhánh manager/admin ủy quyền nguyên vẹn cho
+        ``get_officer_dashboard_scope`` nên trả **403** (PermissionDeniedError),
+        khác nhánh officer (404). Cố ý giữ nguyên để một nguồn sự thật cho cả họ
+        endpoint dashboard — test ghim đúng hành vi này, không ghim theo mong muốn.
+        """
+        resp = await client.get(
+            DISTRIBUTION_URL,
+            params={"unit_id": unrelated_unit},
+            headers=manager_token_headers,
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_manager_out_of_scope_officer_404(
+        self, client: AsyncClient, manager_token_headers, officer_in_unrelated_unit,
+    ):
+        """Drill-down sang officer ngoài phạm vi manager ⇒ 404 (không lộ tồn tại)."""
+        resp = await client.get(
+            DISTRIBUTION_URL,
+            params={"officer_id": officer_in_unrelated_unit["id"]},
+            headers=manager_token_headers,
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_scoring_mode_is_per_unit_not_first_unit(
+        self, client: AsyncClient, officer_token_headers, officer2_in_unit1,
+    ):
+        """scoring_mode top-level PHẢI là tóm tắt đúng của các entry.
+
+        Chấm điểm chạy per-unit; lấy mode của đơn vị ĐẦU TIÊN làm đại diện sẽ
+        giải thích sai cho phần entries còn lại khi phạm vi trải nhiều đơn vị.
+        Ghim: mọi entry có trường riêng, và top-level = mode chung / "mixed" / None.
+        """
+        resp = await client.get(DISTRIBUTION_URL, headers=officer_token_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        entries = body["entries"]
+
+        for e in entries:
+            assert "scoring_mode" in e
+
+        real_modes = {e["scoring_mode"] for e in entries if e["scoring_mode"]}
+        if len(real_modes) > 1:
+            assert body["scoring_mode"] == "mixed"
+        elif len(real_modes) == 1:
+            assert body["scoring_mode"] == next(iter(real_modes))
+        else:
+            assert body["scoring_mode"] is None

--- a/Backend_FastAPI/tests/api/test_officer_dashboard_scope.py
+++ b/Backend_FastAPI/tests/api/test_officer_dashboard_scope.py
@@ -1001,3 +1001,125 @@ class TestMyKpiPlanResponseShape:
         expected = {1: 12.5, 2: 8.0}
         for m in data["months"]:
             assert m["consultations_actual_avg"] == expected.get(m["month"])
+
+
+# ===========================================================================
+# Distribution Panel ("Điểm bận") — scope / IDOR / privacy
+# ===========================================================================
+DISTRIBUTION_URL = "/api/officer/distribution-panel"
+
+
+class TestDistributionPanelScope:
+    """Endpoint này CỐ Ý rộng hơn dashboard: officer xem được CẢ ĐƠN VỊ mình.
+
+    Vì thế phải ghim chặt: không rò sang đơn vị khác, không nhận tham số trỏ
+    người/đơn vị khác, và lời khuyên cá nhân chỉ hiện trên dòng của chính mình.
+    """
+
+    @pytest.mark.asyncio
+    async def test_officer_sees_own_unit_including_colleagues(
+        self, client: AsyncClient, officer_user_in_db, officer_token_headers,
+        officer2_in_unit1,
+    ):
+        """Officer xem được cả đơn vị — thấy CẢ đồng nghiệp cùng unit."""
+        resp = await client.get(DISTRIBUTION_URL, headers=officer_token_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+
+        ids = {e["user_id"] for e in body["entries"]}
+        assert officer_user_in_db["id"] in ids
+        assert officer2_in_unit1["id"] in ids, "phải thấy đồng nghiệp cùng đơn vị"
+        assert body["total_officers"] == len(body["entries"])
+
+    @pytest.mark.asyncio
+    async def test_officer_does_not_see_other_unit(
+        self, client: AsyncClient, officer_token_headers, officer_in_unrelated_unit,
+    ):
+        """Officer KHÔNG thấy người ở đơn vị khác."""
+        resp = await client.get(DISTRIBUTION_URL, headers=officer_token_headers)
+        assert resp.status_code == 200
+        ids = {e["user_id"] for e in resp.json()["entries"]}
+        assert officer_in_unrelated_unit["id"] not in ids
+
+    @pytest.mark.asyncio
+    async def test_officer_other_officer_id_404(
+        self, client: AsyncClient, officer_token_headers, officer2_in_unit1,
+    ):
+        """Trỏ officer_id người khác ⇒ 404 (không lộ tồn tại)."""
+        resp = await client.get(
+            DISTRIBUTION_URL,
+            params={"officer_id": officer2_in_unit1["id"]},
+            headers=officer_token_headers,
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_officer_other_unit_id_404(
+        self, client: AsyncClient, officer_token_headers, unrelated_unit,
+    ):
+        """Trỏ unit_id đơn vị khác ⇒ 404."""
+        resp = await client.get(
+            DISTRIBUTION_URL,
+            params={"unit_id": unrelated_unit},
+            headers=officer_token_headers,
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_boost_only_on_own_row(
+        self, client: AsyncClient, officer_user_in_db, officer_token_headers,
+        officer2_in_unit1,
+    ):
+        """🔒 Lời khuyên CHỈ hiện trên dòng của chính người xem."""
+        resp = await client.get(DISTRIBUTION_URL, headers=officer_token_headers)
+        assert resp.status_code == 200
+        entries = resp.json()["entries"]
+
+        mine = [e for e in entries if e["user_id"] == officer_user_in_db["id"]]
+        others = [e for e in entries if e["user_id"] != officer_user_in_db["id"]]
+        assert len(mine) == 1
+        assert mine[0]["is_current_user"] is True
+        assert mine[0]["boost"], "dòng của mình phải có lời khuyên"
+        for e in others:
+            assert e["is_current_user"] is False
+            assert e["boost"] is None, "KHÔNG được lộ lời khuyên của người khác"
+            # nhưng số liệu + chẩn đoán vẫn công khai (minh bạch)
+            assert e["diagnosis"]
+            assert "eff_util_pct" in e
+
+    @pytest.mark.asyncio
+    async def test_manager_ok(
+        self, client: AsyncClient, manager_user_in_db, manager_token_headers,
+    ):
+        resp = await client.get(DISTRIBUTION_URL, headers=manager_token_headers)
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_admin_ok(
+        self, client: AsyncClient, admin_user_in_db, admin_token_headers,
+    ):
+        resp = await client.get(DISTRIBUTION_URL, headers=admin_token_headers)
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_regular_user_blocked(
+        self, client: AsyncClient, regular_user_token_headers,
+    ):
+        """Role ngoài officer/manager/admin bị chặn (fail-close)."""
+        resp = await client.get(DISTRIBUTION_URL, headers=regular_user_token_headers)
+        assert resp.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_numbers_are_engine_numbers(
+        self, client: AsyncClient, officer_token_headers,
+    ):
+        """Bất biến số liệu: deducted = workload - dist_load, và điểm bận
+        = dist_load/(capacity*weight)*100 — đúng công thức engine."""
+        resp = await client.get(DISTRIBUTION_URL, headers=officer_token_headers)
+        assert resp.status_code == 200
+        for e in resp.json()["entries"]:
+            assert e["deducted"] == e["workload"] - e["dist_load"]
+            expected_eff = round(
+                e["dist_load"] / (e["max_capacity"] * e["weight"]) * 100, 1
+            )
+            assert e["eff_util_pct"] == expected_eff

--- a/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
+++ b/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
@@ -399,7 +399,12 @@ async def test_accountant_deny_rows_seeded(setup_test_database):
         the current matcher (existing `/api/leads/{id}` GET/PUT denies
         already cover these via collision), but locks intent if matcher
         is ever tightened.
-      - Total NOW: 42 deny rows.
+      - Bảng "điểm bận" (2026-07-19) added 1 deny row on
+        /api/officer/distribution-panel (migration
+        `distpanelcasbin20260719`).
+      - Total NOW: 54 deny rows. (Con số này từng ghi 42 trong khi tập
+        thật đã là 53 — các wave sau không cập nhật docstring. Đã đếm
+        lại theo `expected` bên dưới.)
     """
     db_url = os.environ["DATABASE_URL"]
     enforcer, engine = await _seed_test_db_and_load_enforcer(db_url)
@@ -502,6 +507,12 @@ async def test_accountant_deny_rows_seeded(setup_test_database):
             # lead name/phone (PII); accountant kế thừa officer allow → deny
             # (separation-of-duties). Migration `apptacctdeny20260713`.
             ("/api/leads/my/appointments",                         "GET"),
+            # Bảng "điểm bận" (2026-07-19) — GET /api/officer/distribution-panel
+            # trả tải + tên officer toàn đơn vị (workload/eff_util/tự-tuyển);
+            # accountant kế thừa officer allow → deny (separation-of-duties:
+            # finance không giám sát năng suất nhân sự). Migration
+            # `distpanelcasbin20260719`.
+            ("/api/officer/distribution-panel",                    "GET"),
         }
         assert observed == expected, (
             f"Accountant deny-row set drifted. "

--- a/Backend_FastAPI/tests/services/test_assignment_parity.py
+++ b/Backend_FastAPI/tests/services/test_assignment_parity.py
@@ -1,0 +1,261 @@
+# tests/services/test_assignment_parity.py
+"""Parity: dashboard "điểm bận" KHÔNG ĐƯỢC lệch khỏi engine chia lead.
+
+``compute_unit_officer_loads`` là hàm DÙNG CHUNG: ``automatically_assign_lead``
+gọi nó để chọn người, ``officer_service.get_officer_distribution_panel`` gọi nó
+để hiển thị. Bộ test này ghim đúng các bất biến làm cho hai bên không thể lệch:
+
+1. Người engine chọn == phần tử eligible đầu tiên helper trả về.
+2. Thêm officer offline vào pool HIỂN THỊ **không** đổi điểm/thứ tự của nhóm
+   eligible (pool chấm điểm tách khỏi pool hiển thị).
+3. Officer đầy tải vẫn có metric để hiển thị nhưng bị loại khỏi luồng chia —
+   và ``loads`` vẫn đủ dữ liệu dựng capacity_snapshot cho nhánh AT_CAPACITY.
+4. Công thức dist_load (union self ∪ tuition, chống trừ hai lần) khớp tay tính.
+"""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from app import models
+from app.services import assignment_service
+from app.services.assignment_service import (
+    AssignmentFlags,
+    compute_unit_officer_loads,
+)
+from tests.services.conftest import MockWorkloadRow
+
+
+# ---------------------------------------------------------------------------
+# Helpers (cùng khuôn với test_assignment.py)
+# ---------------------------------------------------------------------------
+def _lead_result(lead):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = lead
+    return r
+
+
+def _officers_result(officers):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = officers
+    return r
+
+
+def _workload_result(rows):
+    return list(rows)
+
+
+def _decision_log(mock_db):
+    for c in mock_db.add.call_args_list:
+        if c.args and isinstance(c.args[0], models.AssignmentDecisionLog):
+            return c.args[0]
+    return None
+
+
+def _officer(oid, *, capacity=10, weight=1, availability="available", hours_ago=None):
+    return models.User(
+        id=oid,
+        username=f"officer{oid}",
+        role="officer",
+        status="active",
+        availability_status=availability,
+        unit_id=1,
+        max_capacity=capacity,
+        assignment_weight=weight,
+        last_assigned_at=(
+            None if hours_ago is None
+            else datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+        ),
+    )
+
+
+@pytest.fixture
+def lead_new():
+    lead = models.Lead(id=9001, unit_id=1)
+    lead.assigned_officer_id = None
+    lead.deleted_at = None
+    lead.rejected_by_officer_ids = []
+    lead.consultation_status_id = None
+    return lead
+
+
+# ---------------------------------------------------------------------------
+# 1. Engine chọn ai == helper trả ai (bất biến cốt lõi)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_engine_winner_equals_helper_first_eligible(
+    mock_db_session, lead_new, mocker
+):
+    """Officer engine gán PHẢI là phần tử eligible đầu tiên của helper."""
+    o1 = _officer(101, hours_ago=None)          # lâu chưa nhận nhất
+    o2 = _officer(102, hours_ago=1)
+    rows = [MockWorkloadRow(101, 5), MockWorkloadRow(102, 2)]
+
+    # --- đường HELPER (dashboard dùng) — chạy TRƯỚC vì engine sẽ mutate
+    # ``chosen_one.last_assigned_at = now`` làm đổi khóa sort của lần chạy sau.
+    helper_db = mocker.MagicMock()
+    helper_db.execute = mocker.AsyncMock(return_value=_workload_result(rows))
+    res = await compute_unit_officer_loads(
+        helper_db, [o1, o2], include_at_capacity=True, lead_unit_id=1
+    )
+    eligible = [ol for ol in res.loads if ol["eligible_for_assignment"]]
+    helper_choice = eligible[0]["officer"].id
+
+    # --- đường ENGINE ---
+    mock_db_session.execute.side_effect = [
+        _lead_result(lead_new),
+        _officers_result([o1, o2]),
+        _workload_result(rows),
+    ]
+    await assignment_service.automatically_assign_lead(lead_new.id, mock_db_session)
+    engine_choice = lead_new.assigned_officer_id
+
+    assert engine_choice is not None
+    assert helper_choice == engine_choice
+
+
+# ---------------------------------------------------------------------------
+# 2. 🔴 Blocker 1 — pool HIỂN THỊ không được làm lệch pool CHẤM ĐIỂM
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_offline_officer_does_not_shift_eligible_scores(mocker):
+    """Thêm officer offline vào pool hiển thị KHÔNG đổi điểm/thứ tự người eligible.
+
+    Engine (BƯỚC 2) đã lọc ``availability_status == 'available'`` trước khi chấm
+    điểm; dashboard hiển thị rộng hơn nên phải truyền ``eligible_officer_ids``.
+    """
+    o1 = _officer(101, hours_ago=2)
+    o2 = _officer(102, hours_ago=1)
+    off = _officer(103, availability="offline", hours_ago=5)
+    rows = [
+        MockWorkloadRow(101, 5),
+        MockWorkloadRow(102, 2),
+        MockWorkloadRow(103, 0),
+    ]
+    flags = AssignmentFlags(
+        member_on=True, fairness_on=False, exclude_active=False, finance_on=False
+    )
+
+    # (a) CHỈ officer available (đúng pool engine)
+    db_a = mocker.MagicMock()
+    db_a.execute = mocker.AsyncMock(return_value=_workload_result(rows[:2]))
+    res_a = await compute_unit_officer_loads(
+        db_a, [o1, o2], include_at_capacity=True, lead_unit_id=1, flags=flags
+    )
+
+    # (b) pool HIỂN THỊ có thêm người offline, nhưng eligible chỉ 2 người kia
+    db_b = mocker.MagicMock()
+    db_b.execute = mocker.AsyncMock(return_value=_workload_result(rows))
+    res_b = await compute_unit_officer_loads(
+        db_b,
+        [o1, o2, off],
+        include_at_capacity=True,
+        eligible_officer_ids={o1.id, o2.id},
+        lead_unit_id=1,
+        flags=flags,
+    )
+
+    elig_a = [ol for ol in res_a.loads if ol["eligible_for_assignment"]]
+    elig_b = [ol for ol in res_b.loads if ol["eligible_for_assignment"]]
+
+    # Thứ tự + điểm của nhóm eligible PHẢI y hệt
+    assert [ol["officer"].id for ol in elig_a] == [ol["officer"].id for ol in elig_b]
+    assert [ol["score"] for ol in elig_a] == [ol["score"] for ol in elig_b]
+    assert [ol["eff_util"] for ol in elig_a] == [ol["eff_util"] for ol in elig_b]
+    assert res_a.scoring == res_b.scoring
+
+    # Người offline: CÓ metric để hiển thị nhưng đứng ngoài luồng chia
+    offline_load = next(ol for ol in res_b.loads if ol["officer"].id == off.id)
+    assert offline_load["eligible_for_assignment"] is False
+    assert offline_load["at_capacity"] is False
+    assert offline_load["workload"] == 0
+    assert offline_load["capacity"] == off.max_capacity
+
+
+# ---------------------------------------------------------------------------
+# 3. 🔴 Blocker 2 — officer đầy tải: hiển thị được, không eligible, đủ cho snapshot
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_at_capacity_visible_but_not_eligible(mocker):
+    full = _officer(201, capacity=5)
+    free = _officer(202, capacity=5)
+    rows = [MockWorkloadRow(201, 5), MockWorkloadRow(202, 1)]
+
+    db = mocker.MagicMock()
+    db.execute = mocker.AsyncMock(return_value=_workload_result(rows))
+    res = await compute_unit_officer_loads(
+        db, [full, free], include_at_capacity=True, lead_unit_id=1
+    )
+
+    by_id = {ol["officer"].id: ol for ol in res.loads}
+    assert by_id[201]["at_capacity"] is True
+    assert by_id[201]["eligible_for_assignment"] is False
+    assert by_id[202]["eligible_for_assignment"] is True
+
+    # loads đủ dữ liệu dựng capacity_snapshot của nhánh AT_CAPACITY
+    for ol in res.loads:
+        assert "workload" in ol and "tuition_hold" in ol
+        assert ol["officer"].max_capacity is not None
+
+    # include_at_capacity=False ⇒ người đầy tải biến mất hẳn (hành vi engine cũ)
+    db2 = mocker.MagicMock()
+    db2.execute = mocker.AsyncMock(return_value=_workload_result(rows))
+    res2 = await compute_unit_officer_loads(
+        db2, [full, free], include_at_capacity=False, lead_unit_id=1
+    )
+    assert [ol["officer"].id for ol in res2.loads] == [202]
+
+
+@pytest.mark.asyncio
+async def test_all_at_capacity_skips_scoring(mocker):
+    """Không ai eligible ⇒ KHÔNG chấm điểm, KHÔNG query lịch sử (đúng hành vi cũ)."""
+    a = _officer(301, capacity=3)
+    b = _officer(302, capacity=3)
+    rows = [MockWorkloadRow(301, 3), MockWorkloadRow(302, 4)]
+
+    db = mocker.MagicMock()
+    db.execute = mocker.AsyncMock(return_value=_workload_result(rows))
+    res = await compute_unit_officer_loads(
+        db,
+        [a, b],
+        include_at_capacity=True,
+        lead_unit_id=1,
+        flags=AssignmentFlags(True, True, False, False),  # fairness ON
+    )
+
+    assert res.scoring is None and res.assign_reason is None
+    assert all(not ol["eligible_for_assignment"] for ol in res.loads)
+    # Chỉ đúng 1 query (workload) — KHÔNG có query lịch sử fairness.
+    assert db.execute.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Công thức dist_load — union self ∪ tuition, chống trừ hai lần
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_dist_load_union_dedup_formula(mocker):
+    """workload=8, self=3, tuition=6, overlap=2 ⇒ dist_load = 8-3-6+2 = 1."""
+    o = _officer(401, capacity=20, weight=2)
+    rows = [MockWorkloadRow(401, 8, self_cnt=3, tuition_cnt=6, self_and_tuition_cnt=2)]
+
+    db = mocker.MagicMock()
+    db.execute = mocker.AsyncMock(return_value=_workload_result(rows))
+    res = await compute_unit_officer_loads(
+        db,
+        [o],
+        include_at_capacity=True,
+        lead_unit_id=1,
+        flags=AssignmentFlags(
+            member_on=True, fairness_on=False, exclude_active=True, finance_on=True
+        ),
+    )
+
+    load = res.loads[0]
+    assert load["workload"] == 8
+    assert load["self_cnt"] == 3
+    assert load["tuition_hold"] == 6
+    assert load["dist_load"] == 1
+    assert load["real_util"] == 1 / 20
+    assert load["eff_util"] == 1 / (20 * 2)          # chia thêm cho weight
+    # Cổng an toàn chỉ trừ TUITION (không trừ self): (8-6)/20 = 0.1 < 0.8
+    assert load["overloaded"] is False

--- a/frontend/src/app/(dashboard)/dashboard/officer/_components/OfficerDashboardClient.test.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/officer/_components/OfficerDashboardClient.test.tsx
@@ -120,6 +120,7 @@ vi.mock("lucide-react", () => ({
 let headerProps: Record<string, any> = {};
 let kpiGridProps: Record<string, any> = {};
 let monthlyProps: Record<string, any> = {};
+let distributionProps: Record<string, any> = {};
 
 vi.mock("@/components/officer/dashboard", () => ({
   KPICardsGrid: (props: any) => {
@@ -128,6 +129,10 @@ vi.mock("@/components/officer/dashboard", () => ({
   },
   ActionInsightsPanel: () => <div data-testid="action-insights" />,
   WeeklyLeaderboard: () => <div data-testid="leaderboard" />,
+  OfficerDistributionPanel: (props: any) => {
+    distributionProps = props;
+    return <div data-testid="distribution-panel" />;
+  },
   AnnualProgressCard: () => <div data-testid="annual-progress" />,
   MonthlyBreakdownCard: (props: any) => {
     monthlyProps = props;
@@ -542,5 +547,16 @@ describe("OfficerDashboardClient", () => {
     renderWithProviders();
     await waitFor(() => expect(screen.getByTestId("performance-chart")).toBeInTheDocument());
     expect(perfChartProps.enrollmentPace).toBeNull();
+  });
+
+  it("mounts OfficerDistributionPanel without officerId (bảng so cả đơn vị)", async () => {
+    renderWithProviders();
+    await waitFor(() =>
+      expect(screen.getByTestId("distribution-panel")).toBeInTheDocument()
+    );
+    // Bảng điểm bận so sánh CẢ đơn vị; truyền officerId sẽ khiến backend
+    // drill-down còn 1 dòng và mất ý nghĩa so sánh ⇒ ghim là không truyền.
+    expect(distributionProps.officerId).toBeUndefined();
+    expect("unitId" in distributionProps).toBe(true);
   });
 });

--- a/frontend/src/app/(dashboard)/dashboard/officer/_components/OfficerDashboardClient.test.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/officer/_components/OfficerDashboardClient.test.tsx
@@ -559,4 +559,16 @@ describe("OfficerDashboardClient", () => {
     expect(distributionProps.officerId).toBeUndefined();
     expect("unitId" in distributionProps).toBe(true);
   });
+
+  it("ẨN OfficerDistributionPanel khi drill-down một officer cụ thể", async () => {
+    // Bảng điểm bận chỉ có nghĩa khi SO SÁNH nhiều người cùng đơn vị. Khi
+    // drill-down, panel không biết đơn vị của người được chọn (admin không
+    // chọn unit ⇒ backend mặc định toàn tổ chức) nên sẽ hiện sai ngữ cảnh.
+    setUrlSearch("?scope=organization&unit=42&officer=7");
+    renderWithProviders();
+    await waitFor(() =>
+      expect(screen.getByTestId("smart-header")).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId("distribution-panel")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/(dashboard)/dashboard/officer/_components/OfficerDashboardClient.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/officer/_components/OfficerDashboardClient.tsx
@@ -38,6 +38,7 @@ import {
   KPICardsGrid,
   ActionInsightsPanel,
   WeeklyLeaderboard,
+  OfficerDistributionPanel,
   SmartHeader,
   AnnualProgressCard,
   MonthlyBreakdownCard,
@@ -599,6 +600,11 @@ function DashboardContent({ initialStats }: { initialStats?: EnhancedOfficerStat
 
       {/* Row 5: Leaderboard (supplementary) */}
       <WeeklyLeaderboard scope={scope} unitId={effectiveUnitId} officerId={selectedOfficerId} />
+
+      {/* Row 6: Giải trình phân phối lead ("điểm bận").
+          CỐ Ý không truyền officerId — bảng này so sánh cả đơn vị, truyền
+          drill-down sẽ thu còn 1 dòng. Scope do backend suy theo role. */}
+      <OfficerDistributionPanel unitId={effectiveUnitId} />
     </div>
   );
 }

--- a/frontend/src/app/(dashboard)/dashboard/officer/_components/OfficerDashboardClient.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/officer/_components/OfficerDashboardClient.tsx
@@ -602,9 +602,17 @@ function DashboardContent({ initialStats }: { initialStats?: EnhancedOfficerStat
       <WeeklyLeaderboard scope={scope} unitId={effectiveUnitId} officerId={selectedOfficerId} />
 
       {/* Row 6: Giải trình phân phối lead ("điểm bận").
-          CỐ Ý không truyền officerId — bảng này so sánh cả đơn vị, truyền
-          drill-down sẽ thu còn 1 dòng. Scope do backend suy theo role. */}
-      <OfficerDistributionPanel unitId={effectiveUnitId} />
+          Bảng này chỉ có nghĩa khi SO SÁNH nhiều người trong cùng đơn vị.
+          - CỐ Ý không truyền officerId: backend hiểu đó là drill-down 1 người
+            và sẽ thu bảng còn đúng 1 dòng.
+          - ẨN khi đang drill-down một officer cụ thể: lúc đó phần còn lại của
+            dashboard đang nói về riêng người đó, mà panel lại không biết đơn vị
+            của họ (admin không chọn unit ⇒ backend mặc định toàn tổ chức) nên
+            sẽ hiện nhầm ngữ cảnh. Thà ẩn còn hơn hiện sai.
+            (Cải tiến sau: backend thêm chế độ "đơn vị của officer đang xem".) */}
+      {selectedOfficerId == null && (
+        <OfficerDistributionPanel unitId={effectiveUnitId} />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
@@ -148,6 +148,50 @@ describe("OfficerDistributionPanel", () => {
     expect(screen.queryByText(/Dành riêng cho bạn/)).not.toBeInTheDocument();
   });
 
+  it("🔒 FAIL-CLOSED: peer lỡ có boost vẫn KHÔNG được lộ", () => {
+    // Giả lập backend rò rỉ: entry của người khác lại kèm boost.
+    // UI phải câm vì điều kiện render là is_current_user && boost.
+    const leaky = { ...PEER, boost: "RÒ RỈ KHÔNG ĐƯỢC HIỆN" };
+    render(<EntryTooltip e={leaky} />);
+
+    expect(screen.queryByText("RÒ RỈ KHÔNG ĐƯỢC HIỆN")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Dành riêng cho bạn/)).not.toBeInTheDocument();
+    // nhưng phần công khai vẫn render bình thường
+    expect(
+      screen.getByText("Tải chủ yếu là lead hệ thống chia.")
+    ).toBeInTheDocument();
+  });
+
+  it("gom nhóm theo ĐƠN VỊ khi phạm vi trải nhiều đơn vị", () => {
+    const otherUnit = {
+      ...PEER,
+      rank: 1, // rank đánh RIÊNG từng đơn vị ⇒ trùng số với dòng đơn vị khác
+      user_id: 77,
+      full_name: "Phạm Thu",
+      unit_id: 15,
+      unit_name: "Phòng Đào tạo",
+      scoring_mode: "legacy",
+    };
+    mockPanel([ME, PEER, otherUnit]);
+    render(<OfficerDistributionPanel />);
+
+    // Có header đơn vị cho từng nhóm + cảnh báo không so chéo được
+    expect(screen.getByText("Phòng Tuyển sinh")).toBeInTheDocument();
+    expect(screen.getByText("Phòng Đào tạo")).toBeInTheDocument();
+    expect(screen.getByText(/riêng trong từng đơn vị/)).toBeInTheDocument();
+    // nhãn chế độ xếp hạng hiển thị bằng lời thường
+    expect(screen.getByText(/cách xếp: theo điểm bận/)).toBeInTheDocument();
+    expect(screen.getByText(/cách xếp: luân phiên/)).toBeInTheDocument();
+  });
+
+  it("KHÔNG hiện header đơn vị khi chỉ có một đơn vị", () => {
+    mockPanel([ME, PEER]);
+    render(<OfficerDistributionPanel />);
+
+    expect(screen.queryByText("Phòng Tuyển sinh")).not.toBeInTheDocument();
+    expect(screen.queryByText(/riêng trong từng đơn vị/)).not.toBeInTheDocument();
+  });
+
   it("thanh đo dựng đúng 3 đoạn từ số backend (không tự tính lại)", () => {
     mockPanel([ME]);
     const { container } = render(<OfficerDistributionPanel />);

--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockUseOfficerDistribution = vi.fn();
+vi.mock("@/hooks/officer/useOfficerDistribution", () => ({
+  useOfficerDistribution: (...args: unknown[]) =>
+    mockUseOfficerDistribution(...args),
+}));
+
+// ⚠️ CỐ Ý KHÔNG mock @/components/ui/tooltip: lời khuyên (`boost`) nằm TRONG
+// TooltipContent nên phải mở tooltip bằng tương tác THẬT mới assert được. Mock
+// tooltip sẽ render sẵn nội dung và test mất hết giá trị.
+import {
+  EntryTooltip,
+  OfficerDistributionPanel,
+} from "./OfficerDistributionPanel";
+
+const ME = {
+  rank: 1,
+  user_id: 18,
+  username: "hien",
+  full_name: "Hiền",
+  unit_id: 14,
+  unit_name: "Phòng Tuyển sinh",
+  scoring_mode: "member",
+  workload: 248,
+  max_capacity: 400,
+  weight: 2,
+  self_sourced: 34,
+  tuition_hold: 100,
+  dist_load: 114,
+  deducted: 134,
+  real_util_pct: 28.5,
+  fill_pct: 62.0,
+  eff_util_pct: 14.3,
+  score: 0.1425,
+  overload_gate_pct: 37.0,
+  overloaded: false,
+  at_capacity: false,
+  eligible_for_assignment: true,
+  availability_status: "available",
+  archetype: { key: "tuition_heavy", label: "Chủ yếu chờ học phí" },
+  diagnosis: "100/248 lead đã đóng tiền nên không bị tính.",
+  boost: "LỜI KHUYÊN RIÊNG CỦA HIỀN",
+  is_current_user: true,
+};
+
+const PEER = {
+  ...ME,
+  rank: 2,
+  user_id: 25,
+  username: "kien",
+  full_name: "Kiên",
+  eff_util_pct: 23.0,
+  archetype: { key: "balanced", label: "Cân bằng" },
+  diagnosis: "Tải chủ yếu là lead hệ thống chia.",
+  boost: null,
+  is_current_user: false,
+};
+
+const OFFLINE = {
+  ...PEER,
+  rank: 3,
+  user_id: 99,
+  username: "quocduy",
+  full_name: "Quốc Duy",
+  eligible_for_assignment: false,
+  availability_status: "offline",
+  archetype: { key: "paused", label: "Đang tắt nhận lead" },
+};
+
+function mockPanel(entries: unknown[]) {
+  mockUseOfficerDistribution.mockReturnValue({
+    data: {
+      unit_id: 14,
+      total_officers: entries.length,
+      scoring_mode: "member",
+      flags_snapshot: { member_weighted: true },
+      entries,
+    },
+    isLoading: false,
+    error: null,
+  });
+}
+
+describe("OfficerDistributionPanel", () => {
+  beforeEach(() => {
+    mockUseOfficerDistribution.mockReset();
+  });
+
+  it("hiện mọi người trong đơn vị kèm điểm bận", () => {
+    mockPanel([ME, PEER]);
+    render(<OfficerDistributionPanel />);
+
+    expect(screen.getByText("Hiền")).toBeInTheDocument();
+    expect(screen.getByText("Kiên")).toBeInTheDocument();
+    expect(screen.getByText("14.3")).toBeInTheDocument();
+    expect(screen.getByText("23")).toBeInTheDocument();
+    expect(screen.getByText("BẠN")).toBeInTheDocument();
+  });
+
+  it("tách nhóm người đang không nhận lead", () => {
+    mockPanel([ME, OFFLINE]);
+    render(<OfficerDistributionPanel />);
+
+    expect(screen.getByText("Đang không nhận lead")).toBeInTheDocument();
+    expect(screen.getByText("Quốc Duy")).toBeInTheDocument();
+  });
+
+  it("KHÔNG lộ lời khuyên khi tooltip chưa mở", () => {
+    mockPanel([ME, PEER]);
+    render(<OfficerDistributionPanel />);
+
+    expect(
+      screen.queryByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")
+    ).not.toBeInTheDocument();
+  });
+
+  // Nội dung tooltip test TRỰC TIẾP: Radix chỉ render nó vào portal khi mở, mà
+  // jsdom không drive được tương tác mở của Radix (dự án cũng theo cách này ở
+  // `dialog.test.tsx` — render Radix mở sẵn). Hover thật verify bằng smoke trình duyệt.
+  it("nội dung tooltip dòng của MÌNH: có phép tính + lời khuyên riêng", () => {
+    render(<EntryTooltip e={ME} />);
+
+    expect(screen.getByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")).toBeInTheDocument();
+    expect(screen.getByText(/Dành riêng cho bạn/)).toBeInTheDocument();
+    // phép tính hiện bằng số thật (không phải FE tự tính)
+    expect(
+      screen.getByText(/Điểm bận = 114 ÷ \(400×2\) ×100 = 14\.3/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Chỗ đầy thật = 248\/400 = 62%/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Ngưỡng tạm dừng = \(248−100\)\/400 = 37%/)
+    ).toBeInTheDocument();
+  });
+
+  it("nội dung tooltip ĐỒNG NGHIỆP: có chẩn đoán nhưng KHÔNG có lời khuyên", () => {
+    render(<EntryTooltip e={PEER} />);
+
+    expect(
+      screen.getByText("Tải chủ yếu là lead hệ thống chia.")
+    ).toBeInTheDocument();
+    // 🔒 tuyệt đối không rò lời khuyên của người khác
+    expect(
+      screen.queryByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Dành riêng cho bạn/)).not.toBeInTheDocument();
+  });
+
+  it("thanh đo dựng đúng 3 đoạn từ số backend (không tự tính lại)", () => {
+    mockPanel([ME]);
+    const { container } = render(<OfficerDistributionPanel />);
+
+    // sys = eff_util_pct; weight = real_util - eff_util; skip = fill - real_util
+    const widths = Array.from(
+      container.querySelectorAll<HTMLElement>("span.h-full")
+    ).map((el) => el.style.width);
+    expect(widths).toEqual(["14.3%", "14.2%", "33.5%"]);
+  });
+
+  it("hiện skeleton khi đang tải và thông báo khi lỗi", () => {
+    mockUseOfficerDistribution.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+    const { rerender } = render(<OfficerDistributionPanel />);
+    expect(screen.queryByText("Hiền")).not.toBeInTheDocument();
+
+    mockUseOfficerDistribution.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("boom"),
+    });
+    rerender(<OfficerDistributionPanel />);
+    expect(
+      screen.getByText(/Không tải được bảng điểm bận/)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
@@ -8,18 +8,17 @@ vi.mock("@/hooks/officer/useOfficerDistribution", () => ({
     mockUseOfficerDistribution(...args),
 }));
 
-// ⚠️ CỐ Ý KHÔNG mock @/components/ui/tooltip: lời khuyên (`boost`) nằm TRONG
+// ⚠️ CỐ Ý KHÔNG mock @/components/ui/popover: lời khuyên (`boost`) nằm TRONG
 // TooltipContent nên phải mở tooltip bằng tương tác THẬT mới assert được. Mock
 // tooltip sẽ render sẵn nội dung và test mất hết giá trị.
 import {
-  EntryTooltip,
+  EntryDetails,
   OfficerDistributionPanel,
 } from "./OfficerDistributionPanel";
 
 const ME = {
   rank: 1,
   user_id: 18,
-  username: "hien",
   full_name: "Hiền",
   unit_id: 14,
   unit_name: "Phòng Tuyển sinh",
@@ -27,13 +26,14 @@ const ME = {
   workload: 248,
   max_capacity: 400,
   weight: 2,
-  self_sourced: 34,
+  self_sourced: 54,
   tuition_hold: 100,
+  overlap: 20,
   dist_load: 114,
   deducted: 134,
   real_util_pct: 28.5,
   fill_pct: 62.0,
-  eff_util_pct: 14.3,
+  eff_util_pct: 14.2,
   score: 0.1425,
   overload_gate_pct: 37.0,
   overloaded: false,
@@ -50,7 +50,6 @@ const PEER = {
   ...ME,
   rank: 2,
   user_id: 25,
-  username: "kien",
   full_name: "Kiên",
   eff_util_pct: 23.0,
   archetype: { key: "balanced", label: "Cân bằng" },
@@ -63,7 +62,6 @@ const OFFLINE = {
   ...PEER,
   rank: 3,
   user_id: 99,
-  username: "quocduy",
   full_name: "Quốc Duy",
   eligible_for_assignment: false,
   availability_status: "offline",
@@ -95,7 +93,7 @@ describe("OfficerDistributionPanel", () => {
 
     expect(screen.getByText("Hiền")).toBeInTheDocument();
     expect(screen.getByText("Kiên")).toBeInTheDocument();
-    expect(screen.getByText("14.3")).toBeInTheDocument();
+    expect(screen.getByText("14.2")).toBeInTheDocument();
     expect(screen.getByText("23")).toBeInTheDocument();
     expect(screen.getByText("BẠN")).toBeInTheDocument();
   });
@@ -121,13 +119,13 @@ describe("OfficerDistributionPanel", () => {
   // jsdom không drive được tương tác mở của Radix (dự án cũng theo cách này ở
   // `dialog.test.tsx` — render Radix mở sẵn). Hover thật verify bằng smoke trình duyệt.
   it("nội dung tooltip dòng của MÌNH: có phép tính + lời khuyên riêng", () => {
-    render(<EntryTooltip e={ME} />);
+    render(<EntryDetails e={ME} />);
 
     expect(screen.getByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")).toBeInTheDocument();
     expect(screen.getByText(/Dành riêng cho bạn/)).toBeInTheDocument();
     // phép tính hiện bằng số thật (không phải FE tự tính)
     expect(
-      screen.getByText(/Điểm bận = 114 ÷ \(400×2\) ×100 = 14\.3/)
+      screen.getByText(/Điểm bận = 114 ÷ \(400×2\) ×100 = 14\.2/)
     ).toBeInTheDocument();
     expect(screen.getByText(/Chỗ đầy thật = 248\/400 = 62%/)).toBeInTheDocument();
     expect(
@@ -136,7 +134,7 @@ describe("OfficerDistributionPanel", () => {
   });
 
   it("nội dung tooltip ĐỒNG NGHIỆP: có chẩn đoán nhưng KHÔNG có lời khuyên", () => {
-    render(<EntryTooltip e={PEER} />);
+    render(<EntryDetails e={PEER} />);
 
     expect(
       screen.getByText("Tải chủ yếu là lead hệ thống chia.")
@@ -152,7 +150,7 @@ describe("OfficerDistributionPanel", () => {
     // Giả lập backend rò rỉ: entry của người khác lại kèm boost.
     // UI phải câm vì điều kiện render là is_current_user && boost.
     const leaky = { ...PEER, boost: "RÒ RỈ KHÔNG ĐƯỢC HIỆN" };
-    render(<EntryTooltip e={leaky} />);
+    render(<EntryDetails e={leaky} />);
 
     expect(screen.queryByText("RÒ RỈ KHÔNG ĐƯỢC HIỆN")).not.toBeInTheDocument();
     expect(screen.queryByText(/Dành riêng cho bạn/)).not.toBeInTheDocument();
@@ -200,7 +198,7 @@ describe("OfficerDistributionPanel", () => {
     const widths = Array.from(
       container.querySelectorAll<HTMLElement>("span.h-full")
     ).map((el) => el.style.width);
-    expect(widths).toEqual(["14.3%", "14.2%", "33.5%"]);
+    expect(widths).toEqual(["14.2%", "14.3%", "33.5%"]);
   });
 
   it("hiện skeleton khi đang tải và thông báo khi lỗi", () => {
@@ -221,5 +219,49 @@ describe("OfficerDistributionPanel", () => {
     expect(
       screen.getByText(/Không tải được bảng điểm bận/)
     ).toBeInTheDocument();
+  });
+
+  it("nhãn 'không tính' KHÔNG trình bày như phép cộng khi có phần giao", () => {
+    // deducted = self + tuition − overlap. Nếu in "54 + 100" cạnh "−134",
+    // người đọc thấy một phép cộng không bằng tổng của chính nó.
+    render(<EntryDetails e={ME} />);
+    expect(
+      screen.getByText(/tự tìm 54, đã đóng tiền 100, trùng 20/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/tự tìm 54 \+ đã đóng tiền 100/)).not.toBeInTheDocument();
+  });
+
+  it("không có phần giao thì vẫn dùng dấu + cho dễ đọc", () => {
+    render(<EntryDetails e={{ ...ME, overlap: 0, self_sourced: 34, deducted: 134 }} />);
+    expect(
+      screen.getByText(/tự tìm 34 \+ đã đóng tiền 100/)
+    ).toBeInTheDocument();
+  });
+
+  it("CHẠM/BẤM mở được bảng chi tiết — đường dùng trên điện thoại", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup();
+    mockPanel([ME]);
+    render(<OfficerDistributionPanel />);
+
+    expect(screen.queryByText(/Dành riêng cho bạn/)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Hiền/ }));
+    expect(await screen.findByText(/Dành riêng cho bạn/)).toBeInTheDocument();
+  });
+
+  it("một đơn vị vẫn nói rõ cách xếp (legacy không được hiện điểm bận trơ)", () => {
+    mockUseOfficerDistribution.mockReturnValue({
+      data: {
+        unit_id: 14,
+        total_officers: 1,
+        scoring_mode: "legacy",
+        flags_snapshot: {},
+        entries: [{ ...ME, scoring_mode: "legacy" }],
+      },
+      isLoading: false,
+      error: null,
+    });
+    render(<OfficerDistributionPanel />);
+    expect(screen.getByText(/Cách xếp của đơn vị/)).toBeInTheDocument();
+    expect(screen.getByText(/xếp theo lượt/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
@@ -9,17 +9,18 @@
  *
  * Cách đọc thanh (trục chung 0–100% khả năng nhận, mọi người thẳng hàng):
  *   [ điểm bận ][ ưu tiên kỳ cựu ][ không tính ] …trống… ┊80%
- *   mép phải đoạn xanh dương = ĐIỂM BẬN · vạch cam = chỗ đầy thật
+ *   mép phải đoạn xanh dương = ĐIỂM BẬN · vạch cam = mức đem so vạch 80%
  */
+
+import { useState } from "react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { useOfficerDistribution } from "@/hooks/officer/useOfficerDistribution";
 import type { OfficerDistributionEntry } from "@/lib/zod/officer";
 import { cn } from "@/lib/utils";
@@ -34,12 +35,34 @@ interface OfficerDistributionPanelProps {
 const clamp = (n: number) =>
   Math.round(Math.max(0, Math.min(100, n)) * 100) / 100;
 
-/** Ba đoạn của thanh, tính THUẦN từ số backend trả (không suy diễn thêm). */
+/**
+ * Ba đoạn của thanh, tính THUẦN từ số backend trả (không suy diễn thêm).
+ *
+ * ⚠️ Phải chặn TỔNG, không chỉ từng đoạn: `sys + weight + skip === fill_pct`,
+ * mà `fill_pct` CÓ THỂ > 100 (officer giữ nhiều hơn sức chứa — xảy ra khi admin
+ * hạ `max_capacity` hoặc gán tay). Các đoạn là flex item nên nếu tổng vượt 100%
+ * trình duyệt sẽ CO ĐỀU thay vì để `overflow-hidden` cắt, khiến mép đoạn chàm
+ * (thứ người dùng được dạy đọc là ĐIỂM BẬN) không còn khớp con số in bên cạnh.
+ */
 function segmentsOf(e: OfficerDistributionEntry) {
   const sys = clamp(e.eff_util_pct);
-  const weight = clamp(Math.max(0, e.real_util_pct - e.eff_util_pct));
-  const skip = clamp(Math.max(0, e.fill_pct - e.real_util_pct));
-  return { sys, weight, skip, fill: clamp(e.fill_pct) };
+  const weight = clamp(
+    Math.min(Math.max(0, e.real_util_pct - e.eff_util_pct), 100 - sys)
+  );
+  const skip = clamp(
+    Math.min(Math.max(0, e.fill_pct - e.real_util_pct), 100 - sys - weight)
+  );
+  return {
+    sys,
+    weight,
+    skip,
+    // Mốc so với vạch 80%: PHẢI là đại lượng engine thực sự gate
+    // ((workload − đã đóng tiền)/sức chứa), KHÔNG phải `fill_pct`. Vẽ fill_pct
+    // ở đây từng khiến "cam vượt vạch đứt" bị đọc là quá tải trong khi engine
+    // vẫn đang chia lead cho người đó.
+    gate: clamp(e.overload_gate_pct),
+    overCapacity: e.fill_pct > 100,
+  };
 }
 
 function LedgerRow({
@@ -62,14 +85,11 @@ function LedgerRow({
 }
 
 /**
- * Nội dung tooltip: phép tính bằng số thật + công thức + lời khuyên riêng.
+ * Bảng chi tiết: phép tính bằng số thật + công thức + lời khuyên riêng.
  *
- * Export để test trực tiếp: Radix render phần này vào portal và chỉ khi mở, mà
- * jsdom không drive được tương tác mở của Radix (xem `dialog.test.tsx` — dự án
- * cũng render Radix ở trạng thái mở sẵn thay vì mô phỏng tương tác). Tương tác
- * hover/focus thật được verify bằng smoke trên trình duyệt.
+ * Export để test trực tiếp nội dung mà không phụ thuộc cơ chế mở của Radix.
  */
-export function EntryTooltip({ e }: { e: OfficerDistributionEntry }) {
+export function EntryDetails({ e }: { e: OfficerDistributionEntry }) {
   return (
     <div className="space-y-2 text-xs">
       <div>
@@ -79,8 +99,15 @@ export function EntryTooltip({ e }: { e: OfficerDistributionEntry }) {
 
       <div className="space-y-1">
         <LedgerRow label="Lead đang giữ" value={String(e.workload)} />
+        {/* ⚠️ KHÔNG viết "X + Y" khi có phần giao: lead vừa tự tìm vừa đã đóng
+            tiền chỉ được trừ MỘT lần, nên self + tuition > deducted và người
+            đọc sẽ thấy một phép cộng không bằng tổng của chính nó. */}
         <LedgerRow
-          label={`− Không tính (tự tìm ${e.self_sourced} + đã đóng tiền ${e.tuition_hold})`}
+          label={
+            e.overlap > 0
+              ? `− Không tính (tự tìm ${e.self_sourced}, đã đóng tiền ${e.tuition_hold}, trùng ${e.overlap})`
+              : `− Không tính (tự tìm ${e.self_sourced} + đã đóng tiền ${e.tuition_hold})`
+          }
           value={`−${e.deducted}`}
           muted
         />
@@ -130,12 +157,18 @@ export function EntryTooltip({ e }: { e: OfficerDistributionEntry }) {
 function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
   const seg = segmentsOf(e);
   const dimmed = !e.eligible_for_assignment;
+  // ⚠️ Dùng Popover, KHÔNG dùng Tooltip: Radix Tooltip bỏ qua pointerType
+  // 'touch' và đóng ngay ở onPointerDown, nên trên điện thoại — đúng đường dùng
+  // thực địa của officer — toàn bộ nội dung sẽ không bao giờ mở được. Popover
+  // mở bằng bấm/chạm/bàn phím, phủ mọi thiết bị bằng MỘT đường duy nhất.
+  const [open, setOpen] = useState(false);
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
         <button
           type="button"
+          aria-expanded={open}
           aria-label={`${e.full_name}: điểm bận ${e.eff_util_pct} trên 100, đang giữ ${e.workload} trên ${e.max_capacity} lead`}
           className={cn(
             "grid w-full grid-cols-[minmax(96px,140px)_1fr_36px] items-center gap-3 rounded-md px-1 py-2 text-left",
@@ -163,16 +196,17 @@ function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
           {/* Thanh đo — trục chung 0–100% khả năng nhận */}
           <span className="relative block h-6 rounded border bg-muted">
             <span className="absolute inset-0 flex overflow-hidden rounded">
+              {/* shrink-0: không cho flex co đoạn khi tổng chạm trần */}
               <span
-                className="h-full bg-primary"
+                className="h-full shrink-0 bg-primary"
                 style={{ width: `${seg.sys}%` }}
               />
               <span
-                className="h-full bg-info-500"
+                className="h-full shrink-0 bg-info-500"
                 style={{ width: `${seg.weight}%` }}
               />
               <span
-                className="h-full bg-success-500"
+                className="h-full shrink-0 bg-success-500"
                 style={{ width: `${seg.skip}%` }}
               />
             </span>
@@ -182,11 +216,11 @@ function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
               className="absolute -top-0.5 -bottom-0.5 border-l-2 border-dashed border-error-500"
               style={{ left: "80%" }}
             />
-            {/* Chỗ đầy thật */}
+            {/* Mốc dùng để SO với vạch 80% — đại lượng engine thật sự gate */}
             <span
               aria-hidden="true"
               className="absolute -top-1 -bottom-1 w-0.5 rounded bg-warning-500"
-              style={{ left: `${seg.fill}%` }}
+              style={{ left: `${seg.gate}%` }}
             />
           </span>
 
@@ -195,11 +229,17 @@ function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
             {e.eff_util_pct}
           </span>
         </button>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="max-w-[320px]">
-        <EntryTooltip e={e} />
-      </TooltipContent>
-    </Tooltip>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="start"
+        className="max-w-[340px] text-xs"
+        // Nội dung chỉ để ĐỌC — đừng cướp focus khỏi hàng vừa bấm.
+        onOpenAutoFocus={(ev) => ev.preventDefault()}
+      >
+        <EntryDetails e={e} />
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -303,17 +343,17 @@ export function OfficerDistributionPanel({
       <CardHeader className="pb-3">
         <CardTitle className="text-base">Vì sao bạn được chia lead</CardTitle>
         <p className="text-xs text-muted-foreground">
-          Điểm bận (0–100): càng thấp càng được chia nhiều. Di chuột / chạm vào
-          từng người để xem phép tính.
+          Điểm bận (0–100): càng thấp càng được chia nhiều. Bấm vào từng người để
+          xem phép tính đầy đủ.
         </p>
         <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1">
           <LegendSwatch className="bg-primary" label="Điểm bận" />
           <LegendSwatch className="bg-info-500" label="Ưu tiên kỳ cựu" />
           <LegendSwatch className="bg-success-500" label="Không tính" />
-          <LegendSwatch className="bg-warning-500" label="Chỗ đầy thật" />
+          <LegendSwatch className="bg-warning-500" label="Mức so ngưỡng" />
           <LegendSwatch
             className="border-l-2 border-dashed border-error-500 bg-transparent"
-            label="Ngưỡng 80%"
+            label="Ngưỡng tạm dừng 80%"
           />
         </div>
       </CardHeader>
@@ -340,7 +380,7 @@ export function OfficerDistributionPanel({
         )}
 
         {!isLoading && !error && data && data.entries.length > 0 && (
-          <TooltipProvider delayDuration={150}>
+          <>
             {/* Trục chung — thẳng hàng với vùng thanh của mọi dòng */}
             <div
               aria-hidden="true"
@@ -363,11 +403,32 @@ export function OfficerDistributionPanel({
               const multiUnit = groups.length > 1;
               return (
                 <>
-                  {multiUnit && (
+                  {multiUnit ? (
                     <p className="px-1 pb-2 text-[11px] text-muted-foreground">
                       Phạm vi gồm {groups.length} đơn vị — điểm bận và thứ hạng
                       tính <b>riêng trong từng đơn vị</b>, không so chéo được.
                     </p>
+                  ) : (
+                    // Một đơn vị vẫn PHẢI nói rõ cách xếp: ở chế độ `legacy`
+                    // engine sắp theo (quá tải, lâu chưa nhận) và KHÔNG đọc điểm
+                    // bận — hiện con số to mà không chú thích sẽ khiến người xem
+                    // tưởng đó là lý do phân phối.
+                    groups[0]?.scoringMode && (
+                      <p className="px-1 pb-2 text-[11px] text-muted-foreground">
+                        Cách xếp của đơn vị:{" "}
+                        <b>
+                          {SCORING_LABEL[groups[0].scoringMode] ??
+                            groups[0].scoringMode}
+                        </b>
+                        {groups[0].scoringMode === "legacy" && (
+                          <>
+                            {" "}
+                            — chế độ này xếp theo lượt (lâu chưa nhận trước),
+                            điểm bận chỉ để tham khảo.
+                          </>
+                        )}
+                      </p>
+                    )
                   )}
                   {groups.map((g) => (
                     <div key={g.key} className={multiUnit ? "mt-4 first:mt-0" : undefined}>
@@ -393,7 +454,7 @@ export function OfficerDistributionPanel({
                 </>
               );
             })()}
-          </TooltipProvider>
+          </>
         )}
       </CardContent>
     </Card>

--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+/**
+ * Bảng "Điểm bận" — giải trình vì sao engine chia mỗi người nhiều/ít lead.
+ *
+ * Thin client tuyệt đối: MỌI con số do backend (`compute_unit_officer_loads`,
+ * đúng hàm engine chia lead dùng) trả về; component chỉ đổi số thành chiều dài
+ * đoạn trên thanh. KHÔNG tính lại workload/điểm bận ở đây.
+ *
+ * Cách đọc thanh (trục chung 0–100% khả năng nhận, mọi người thẳng hàng):
+ *   [ điểm bận ][ ưu tiên kỳ cựu ][ không tính ] …trống… ┊80%
+ *   mép phải đoạn xanh dương = ĐIỂM BẬN · vạch cam = chỗ đầy thật
+ */
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useOfficerDistribution } from "@/hooks/officer/useOfficerDistribution";
+import type { OfficerDistributionEntry } from "@/lib/zod/officer";
+import { cn } from "@/lib/utils";
+
+interface OfficerDistributionPanelProps {
+  unitId?: number | null;
+  className?: string;
+}
+
+// Làm tròn 2 chữ số: hiệu hai số backend có thể sinh nhiễu dấu phẩy động
+// (28.5 − 14.3 = 14.200000000000001) làm width CSS xấu và test giòn.
+const clamp = (n: number) =>
+  Math.round(Math.max(0, Math.min(100, n)) * 100) / 100;
+
+/** Ba đoạn của thanh, tính THUẦN từ số backend trả (không suy diễn thêm). */
+function segmentsOf(e: OfficerDistributionEntry) {
+  const sys = clamp(e.eff_util_pct);
+  const weight = clamp(Math.max(0, e.real_util_pct - e.eff_util_pct));
+  const skip = clamp(Math.max(0, e.fill_pct - e.real_util_pct));
+  return { sys, weight, skip, fill: clamp(e.fill_pct) };
+}
+
+function LedgerRow({
+  label,
+  value,
+  strong,
+  muted,
+}: {
+  label: string;
+  value: string;
+  strong?: boolean;
+  muted?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <span className={cn(muted && "text-muted-foreground")}>{label}</span>
+      <span className={cn("tabular-nums", strong && "font-bold")}>{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Nội dung tooltip: phép tính bằng số thật + công thức + lời khuyên riêng.
+ *
+ * Export để test trực tiếp: Radix render phần này vào portal và chỉ khi mở, mà
+ * jsdom không drive được tương tác mở của Radix (xem `dialog.test.tsx` — dự án
+ * cũng render Radix ở trạng thái mở sẵn thay vì mô phỏng tương tác). Tương tác
+ * hover/focus thật được verify bằng smoke trên trình duyệt.
+ */
+export function EntryTooltip({ e }: { e: OfficerDistributionEntry }) {
+  return (
+    <div className="space-y-2 text-xs">
+      <div>
+        <p className="text-sm font-semibold">{e.full_name}</p>
+        <p className="opacity-80">{e.archetype.label}</p>
+      </div>
+
+      <div className="space-y-1">
+        <LedgerRow label="Lead đang giữ" value={String(e.workload)} />
+        <LedgerRow
+          label={`− Không tính (tự tìm ${e.self_sourced} + đã đóng tiền ${e.tuition_hold})`}
+          value={`−${e.deducted}`}
+          muted
+        />
+        <LedgerRow label="= Lead hệ thống tính" value={String(e.dist_load)} />
+        <LedgerRow
+          label="÷ Khả năng nhận"
+          value={String(e.max_capacity)}
+          muted
+        />
+        {e.weight > 1 && (
+          <LedgerRow label="÷ Ưu tiên kỳ cựu" value={`×${e.weight}`} muted />
+        )}
+        <LedgerRow label="Điểm bận" value={`${e.eff_util_pct}`} strong />
+      </div>
+
+      <div className="space-y-0.5 border-t pt-1.5 opacity-90">
+        <p className="tabular-nums">
+          Điểm bận = {e.dist_load} ÷ ({e.max_capacity}×{e.weight}) ×100 ={" "}
+          {e.eff_util_pct}
+        </p>
+        <p className="tabular-nums">
+          Chỗ đầy thật = {e.workload}/{e.max_capacity} = {e.fill_pct}%
+        </p>
+        <p className="tabular-nums">
+          Ngưỡng tạm dừng = ({e.workload}−{e.tuition_hold})/{e.max_capacity} ={" "}
+          {e.overload_gate_pct}% (dừng khi ≥80%)
+        </p>
+      </div>
+
+      <p className="border-t pt-1.5 leading-relaxed">{e.diagnosis}</p>
+
+      {e.boost && (
+        <div className="border-t pt-1.5">
+          <p className="mb-0.5 font-semibold uppercase tracking-wide">
+            💡 Dành riêng cho bạn · 🔒 chỉ bạn thấy
+          </p>
+          <p className="leading-relaxed">{e.boost}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
+  const seg = segmentsOf(e);
+  const dimmed = !e.eligible_for_assignment;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={`${e.full_name}: điểm bận ${e.eff_util_pct} trên 100, đang giữ ${e.workload} trên ${e.max_capacity} lead`}
+          className={cn(
+            "grid w-full grid-cols-[minmax(96px,140px)_1fr_36px] items-center gap-3 rounded-md px-1 py-2 text-left",
+            "hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            dimmed && "opacity-60"
+          )}
+        >
+          {/* Tên + nhãn kiểu */}
+          <span className="min-w-0">
+            <span className="flex items-center gap-1.5">
+              <span className="truncate text-sm font-medium">
+                {e.full_name}
+              </span>
+              {e.is_current_user && (
+                <span className="shrink-0 rounded border border-primary px-1 text-[9px] font-bold text-primary">
+                  BẠN
+                </span>
+              )}
+            </span>
+            <span className="block truncate text-[11px] text-muted-foreground">
+              {e.archetype.label}
+            </span>
+          </span>
+
+          {/* Thanh đo — trục chung 0–100% khả năng nhận */}
+          <span className="relative block h-6 rounded border bg-muted">
+            <span className="absolute inset-0 flex overflow-hidden rounded">
+              <span
+                className="h-full bg-primary"
+                style={{ width: `${seg.sys}%` }}
+              />
+              <span
+                className="h-full bg-info-500"
+                style={{ width: `${seg.weight}%` }}
+              />
+              <span
+                className="h-full bg-success-500"
+                style={{ width: `${seg.skip}%` }}
+              />
+            </span>
+            {/* Ngưỡng tạm dừng 80% */}
+            <span
+              aria-hidden="true"
+              className="absolute -top-0.5 -bottom-0.5 border-l-2 border-dashed border-error-500"
+              style={{ left: "80%" }}
+            />
+            {/* Chỗ đầy thật */}
+            <span
+              aria-hidden="true"
+              className="absolute -top-1 -bottom-1 w-0.5 rounded bg-warning-500"
+              style={{ left: `${seg.fill}%` }}
+            />
+          </span>
+
+          {/* Điểm bận */}
+          <span className="text-right text-base font-bold tabular-nums text-primary">
+            {e.eff_util_pct}
+          </span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-[320px]">
+        <EntryTooltip e={e} />
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function LegendSwatch({
+  className,
+  label,
+}: {
+  className: string;
+  label: string;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
+      <span className={cn("inline-block h-3 w-3 rounded-sm", className)} />
+      {label}
+    </span>
+  );
+}
+
+export function OfficerDistributionPanel({
+  unitId,
+  className,
+}: OfficerDistributionPanelProps) {
+  const { data, isLoading, error } = useOfficerDistribution({ unitId });
+
+  return (
+    <Card className={className}>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Vì sao bạn được chia lead</CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Điểm bận (0–100): càng thấp càng được chia nhiều. Di chuột / chạm vào
+          từng người để xem phép tính.
+        </p>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1">
+          <LegendSwatch className="bg-primary" label="Điểm bận" />
+          <LegendSwatch className="bg-info-500" label="Ưu tiên kỳ cựu" />
+          <LegendSwatch className="bg-success-500" label="Không tính" />
+          <LegendSwatch className="bg-warning-500" label="Chỗ đầy thật" />
+          <LegendSwatch
+            className="border-l-2 border-dashed border-error-500 bg-transparent"
+            label="Ngưỡng 80%"
+          />
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-2">
+            {[0, 1, 2, 3].map((i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        )}
+
+        {!isLoading && error && (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            Không tải được bảng điểm bận. Thử lại sau.
+          </p>
+        )}
+
+        {!isLoading && !error && data && data.entries.length === 0 && (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            Chưa có nhân viên nào trong phạm vi này.
+          </p>
+        )}
+
+        {!isLoading && !error && data && data.entries.length > 0 && (
+          <TooltipProvider delayDuration={150}>
+            {/* Trục chung — thẳng hàng với vùng thanh của mọi dòng */}
+            <div
+              aria-hidden="true"
+              className="grid grid-cols-[minmax(96px,140px)_1fr_36px] gap-3 px-1 pb-1"
+            >
+              <span />
+              <span className="relative block h-3 text-[10px] text-muted-foreground">
+                <span className="absolute left-0">0</span>
+                <span className="absolute left-1/2 -translate-x-1/2">50%</span>
+                <span className="absolute left-[80%] -translate-x-1/2 font-semibold text-error-500">
+                  80%
+                </span>
+                <span className="absolute right-0">100%</span>
+              </span>
+              <span />
+            </div>
+
+            <div className="divide-y">
+              {data.entries
+                .filter((e) => e.eligible_for_assignment)
+                .map((e) => (
+                  <OfficerRow key={e.user_id} e={e} />
+                ))}
+            </div>
+
+            {data.entries.some((e) => !e.eligible_for_assignment) && (
+              <div className="mt-3 border-t pt-2">
+                <p className="px-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Đang không nhận lead
+                </p>
+                <div className="divide-y">
+                  {data.entries
+                    .filter((e) => !e.eligible_for_assignment)
+                    .map((e) => (
+                      <OfficerRow key={e.user_id} e={e} />
+                    ))}
+                </div>
+              </div>
+            )}
+          </TooltipProvider>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
@@ -112,7 +112,10 @@ export function EntryTooltip({ e }: { e: OfficerDistributionEntry }) {
 
       <p className="border-t pt-1.5 leading-relaxed">{e.diagnosis}</p>
 
-      {e.boost && (
+      {/* 🔒 FAIL-CLOSED: phải THOẢ CẢ HAI. Backend hiện chỉ set `boost` cho
+          chính người xem, nhưng FE không được phụ thuộc DUY NHẤT vào điều đó —
+          nếu backend lỡ rò `boost` của người khác, UI vẫn phải câm. */}
+      {e.is_current_user && e.boost && (
         <div className="border-t pt-1.5">
           <p className="mb-0.5 font-semibold uppercase tracking-wide">
             💡 Dành riêng cho bạn · 🔒 chỉ bạn thấy
@@ -200,6 +203,80 @@ function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
   );
 }
 
+/** Nhãn đời thường cho chế độ chấm điểm của engine (backend trả key kỹ thuật). */
+const SCORING_LABEL: Record<string, string> = {
+  legacy: "luân phiên",
+  member: "theo điểm bận",
+  fairness: "cân bằng lịch sử",
+  member_fairness: "điểm bận + cân bằng lịch sử",
+};
+
+/**
+ * Gom entry theo ĐƠN VỊ.
+ *
+ * ⚠️ Bắt buộc: backend chấm điểm VÀ đánh `rank` theo TỪNG đơn vị. Manager có
+ * scope gồm đơn vị con, admin mặc định toàn tổ chức ⇒ trộn phẳng sẽ hiện nhiều
+ * dòng cùng rank #1 và so sánh sai ngữ cảnh (điểm bận chỉ so được trong cùng
+ * một đơn vị vì phụ thuộc khả năng nhận / trọng số của pool đó).
+ */
+function groupByUnit(entries: OfficerDistributionEntry[]) {
+  const map = new Map<
+    string,
+    {
+      key: string;
+      unitId: number | null;
+      unitName: string | null;
+      scoringMode: string | null;
+      entries: OfficerDistributionEntry[];
+    }
+  >();
+  for (const e of entries) {
+    const key = String(e.unit_id ?? "none");
+    let g = map.get(key);
+    if (!g) {
+      g = {
+        key,
+        unitId: e.unit_id ?? null,
+        unitName: e.unit_name ?? null,
+        scoringMode: e.scoring_mode ?? null,
+        entries: [],
+      };
+      map.set(key, g);
+    }
+    g.entries.push(e);
+  }
+  return Array.from(map.values());
+}
+
+/** Danh sách trong MỘT đơn vị: nhóm đang nhận trước, nhóm ngoài luồng sau. */
+function EntryList({ entries }: { entries: OfficerDistributionEntry[] }) {
+  const eligible = entries.filter((e) => e.eligible_for_assignment);
+  const others = entries.filter((e) => !e.eligible_for_assignment);
+
+  return (
+    <>
+      <div className="divide-y">
+        {eligible.map((e) => (
+          <OfficerRow key={e.user_id} e={e} />
+        ))}
+      </div>
+
+      {others.length > 0 && (
+        <div className="mt-2 border-t pt-2">
+          <p className="px-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Đang không nhận lead
+          </p>
+          <div className="divide-y">
+            {others.map((e) => (
+              <OfficerRow key={e.user_id} e={e} />
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
 function LegendSwatch({
   className,
   label,
@@ -281,28 +358,41 @@ export function OfficerDistributionPanel({
               <span />
             </div>
 
-            <div className="divide-y">
-              {data.entries
-                .filter((e) => e.eligible_for_assignment)
-                .map((e) => (
-                  <OfficerRow key={e.user_id} e={e} />
-                ))}
-            </div>
-
-            {data.entries.some((e) => !e.eligible_for_assignment) && (
-              <div className="mt-3 border-t pt-2">
-                <p className="px-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                  Đang không nhận lead
-                </p>
-                <div className="divide-y">
-                  {data.entries
-                    .filter((e) => !e.eligible_for_assignment)
-                    .map((e) => (
-                      <OfficerRow key={e.user_id} e={e} />
-                    ))}
-                </div>
-              </div>
-            )}
+            {(() => {
+              const groups = groupByUnit(data.entries);
+              const multiUnit = groups.length > 1;
+              return (
+                <>
+                  {multiUnit && (
+                    <p className="px-1 pb-2 text-[11px] text-muted-foreground">
+                      Phạm vi gồm {groups.length} đơn vị — điểm bận và thứ hạng
+                      tính <b>riêng trong từng đơn vị</b>, không so chéo được.
+                    </p>
+                  )}
+                  {groups.map((g) => (
+                    <div key={g.key} className={multiUnit ? "mt-4 first:mt-0" : undefined}>
+                      {multiUnit && (
+                        <div className="flex flex-wrap items-baseline gap-x-2 border-b px-1 pb-1">
+                          <span className="text-sm font-semibold">
+                            {g.unitName ??
+                              (g.unitId != null
+                                ? `Đơn vị #${g.unitId}`
+                                : "Chưa gán đơn vị")}
+                          </span>
+                          <span className="text-[11px] text-muted-foreground">
+                            {g.entries.length} người
+                            {g.scoringMode
+                              ? ` · cách xếp: ${SCORING_LABEL[g.scoringMode] ?? g.scoringMode}`
+                              : ""}
+                          </span>
+                        </div>
+                      )}
+                      <EntryList entries={g.entries} />
+                    </div>
+                  ))}
+                </>
+              );
+            })()}
           </TooltipProvider>
         )}
       </CardContent>

--- a/frontend/src/components/officer/dashboard/index.ts
+++ b/frontend/src/components/officer/dashboard/index.ts
@@ -9,6 +9,7 @@ export { PriorityActionCard, type PriorityAction } from "./PriorityActionCard";
 export { PriorityActionsPanel } from "./PriorityActionsPanel";
 export { ActionInsightsPanel } from "./ActionInsightsPanel";
 export { WeeklyLeaderboard } from "./WeeklyLeaderboard";
+export { OfficerDistributionPanel } from "./OfficerDistributionPanel";
 export { SmartHeader } from "./SmartHeader";
 export { RecommendationsPanel } from "./RecommendationsPanel";
 export { AnnualProgressCard, type AnnualProgressInfo } from "./AnnualProgressCard";

--- a/frontend/src/hooks/officer/useOfficerDistribution.ts
+++ b/frontend/src/hooks/officer/useOfficerDistribution.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { ZodError } from "zod";
 import { officerApi } from "@/lib/api/officer";
 import type { OfficerDistributionPanel } from "@/lib/zod/officer";
 import { officerKeys } from "./useWeeklyLeaderboard";
@@ -21,8 +22,17 @@ export function useOfficerDistribution(
   return useQuery<OfficerDistributionPanel>({
     queryKey: officerKeys.distributionPanel(unitId ?? null),
     queryFn: async () => officerApi.getDistributionPanel({ unitId }),
-    staleTime: 60000, // 1 phút
+    // staleTime khớp refetchInterval: để 60s thì mỗi lần điều hướng lại trong
+    // vòng 5 phút sẽ bắn thêm một request mà bản cache vẫn phục vụ được — mỗi
+    // request là một fan-out aggregate đa-đơn-vị ở backend.
+    staleTime: 300000,
     refetchInterval: 300000, // 5 phút
     enabled: options?.enabled ?? true,
+    // Lỗi hợp đồng (zod parse) là DETERMINISTIC — retry chỉ lặp lại đúng lỗi đó
+    // và nhân 4 lần fan-out backend. Chỉ retry lỗi mạng/5xx.
+    retry: (failureCount, error) => {
+      if (error instanceof ZodError) return false;
+      return failureCount < 3;
+    },
   });
 }

--- a/frontend/src/hooks/officer/useOfficerDistribution.ts
+++ b/frontend/src/hooks/officer/useOfficerDistribution.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import { officerApi } from "@/lib/api/officer";
+import type { OfficerDistributionPanel } from "@/lib/zod/officer";
+import { officerKeys } from "./useWeeklyLeaderboard";
+
+export interface UseOfficerDistributionOptions {
+  /**
+   * Chỉ dùng cho admin chọn một đơn vị cụ thể. CỐ Ý không truyền `scope`:
+   * backend tự suy theo role (officer → đơn vị của mình, manager → unit,
+   * admin → organization), nên frontend không thể gửi sai scope.
+   */
+  unitId?: number | null;
+  enabled?: boolean;
+}
+
+export function useOfficerDistribution(
+  options?: UseOfficerDistributionOptions
+) {
+  const unitId = options?.unitId ?? undefined;
+
+  return useQuery<OfficerDistributionPanel>({
+    queryKey: officerKeys.distributionPanel(unitId ?? null),
+    queryFn: async () => officerApi.getDistributionPanel({ unitId }),
+    staleTime: 60000, // 1 phút
+    refetchInterval: 300000, // 5 phút
+    enabled: options?.enabled ?? true,
+  });
+}

--- a/frontend/src/hooks/officer/useWeeklyLeaderboard.ts
+++ b/frontend/src/hooks/officer/useWeeklyLeaderboard.ts
@@ -12,6 +12,8 @@ export const officerKeys = {
     filters?.unitId,
     filters?.officerId,
   ] as const,
+  distributionPanel: (unitId?: number | null) =>
+    [...officerKeys.all, "distribution-panel", unitId ?? null] as const,
   upcomingActivities: (month: number, year: number) => [...officerKeys.all, "upcoming-activities", month, year] as const,
   recommendations: (limit: number, startDate?: string, endDate?: string) =>
     [...officerKeys.all, "recommendations", limit, startDate, endDate] as const,

--- a/frontend/src/lib/api/officer.ts
+++ b/frontend/src/lib/api/officer.ts
@@ -88,7 +88,9 @@ export const officerApi = {
   ): Promise<OfficerDistributionPanel> => {
     const params = new URLSearchParams();
     if (filters?.scope) params.append("scope", filters.scope);
-    if (filters?.unitId) params.append("unit_id", filters.unitId.toString());
+    // `!= null` chứ không phải truthiness: unitId = 0 là id hợp lệ về mặt kiểu,
+    // dùng `if (unitId)` sẽ âm thầm nuốt mất và rơi về phạm vi rộng hơn.
+    if (filters?.unitId != null) params.append("unit_id", filters.unitId.toString());
 
     const url = `/api/officer/distribution-panel${
       params.toString() ? `?${params.toString()}` : ""

--- a/frontend/src/lib/api/officer.ts
+++ b/frontend/src/lib/api/officer.ts
@@ -1,4 +1,13 @@
 import { api } from "./client";
+import {
+  officerDistributionPanelSchema,
+  type OfficerDistributionPanel,
+} from "@/lib/zod/officer";
+
+export interface DistributionFilters {
+  scope?: "personal" | "unit" | "organization";
+  unitId?: number | null;
+}
 
 export interface LeaderboardEntry {
   rank: number;
@@ -67,6 +76,27 @@ export interface AvailabilityPayload {
  * Handles all officer dashboard related endpoints
  */
 export const officerApi = {
+  /**
+   * Bảng "điểm bận" — giải trình engine chia lead cho cả đơn vị.
+   *
+   * ⚠️ CỐ Ý không gửi `officer_id`: backend hiểu tham số đó là drill-down một
+   * người, sẽ thu bảng còn đúng 1 dòng và mất ý nghĩa so sánh cả phòng.
+   * Parse bằng zod để lệch contract nổ ngay tại đây thay vì render số sai.
+   */
+  getDistributionPanel: async (
+    filters?: DistributionFilters
+  ): Promise<OfficerDistributionPanel> => {
+    const params = new URLSearchParams();
+    if (filters?.scope) params.append("scope", filters.scope);
+    if (filters?.unitId) params.append("unit_id", filters.unitId.toString());
+
+    const url = `/api/officer/distribution-panel${
+      params.toString() ? `?${params.toString()}` : ""
+    }`;
+    const response = await api.get(url);
+    return officerDistributionPanelSchema.parse(response.data);
+  },
+
   getLeaderboard: async (filters?: LeaderboardFilters) => {
     const params = new URLSearchParams();
     if (filters?.startDate) params.append("start_date", filters.startDate);

--- a/frontend/src/lib/zod/officer.ts
+++ b/frontend/src/lib/zod/officer.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+/**
+ * Contract cho bảng "điểm bận" (`GET /api/officer/distribution-panel`).
+ *
+ * Mirror nghiêm ngặt Pydantic `OfficerDistributionEntry` / `OfficerDistributionPanel`
+ * (Backend_FastAPI/app/schemas/officer.py). Parse ở api client để lệch contract
+ * nổ NGAY thay vì render số sai — mọi con số tải ở đây do engine chia lead tính,
+ * frontend TUYỆT ĐỐI không tính lại.
+ */
+export const officerArchetypeSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+});
+
+export const officerDistributionEntrySchema = z.object({
+  rank: z.number().int(),
+  user_id: z.number().int(),
+  username: z.string(),
+  full_name: z.string(),
+  unit_id: z.number().int().nullable().optional(),
+  unit_name: z.string().nullable().optional(),
+  /** Chế độ chấm điểm của ĐƠN VỊ dòng này (per-unit). */
+  scoring_mode: z.string().nullable().optional(),
+
+  // --- Số liệu tải (nguyên bản từ engine) ---
+  workload: z.number().int(), // Lead đang giữ
+  max_capacity: z.number().int(), // Khả năng nhận
+  weight: z.number().int(), // Ưu tiên kỳ cựu (×N)
+  self_sourced: z.number().int(), // Lead tự tìm
+  tuition_hold: z.number().int(), // Hồ sơ đã đóng tiền
+  dist_load: z.number().int(), // Lead hệ thống tính
+  deducted: z.number().int(), // Không tính = workload - dist_load
+  real_util_pct: z.number(), // dist_load/cap  (%)
+  fill_pct: z.number(), // workload/cap   (%) — chỗ đầy thật
+  eff_util_pct: z.number(), // ĐIỂM BẬN = dist/(cap*weight) (%)
+  score: z.number(),
+  overload_gate_pct: z.number(), // (workload-tuition)/cap (%) — ngưỡng 80%
+
+  // --- Cờ trạng thái ---
+  overloaded: z.boolean(),
+  at_capacity: z.boolean(),
+  eligible_for_assignment: z.boolean(),
+  availability_status: z.string(),
+
+  // --- Diễn giải (backend tính) ---
+  archetype: officerArchetypeSchema,
+  diagnosis: z.string(),
+  /** 🔒 Backend chỉ trả cho chính người đang xem. */
+  boost: z.string().nullable().optional(),
+  is_current_user: z.boolean(),
+});
+
+export const officerDistributionPanelSchema = z.object({
+  unit_id: z.number().int().nullable().optional(),
+  total_officers: z.number().int(),
+  /** Tóm tắt: mode chung | "mixed" | null. Chính xác ở entries[].scoring_mode. */
+  scoring_mode: z.string().nullable().optional(),
+  flags_snapshot: z.record(z.string(), z.boolean()),
+  entries: z.array(officerDistributionEntrySchema),
+});
+
+export type OfficerArchetype = z.infer<typeof officerArchetypeSchema>;
+export type OfficerDistributionEntry = z.infer<
+  typeof officerDistributionEntrySchema
+>;
+export type OfficerDistributionPanel = z.infer<
+  typeof officerDistributionPanelSchema
+>;

--- a/frontend/src/lib/zod/officer.ts
+++ b/frontend/src/lib/zod/officer.ts
@@ -16,7 +16,7 @@ export const officerArchetypeSchema = z.object({
 export const officerDistributionEntrySchema = z.object({
   rank: z.number().int(),
   user_id: z.number().int(),
-  username: z.string(),
+  // Backend CỐ Ý không trả `username` (login-id đồng nghiệp = PII vô ích ở đây).
   full_name: z.string(),
   unit_id: z.number().int().nullable().optional(),
   unit_name: z.string().nullable().optional(),
@@ -29,8 +29,11 @@ export const officerDistributionEntrySchema = z.object({
   weight: z.number().int(), // Ưu tiên kỳ cựu (×N)
   self_sourced: z.number().int(), // Lead tự tìm
   tuition_hold: z.number().int(), // Hồ sơ đã đóng tiền
+  /** Phần GIAO tự-tìm ∩ đã-đóng-tiền — chỉ bị trừ MỘT lần. */
+  overlap: z.number().int(),
   dist_load: z.number().int(), // Lead hệ thống tính
-  deducted: z.number().int(), // Không tính = workload - dist_load
+  /** = self_sourced + tuition_hold − overlap (KHÔNG phải phép cộng đơn thuần). */
+  deducted: z.number().int(),
   real_util_pct: z.number(), // dist_load/cap  (%)
   fill_pct: z.number(), // workload/cap   (%) — chỗ đầy thật
   eff_util_pct: z.number(), // ĐIỂM BẬN = dist/(cap*weight) (%)


### PR DESCRIPTION
## Vấn đề

Bảng xếp hạng officer hiện tại chỉ xếp theo **số buổi tư vấn** — không trả lời được câu hỏi officer thực sự hỏi: *"vì sao tôi được chia ít/nhiều lead hơn người khác?"*. Dữ liệu để trả lời vốn đã có trong `assignment_decision_log.scores_snapshot` nhưng là **audit thuần, không consumer nào đọc**.

## Giải pháp

Thêm `GET /api/officer/distribution-panel` + panel trên `/dashboard/officer`: mỗi officer thấy **cả đơn vị** trên một trục chung, hiểu được vì sao engine chia như vậy, và bấm vào từng người để xem **đúng phép tính bằng số thật**.

### Cốt lõi: số liệu KHÔNG THỂ lệch khỏi engine

Thay vì để dashboard tự tính lại (sẽ drift ngay khi engine đổi), PR **tách `compute_unit_officer_loads()`** — gom BƯỚC 3+4+5 khỏi `automatically_assign_lead` thành hàm thuần — để **engine và dashboard đi CHUNG một đường code**.

- Engine gọi `include_at_capacity=True` rồi lọc `eligible_for_assignment`; snapshot success/AT_CAPACITY dựng lại từ `res.loads` + `res.flags` ⇒ **audit shape byte-identical**.
- Tham số `eligible_officer_ids` tách **pool chấm-điểm** khỏi **pool hiển thị**: officer offline/busy vẫn có metric để hiện nhưng không vào scoring/sort. Đường engine truyền `None` ⇒ hành vi cũ nguyên vẹn.

### Quyền
`get_officer_distribution_scope` chỉ khác nhánh officer (xem cả đơn vị mình, `unit_id` lấy từ `current_user`, trỏ người/đơn vị khác ⇒ 404); manager/admin **ủy quyền nguyên vẹn** cho `get_officer_dashboard_scope` để một nguồn sự thật. Casbin: allow `role:officer` + **deny `role:accountant`** tường minh (kế thừa officer nhưng dữ liệu nhân sự phòng tư vấn ngoài phạm vi kế toán).

## Kiểm chứng

- 🔒 **Golden gate 29/29 với 0 dòng test bị sửa** — bằng chứng engine chia lead không đổi hành vi
- Backend **95 test** (parity 5 · scope 61 · golden 29) · FE **type-check + 182 file / 1869 test** · eslint 0 error
- **Smoke trình duyệt 7/7** trên stack cô lập với dữ liệu có chủ đích (overlap, vượt sức chứa 150%, đa đơn vị)
- `alembic heads` = 1 sau khi rebase lên main (#486 cũng phân nhánh từ `consultacctdeny20260716` ⇒ đã nối lại để tránh ambiguous head làm hỏng deploy)

## Đã qua 3 vòng review, sửa 15 finding

Vòng cuối (`/code-review max`) bắt được các lỗi **người dùng đọc thấy** mà smoke thủ công đã bỏ sót:

| Lỗi | Sửa |
|---|---|
| Tooltip bày phép cộng không bằng tổng: "(tự tìm 8 + đã đóng tiền 14) → −14" vì `deducted = X+Y−overlap` | Surface `overlap` lên wire, nhãn đổi thành "tự tìm 8, đã đóng tiền 14, **trùng 8**" |
| `officer_id` thu pool còn 1 người ⇒ `score`/`scoring_mode` engine không bao giờ sinh | officer_id = **tiêu điểm**, mở rộng ra đơn vị của người đó |
| `rank` đóng lên danh sách chưa sort ⇒ thứ tự DB tuỳ ý thành "bảng xếp hạng" | Sort ổn định cả nhánh `others` lẫn early-return |
| Vạch 80% so với `fill_pct` trong khi gate thật là `(wl−tuition)/cap` ⇒ đọc ngược kết luận | Mốc cam = `overload_gate_pct` |
| Radix Tooltip không mở khi **chạm** ⇒ mobile mù | Đổi sang Popover (bấm/chạm/bàn phím) |
| Thanh co méo khi officer vượt sức chứa | Chặn **tổng** ≤100% + `shrink-0` |
| `round()` banker's (80) vs `round(x,1)` (80.5) mâu thuẫn cùng tooltip | Truyền `fill_pct` vào, không tính lại |
| `diagnosis` xưng "bạn" nhưng render ở mọi dòng | Chuyển ngôi thứ ba |
| Rate limit vô hiệu (decorator order) trên endpoint đọc đắt nhất | Đảo thứ tự |
| `select(User)` kéo `password_hash`/`totp_secret` vào đường đọc; `username` lên wire vô ích | `load_only` 8 cột + bỏ `username` |

**Đáng chú ý nhất — test rỗng:** `.env.test` không set cờ nào nên **mọi test chạy với 4 cờ TẮT**; khi đó `deducted=0`, `weight=1`, `eff_util==real_util==fill` ⇒ các assert rút gọn thành `0==0`. Chế độ đang chạy prod có **zero coverage**. Đã thêm fixture `prod_flags` + **canary** đỏ ngay nếu test lại rơi về mặc định.

## Rủi ro / lưu ý khi merge

- Migration chỉ **INSERT casbin** (idempotent kiểu upsert, tự chữa `eft` drift), không đụng schema.
- Tính năng **không có feature flag** — panel hiện ngay sau deploy. Chỉ đọc, không mutation.
- ⚠️ Rollback về trước `phase3_02` sẽ khôi phục cạnh `admin→accountant`, khi đó deny mới sẽ chặn cả admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)