### PR TITLE
fix(ops): lớp backup offsite thất bại TO TIẾNG thay vì im lặng

### DIFF
--- a/scripts/backup-with-offsite.sh
+++ b/scripts/backup-with-offsite.sh
@@ -1,14 +1,82 @@
 #!/usr/bin/env bash
-# Backup local (backup-cron.sh) + đẩy bản mã hóa lên Google Drive
+# Backup local (backup-cron.sh) + đẩy bản mã hoá lên Google Drive.
+#
+# NGUYÊN TẮC (review 2026-07-20): đây là đường cứu dữ liệu CUỐI CÙNG khi mất
+# máy chủ. Nó phải HOẶC chạy đúng, HOẶC kêu to. Tuyệt đối không được thoát 0
+# sau khi đã bỏ qua việc đẩy dữ liệu đi — cron hiểu "thoát 0" là thành công,
+# và lớp offsite có thể chết hàng tháng mà không ai biết.
+#
+# Bản trước vi phạm đúng điều đó: `rclone` nằm trong phần điều kiện của `if`
+# nên `set -e` bị vô hiệu; thiếu binary / mất config / sai HOME đều rơi vào
+# nhánh `else`, in một dòng WARN rồi THOÁT 0.
 set -euo pipefail
+
 cd /opt/qlts
+
+log() { echo "[$(date)] [OFFSITE] $*"; }
+die() { log "FATAL: $*"; exit 1; }
+
 bash scripts/backup-cron.sh
-LATEST=$(ls -t backups/qlts_*.sql.gz | head -1)
-if rclone listremotes | grep -q '^gdrive-crypt:'; then
-  echo "[$(date)] Offsite: upload mã hóa $(basename "$LATEST") lên Google Drive..."
-  rclone copy "$LATEST" gdrive-crypt:
-  rclone delete gdrive-crypt: --min-age 14d 2>/dev/null || true
-  echo "[$(date)] Offsite OK"
-else
-  echo "[$(date)] WARN: remote gdrive-crypt không có → bỏ qua offsite"
+
+# `|| true` là cần thiết: `head -1` đóng pipe sớm nên `ls` có thể nhận SIGPIPE
+# (mã 141) và `pipefail` sẽ giết script. Hiện chưa chạm ngưỡng (~1600 file)
+# nhưng đây là mìn hẹn giờ khi số file backup tăng.
+LATEST=$(ls -t backups/qlts_*.sql.gz 2>/dev/null | head -1 || true)
+[ -n "$LATEST" ] || die "không tìm thấy file backup nào trong backups/"
+
+# ── Cổng toàn vẹn: không đẩy rác lên rồi báo OK ─────────────────────────────
+# rclone chỉ xác nhận "đã truyền đủ byte", KHÔNG xác nhận file là backup hợp
+# lệ; trên remote crypt thì hash cũng không dùng được nên nó tụt xuống chỉ so
+# kích thước. Vậy phải tự kiểm trước khi upload.
+gunzip -t "$LATEST" 2>/dev/null \
+  || die "$LATEST hỏng (gunzip -t thất bại) — KHÔNG upload"
+
+SIZE=$(stat -c%s "$LATEST")
+PREV=$(ls -t backups/qlts_*.sql.gz 2>/dev/null | sed -n 2p || true)
+if [ -n "$PREV" ]; then
+    PREV_SIZE=$(stat -c%s "$PREV")
+    # Bắt kịch bản "pg_dump trúng DB rỗng/sai tên nhưng vẫn exit 0" — file sẽ
+    # nhỏ bất thường. So với bản hôm trước thay vì đặt ngưỡng cứng, để khỏi
+    # phải chỉnh tay khi dữ liệu lớn dần theo mùa tuyển sinh.
+    if [ "$SIZE" -lt $(( PREV_SIZE / 2 )) ]; then
+        die "$LATEST chỉ $SIZE byte, chưa tới 50% bản trước ($PREV_SIZE byte) — nghi dump hỏng, KHÔNG upload"
+    fi
 fi
+
+# ── Thiếu công cụ/remote là LỖI, không phải "bỏ qua" ────────────────────────
+command -v rclone >/dev/null 2>&1 \
+  || die "không tìm thấy rclone — offsite KHÔNG chạy (kiểm PATH của cron)"
+rclone listremotes | grep -q '^gdrive-crypt:' \
+  || die "remote gdrive-crypt không tồn tại — offsite KHÔNG chạy (kiểm rclone.conf của user chạy cron)"
+
+log "upload $(basename "$LATEST") ($SIZE byte) → gdrive-crypt:"
+rclone copy "$LATEST" gdrive-crypt:
+log "upload OK — bản hôm nay ĐÃ an toàn ngoài máy chủ"
+
+# ── Dọn bản cũ: hỏng thì KÊU, không nuốt ────────────────────────────────────
+# Trước đây là `2>/dev/null || true` — hết quota / token hết hạn / remote đổi
+# tên đều biến mất không dấu vết, trong khi dòng "Offsite OK" vẫn in ra.
+RETENTION_RC=0
+rclone delete gdrive-crypt: --min-age 14d || RETENTION_RC=$?
+if [ "$RETENTION_RC" -ne 0 ]; then
+    log "WARN: dọn bản >14 ngày THẤT BẠI (mã $RETENTION_RC)."
+    log "WARN: bản upload hôm nay VẪN AN TOÀN, nhưng nếu lỗi lặp lại thì Drive"
+    log "WARN: sẽ đầy dần rồi chặn luôn đường upload. Cần xử sớm."
+fi
+
+# ── Công tắc người chết (tuỳ chọn, mặc định TẮT) ────────────────────────────
+# Ba sửa đổi trên khiến script THẤT BẠI TO TIẾNG — nhưng tiếng đó rơi vào
+# /var/log/qlts-backup.log, nơi không ai ngồi canh. Đặt HEALTHCHECK_PING_URL
+# (healthchecks.io hoặc tương đương) để biến IM LẶNG thành CẢNH BÁO: dịch vụ
+# sẽ chủ động báo khi quá hạn mà không nhận được ping.
+# Ping ở đây nghĩa là "bản hôm nay đã nằm ngoài máy chủ", nên vẫn ping kể cả
+# khi dọn dẹp lỗi — dữ liệu an toàn và dọn dẹp sạch là hai chuyện khác nhau.
+if [ -n "${HEALTHCHECK_PING_URL:-}" ]; then
+    curl -fsS -m 10 --retry 3 "$HEALTHCHECK_PING_URL" >/dev/null \
+      && log "đã ping healthcheck" \
+      || log "WARN: ping healthcheck thất bại (backup vẫn OK)"
+fi
+
+# Thoát khác 0 nếu có bước nào không trọn vẹn — để cron/giám sát nhìn thấy.
+[ "$RETENTION_RC" -eq 0 ] || exit 1
+log "HOÀN TẤT"


### PR DESCRIPTION
Tiếp nối #489. PR đó chép `backup-with-offsite.sh` vào repo **nguyên văn** để mã nguồn khớp máy chủ, cố ý không đổi hành vi. Bất biến đó xong rồi — giờ sửa được.

## Vấn đề: script KHÔNG hỏng, nhưng không biết cách kêu khi hỏng

Nó chạy tốt hằng ngày (`Offsite OK` liên tục). Nhưng:

```bash
if rclone listremotes | grep -q '^gdrive-crypt:'; then
    ...upload...
else
    echo "WARN: remote gdrive-crypt không có → bỏ qua offsite"
fi
```

`rclone` nằm trong **phần điều kiện của `if`** nên `set -e` bị vô hiệu. Thiếu binary, mất `rclone.conf`, cron chạy dưới user khác — tất cả rơi vào nhánh `else`, in một dòng WARN rồi **thoát 0**. Cron hiểu 0 là thành công, còn backup nội bộ vẫn chạy nên nhìn đâu cũng thấy ổn.

Hệ quả: lớp sao lưu ngoại vi có thể chết **hàng tháng** mà không ai biết, cho tới lúc cần dùng.

## Sửa 4 điểm

| # | Trước | Sau |
|---|---|---|
| 1 | Thiếu rclone / remote → "bỏ qua offsite", **thoát 0** | **FATAL exit 1**, thông báo chỉ thẳng chỗ cần kiểm (PATH của cron / `rclone.conf` của user) |
| 2 | Upload thẳng, không kiểm gì | **Cổng toàn vẹn**: `gunzip -t` + so kích thước với bản hôm trước (<50% là chặn) |
| 3 | `2>/dev/null \|\| true` nuốt sạch lỗi retention | **WARN rõ ràng + exit khác 0**; upload vẫn ghi nhận thành công (dữ liệu an toàn là chuyện khác với dọn dẹp sạch) |
| 4 | `ls -t \| head -1` — `head` đóng pipe sớm, `pipefail` có thể giết script | Thêm `\|\| true` |

**Vì sao cần cổng toàn vẹn:** `rclone copy` chỉ xác nhận *đã truyền đủ byte*, không xác nhận file là backup hợp lệ — và trên remote **crypt** thì hash không dùng được nên nó tụt xuống chỉ so kích thước. Không đủ để bắt kịch bản `pg_dump` trúng DB rỗng/sai tên mà vẫn exit 0. Repo đã có tiền lệ đúng lỗi này (`phase3-pre-deploy-snapshot.sh` sai dbname → snapshot rollback fail âm thầm).

## Hook tuỳ chọn `HEALTHCHECK_PING_URL` (mặc định TẮT)

Ba sửa đổi trên làm script kêu to — nhưng tiếng đó rơi vào `/var/log/qlts-backup.log`, nơi không ai ngồi canh. **`exit 1` chỉ có giá trị nếu có thứ gì đó đang theo dõi exit code.**

Thứ thực sự biến im lặng thành cảnh báo là công tắc người chết: ping một dịch vụ giám sát sau khi upload xong, quá hạn không thấy ping thì dịch vụ chủ động báo. PR này **dựng sẵn chỗ cắm**, không đăng ký dịch vụ ngoài — chờ quyết định + URL. Không đặt biến thì đoạn này bị bỏ qua hoàn toàn.

## Diễn tập — 6 ca, toàn bộ đạt

Container `debian` dùng-một-lần, `rclone` giả điều khiển được bằng biến môi trường. Đã teardown.

| Ca | Kết quả |
|---|---|
| **Đối chứng bản cũ** — gỡ rclone | ✅ **vẫn thoát 0** → tái hiện đúng lỗi |
| 1. Đường thuận | ✅ exit 0, đủ `upload OK` + `HOÀN TẤT` |
| 2. rclone biến mất | ✅ **exit 1** (trước là 0) — lỗi cốt lõi |
| 3. Remote không tồn tại | ✅ exit 1 |
| 4. File gzip hỏng | ✅ exit 1 và **không upload** |
| 5. File teo (1023 byte vs 400083 byte hôm trước) | ✅ exit 1, chặn |
| 6. Retention lỗi | ✅ upload vẫn OK · WARN rõ · exit 1 |

`bash -n` sạch. Không đụng code backend/frontend ⇒ không ảnh hưởng test hiện có.

## Lưu ý khi deploy

Lần này **không có vật cản** như #489: `backup-with-offsite.sh` giờ đã là file tracked trên prod (do #489 mang xuống), nên `git pull` chỉ cập nhật nội dung, không vướng untracked.

## Chưa xử

- **Chưa có runbook khôi phục** từ `gdrive-crypt` — cơ chế DR chưa từng diễn tập restore thì chưa phải cơ chế DR
- `pre_deploy_*.sql` tích tụ **241 file / 2.2 GB** trên prod, `find -name 'qlts_*.sql.gz'` không khớp nên không bao giờ dọn
- `rclone delete` vẫn thiếu `--include` (bán kính đã xác minh chỉ trong `gdrive:qlts-backups`, nên mức độ thấp)
- Không có `flock` chống chạy chồng

🤖 Generated with [Claude Code](https://claude.com/claude-code)