### PR TITLE
chore(ops): đồng bộ drift prod + sửa đường rollback deploy nói dối

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -319,3 +319,11 @@ smoke-*.png
 # officer/lead activity reports — query exports chứa PII (tên, lead counts,
 # timestamps). KHÔNG commit; canonical metric = KPI dashboard.
 Documents/reports/officer_*.csv
+
+# nginx runtime config SINH RA bởi deploy.sh Step 3 (`envsubst` từ
+# nginx/conf.d/default.conf.template với ${DOMAIN} + ${NGINX_ADMISSION_FROZEN}).
+# Chỉ .template là nguồn sự thật. Trước đây file sinh ra này KHÔNG được ignore
+# nên `git status` trên prod LUÔN bẩn — khiến người vận hành quen mắt bỏ qua
+# trạng thái bẩn, và 5 thay đổi tay khác nằm đó nhiều tháng không ai thấy
+# (audit 2026-07-20).
+nginx/conf.d/default.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -265,6 +265,12 @@ services:
   # --- Certbot (SSL Certificate Management) ---
   certbot:
     image: certbot/certbot
+    # Không có restart policy thì certbot KHÔNG dậy lại sau reboot VPS /
+    # docker daemon restart => vòng lặp `certbot renew` 12h chết âm thầm và
+    # chứng chỉ hết hạn mà không ai biết (nginx vẫn phục vụ cert cũ tới lúc
+    # hết hạn). Dòng này đã được sửa TAY trên prod từ 2026-07-15 nhưng chưa
+    # từng commit — đưa vào repo để prod và repo không còn lệch.
+    restart: unless-stopped
     profiles:
       - production
     volumes:

--- a/scripts/backup-cron.sh
+++ b/scripts/backup-cron.sh
@@ -26,7 +26,14 @@ echo "[$(date)] Starting database backup..."
 
 # Dump database
 BACKUP_FILE="$BACKUP_DIR/qlts_${TIMESTAMP}.sql.gz"
-docker compose exec -T postgres pg_dump \
+# ``-f docker-compose.yml`` BẮT BUỘC (review 2026-07-20): không có nó thì
+# docker compose tự nạp thêm ``docker-compose.override.yml`` — file ĐƯỢC
+# TRACK trong repo và khai ``env_file: ./Backend_FastAPI/.env``, mà file env
+# đó bị gitignore. Trên VPS dựng lại từ repo, override có mặt còn env thì
+# không ⇒ compose thoát 1 với "env file not found" ⇒ set -e giết script ⇒
+# KHÔNG có backup nào, cả local lẫn offsite. Prod hiện thoát nạn chỉ vì
+# override đã bị xoá tay. 11 lời gọi compose khác trong repo đều có -f.
+docker compose -f docker-compose.yml exec -T postgres pg_dump \
     -U "${POSTGRES_USER:-qlts}" \
     "${POSTGRES_DB:-qlts_production}" \
     | gzip > "$BACKUP_FILE"

--- a/scripts/backup-with-offsite.sh
+++ b/scripts/backup-with-offsite.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Backup local (backup-cron.sh) + đẩy bản mã hóa lên Google Drive
+set -euo pipefail
+cd /opt/qlts
+bash scripts/backup-cron.sh
+LATEST=$(ls -t backups/qlts_*.sql.gz | head -1)
+if rclone listremotes | grep -q '^gdrive-crypt:'; then
+  echo "[$(date)] Offsite: upload mã hóa $(basename "$LATEST") lên Google Drive..."
+  rclone copy "$LATEST" gdrive-crypt:
+  rclone delete gdrive-crypt: --min-age 14d 2>/dev/null || true
+  echo "[$(date)] Offsite OK"
+else
+  echo "[$(date)] WARN: remote gdrive-crypt không có → bỏ qua offsite"
+fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -191,13 +191,29 @@ docker compose -f docker-compose.yml --profile production --env-file .env.produc
 log "Step 5/8: Backing up database..."
 mkdir -p "$BACKUP_DIR"
 
+# Review 2026-07-20: ba sửa đổi, cùng một gốc — bản backup này là đường
+# rollback DUY NHẤT của Step 6 nên nó phải hoặc dùng được, hoặc biến mất
+# hẳn; tuyệt đối không được tồn tại ở dạng "có file nhưng vô dụng".
+#   1. Bỏ ``2>/dev/null``: trước đây lý do pg_dump chết bị nuốt sạch, vận
+#      hành chỉ thấy "may be first deploy" — câu chẩn đoán sai hướng.
+#   2. ``--clean --if-exists``: dump cũ KHÔNG có DROP nên khi Step 6 phát
+#      lại lên DB còn nguyên object thì mọi câu lệnh lỗi "already exists".
+#      Tức đường rollback trước đây KHÔNG THỂ khôi phục kể cả với file dump
+#      hoàn hảo. Có DROP thì replay mới thực sự đưa DB về trạng thái cũ.
+#   3. Xoá xác file khi dump fail: phép chuyển hướng ``>`` tạo file NGAY CẢ
+#      khi pg_dump chết, để lại file 0 byte. Cổng ``[ -s ]`` ở Step 6 đã
+#      chặn được, nhưng dọn luôn cho khỏi ai nhặt nhầm sau này.
 if docker compose -f docker-compose.yml --env-file .env.production exec -T postgres pg_isready -U "${POSTGRES_USER:-qlts}" >/dev/null 2>&1; then
-    docker compose -f docker-compose.yml --env-file .env.production exec -T postgres pg_dump \
+    if docker compose -f docker-compose.yml --env-file .env.production exec -T postgres pg_dump \
+        --clean --if-exists \
         -U "${POSTGRES_USER:-qlts}" \
         "${POSTGRES_DB:-qlts_production}" \
-        > "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql" 2>/dev/null \
-        && log "Database backup saved: pre_deploy_${TIMESTAMP}.sql" \
-        || warn "Database backup failed (may be first deploy)"
+        > "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql"; then
+        log "Database backup saved: pre_deploy_${TIMESTAMP}.sql"
+    else
+        rm -f "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql"
+        warn "Database backup FAILED — deploy này sẽ KHÔNG có đường rollback tự động"
+    fi
 else
     warn "PostgreSQL not running, skipping backup (first deploy?)"
 fi
@@ -228,12 +244,26 @@ else
         && log "Migrations completed successfully" \
         || {
             warn "Migration failed! Rolling back..."
-            if [ -f "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql" ]; then
-                docker compose -f docker-compose.yml --env-file .env.production exec -T postgres psql \
+            # Review 2026-07-20: cổng này trước đây NÓI DỐI theo hai cách.
+            #   1. ``[ -f ]`` chỉ hỏi "file có tồn tại", mà Step 5 tạo file
+            #      kể cả khi pg_dump chết ⇒ luôn TRUE ⇒ phát lại 0 byte.
+            #      Nay ``[ -s ]`` đòi file KHÁC RỖNG.
+            #   2. psql không có ``ON_ERROR_STOP=1`` nên chạy tiếp qua mọi
+            #      lỗi rồi thoát 0 ⇒ dòng "Database restored" in ra vô điều
+            #      kiện, kể cả khi không một câu lệnh nào chạy được. Nay
+            #      psql dừng ở lỗi đầu tiên và ta CHỈ báo đã khôi phục khi
+            #      psql thực sự thành công.
+            # Trạng thái tệ nhất (migration hỏng VÀ restore hỏng) giờ được
+            # nói thẳng kèm đường dẫn file, thay vì bị che bằng lời trấn an.
+            if [ -s "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql" ]; then
+                if docker compose -f docker-compose.yml --env-file .env.production exec -T postgres psql \
+                    -v ON_ERROR_STOP=1 \
                     -U "${POSTGRES_USER:-qlts}" \
                     "${POSTGRES_DB:-qlts_production}" \
-                    < "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql"
-                error "Migration failed. Database restored from backup."
+                    < "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql"; then
+                    error "Migration failed. Database restored from backup."
+                fi
+                error "Migration failed AND restore FAILED. DB có thể đang ở trạng thái LAI (schema nửa cũ nửa mới). KHÔNG deploy tiếp. Khôi phục tay từ: $BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql"
             fi
             error "Migration failed. No backup available to restore."
         }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -255,6 +255,14 @@ else
             #      psql thực sự thành công.
             # Trạng thái tệ nhất (migration hỏng VÀ restore hỏng) giờ được
             # nói thẳng kèm đường dẫn file, thay vì bị che bằng lời trấn an.
+            #
+            # ⚠️ GIỚI HẠN ĐÃ ĐO (diễn tập 2026-07-20, postgres 16.13):
+            # dump chỉ DROP những object nó BIẾT, tức những gì tồn tại lúc
+            # chụp ở Step 5. Bảng/kiểu do migration hỏng tạo ra SAU đó sẽ
+            # SỐNG SÓT qua restore. Dữ liệu, cột, index và alembic_version
+            # đều về đúng bản cũ (đã kiểm), nhưng "restored" KHÔNG đồng
+            # nghĩa "sạch như chưa từng deploy" — kiểm object thừa bằng
+            # ``\dt`` trước khi deploy lại.
             if [ -s "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql" ]; then
                 if docker compose -f docker-compose.yml --env-file .env.production exec -T postgres psql \
                     -v ON_ERROR_STOP=1 \


### PR DESCRIPTION
## Bối cảnh

Sau khi deploy #487, tôi audit `git status` trên prod `/opt/qlts` và thấy **6 thay đổi tay chưa từng commit**. PR bắt đầu từ việc đưa 3 mục an toàn nhất vào repo — rồi `/code-review max` trên chính PR đó phát hiện **hai lỗi nặng hơn nằm ngoài diff**, nên PR mở rộng để sửa luôn.

---

# Phần 1 — Đồng bộ drift prod (3 mục)

### 1. `scripts/backup-with-offsite.sh` — cơ chế cứu hộ nằm ngoài git

```
crontab prod: 0 3 * * * cd /opt/qlts && bash scripts/backup-with-offsite.sh >> /var/log/qlts-backup.log 2>&1
```

Đang chạy tốt (log `Offsite OK` liên tục tới 20-07), nhưng **chỉ tồn tại trên đúng cái máy nó có nhiệm vụ cứu**. Commit **nguyên văn** bản đang chạy (560 byte, không sửa một ký tự) để repo phản ánh đúng thực tế.

### 2. `docker-compose.yml` — certbot `restart: unless-stopped`

Sửa tay trên prod từ 15-07. Thiếu nó thì certbot không dậy sau reboot → cert hết hạn âm thầm. Đây cũng là service **duy nhất trong 8** còn thiếu restart policy ⇒ thay đổi này khôi phục tính nhất quán.

### 3. `.gitignore` — bỏ qua `nginx/conf.d/default.conf`

File do `deploy.sh` Step 3 `envsubst` sinh ra. Không được ignore nên `git status` trên prod **luôn bẩn** — chính điều đó khiến 5 drift còn lại nằm im nhiều tháng.

---

# Phần 2 — Sửa đường rollback đang NÓI DỐI 🔴

`/code-review max` tìm ra: khi migration hỏng, `deploy.sh` in **"Database restored from backup"** trong khi database **chưa hề được khôi phục**. Hai lỗi độc lập:

**A. Cổng `[ -f ]` luôn TRUE.** Step 5 dùng `>` nên file backup được tạo *kể cả khi `pg_dump` chết*, để lại 0 byte; `2>/dev/null` nuốt mất lý do nên vận hành chỉ thấy `may be first deploy`.

**B. Kể cả với file dump hoàn hảo, restore vẫn không thể chạy.** Dump không có `DROP`, replay lên DB còn nguyên object ⇒ mọi câu lỗi `already exists`; psql thiếu `ON_ERROR_STOP` nên chạy tiếp qua hết rồi **exit 0**.

### Đã sửa
- `[ -f ]` → `[ -s ]` (đòi file khác rỗng)
- Bỏ `2>/dev/null`, và xoá xác file 0 byte khi dump fail
- `pg_dump --clean --if-exists` → dump có `DROP` nên replay mới thực sự khôi phục
- `psql -v ON_ERROR_STOP=1`, và **chỉ báo đã khôi phục khi psql thật sự thành công**
- Trạng thái tệ nhất (migration hỏng **và** restore hỏng) nay được nói thẳng kèm đường dẫn file

---

# Phần 3 — `backup-cron.sh` thiếu `-f docker-compose.yml`

Lời gọi `docker compose` **duy nhất** trong repo không truyền `-f` (11 chỗ khác đều có) ⇒ tự nạp thêm `docker-compose.override.yml`, file **được track** và khai `env_file: ./Backend_FastAPI/.env` — file env bị gitignore.

Trên VPS dựng lại từ repo: override có mặt, env thì không ⇒ compose exit 1 ⇒ `set -e` giết script **trước** khối rclone ⇒ **không backup local, không backup offsite**, đến dòng WARN cũng không kịp in.

Đúng kịch bản mà Phần 1 tuyên bố đi bảo vệ. Prod hiện thoát nạn **chỉ vì** override đã bị xoá tay — tức đang phụ thuộc vào chính cái drift PR này chữa.

---

# Diễn tập rollback (postgres 16.13 dùng-một-lần, khớp phiên bản prod)

**Toàn bộ đạt.** Không chạm stack chính.

| Kiểm | Kết quả |
|---|---|
| Tái hiện lỗi CŨ | ✅ psql exit 0 nhưng dữ liệu KHÔNG khôi phục; 10 dòng lỗi bị nuốt; `alembic_version` bị nhân thành **HAI dòng** |
| `\restrict` (dump 16.13 có sinh) | ✅ KHÔNG làm `ON_ERROR_STOP` chết — lo hão, nhưng đã kiểm |
| Khôi phục mới | ✅ 3/3 dữ liệu về đúng · `alembic_version` LÙI đúng · cột thừa biến mất |
| File rỗng | ✅ `[ -s ]` chặn (`[ -f ]` cũ cho qua) |
| File hỏng giữa chừng | ✅ psql exit 3 → báo thất bại trung thực |

⚠️ **Giới hạn đo được, đã ghi vào code**: dump chỉ `DROP` object tồn tại lúc chụp, nên bảng do migration hỏng tạo ra *sau* đó vẫn sống sót. "Restored" = dữ liệu và schema cũ đã về, **không phải** "sạch như chưa từng deploy".

---

# 🔴 Bắt buộc trước khi deploy PR này

PR chạm `docker-compose.yml` — đúng file đang bị sửa tay trên prod ⇒ `git pull` ở Step 2 **sẽ abort**:

```bash
cd /opt/qlts && git checkout -- docker-compose.yml
```

Nội dung repo giờ đã bằng nội dung sửa tay nên không mất gì. Đây chính là quả mìn PR này đi gỡ — lần gỡ đầu phải làm tay.

⚠️ Bản vá `deploy.sh` **chưa bảo vệ ngay lần deploy mang nó xuống**: bash nạp script vào bộ nhớ lúc gọi, Step 2 pull bản mới xuống đĩa còn bản đang chạy vẫn là bản cũ (chính file ghi ở dòng 37-38). Có hiệu lực từ lần deploy kế tiếp nữa.

---

# Chưa xử trong PR này

- Script offsite vẫn **thất bại kiểu im lặng** (nhánh `else` thoát 0 khi rclone hỏng); thiếu `flock`; thiếu `gunzip -t`; `rclone delete` thiếu `--include`
- **Chưa có runbook khôi phục** từ `gdrive-crypt`; tài liệu duy nhất trong repo trỏ sai đường dẫn và sai định dạng
- `pre_deploy_*.sql` tích tụ: **241 file / 2.2 GB** trên prod, không cơ chế nào dọn
- `docker-compose.override.yml` bị xoá tay trên prod — cần thiết kế tử tế, không vá vội

Để PR sau, vì sửa trong PR này sẽ phá bất biến *repo == prod nguyên văn* của Phần 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)