### PR TITLE
fix(officer): vòng UX bảng "điểm bận" — lời khuyên lên mặt bảng + nối màu số↔thanh + rê/ghim

### DIFF
--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
@@ -221,6 +221,37 @@ describe("OfficerDistributionPanel", () => {
     expect(screen.getByText(/cách xếp: luân phiên/)).toBeInTheDocument();
   });
 
+  it("hai đơn vị TRÙNG TÊN vẫn phân biệt được (prod có thật)", () => {
+    // Admin nhìn toàn tổ chức sẽ thấy hai khối "Phòng Tuyển Sinh" giống hệt
+    // nhau; điểm bận chỉ so được trong cùng một đơn vị nên phải tách bạch.
+    const sameName = {
+      ...PEER,
+      user_id: 88,
+      full_name: "Trần Thị Cẩm",
+      unit_id: 20,
+      unit_name: "Phòng Tuyển sinh", // trùng tên với unit 14
+    };
+    mockPanel([ME, sameName]);
+    render(<OfficerDistributionPanel />);
+
+    expect(screen.getByText("Phòng Tuyển sinh #14")).toBeInTheDocument();
+    expect(screen.getByText("Phòng Tuyển sinh #20")).toBeInTheDocument();
+  });
+
+  it("tên đơn vị KHÔNG mang số id khi không trùng", () => {
+    const other = {
+      ...PEER,
+      user_id: 77,
+      unit_id: 15,
+      unit_name: "Phòng Đào tạo",
+    };
+    mockPanel([ME, other]);
+    render(<OfficerDistributionPanel />);
+
+    expect(screen.getByText("Phòng Tuyển sinh")).toBeInTheDocument();
+    expect(screen.queryByText(/Phòng Tuyển sinh #/)).not.toBeInTheDocument();
+  });
+
   it("KHÔNG hiện header đơn vị khi chỉ có một đơn vị", () => {
     mockPanel([ME, PEER]);
     render(<OfficerDistributionPanel />);

--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockUseOfficerDistribution = vi.fn();
 vi.mock("@/hooks/officer/useOfficerDistribution", () => ({
@@ -93,7 +93,8 @@ describe("OfficerDistributionPanel", () => {
 
     expect(screen.getByText("Hiền")).toBeInTheDocument();
     expect(screen.getByText("Kiên")).toBeInTheDocument();
-    expect(screen.getByText("14.2")).toBeInTheDocument();
+    // 14.2 in ở CẢ thẻ "của bạn" lẫn hàng danh sách — hai vai trò khác nhau
+    expect(screen.getAllByText("14.2").length).toBeGreaterThan(0);
     expect(screen.getByText("23")).toBeInTheDocument();
     expect(screen.getByText("BẠN")).toBeInTheDocument();
   });
@@ -106,13 +107,51 @@ describe("OfficerDistributionPanel", () => {
     expect(screen.getByText("Quốc Duy")).toBeInTheDocument();
   });
 
-  it("KHÔNG lộ lời khuyên khi tooltip chưa mở", () => {
+  it("lời khuyên của MÌNH đọc được NGAY, không phải bấm", () => {
+    // Đây là lý do tồn tại của thẻ "Việc của bạn": `boost` là thứ duy nhất
+    // officer hành động được, chôn nó trong popover = gần như không ai đọc.
     mockPanel([ME, PEER]);
     render(<OfficerDistributionPanel />);
 
+    expect(screen.getByText("Việc của bạn")).toBeInTheDocument();
+    expect(screen.getByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")).toBeInTheDocument();
+  });
+
+  it("🔒 thẻ 'của bạn' KHÔNG hiện với người xem không có dòng nào của mình", () => {
+    // Admin/manager: mọi entry đều is_current_user=false. Kể cả khi backend lỡ
+    // rò `boost` của officer, mặt bảng phải câm.
+    mockPanel([{ ...PEER, boost: "RÒ RỈ KHÔNG ĐƯỢC HIỆN" }]);
+    render(<OfficerDistributionPanel />);
+
+    expect(screen.queryByText("Việc của bạn")).not.toBeInTheDocument();
+    expect(screen.queryByText("RÒ RỈ KHÔNG ĐƯỢC HIỆN")).not.toBeInTheDocument();
+    // ...và tiêu đề không xưng "bạn" với người không nằm trong bảng
     expect(
-      screen.queryByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")
-    ).not.toBeInTheDocument();
+      screen.getByText("Vì sao hệ thống chia lead cho từng người")
+    ).toBeInTheDocument();
+  });
+
+  it("xưng 'bạn' chỉ khi người xem thật sự có dòng trong bảng", () => {
+    mockPanel([ME, PEER]);
+    render(<OfficerDistributionPanel />);
+
+    expect(screen.getByText("Vì sao bạn được chia lead")).toBeInTheDocument();
+  });
+
+  it("thẻ 'của bạn' nói rõ thứ hạng, nhưng im khi đơn vị xếp luân phiên", () => {
+    // `legacy` xếp theo lượt chứ không đọc điểm bận ⇒ in thứ hạng là nói sai
+    // cơ chế phân phối.
+    mockPanel([ME, PEER]);
+    const first = render(<OfficerDistributionPanel />);
+    expect(screen.getByText(/Đang xếp thứ/)).toBeInTheDocument();
+    first.unmount();
+
+    mockPanel([
+      { ...ME, scoring_mode: "legacy" },
+      { ...PEER, scoring_mode: "legacy" },
+    ]);
+    render(<OfficerDistributionPanel />);
+    expect(screen.queryByText(/Đang xếp thứ/)).not.toBeInTheDocument();
   });
 
   // Nội dung tooltip test TRỰC TIẾP: Radix chỉ render nó vào portal khi mở, mà
@@ -122,7 +161,7 @@ describe("OfficerDistributionPanel", () => {
     render(<EntryDetails e={ME} />);
 
     expect(screen.getByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")).toBeInTheDocument();
-    expect(screen.getByText(/Dành riêng cho bạn/)).toBeInTheDocument();
+    expect(screen.getByText(/chỉ bạn thấy/)).toBeInTheDocument();
     // phép tính hiện bằng số thật (không phải FE tự tính)
     expect(
       screen.getByText(/Điểm bận = 114 ÷ \(400×2\) ×100 = 14\.2/)
@@ -143,7 +182,7 @@ describe("OfficerDistributionPanel", () => {
     expect(
       screen.queryByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")
     ).not.toBeInTheDocument();
-    expect(screen.queryByText(/Dành riêng cho bạn/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/chỉ bạn thấy/)).not.toBeInTheDocument();
   });
 
   it("🔒 FAIL-CLOSED: peer lỡ có boost vẫn KHÔNG được lộ", () => {
@@ -153,7 +192,7 @@ describe("OfficerDistributionPanel", () => {
     render(<EntryDetails e={leaky} />);
 
     expect(screen.queryByText("RÒ RỈ KHÔNG ĐƯỢC HIỆN")).not.toBeInTheDocument();
-    expect(screen.queryByText(/Dành riêng cho bạn/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/chỉ bạn thấy/)).not.toBeInTheDocument();
     // nhưng phần công khai vẫn render bình thường
     expect(
       screen.getByText("Tải chủ yếu là lead hệ thống chia.")
@@ -191,14 +230,50 @@ describe("OfficerDistributionPanel", () => {
   });
 
   it("thanh đo dựng đúng 3 đoạn từ số backend (không tự tính lại)", () => {
-    mockPanel([ME]);
+    mockPanel([PEER]); // peer ⇒ đúng MỘT thanh (không có thẻ "của bạn")
     const { container } = render(<OfficerDistributionPanel />);
 
     // sys = eff_util_pct; weight = real_util - eff_util; skip = fill - real_util
-    const widths = Array.from(
-      container.querySelectorAll<HTMLElement>("span.h-full")
+    const widthOf = (seg: string) =>
+      container.querySelector<HTMLElement>(`[data-seg="${seg}"]`)?.style.width;
+    expect(widthOf("sys")).toBe("23%");
+    expect(widthOf("weight")).toBe("5.5%");
+    expect(widthOf("skip")).toBe("33.5%");
+    // vạch mốc so ngưỡng đặt theo overload_gate_pct, KHÔNG theo fill_pct
+    expect(container.querySelector<HTMLElement>('[data-seg="gate"]')?.style.left).toBe(
+      "37%"
+    );
+  });
+
+  it("thẻ 'của bạn' và hàng danh sách vẽ CÙNG một thanh", () => {
+    // Hai chỗ cùng đọc `segmentsOf` ⇒ không thể lệch nhau; nếu sau này ai tách
+    // logic ra hai nơi, test này đỏ.
+    mockPanel([ME]);
+    const { container } = render(<OfficerDistributionPanel />);
+
+    const sys = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-seg="sys"]')
     ).map((el) => el.style.width);
-    expect(widths).toEqual(["14.2%", "14.3%", "33.5%"]);
+    expect(sys).toHaveLength(2); // thẻ + hàng
+    expect(new Set(sys)).toEqual(new Set(["14.2%"]));
+  });
+
+  it("mỗi con số trong bảng chi tiết đeo đúng màu của đoạn sinh ra nó", () => {
+    // Đây là cầu nối bar ↔ số: không có nó người xem phải tự dò.
+    const { container } = render(<EntryDetails e={ME} />);
+
+    const swatch = (seg: string) =>
+      container.querySelector<HTMLElement>(`[data-swatch="${seg}"]`);
+    // "không tính" = đoạn xanh lá, "hệ thống tính"/"điểm bận" = đoạn chàm,
+    // "ưu tiên kỳ cựu" = đoạn xanh dương nhạt
+    expect(swatch("skip")?.className).toContain("bg-success-500");
+    expect(swatch("sys")?.className).toContain("bg-primary");
+    expect(swatch("weight")?.className).toContain("bg-info-500");
+  });
+
+  it("KHÔNG hiện dòng 'ưu tiên kỳ cựu' khi trọng số = 1", () => {
+    const { container } = render(<EntryDetails e={{ ...ME, weight: 1 }} />);
+    expect(container.querySelector('[data-swatch="weight"]')).toBeNull();
   });
 
   it("hiện skeleton khi đang tải và thông báo khi lỗi", () => {
@@ -243,9 +318,9 @@ describe("OfficerDistributionPanel", () => {
     mockPanel([ME]);
     render(<OfficerDistributionPanel />);
 
-    expect(screen.queryByText(/Dành riêng cho bạn/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/chỉ bạn thấy/)).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /Hiền/ }));
-    expect(await screen.findByText(/Dành riêng cho bạn/)).toBeInTheDocument();
+    expect(await screen.findByText(/chỉ bạn thấy/)).toBeInTheDocument();
   });
 
   it("một đơn vị vẫn nói rõ cách xếp (legacy không được hiện điểm bận trơ)", () => {
@@ -263,5 +338,108 @@ describe("OfficerDistributionPanel", () => {
     render(<OfficerDistributionPanel />);
     expect(screen.getByText(/Cách xếp của đơn vị/)).toBeInTheDocument();
     expect(screen.getByText(/xếp theo lượt/)).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// Hai đường mở bảng chi tiết. Rê chuột là lớp tăng tiến cho máy để bàn; nó
+// KHÔNG được lấy mất hành vi bấm-để-giữ, vì bảng dài và người đọc phải rời
+// chuột được. jsdom không có `matchMedia` nên phải mock để bật nhánh này.
+// =============================================================================
+describe("OfficerDistributionPanel — rê chuột vs bấm ghim", () => {
+  const DIAG = "Tải chủ yếu là lead hệ thống chia.";
+
+  beforeEach(() => {
+    mockUseOfficerDistribution.mockReset();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: (query: string) => ({
+        matches: true, // giả lập máy có chuột thật
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    // Trả jsdom về trạng thái không-hover để không rò sang file test khác.
+    delete (window as unknown as Record<string, unknown>).matchMedia;
+  });
+
+  const settle = async (ms: number) => {
+    await act(async () => {
+      vi.advanceTimersByTime(ms);
+    });
+  };
+
+  it("rê vào thì mở, rê ra thì đóng", async () => {
+    mockPanel([PEER]);
+    render(<OfficerDistributionPanel />);
+    const row = screen.getByRole("button", { name: /Kiên/ });
+
+    fireEvent.pointerEnter(row, { pointerType: "mouse" });
+    await settle(300);
+    expect(screen.getByText(DIAG)).toBeInTheDocument();
+
+    fireEvent.pointerLeave(row, { pointerType: "mouse" });
+    await settle(300);
+    expect(screen.queryByText(DIAG)).not.toBeInTheDocument();
+  });
+
+  it("BẤM là ghim: rê chuột ra vẫn đọc tiếp được", async () => {
+    mockPanel([PEER]);
+    render(<OfficerDistributionPanel />);
+    const row = screen.getByRole("button", { name: /Kiên/ });
+
+    fireEvent.click(row);
+    await settle(0);
+    expect(screen.getByText(DIAG)).toBeInTheDocument();
+
+    fireEvent.pointerLeave(row, { pointerType: "mouse" });
+    await settle(600);
+    expect(screen.getByText(DIAG)).toBeInTheDocument();
+  });
+
+  it("máy KHÔNG có chuột: rê không mở, mà chạm thì vẫn mở và giữ", async () => {
+    // Chốt chặn thật cho điện thoại là media query, không phải `pointerType`
+    // (jsdom không truyền được trường đó nên đừng test bằng nó). Trên cảm ứng
+    // pointerEnter bắn kèm cú chạm rồi pointerLeave ngay khi nhấc ngón — nếu
+    // nhánh rê chuột ăn cặp sự kiện này thì bảng vừa mở đã tự đóng.
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: (query: string) => ({
+        matches: false, // không hover, không con trỏ tinh
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    });
+
+    mockPanel([PEER]);
+    render(<OfficerDistributionPanel />);
+    const row = screen.getByRole("button", { name: /Kiên/ });
+
+    fireEvent.pointerEnter(row);
+    await settle(300);
+    expect(screen.queryByText(DIAG)).not.toBeInTheDocument();
+
+    fireEvent.click(row); // cú chạm thật sự
+    await settle(0);
+    fireEvent.pointerLeave(row);
+    await settle(600);
+    expect(screen.getByText(DIAG)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.test.tsx
@@ -4,17 +4,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockUseOfficerDistribution = vi.fn();
 vi.mock("@/hooks/officer/useOfficerDistribution", () => ({
-  useOfficerDistribution: (...args: unknown[]) =>
-    mockUseOfficerDistribution(...args),
+  useOfficerDistribution: (...args: unknown[]) => mockUseOfficerDistribution(...args),
 }));
 
 // ⚠️ CỐ Ý KHÔNG mock @/components/ui/popover: lời khuyên (`boost`) nằm TRONG
 // TooltipContent nên phải mở tooltip bằng tương tác THẬT mới assert được. Mock
 // tooltip sẽ render sẵn nội dung và test mất hết giá trị.
-import {
-  EntryDetails,
-  OfficerDistributionPanel,
-} from "./OfficerDistributionPanel";
+import { EntryDetails, OfficerDistributionPanel } from "./OfficerDistributionPanel";
 
 const ME = {
   rank: 1,
@@ -46,12 +42,28 @@ const ME = {
   is_current_user: true,
 };
 
+// ⚠️ PEER phải là bộ số TỰ NHẤT QUÁN (đúng cùng lớp lỗi 14.3 cũ): mọi % phải
+// sinh ra được từ chính workload/cap/weight/dist của nó, không thì test dựng
+// trên trạng thái backend không bao giờ tồn tại.
+//   dist 184 → eff = 184/(400×2)×100 = 23.0
+//            → real = 184/400×100  = 46.0
+//   deducted 64 = self 40 + tuition 44 − overlap 20
+//   fill = 248/400×100 = 62.0 ; gate = (248−44)/400×100 = 51.0
 const PEER = {
   ...ME,
   rank: 2,
   user_id: 25,
   full_name: "Kiên",
+  self_sourced: 40,
+  tuition_hold: 44,
+  overlap: 20,
+  dist_load: 184,
+  deducted: 64,
+  real_util_pct: 46.0,
+  fill_pct: 62.0,
   eff_util_pct: 23.0,
+  overload_gate_pct: 51.0,
+  score: 0.23,
   archetype: { key: "balanced", label: "Cân bằng" },
   diagnosis: "Tải chủ yếu là lead hệ thống chia.",
   boost: null,
@@ -113,8 +125,19 @@ describe("OfficerDistributionPanel", () => {
     mockPanel([ME, PEER]);
     render(<OfficerDistributionPanel />);
 
-    expect(screen.getByText("Việc của bạn")).toBeInTheDocument();
+    expect(screen.getByText(/Việc của bạn/)).toBeInTheDocument();
     expect(screen.getByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")).toBeInTheDocument();
+    // 🔒 Nơi lời khuyên hiện nổi bật nhất PHẢI giữ dấu riêng tư — bảng này mọi
+    // đồng nghiệp cùng xem.
+    expect(screen.getByText(/chỉ bạn thấy/)).toBeInTheDocument();
+  });
+
+  it("chú thích có mục 'Ngưỡng tạm dừng 80%' vì vạch đỏ vẫn được vẽ", () => {
+    // Vạch đỏ đứt vẽ trên mọi thanh; bỏ mục legend đi là để lại một vạch vô
+    // danh — đúng cái nhầm-lẫn-%-số bảng này có tiền sử.
+    mockPanel([ME]);
+    render(<OfficerDistributionPanel />);
+    expect(screen.getByText("Ngưỡng tạm dừng 80%")).toBeInTheDocument();
   });
 
   it("🔒 thẻ 'của bạn' KHÔNG hiện với người xem không có dòng nào của mình", () => {
@@ -126,9 +149,7 @@ describe("OfficerDistributionPanel", () => {
     expect(screen.queryByText("Việc của bạn")).not.toBeInTheDocument();
     expect(screen.queryByText("RÒ RỈ KHÔNG ĐƯỢC HIỆN")).not.toBeInTheDocument();
     // ...và tiêu đề không xưng "bạn" với người không nằm trong bảng
-    expect(
-      screen.getByText("Vì sao hệ thống chia lead cho từng người")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Vì sao hệ thống chia lead cho từng người")).toBeInTheDocument();
   });
 
   it("xưng 'bạn' chỉ khi người xem thật sự có dòng trong bảng", () => {
@@ -163,25 +184,17 @@ describe("OfficerDistributionPanel", () => {
     expect(screen.getByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")).toBeInTheDocument();
     expect(screen.getByText(/chỉ bạn thấy/)).toBeInTheDocument();
     // phép tính hiện bằng số thật (không phải FE tự tính)
-    expect(
-      screen.getByText(/Điểm bận = 114 ÷ \(400×2\) ×100 = 14\.2/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Điểm bận = 114 ÷ \(400×2\) ×100 = 14\.2/)).toBeInTheDocument();
     expect(screen.getByText(/Chỗ đầy thật = 248\/400 = 62%/)).toBeInTheDocument();
-    expect(
-      screen.getByText(/Ngưỡng tạm dừng = \(248−100\)\/400 = 37%/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Ngưỡng tạm dừng = \(248−100\)\/400 = 37%/)).toBeInTheDocument();
   });
 
   it("nội dung tooltip ĐỒNG NGHIỆP: có chẩn đoán nhưng KHÔNG có lời khuyên", () => {
     render(<EntryDetails e={PEER} />);
 
-    expect(
-      screen.getByText("Tải chủ yếu là lead hệ thống chia.")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Tải chủ yếu là lead hệ thống chia.")).toBeInTheDocument();
     // 🔒 tuyệt đối không rò lời khuyên của người khác
-    expect(
-      screen.queryByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("LỜI KHUYÊN RIÊNG CỦA HIỀN")).not.toBeInTheDocument();
     expect(screen.queryByText(/chỉ bạn thấy/)).not.toBeInTheDocument();
   });
 
@@ -194,9 +207,7 @@ describe("OfficerDistributionPanel", () => {
     expect(screen.queryByText("RÒ RỈ KHÔNG ĐƯỢC HIỆN")).not.toBeInTheDocument();
     expect(screen.queryByText(/chỉ bạn thấy/)).not.toBeInTheDocument();
     // nhưng phần công khai vẫn render bình thường
-    expect(
-      screen.getByText("Tải chủ yếu là lead hệ thống chia.")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Tải chủ yếu là lead hệ thống chia.")).toBeInTheDocument();
   });
 
   it("gom nhóm theo ĐƠN VỊ khi phạm vi trải nhiều đơn vị", () => {
@@ -267,13 +278,11 @@ describe("OfficerDistributionPanel", () => {
     // sys = eff_util_pct; weight = real_util - eff_util; skip = fill - real_util
     const widthOf = (seg: string) =>
       container.querySelector<HTMLElement>(`[data-seg="${seg}"]`)?.style.width;
-    expect(widthOf("sys")).toBe("23%");
-    expect(widthOf("weight")).toBe("5.5%");
-    expect(widthOf("skip")).toBe("33.5%");
+    expect(widthOf("sys")).toBe("23%"); // eff
+    expect(widthOf("weight")).toBe("23%"); // real 46 − eff 23
+    expect(widthOf("skip")).toBe("16%"); // fill 62 − real 46
     // vạch mốc so ngưỡng đặt theo overload_gate_pct, KHÔNG theo fill_pct
-    expect(container.querySelector<HTMLElement>('[data-seg="gate"]')?.style.left).toBe(
-      "37%"
-    );
+    expect(container.querySelector<HTMLElement>('[data-seg="gate"]')?.style.left).toBe("51%");
   });
 
   it("thẻ 'của bạn' và hàng danh sách vẽ CÙNG một thanh", () => {
@@ -282,9 +291,9 @@ describe("OfficerDistributionPanel", () => {
     mockPanel([ME]);
     const { container } = render(<OfficerDistributionPanel />);
 
-    const sys = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-seg="sys"]')
-    ).map((el) => el.style.width);
+    const sys = Array.from(container.querySelectorAll<HTMLElement>('[data-seg="sys"]')).map(
+      (el) => el.style.width
+    );
     expect(sys).toHaveLength(2); // thẻ + hàng
     expect(new Set(sys)).toEqual(new Set(["14.2%"]));
   });
@@ -293,8 +302,7 @@ describe("OfficerDistributionPanel", () => {
     // Đây là cầu nối bar ↔ số: không có nó người xem phải tự dò.
     const { container } = render(<EntryDetails e={ME} />);
 
-    const swatch = (seg: string) =>
-      container.querySelector<HTMLElement>(`[data-swatch="${seg}"]`);
+    const swatch = (seg: string) => container.querySelector<HTMLElement>(`[data-swatch="${seg}"]`);
     // "không tính" = đoạn xanh lá, "hệ thống tính"/"điểm bận" = đoạn chàm,
     // "ưu tiên kỳ cựu" = đoạn xanh dương nhạt
     expect(swatch("skip")?.className).toContain("bg-success-500");
@@ -322,26 +330,20 @@ describe("OfficerDistributionPanel", () => {
       error: new Error("boom"),
     });
     rerender(<OfficerDistributionPanel />);
-    expect(
-      screen.getByText(/Không tải được bảng điểm bận/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Không tải được bảng điểm bận/)).toBeInTheDocument();
   });
 
   it("nhãn 'không tính' KHÔNG trình bày như phép cộng khi có phần giao", () => {
     // deducted = self + tuition − overlap. Nếu in "54 + 100" cạnh "−134",
     // người đọc thấy một phép cộng không bằng tổng của chính nó.
     render(<EntryDetails e={ME} />);
-    expect(
-      screen.getByText(/tự tìm 54, đã đóng tiền 100, trùng 20/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/tự tìm 54, đã đóng tiền 100, trùng 20/)).toBeInTheDocument();
     expect(screen.queryByText(/tự tìm 54 \+ đã đóng tiền 100/)).not.toBeInTheDocument();
   });
 
   it("không có phần giao thì vẫn dùng dấu + cho dễ đọc", () => {
     render(<EntryDetails e={{ ...ME, overlap: 0, self_sourced: 34, deducted: 134 }} />);
-    expect(
-      screen.getByText(/tự tìm 34 \+ đã đóng tiền 100/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/tự tìm 34 \+ đã đóng tiền 100/)).toBeInTheDocument();
   });
 
   it("CHẠM/BẤM mở được bảng chi tiết — đường dùng trên điện thoại", async () => {
@@ -349,9 +351,12 @@ describe("OfficerDistributionPanel", () => {
     mockPanel([ME]);
     render(<OfficerDistributionPanel />);
 
-    expect(screen.queryByText(/chỉ bạn thấy/)).not.toBeInTheDocument();
+    // Dùng phép tính popover làm dấu — "chỉ bạn thấy" giờ hiện SẴN ở thẻ "của
+    // bạn" nên không còn phân biệt được popover đã mở hay chưa.
+    const marker = /Chỗ đầy thật = 248\/400/;
+    expect(screen.queryByText(marker)).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /Hiền/ }));
-    expect(await screen.findByText(/chỉ bạn thấy/)).toBeInTheDocument();
+    expect(await screen.findByText(marker)).toBeInTheDocument();
   });
 
   it("một đơn vị vẫn nói rõ cách xếp (legacy không được hiện điểm bận trơ)", () => {
@@ -385,8 +390,11 @@ describe("OfficerDistributionPanel — rê chuột vs bấm ghim", () => {
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       configurable: true,
+      // Parse query THẬT: chỉ khớp khi có CẢ hover:hover và pointer:fine —
+      // component gõ sai query (typo media feature) sẽ khiến matches=false và
+      // các test rê chuột đỏ, thay vì luôn-true nuốt mọi typo.
       value: (query: string) => ({
-        matches: true, // giả lập máy có chuột thật
+        matches: /hover:\s*hover/.test(query) && /pointer:\s*fine/.test(query),
         media: query,
         onchange: null,
         addListener: vi.fn(),
@@ -437,6 +445,51 @@ describe("OfficerDistributionPanel — rê chuột vs bấm ghim", () => {
     fireEvent.pointerLeave(row, { pointerType: "mouse" });
     await settle(600);
     expect(screen.getByText(DIAG)).toBeInTheDocument();
+  });
+
+  it("rê MỞ rồi BẤM = GHIM, không phải đóng (đường click chưa test trước đây)", async () => {
+    // Nếu preventDefault (chặn Radix toggle trong handleClick) hỏng, cú bấm khi
+    // đang mở-do-rê sẽ ĐÓNG popover — và cả suite vẫn xanh nếu không có test này.
+    mockPanel([PEER]);
+    render(<OfficerDistributionPanel />);
+    const row = screen.getByRole("button", { name: /Kiên/ });
+
+    fireEvent.pointerEnter(row, { pointerType: "mouse" });
+    await settle(300);
+    expect(screen.getByText(DIAG)).toBeInTheDocument();
+
+    fireEvent.click(row); // bấm khi ĐANG mở do rê ⇒ chuyển thành ghim
+    await settle(0);
+    expect(screen.getByText(DIAG)).toBeInTheDocument();
+
+    fireEvent.pointerLeave(row, { pointerType: "mouse" });
+    await settle(600);
+    expect(screen.getByText(DIAG)).toBeInTheDocument(); // đã ghim ⇒ không đóng
+  });
+
+  // ⚠️ #1 (onCloseAutoFocus chặn cướp focus) KHÔNG có test ở đây: đã thử và
+  // xác nhận jsdom không mô phỏng focus-scope restore của Radix — test kiểu đó
+  // xanh CẢ khi gỡ fix (mutation test), tức vô giá trị. Đối xứng với
+  // onOpenAutoFocus (vốn hoạt động) là bằng chứng thiết kế; verify hành vi thật
+  // phải bằng Playwright/thao tác người thật, không phải jsdom.
+
+  it("CHỈ MỘT hàng mở: ghim A rồi rê B thì A tự đóng", async () => {
+    const DIAG_ME = "100/248 lead đã đóng tiền nên không bị tính.";
+    mockPanel([ME, PEER]);
+    render(<OfficerDistributionPanel />);
+
+    // Ghim hàng của mình (Hiền) bằng bấm.
+    fireEvent.click(screen.getByRole("button", { name: /Hiền: điểm bận/ }));
+    await settle(0);
+    expect(screen.getByText(DIAG_ME)).toBeInTheDocument();
+
+    // Rê sang Kiên: popover Kiên mở, Hiền PHẢI tự đóng (popover che nhau khi so).
+    fireEvent.pointerEnter(screen.getByRole("button", { name: /Kiên: điểm bận/ }), {
+      pointerType: "mouse",
+    });
+    await settle(300);
+    expect(screen.getByText(DIAG)).toBeInTheDocument();
+    expect(screen.queryByText(DIAG_ME)).not.toBeInTheDocument();
   });
 
   it("máy KHÔNG có chuột: rê không mở, mà chạm thì vẫn mở và giữ", async () => {

--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
@@ -10,9 +10,17 @@
  * Cách đọc thanh (trục chung 0–100% khả năng nhận, mọi người thẳng hàng):
  *   [ điểm bận ][ ưu tiên kỳ cựu ][ không tính ] …trống… ┊80%
  *   mép phải đoạn xanh dương = ĐIỂM BẬN · vạch cam = mức đem so vạch 80%
+ *
+ * Ba quyết định trình bày, xếp theo thứ tự người dùng cần:
+ *   1. Với officer, thứ HỌ làm được (`boost`, backend sinh) phải đọc được NGAY
+ *      trên mặt bảng — trước đây nó nằm ở đáy một popover phải bấm mới ra.
+ *   2. Mỗi con số trong bảng chi tiết đeo đúng màu của đoạn sinh ra nó, cộng
+ *      chính cái thanh đó lặp lại ở đầu popover: mắt nối được số ↔ đoạn.
+ *   3. Trục có nhãn hai đầu. Điểm bận là thang NGHỊCH (thấp = được chia nhiều),
+ *      không nói ra thì con số to trông như điểm thành tích.
  */
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -29,6 +37,24 @@ interface OfficerDistributionPanelProps {
   unitId?: number | null;
   className?: string;
 }
+
+// =============================================================================
+// NGỮ NGHĨA MÀU — nguồn DUY NHẤT
+// =============================================================================
+
+/**
+ * Đoạn thanh, chấm cạnh con số và ô chú thích PHẢI cùng đọc bảng này. Trước đây
+ * màu chỉ tồn tại ở thanh + legend, còn bảng chi tiết thì không — mở popover ra
+ * là mất dấu, người xem phải tự dò số nào ứng với đoạn nào.
+ */
+type SegKey = "sys" | "weight" | "skip" | "gate";
+
+const SEG_META: Record<SegKey, { bar: string; label: string }> = {
+  sys: { bar: "bg-primary", label: "Lead hệ thống tính" },
+  weight: { bar: "bg-info-500", label: "Ưu tiên kỳ cựu" },
+  skip: { bar: "bg-success-500", label: "Không tính" },
+  gate: { bar: "bg-warning-500", label: "Mức so ngưỡng" },
+};
 
 // Làm tròn 2 chữ số: hiệu hai số backend có thể sinh nhiễu dấu phẩy động
 // (28.5 − 14.3 = 14.200000000000001) làm width CSS xấu và test giòn.
@@ -65,37 +91,186 @@ function segmentsOf(e: OfficerDistributionEntry) {
   };
 }
 
+// =============================================================================
+// THANH ĐO — dùng chung cho hàng danh sách, thẻ "của bạn" và bảng chi tiết
+// =============================================================================
+
+/**
+ * @param highlight khi có, mọi đoạn KHÁC mờ đi. Dùng lúc người xem rê vào một
+ *   dòng số trong bảng chi tiết: đoạn sinh ra con số đó tự sáng lên.
+ */
+function LoadBar({
+  e,
+  highlight,
+  size = "sm",
+}: {
+  e: OfficerDistributionEntry;
+  highlight?: SegKey | null;
+  size?: "sm" | "lg";
+}) {
+  const seg = segmentsOf(e);
+  const dim = (k: SegKey) =>
+    highlight && highlight !== k ? "opacity-20" : "opacity-100";
+
+  return (
+    <span
+      className={cn(
+        "relative block rounded border bg-muted",
+        size === "lg" ? "h-8" : "h-6"
+      )}
+    >
+      <span className="absolute inset-0 flex overflow-hidden rounded">
+        {/* shrink-0: không cho flex co đoạn khi tổng chạm trần */}
+        <span
+          data-seg="sys"
+          className={cn(
+            "h-full shrink-0 transition-opacity",
+            SEG_META.sys.bar,
+            dim("sys")
+          )}
+          style={{ width: `${seg.sys}%` }}
+        />
+        <span
+          data-seg="weight"
+          className={cn(
+            "h-full shrink-0 transition-opacity",
+            SEG_META.weight.bar,
+            dim("weight")
+          )}
+          style={{ width: `${seg.weight}%` }}
+        />
+        <span
+          data-seg="skip"
+          className={cn(
+            "h-full shrink-0 transition-opacity",
+            SEG_META.skip.bar,
+            dim("skip")
+          )}
+          style={{ width: `${seg.skip}%` }}
+        />
+      </span>
+      {/* Ngưỡng tạm dừng 80% */}
+      <span
+        aria-hidden="true"
+        className="absolute -top-0.5 -bottom-0.5 border-l-2 border-dashed border-error-500"
+        style={{ left: "80%" }}
+      />
+      {/* Mốc dùng để SO với vạch 80% — đại lượng engine thật sự gate */}
+      <span
+        aria-hidden="true"
+        data-seg="gate"
+        className={cn(
+          "absolute -top-1 -bottom-1 w-0.5 rounded transition-opacity",
+          SEG_META.gate.bar,
+          dim("gate")
+        )}
+        style={{ left: `${seg.gate}%` }}
+      />
+      {/* Giữ nhiều hơn sức chứa: thanh đã kịch trần nên phải nói ra bằng dấu,
+          không thì 100% và 130% trông y hệt nhau. */}
+      {seg.overCapacity && (
+        <span
+          aria-hidden="true"
+          className="absolute right-0.5 top-1/2 -translate-y-1/2 text-[10px] font-bold leading-none text-background"
+        >
+          ›
+        </span>
+      )}
+    </span>
+  );
+}
+
+/** Nhãn hai đầu trục — nói thẳng chiều nghịch của thang điểm bận. */
+function AxisMeaning({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        // flex-wrap: hai vế đủ dài để tràn ở bề ngang điện thoại, thà xuống
+        // dòng còn hơn cắt mất chiều nghĩa của thang đo.
+        "flex flex-wrap items-center justify-between gap-x-3 text-[10px] text-muted-foreground",
+        className
+      )}
+    >
+      <span>← càng ít màu, càng được chia lead trước</span>
+      <span>đầy = tạm dừng chia →</span>
+    </span>
+  );
+}
+
+// =============================================================================
+// BẢNG CHI TIẾT (popover)
+// =============================================================================
+
 function LedgerRow({
   label,
   value,
+  seg,
   strong,
   muted,
+  onFocusSeg,
 }: {
   label: string;
   value: string;
+  seg?: SegKey;
   strong?: boolean;
   muted?: boolean;
+  onFocusSeg?: (k: SegKey | null) => void;
 }) {
+  const interactive = Boolean(seg && onFocusSeg);
+
   return (
-    <div className="flex items-baseline justify-between gap-4">
-      <span className={cn(muted && "text-muted-foreground")}>{label}</span>
+    <div
+      className={cn(
+        "-mx-1 flex items-baseline justify-between gap-4 rounded px-1",
+        interactive && "hover:bg-muted"
+      )}
+      onPointerEnter={
+        interactive ? () => onFocusSeg?.(seg as SegKey) : undefined
+      }
+      onPointerLeave={interactive ? () => onFocusSeg?.(null) : undefined}
+    >
+      <span
+        className={cn(
+          "flex items-baseline gap-1.5",
+          muted && "text-muted-foreground"
+        )}
+      >
+        {/* Chấm màu = cầu nối duy nhất giữa con số và đoạn trên thanh. */}
+        {seg && (
+          <span
+            aria-hidden="true"
+            data-swatch={seg}
+            className={cn(
+              "inline-block h-2 w-2 shrink-0 self-center rounded-sm",
+              SEG_META[seg].bar
+            )}
+          />
+        )}
+        <span>{label}</span>
+      </span>
       <span className={cn("tabular-nums", strong && "font-bold")}>{value}</span>
     </div>
   );
 }
 
 /**
- * Bảng chi tiết: phép tính bằng số thật + công thức + lời khuyên riêng.
+ * Bảng chi tiết: thanh của chính người đó + phép tính bằng số thật + lời khuyên.
  *
  * Export để test trực tiếp nội dung mà không phụ thuộc cơ chế mở của Radix.
  */
 export function EntryDetails({ e }: { e: OfficerDistributionEntry }) {
+  const [focusSeg, setFocusSeg] = useState<SegKey | null>(null);
+
   return (
     <div className="space-y-2 text-xs">
       <div>
         <p className="text-sm font-semibold">{e.full_name}</p>
         <p className="opacity-80">{e.archetype.label}</p>
       </div>
+
+      {/* Chính cái thanh ở hàng vừa mở, lặp lại tại đây: popover che mất hàng
+          gốc, không có nó thì người xem phải nhớ hình dạng thanh. */}
+      <LoadBar e={e} highlight={focusSeg} />
 
       <div className="space-y-1">
         <LedgerRow label="Lead đang giữ" value={String(e.workload)} />
@@ -109,18 +284,37 @@ export function EntryDetails({ e }: { e: OfficerDistributionEntry }) {
               : `− Không tính (tự tìm ${e.self_sourced} + đã đóng tiền ${e.tuition_hold})`
           }
           value={`−${e.deducted}`}
+          seg="skip"
           muted
+          onFocusSeg={setFocusSeg}
         />
-        <LedgerRow label="= Lead hệ thống tính" value={String(e.dist_load)} />
+        <LedgerRow
+          label="= Lead hệ thống tính"
+          value={String(e.dist_load)}
+          seg="sys"
+          onFocusSeg={setFocusSeg}
+        />
         <LedgerRow
           label="÷ Khả năng nhận"
           value={String(e.max_capacity)}
           muted
         />
         {e.weight > 1 && (
-          <LedgerRow label="÷ Ưu tiên kỳ cựu" value={`×${e.weight}`} muted />
+          <LedgerRow
+            label="÷ Ưu tiên kỳ cựu"
+            value={`×${e.weight}`}
+            seg="weight"
+            muted
+            onFocusSeg={setFocusSeg}
+          />
         )}
-        <LedgerRow label="Điểm bận" value={`${e.eff_util_pct}`} strong />
+        <LedgerRow
+          label="Điểm bận"
+          value={`${e.eff_util_pct}`}
+          seg="sys"
+          strong
+          onFocusSeg={setFocusSeg}
+        />
       </div>
 
       <div className="space-y-0.5 border-t pt-1.5 opacity-90">
@@ -131,7 +325,11 @@ export function EntryDetails({ e }: { e: OfficerDistributionEntry }) {
         <p className="tabular-nums">
           Chỗ đầy thật = {e.workload}/{e.max_capacity} = {e.fill_pct}%
         </p>
-        <p className="tabular-nums">
+        <p
+          className="tabular-nums"
+          onPointerEnter={() => setFocusSeg("gate")}
+          onPointerLeave={() => setFocusSeg(null)}
+        >
           Ngưỡng tạm dừng = ({e.workload}−{e.tuition_hold})/{e.max_capacity} ={" "}
           {e.overload_gate_pct}% (dừng khi ≥80%)
         </p>
@@ -145,7 +343,7 @@ export function EntryDetails({ e }: { e: OfficerDistributionEntry }) {
       {e.is_current_user && e.boost && (
         <div className="border-t pt-1.5">
           <p className="mb-0.5 font-semibold uppercase tracking-wide">
-            💡 Dành riêng cho bạn · 🔒 chỉ bạn thấy
+            💡 Việc của bạn · 🔒 chỉ bạn thấy
           </p>
           <p className="leading-relaxed">{e.boost}</p>
         </div>
@@ -154,22 +352,174 @@ export function EntryDetails({ e }: { e: OfficerDistributionEntry }) {
   );
 }
 
-function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
-  const seg = segmentsOf(e);
-  const dimmed = !e.eligible_for_assignment;
-  // ⚠️ Dùng Popover, KHÔNG dùng Tooltip: Radix Tooltip bỏ qua pointerType
-  // 'touch' và đóng ngay ở onPointerDown, nên trên điện thoại — đúng đường dùng
-  // thực địa của officer — toàn bộ nội dung sẽ không bao giờ mở được. Popover
-  // mở bằng bấm/chạm/bàn phím, phủ mọi thiết bị bằng MỘT đường duy nhất.
-  const [open, setOpen] = useState(false);
+// =============================================================================
+// THẺ "VIỆC CỦA BẠN" — lớp đọc được mà KHÔNG cần thao tác
+// =============================================================================
+
+/**
+ * Thẻ riêng cho chính người đang xem.
+ *
+ * Lý do tách khỏi danh sách: officer mở dashboard để biết "tôi cần làm gì", mà
+ * thứ trả lời câu đó (`boost`) trước đây nằm ở đáy một popover phải bấm mới ra
+ * — tức là gần như không ai đọc. Dòng của họ vẫn còn trong danh sách bên dưới,
+ * nhưng vai trò khác: để SO SÁNH với đồng nghiệp.
+ *
+ * 🔒 Chỉ render khi `is_current_user`. Admin/manager xem người khác không có
+ * thẻ này và không được thấy `boost` của bất kỳ ai.
+ */
+function YourCard({
+  e,
+  peersInUnit,
+}: {
+  e: OfficerDistributionEntry;
+  peersInUnit: number;
+}) {
+  // `rank` chỉ có nghĩa khi đơn vị thật sự chấm theo điểm bận VÀ người này đang
+  // trong pool: chế độ `legacy` xếp theo lượt nên in thứ hạng ở đây là nói sai
+  // cơ chế, còn người tắt nhận lead thì không nằm trong bảng xếp nào cả.
+  const showRank =
+    e.eligible_for_assignment && e.scoring_mode !== "legacy" && peersInUnit > 1;
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <div className="mb-4 rounded-lg border border-primary/40 bg-primary/5 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-primary">
+            Của bạn · {e.archetype.label}
+          </p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Điểm bận càng thấp, hệ thống càng chia lead cho bạn trước.
+          </p>
+        </div>
+        <div className="shrink-0 text-right">
+          <p className="text-2xl font-bold leading-none tabular-nums text-primary">
+            {e.eff_util_pct}
+          </p>
+          <p className="text-[10px] text-muted-foreground">điểm bận</p>
+        </div>
+      </div>
+
+      <div className="mt-2.5">
+        <LoadBar e={e} size="lg" />
+        <AxisMeaning className="mt-1" />
+      </div>
+
+      {showRank && (
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          Đang xếp thứ <b className="text-foreground">{e.rank}</b> trong{" "}
+          {peersInUnit} người của đơn vị — thứ tự này quyết định ai được chia
+          trước.
+        </p>
+      )}
+
+      {/* 🔒 Giữ cả `is_current_user` dù caller đã lọc: thẻ này là chỗ DUY NHẤT
+          lời khuyên hiện ra mà không cần thao tác, nên điều kiện phải đứng ngay
+          tại điểm render — không phụ thuộc chỗ gọi chọn đúng entry. */}
+      {e.is_current_user && e.boost && (
+        <div className="mt-2.5 border-t pt-2">
+          <p className="text-[11px] font-semibold uppercase tracking-wide">
+            Việc của bạn
+          </p>
+          <p className="mt-0.5 text-xs leading-relaxed">{e.boost}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// =============================================================================
+// HÀNG DANH SÁCH
+// =============================================================================
+
+const HOVER_OPEN_MS = 160;
+const HOVER_CLOSE_MS = 140;
+
+/**
+ * Mở bảng chi tiết bằng RÊ CHUỘT trên máy để bàn, giữ nguyên bấm/chạm ở mọi nơi
+ * khác.
+ *
+ * ⚠️ Vẫn là Popover, KHÔNG đổi sang Tooltip: Radix Tooltip bỏ qua pointerType
+ * 'touch' và đóng ngay ở onPointerDown, nên trên điện thoại — đúng đường dùng
+ * thực địa của officer — nội dung sẽ không bao giờ mở được. Hover ở đây chỉ là
+ * lớp tăng tiến, chặn bằng `(hover: hover) and (pointer: fine)` để máy cảm ứng
+ * và bút không kích hoạt nhầm rồi popover tự đóng ngay khi ngón tay rời.
+ */
+function useHoverIntent(
+  setOpen: (v: boolean) => void,
+  pinnedRef: React.RefObject<boolean>
+) {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clear = useCallback(() => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  }, []);
+
+  // Không dọn timer khi unmount thì setOpen chạy trên component đã tháo.
+  useEffect(() => clear, [clear]);
+
+  const canHover = () =>
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+
+  const schedule =
+    (open: boolean, delay: number) => (ev: React.PointerEvent) => {
+      if (ev.pointerType === "touch" || ev.pointerType === "pen") return;
+      if (!canHover()) return;
+      clear();
+      timer.current = setTimeout(() => {
+        // ⚠️ Đọc cờ ghim TẠI LÚC CHẠY, không phải lúc đặt hẹn: người dùng có
+        // thể bấm ghim trong khoảng chờ. Đọc qua state sẽ dính giá trị cũ.
+        if (!open && pinnedRef.current) return;
+        setOpen(open);
+      }, delay);
+    };
+
+  return {
+    open: schedule(true, HOVER_OPEN_MS),
+    close: schedule(false, HOVER_CLOSE_MS),
+    clear,
+  };
+}
+
+function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
+  const dimmed = !e.eligible_for_assignment;
+  const [open, setOpen] = useState(false);
+  // GHIM = mở bằng bấm/chạm. Bảng này dài (10 dòng số + lời khuyên) nên người
+  // đọc phải được rời chuột mà nó không biến mất — chỉ bản mở-bằng-rê mới tự
+  // đóng. Dùng ref vì hẹn giờ hover đọc cờ ở tương lai, state sẽ stale.
+  const pinnedRef = useRef(false);
+  const hover = useHoverIntent(setOpen, pinnedRef);
+
+  const handleOpenChange = (v: boolean) => {
+    if (!v) pinnedRef.current = false;
+    setOpen(v);
+  };
+
+  const handleClick = (ev: React.MouseEvent) => {
+    if (open && !pinnedRef.current) {
+      // Đang mở do rê chuột: cú bấm này có nghĩa "giữ lại", không phải "đóng".
+      // preventDefault chặn Radix toggle (composeEventHandlers tôn trọng nó).
+      ev.preventDefault();
+      pinnedRef.current = true;
+      return;
+    }
+    pinnedRef.current = !open;
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <button
           type="button"
           aria-expanded={open}
           aria-label={`${e.full_name}: điểm bận ${e.eff_util_pct} trên 100, đang giữ ${e.workload} trên ${e.max_capacity} lead`}
+          onClick={handleClick}
+          onPointerEnter={hover.open}
+          onPointerLeave={hover.close}
           className={cn(
             "grid w-full grid-cols-[minmax(96px,140px)_1fr_36px] items-center gap-3 rounded-md px-1 py-2 text-left",
             "hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -194,35 +544,7 @@ function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
           </span>
 
           {/* Thanh đo — trục chung 0–100% khả năng nhận */}
-          <span className="relative block h-6 rounded border bg-muted">
-            <span className="absolute inset-0 flex overflow-hidden rounded">
-              {/* shrink-0: không cho flex co đoạn khi tổng chạm trần */}
-              <span
-                className="h-full shrink-0 bg-primary"
-                style={{ width: `${seg.sys}%` }}
-              />
-              <span
-                className="h-full shrink-0 bg-info-500"
-                style={{ width: `${seg.weight}%` }}
-              />
-              <span
-                className="h-full shrink-0 bg-success-500"
-                style={{ width: `${seg.skip}%` }}
-              />
-            </span>
-            {/* Ngưỡng tạm dừng 80% */}
-            <span
-              aria-hidden="true"
-              className="absolute -top-0.5 -bottom-0.5 border-l-2 border-dashed border-error-500"
-              style={{ left: "80%" }}
-            />
-            {/* Mốc dùng để SO với vạch 80% — đại lượng engine thật sự gate */}
-            <span
-              aria-hidden="true"
-              className="absolute -top-1 -bottom-1 w-0.5 rounded bg-warning-500"
-              style={{ left: `${seg.gate}%` }}
-            />
-          </span>
+          <LoadBar e={e} />
 
           {/* Điểm bận */}
           <span className="text-right text-base font-bold tabular-nums text-primary">
@@ -236,6 +558,9 @@ function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
         className="max-w-[340px] text-xs"
         // Nội dung chỉ để ĐỌC — đừng cướp focus khỏi hàng vừa bấm.
         onOpenAutoFocus={(ev) => ev.preventDefault()}
+        // Rê từ hàng sang chính bảng chi tiết không được làm nó đóng.
+        onPointerEnter={hover.clear}
+        onPointerLeave={hover.close}
       >
         <EntryDetails e={e} />
       </PopoverContent>
@@ -317,17 +642,14 @@ function EntryList({ entries }: { entries: OfficerDistributionEntry[] }) {
   );
 }
 
-function LegendSwatch({
-  className,
-  label,
-}: {
-  className: string;
-  label: string;
-}) {
+function LegendSwatch({ seg }: { seg: SegKey }) {
   return (
     <span className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
-      <span className={cn("inline-block h-3 w-3 rounded-sm", className)} />
-      {label}
+      <span
+        aria-hidden="true"
+        className={cn("inline-block h-3 w-3 rounded-sm", SEG_META[seg].bar)}
+      />
+      {SEG_META[seg].label}
     </span>
   );
 }
@@ -338,23 +660,32 @@ export function OfficerDistributionPanel({
 }: OfficerDistributionPanelProps) {
   const { data, isLoading, error } = useOfficerDistribution({ unitId });
 
+  const entries = data?.entries ?? [];
+  const me = entries.find((e) => e.is_current_user) ?? null;
+  // Số người CÙNG ĐƠN VỊ với mình — thứ hạng chỉ so được trong phạm vi đó.
+  const peersInUnit = me
+    ? entries.filter((e) => e.unit_id === me.unit_id).length
+    : 0;
+
   return (
     <Card className={className}>
       <CardHeader className="pb-3">
-        <CardTitle className="text-base">Vì sao bạn được chia lead</CardTitle>
+        {/* Admin/manager không có dòng nào là của mình ⇒ xưng "bạn" là sai đối
+            tượng: với họ đây là bảng giám sát cả đơn vị. */}
+        <CardTitle className="text-base">
+          {me
+            ? "Vì sao bạn được chia lead"
+            : "Vì sao hệ thống chia lead cho từng người"}
+        </CardTitle>
         <p className="text-xs text-muted-foreground">
-          Điểm bận (0–100): càng thấp càng được chia nhiều. Bấm vào từng người để
-          xem phép tính đầy đủ.
+          Điểm bận (0–100): càng thấp càng được chia nhiều. Rê chuột hoặc bấm vào
+          từng người để xem phép tính đầy đủ.
         </p>
         <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1">
-          <LegendSwatch className="bg-primary" label="Điểm bận" />
-          <LegendSwatch className="bg-info-500" label="Ưu tiên kỳ cựu" />
-          <LegendSwatch className="bg-success-500" label="Không tính" />
-          <LegendSwatch className="bg-warning-500" label="Mức so ngưỡng" />
-          <LegendSwatch
-            className="border-l-2 border-dashed border-error-500 bg-transparent"
-            label="Ngưỡng tạm dừng 80%"
-          />
+          <LegendSwatch seg="sys" />
+          <LegendSwatch seg="weight" />
+          <LegendSwatch seg="skip" />
+          <LegendSwatch seg="gate" />
         </div>
       </CardHeader>
 
@@ -373,14 +704,22 @@ export function OfficerDistributionPanel({
           </p>
         )}
 
-        {!isLoading && !error && data && data.entries.length === 0 && (
+        {!isLoading && !error && data && entries.length === 0 && (
           <p className="py-6 text-center text-sm text-muted-foreground">
             Chưa có nhân viên nào trong phạm vi này.
           </p>
         )}
 
-        {!isLoading && !error && data && data.entries.length > 0 && (
+        {!isLoading && !error && data && entries.length > 0 && (
           <>
+            {me && <YourCard e={me} peersInUnit={peersInUnit} />}
+
+            {me && entries.length > 1 && (
+              <p className="px-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                So với đồng nghiệp
+              </p>
+            )}
+
             {/* Trục chung — thẳng hàng với vùng thanh của mọi dòng */}
             <div
               aria-hidden="true"
@@ -399,7 +738,7 @@ export function OfficerDistributionPanel({
             </div>
 
             {(() => {
-              const groups = groupByUnit(data.entries);
+              const groups = groupByUnit(entries);
               const multiUnit = groups.length > 1;
               return (
                 <>
@@ -431,7 +770,10 @@ export function OfficerDistributionPanel({
                     )
                   )}
                   {groups.map((g) => (
-                    <div key={g.key} className={multiUnit ? "mt-4 first:mt-0" : undefined}>
+                    <div
+                      key={g.key}
+                      className={multiUnit ? "mt-4 first:mt-0" : undefined}
+                    >
                       {multiUnit && (
                         <div className="flex flex-wrap items-baseline gap-x-2 border-b px-1 pb-1">
                           <span className="text-sm font-semibold">
@@ -451,6 +793,10 @@ export function OfficerDistributionPanel({
                       <EntryList entries={g.entries} />
                     </div>
                   ))}
+                  {/* Nhãn chiều thang đặt SAU danh sách cho người KHÔNG có thẻ
+                      "của bạn" (admin/manager): họ vẫn phải biết ít màu là rảnh,
+                      nhưng thông tin đó không đáng chiếm đầu bảng. */}
+                  {!me && <AxisMeaning className="mt-2 px-1" />}
                 </>
               );
             })()}

--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
@@ -613,6 +613,27 @@ function groupByUnit(entries: OfficerDistributionEntry[]) {
   return Array.from(map.values());
 }
 
+/**
+ * Tên hiển thị của một nhóm đơn vị.
+ *
+ * ⚠️ Prod CÓ hai đơn vị khác id nhưng TRÙNG TÊN ("Phòng Tuyển Sinh"). Với admin
+ * (phạm vi toàn tổ chức) chúng nằm cạnh nhau thành hai khối giống hệt nhau —
+ * người xem không biết khối nào là đơn vị nào, mà điểm bận thì chỉ so được
+ * trong CÙNG một đơn vị. Chỉ gắn thêm id khi thật sự trùng, để trường hợp
+ * thường không phải mang một con số kỹ thuật vô ích.
+ */
+function unitLabel(
+  g: { unitId: number | null; unitName: string | null },
+  duplicated: boolean
+) {
+  if (g.unitName == null) {
+    return g.unitId != null ? `Đơn vị #${g.unitId}` : "Chưa gán đơn vị";
+  }
+  return duplicated && g.unitId != null
+    ? `${g.unitName} #${g.unitId}`
+    : g.unitName;
+}
+
 /** Danh sách trong MỘT đơn vị: nhóm đang nhận trước, nhóm ngoài luồng sau. */
 function EntryList({ entries }: { entries: OfficerDistributionEntry[] }) {
   const eligible = entries.filter((e) => e.eligible_for_assignment);
@@ -732,7 +753,9 @@ export function OfficerDistributionPanel({
                 <span className="absolute left-[80%] -translate-x-1/2 font-semibold text-error-500">
                   80%
                 </span>
-                <span className="absolute right-0">100%</span>
+                {/* KHÔNG in nhãn "100%": ở bề ngang điện thoại nó đè lên nhãn
+                    80% (mốc quan trọng nhất — ngưỡng tạm dừng). Mép phải thanh
+                    đã có viền, hết trục là 100% không cần nói. */}
               </span>
               <span />
             </div>
@@ -740,6 +763,11 @@ export function OfficerDistributionPanel({
             {(() => {
               const groups = groupByUnit(entries);
               const multiUnit = groups.length > 1;
+              const nameSeen = new Map<string, number>();
+              for (const g of groups) {
+                if (g.unitName == null) continue;
+                nameSeen.set(g.unitName, (nameSeen.get(g.unitName) ?? 0) + 1);
+              }
               return (
                 <>
                   {multiUnit ? (
@@ -777,10 +805,11 @@ export function OfficerDistributionPanel({
                       {multiUnit && (
                         <div className="flex flex-wrap items-baseline gap-x-2 border-b px-1 pb-1">
                           <span className="text-sm font-semibold">
-                            {g.unitName ??
-                              (g.unitId != null
-                                ? `Đơn vị #${g.unitId}`
-                                : "Chưa gán đơn vị")}
+                            {unitLabel(
+                              g,
+                              g.unitName != null &&
+                                (nameSeen.get(g.unitName) ?? 0) > 1
+                            )}
                           </span>
                           <span className="text-[11px] text-muted-foreground">
                             {g.entries.length} người

--- a/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
+++ b/frontend/src/components/officer/dashboard/OfficerDistributionPanel.tsx
@@ -20,15 +20,11 @@
  *      không nói ra thì con số to trông như điểm thành tích.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useOfficerDistribution } from "@/hooks/officer/useOfficerDistribution";
 import type { OfficerDistributionEntry } from "@/lib/zod/officer";
 import { cn } from "@/lib/utils";
@@ -58,8 +54,7 @@ const SEG_META: Record<SegKey, { bar: string; label: string }> = {
 
 // Làm tròn 2 chữ số: hiệu hai số backend có thể sinh nhiễu dấu phẩy động
 // (28.5 − 14.3 = 14.200000000000001) làm width CSS xấu và test giòn.
-const clamp = (n: number) =>
-  Math.round(Math.max(0, Math.min(100, n)) * 100) / 100;
+const clamp = (n: number) => Math.round(Math.max(0, Math.min(100, n)) * 100) / 100;
 
 /**
  * Ba đoạn của thanh, tính THUẦN từ số backend trả (không suy diễn thêm).
@@ -72,12 +67,8 @@ const clamp = (n: number) =>
  */
 function segmentsOf(e: OfficerDistributionEntry) {
   const sys = clamp(e.eff_util_pct);
-  const weight = clamp(
-    Math.min(Math.max(0, e.real_util_pct - e.eff_util_pct), 100 - sys)
-  );
-  const skip = clamp(
-    Math.min(Math.max(0, e.fill_pct - e.real_util_pct), 100 - sys - weight)
-  );
+  const weight = clamp(Math.min(Math.max(0, e.real_util_pct - e.eff_util_pct), 100 - sys));
+  const skip = clamp(Math.min(Math.max(0, e.fill_pct - e.real_util_pct), 100 - sys - weight));
   return {
     sys,
     weight,
@@ -109,50 +100,32 @@ function LoadBar({
   size?: "sm" | "lg";
 }) {
   const seg = segmentsOf(e);
-  const dim = (k: SegKey) =>
-    highlight && highlight !== k ? "opacity-20" : "opacity-100";
+  const dim = (k: SegKey) => (highlight && highlight !== k ? "opacity-20" : "opacity-100");
 
   return (
-    <span
-      className={cn(
-        "relative block rounded border bg-muted",
-        size === "lg" ? "h-8" : "h-6"
-      )}
-    >
+    <span className={cn("relative block rounded border bg-muted", size === "lg" ? "h-8" : "h-6")}>
       <span className="absolute inset-0 flex overflow-hidden rounded">
         {/* shrink-0: không cho flex co đoạn khi tổng chạm trần */}
         <span
           data-seg="sys"
-          className={cn(
-            "h-full shrink-0 transition-opacity",
-            SEG_META.sys.bar,
-            dim("sys")
-          )}
+          className={cn("h-full shrink-0 transition-opacity", SEG_META.sys.bar, dim("sys"))}
           style={{ width: `${seg.sys}%` }}
         />
         <span
           data-seg="weight"
-          className={cn(
-            "h-full shrink-0 transition-opacity",
-            SEG_META.weight.bar,
-            dim("weight")
-          )}
+          className={cn("h-full shrink-0 transition-opacity", SEG_META.weight.bar, dim("weight"))}
           style={{ width: `${seg.weight}%` }}
         />
         <span
           data-seg="skip"
-          className={cn(
-            "h-full shrink-0 transition-opacity",
-            SEG_META.skip.bar,
-            dim("skip")
-          )}
+          className={cn("h-full shrink-0 transition-opacity", SEG_META.skip.bar, dim("skip"))}
           style={{ width: `${seg.skip}%` }}
         />
       </span>
       {/* Ngưỡng tạm dừng 80% */}
       <span
         aria-hidden="true"
-        className="absolute -top-0.5 -bottom-0.5 border-l-2 border-dashed border-error-500"
+        className="absolute -bottom-0.5 -top-0.5 border-l-2 border-dashed border-error-500"
         style={{ left: "80%" }}
       />
       {/* Mốc dùng để SO với vạch 80% — đại lượng engine thật sự gate */}
@@ -160,7 +133,7 @@ function LoadBar({
         aria-hidden="true"
         data-seg="gate"
         className={cn(
-          "absolute -top-1 -bottom-1 w-0.5 rounded transition-opacity",
+          "absolute -bottom-1 -top-1 w-0.5 rounded transition-opacity",
           SEG_META.gate.bar,
           dim("gate")
         )}
@@ -224,17 +197,10 @@ function LedgerRow({
         "-mx-1 flex items-baseline justify-between gap-4 rounded px-1",
         interactive && "hover:bg-muted"
       )}
-      onPointerEnter={
-        interactive ? () => onFocusSeg?.(seg as SegKey) : undefined
-      }
+      onPointerEnter={interactive ? () => onFocusSeg?.(seg as SegKey) : undefined}
       onPointerLeave={interactive ? () => onFocusSeg?.(null) : undefined}
     >
-      <span
-        className={cn(
-          "flex items-baseline gap-1.5",
-          muted && "text-muted-foreground"
-        )}
-      >
+      <span className={cn("flex items-baseline gap-1.5", muted && "text-muted-foreground")}>
         {/* Chấm màu = cầu nối duy nhất giữa con số và đoạn trên thanh. */}
         {seg && (
           <span
@@ -294,11 +260,7 @@ export function EntryDetails({ e }: { e: OfficerDistributionEntry }) {
           seg="sys"
           onFocusSeg={setFocusSeg}
         />
-        <LedgerRow
-          label="÷ Khả năng nhận"
-          value={String(e.max_capacity)}
-          muted
-        />
+        <LedgerRow label="÷ Khả năng nhận" value={String(e.max_capacity)} muted />
         {e.weight > 1 && (
           <LedgerRow
             label="÷ Ưu tiên kỳ cựu"
@@ -319,8 +281,7 @@ export function EntryDetails({ e }: { e: OfficerDistributionEntry }) {
 
       <div className="space-y-0.5 border-t pt-1.5 opacity-90">
         <p className="tabular-nums">
-          Điểm bận = {e.dist_load} ÷ ({e.max_capacity}×{e.weight}) ×100 ={" "}
-          {e.eff_util_pct}
+          Điểm bận = {e.dist_load} ÷ ({e.max_capacity}×{e.weight}) ×100 = {e.eff_util_pct}
         </p>
         <p className="tabular-nums">
           Chỗ đầy thật = {e.workload}/{e.max_capacity} = {e.fill_pct}%
@@ -330,8 +291,8 @@ export function EntryDetails({ e }: { e: OfficerDistributionEntry }) {
           onPointerEnter={() => setFocusSeg("gate")}
           onPointerLeave={() => setFocusSeg(null)}
         >
-          Ngưỡng tạm dừng = ({e.workload}−{e.tuition_hold})/{e.max_capacity} ={" "}
-          {e.overload_gate_pct}% (dừng khi ≥80%)
+          Ngưỡng tạm dừng = ({e.workload}−{e.tuition_hold})/{e.max_capacity} = {e.overload_gate_pct}
+          % (dừng khi ≥80%)
         </p>
       </div>
 
@@ -367,21 +328,14 @@ export function EntryDetails({ e }: { e: OfficerDistributionEntry }) {
  * 🔒 Chỉ render khi `is_current_user`. Admin/manager xem người khác không có
  * thẻ này và không được thấy `boost` của bất kỳ ai.
  */
-function YourCard({
-  e,
-  peersInUnit,
-}: {
-  e: OfficerDistributionEntry;
-  peersInUnit: number;
-}) {
+function YourCard({ e, peersInUnit }: { e: OfficerDistributionEntry; peersInUnit: number }) {
   // `rank` chỉ có nghĩa khi đơn vị thật sự chấm theo điểm bận VÀ người này đang
   // trong pool: chế độ `legacy` xếp theo lượt nên in thứ hạng ở đây là nói sai
   // cơ chế, còn người tắt nhận lead thì không nằm trong bảng xếp nào cả.
-  const showRank =
-    e.eligible_for_assignment && e.scoring_mode !== "legacy" && peersInUnit > 1;
+  const showRank = e.eligible_for_assignment && e.scoring_mode !== "legacy" && peersInUnit > 1;
 
   return (
-    <div className="mb-4 rounded-lg border border-primary/40 bg-primary/5 p-3">
+    <div className="border-primary/40 bg-primary/5 mb-4 rounded-lg border p-3">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <p className="text-[11px] font-semibold uppercase tracking-wide text-primary">
@@ -392,7 +346,7 @@ function YourCard({
           </p>
         </div>
         <div className="shrink-0 text-right">
-          <p className="text-2xl font-bold leading-none tabular-nums text-primary">
+          <p className="text-2xl font-bold tabular-nums leading-none text-primary">
             {e.eff_util_pct}
           </p>
           <p className="text-[10px] text-muted-foreground">điểm bận</p>
@@ -406,9 +360,8 @@ function YourCard({
 
       {showRank && (
         <p className="mt-2 text-[11px] text-muted-foreground">
-          Đang xếp thứ <b className="text-foreground">{e.rank}</b> trong{" "}
-          {peersInUnit} người của đơn vị — thứ tự này quyết định ai được chia
-          trước.
+          Đang xếp thứ <b className="text-foreground">{e.rank}</b> trong {peersInUnit} người của đơn
+          vị — thứ tự này quyết định ai được chia trước.
         </p>
       )}
 
@@ -417,8 +370,12 @@ function YourCard({
           tại điểm render — không phụ thuộc chỗ gọi chọn đúng entry. */}
       {e.is_current_user && e.boost && (
         <div className="mt-2.5 border-t pt-2">
+          {/* 🔒 PHẢI giữ dấu bảo mật ở đây: thẻ này là chỗ lời khuyên hiện ra
+              NỔI BẬT NHẤT, trên đúng cái bảng mọi đồng nghiệp cùng xem — mất
+              tín hiệu "riêng tư" ở nơi riêng tư nhất là sai chỗ nhất. */}
           <p className="text-[11px] font-semibold uppercase tracking-wide">
-            Việc của bạn
+            Việc của bạn{" "}
+            <span className="font-normal normal-case text-muted-foreground">· 🔒 chỉ bạn thấy</span>
           </p>
           <p className="mt-0.5 text-xs leading-relaxed">{e.boost}</p>
         </div>
@@ -435,6 +392,18 @@ const HOVER_OPEN_MS = 160;
 const HOVER_CLOSE_MS = 140;
 
 /**
+ * Hàng đang mở bảng chi tiết trong CẢ panel (theo user_id, null = không có).
+ *
+ * ⚠️ Bảng này tồn tại để SO SÁNH, mà popover che khuất các hàng khác — nên mở
+ * cái này phải đóng cái kia. Trước đây mỗi hàng giữ open riêng ⇒ ghim A rồi rê
+ * B làm hai popover chồng lên nhau, phản đúng ý đồ. Điều phối tập trung ở đây.
+ */
+const OpenRowContext = createContext<{
+  openId: number | null;
+  setOpenId: (id: number | null) => void;
+}>({ openId: null, setOpenId: () => {} });
+
+/**
  * Mở bảng chi tiết bằng RÊ CHUỘT trên máy để bàn, giữ nguyên bấm/chạm ở mọi nơi
  * khác.
  *
@@ -444,10 +413,7 @@ const HOVER_CLOSE_MS = 140;
  * lớp tăng tiến, chặn bằng `(hover: hover) and (pointer: fine)` để máy cảm ứng
  * và bút không kích hoạt nhầm rồi popover tự đóng ngay khi ngón tay rời.
  */
-function useHoverIntent(
-  setOpen: (v: boolean) => void,
-  pinnedRef: React.RefObject<boolean>
-) {
+function useHoverIntent(setOpen: (v: boolean) => void, pinnedRef: React.RefObject<boolean>) {
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clear = useCallback(() => {
@@ -465,18 +431,17 @@ function useHoverIntent(
     typeof window.matchMedia === "function" &&
     window.matchMedia("(hover: hover) and (pointer: fine)").matches;
 
-  const schedule =
-    (open: boolean, delay: number) => (ev: React.PointerEvent) => {
-      if (ev.pointerType === "touch" || ev.pointerType === "pen") return;
-      if (!canHover()) return;
-      clear();
-      timer.current = setTimeout(() => {
-        // ⚠️ Đọc cờ ghim TẠI LÚC CHẠY, không phải lúc đặt hẹn: người dùng có
-        // thể bấm ghim trong khoảng chờ. Đọc qua state sẽ dính giá trị cũ.
-        if (!open && pinnedRef.current) return;
-        setOpen(open);
-      }, delay);
-    };
+  const schedule = (open: boolean, delay: number) => (ev: React.PointerEvent) => {
+    if (ev.pointerType === "touch" || ev.pointerType === "pen") return;
+    if (!canHover()) return;
+    clear();
+    timer.current = setTimeout(() => {
+      // ⚠️ Đọc cờ ghim TẠI LÚC CHẠY, không phải lúc đặt hẹn: người dùng có
+      // thể bấm ghim trong khoảng chờ. Đọc qua state sẽ dính giá trị cũ.
+      if (!open && pinnedRef.current) return;
+      setOpen(open);
+    }, delay);
+  };
 
   return {
     open: schedule(true, HOVER_OPEN_MS),
@@ -487,12 +452,30 @@ function useHoverIntent(
 
 function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
   const dimmed = !e.eligible_for_assignment;
-  const [open, setOpen] = useState(false);
+  // Open state SỐNG Ở PANEL (một hàng mở tại một thời điểm). Hàng này mở ⇔
+  // openId trỏ đúng nó.
+  const { openId, setOpenId } = useContext(OpenRowContext);
+  const open = openId === e.user_id;
+
+  const setOpen = useCallback(
+    (v: boolean) => {
+      setOpenId(v ? e.user_id : null);
+    },
+    [e.user_id, setOpenId]
+  );
+
   // GHIM = mở bằng bấm/chạm. Bảng này dài (10 dòng số + lời khuyên) nên người
   // đọc phải được rời chuột mà nó không biến mất — chỉ bản mở-bằng-rê mới tự
   // đóng. Dùng ref vì hẹn giờ hover đọc cờ ở tương lai, state sẽ stale.
   const pinnedRef = useRef(false);
   const hover = useHoverIntent(setOpen, pinnedRef);
+
+  // Khi hàng này đóng vì BẤT KỲ lý do gì — kể cả một hàng KHÁC được mở làm
+  // openId đổi (Radix KHÔNG phát onOpenChange trong trường hợp đó) — phải bỏ
+  // ghim, không thì lần rê sau tưởng vẫn đang ghim và từ chối tự đóng.
+  useEffect(() => {
+    if (!open) pinnedRef.current = false;
+  }, [open]);
 
   const handleOpenChange = (v: boolean) => {
     if (!v) pinnedRef.current = false;
@@ -529,9 +512,7 @@ function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
           {/* Tên + nhãn kiểu */}
           <span className="min-w-0">
             <span className="flex items-center gap-1.5">
-              <span className="truncate text-sm font-medium">
-                {e.full_name}
-              </span>
+              <span className="truncate text-sm font-medium">{e.full_name}</span>
               {e.is_current_user && (
                 <span className="shrink-0 rounded border border-primary px-1 text-[9px] font-bold text-primary">
                   BẠN
@@ -558,6 +539,12 @@ function OfficerRow({ e }: { e: OfficerDistributionEntry }) {
         className="max-w-[340px] text-xs"
         // Nội dung chỉ để ĐỌC — đừng cướp focus khỏi hàng vừa bấm.
         onOpenAutoFocus={(ev) => ev.preventDefault()}
+        // ⚠️ PHẢI chặn CẢ đóng: hover-mở khiến popover có thể mở khi con trỏ
+        // đang ở NƠI KHÁC (đang gõ ô tìm kiếm). Mặc định Radix giật focus về
+        // nút hàng khi đóng ⇒ nuốt ký tự người dùng đang gõ và có thể kéo cuộn.
+        // Focus chỉ nên nhảy về trigger khi chính người dùng đóng bằng bàn phím
+        // — nhưng ta không mở bằng bàn phím tự động nên chặn là an toàn.
+        onCloseAutoFocus={(ev) => ev.preventDefault()}
         // Rê từ hàng sang chính bảng chi tiết không được làm nó đóng.
         onPointerEnter={hover.clear}
         onPointerLeave={hover.close}
@@ -622,16 +609,11 @@ function groupByUnit(entries: OfficerDistributionEntry[]) {
  * trong CÙNG một đơn vị. Chỉ gắn thêm id khi thật sự trùng, để trường hợp
  * thường không phải mang một con số kỹ thuật vô ích.
  */
-function unitLabel(
-  g: { unitId: number | null; unitName: string | null },
-  duplicated: boolean
-) {
+function unitLabel(g: { unitId: number | null; unitName: string | null }, duplicated: boolean) {
   if (g.unitName == null) {
     return g.unitId != null ? `Đơn vị #${g.unitId}` : "Chưa gán đơn vị";
   }
-  return duplicated && g.unitId != null
-    ? `${g.unitName} #${g.unitId}`
-    : g.unitName;
+  return duplicated && g.unitId != null ? `${g.unitName} #${g.unitId}` : g.unitName;
 }
 
 /** Danh sách trong MỘT đơn vị: nhóm đang nhận trước, nhóm ngoài luồng sau. */
@@ -675,163 +657,164 @@ function LegendSwatch({ seg }: { seg: SegKey }) {
   );
 }
 
-export function OfficerDistributionPanel({
-  unitId,
-  className,
-}: OfficerDistributionPanelProps) {
+export function OfficerDistributionPanel({ unitId, className }: OfficerDistributionPanelProps) {
   const { data, isLoading, error } = useOfficerDistribution({ unitId });
 
   const entries = data?.entries ?? [];
   const me = entries.find((e) => e.is_current_user) ?? null;
   // Số người CÙNG ĐƠN VỊ với mình — thứ hạng chỉ so được trong phạm vi đó.
-  const peersInUnit = me
-    ? entries.filter((e) => e.unit_id === me.unit_id).length
-    : 0;
+  const peersInUnit = me ? entries.filter((e) => e.unit_id === me.unit_id).length : 0;
+
+  // Điều phối "chỉ một hàng mở" cho TOÀN panel (xem OpenRowContext).
+  const [openId, setOpenId] = useState<number | null>(null);
 
   return (
-    <Card className={className}>
-      <CardHeader className="pb-3">
-        {/* Admin/manager không có dòng nào là của mình ⇒ xưng "bạn" là sai đối
+    <OpenRowContext.Provider value={{ openId, setOpenId }}>
+      <Card className={className}>
+        <CardHeader className="pb-3">
+          {/* Admin/manager không có dòng nào là của mình ⇒ xưng "bạn" là sai đối
             tượng: với họ đây là bảng giám sát cả đơn vị. */}
-        <CardTitle className="text-base">
-          {me
-            ? "Vì sao bạn được chia lead"
-            : "Vì sao hệ thống chia lead cho từng người"}
-        </CardTitle>
-        <p className="text-xs text-muted-foreground">
-          Điểm bận (0–100): càng thấp càng được chia nhiều. Rê chuột hoặc bấm vào
-          từng người để xem phép tính đầy đủ.
-        </p>
-        <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1">
-          <LegendSwatch seg="sys" />
-          <LegendSwatch seg="weight" />
-          <LegendSwatch seg="skip" />
-          <LegendSwatch seg="gate" />
-        </div>
-      </CardHeader>
-
-      <CardContent>
-        {isLoading && (
-          <div className="space-y-2">
-            {[0, 1, 2, 3].map((i) => (
-              <Skeleton key={i} className="h-10 w-full" />
-            ))}
+          <CardTitle className="text-base">
+            {me ? "Vì sao bạn được chia lead" : "Vì sao hệ thống chia lead cho từng người"}
+          </CardTitle>
+          <p className="text-xs text-muted-foreground">
+            Điểm bận (0–100): càng thấp càng được chia nhiều. Rê chuột hoặc bấm vào từng người để
+            xem phép tính đầy đủ.
+          </p>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1">
+            <LegendSwatch seg="sys" />
+            <LegendSwatch seg="weight" />
+            <LegendSwatch seg="skip" />
+            <LegendSwatch seg="gate" />
+            {/* Vạch đỏ đứt được vẽ trên MỌI thanh (LoadBar) nên PHẢI có mục chú
+              thích — bỏ nó đi thì người xem thấy một vạch đỏ vô danh, đúng cái
+              "nhầm 4 đại lượng %" bảng này có tiền sử. */}
+            <span className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
+              <span
+                aria-hidden="true"
+                className="inline-block h-3 w-0 border-l-2 border-dashed border-error-500"
+              />
+              Ngưỡng tạm dừng 80%
+            </span>
           </div>
-        )}
+        </CardHeader>
 
-        {!isLoading && error && (
-          <p className="py-6 text-center text-sm text-muted-foreground">
-            Không tải được bảng điểm bận. Thử lại sau.
-          </p>
-        )}
+        <CardContent>
+          {isLoading && (
+            <div className="space-y-2">
+              {[0, 1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          )}
 
-        {!isLoading && !error && data && entries.length === 0 && (
-          <p className="py-6 text-center text-sm text-muted-foreground">
-            Chưa có nhân viên nào trong phạm vi này.
-          </p>
-        )}
+          {!isLoading && error && (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              Không tải được bảng điểm bận. Thử lại sau.
+            </p>
+          )}
 
-        {!isLoading && !error && data && entries.length > 0 && (
-          <>
-            {me && <YourCard e={me} peersInUnit={peersInUnit} />}
+          {!isLoading && !error && data && entries.length === 0 && (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              Chưa có nhân viên nào trong phạm vi này.
+            </p>
+          )}
 
-            {me && entries.length > 1 && (
-              <p className="px-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                So với đồng nghiệp
-              </p>
-            )}
+          {!isLoading && !error && data && entries.length > 0 && (
+            <>
+              {me && <YourCard e={me} peersInUnit={peersInUnit} />}
 
-            {/* Trục chung — thẳng hàng với vùng thanh của mọi dòng */}
-            <div
-              aria-hidden="true"
-              className="grid grid-cols-[minmax(96px,140px)_1fr_36px] gap-3 px-1 pb-1"
-            >
-              <span />
-              <span className="relative block h-3 text-[10px] text-muted-foreground">
-                <span className="absolute left-0">0</span>
-                <span className="absolute left-1/2 -translate-x-1/2">50%</span>
-                <span className="absolute left-[80%] -translate-x-1/2 font-semibold text-error-500">
-                  80%
-                </span>
-                {/* KHÔNG in nhãn "100%": ở bề ngang điện thoại nó đè lên nhãn
+              {me && entries.length > 1 && (
+                <p className="px-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  So với đồng nghiệp
+                </p>
+              )}
+
+              {/* Trục chung — thẳng hàng với vùng thanh của mọi dòng */}
+              <div
+                aria-hidden="true"
+                className="grid grid-cols-[minmax(96px,140px)_1fr_36px] gap-3 px-1 pb-1"
+              >
+                <span />
+                <span className="relative block h-3 text-[10px] text-muted-foreground">
+                  <span className="absolute left-0">0</span>
+                  <span className="absolute left-1/2 -translate-x-1/2">50%</span>
+                  <span className="absolute left-[80%] -translate-x-1/2 font-semibold text-error-500">
+                    80%
+                  </span>
+                  {/* KHÔNG in nhãn "100%": ở bề ngang điện thoại nó đè lên nhãn
                     80% (mốc quan trọng nhất — ngưỡng tạm dừng). Mép phải thanh
                     đã có viền, hết trục là 100% không cần nói. */}
-              </span>
-              <span />
-            </div>
+                </span>
+                <span />
+              </div>
 
-            {(() => {
-              const groups = groupByUnit(entries);
-              const multiUnit = groups.length > 1;
-              const nameSeen = new Map<string, number>();
-              for (const g of groups) {
-                if (g.unitName == null) continue;
-                nameSeen.set(g.unitName, (nameSeen.get(g.unitName) ?? 0) + 1);
-              }
-              return (
-                <>
-                  {multiUnit ? (
-                    <p className="px-1 pb-2 text-[11px] text-muted-foreground">
-                      Phạm vi gồm {groups.length} đơn vị — điểm bận và thứ hạng
-                      tính <b>riêng trong từng đơn vị</b>, không so chéo được.
-                    </p>
-                  ) : (
-                    // Một đơn vị vẫn PHẢI nói rõ cách xếp: ở chế độ `legacy`
-                    // engine sắp theo (quá tải, lâu chưa nhận) và KHÔNG đọc điểm
-                    // bận — hiện con số to mà không chú thích sẽ khiến người xem
-                    // tưởng đó là lý do phân phối.
-                    groups[0]?.scoringMode && (
+              {(() => {
+                const groups = groupByUnit(entries);
+                const multiUnit = groups.length > 1;
+                const nameSeen = new Map<string, number>();
+                for (const g of groups) {
+                  if (g.unitName == null) continue;
+                  nameSeen.set(g.unitName, (nameSeen.get(g.unitName) ?? 0) + 1);
+                }
+                return (
+                  <>
+                    {multiUnit ? (
                       <p className="px-1 pb-2 text-[11px] text-muted-foreground">
-                        Cách xếp của đơn vị:{" "}
-                        <b>
-                          {SCORING_LABEL[groups[0].scoringMode] ??
-                            groups[0].scoringMode}
-                        </b>
-                        {groups[0].scoringMode === "legacy" && (
-                          <>
-                            {" "}
-                            — chế độ này xếp theo lượt (lâu chưa nhận trước),
-                            điểm bận chỉ để tham khảo.
-                          </>
-                        )}
+                        Phạm vi gồm {groups.length} đơn vị — điểm bận và thứ hạng tính{" "}
+                        <b>riêng trong từng đơn vị</b>, không so chéo được.
                       </p>
-                    )
-                  )}
-                  {groups.map((g) => (
-                    <div
-                      key={g.key}
-                      className={multiUnit ? "mt-4 first:mt-0" : undefined}
-                    >
-                      {multiUnit && (
-                        <div className="flex flex-wrap items-baseline gap-x-2 border-b px-1 pb-1">
-                          <span className="text-sm font-semibold">
-                            {unitLabel(
-                              g,
-                              g.unitName != null &&
-                                (nameSeen.get(g.unitName) ?? 0) > 1
-                            )}
-                          </span>
-                          <span className="text-[11px] text-muted-foreground">
-                            {g.entries.length} người
-                            {g.scoringMode
-                              ? ` · cách xếp: ${SCORING_LABEL[g.scoringMode] ?? g.scoringMode}`
-                              : ""}
-                          </span>
-                        </div>
-                      )}
-                      <EntryList entries={g.entries} />
-                    </div>
-                  ))}
-                  {/* Nhãn chiều thang đặt SAU danh sách cho người KHÔNG có thẻ
+                    ) : (
+                      // Một đơn vị vẫn PHẢI nói rõ cách xếp: ở chế độ `legacy`
+                      // engine sắp theo (quá tải, lâu chưa nhận) và KHÔNG đọc điểm
+                      // bận — hiện con số to mà không chú thích sẽ khiến người xem
+                      // tưởng đó là lý do phân phối.
+                      groups[0]?.scoringMode && (
+                        <p className="px-1 pb-2 text-[11px] text-muted-foreground">
+                          Cách xếp của đơn vị:{" "}
+                          <b>{SCORING_LABEL[groups[0].scoringMode] ?? groups[0].scoringMode}</b>
+                          {groups[0].scoringMode === "legacy" && (
+                            <>
+                              {" "}
+                              — chế độ này xếp theo lượt (lâu chưa nhận trước), điểm bận chỉ để tham
+                              khảo.
+                            </>
+                          )}
+                        </p>
+                      )
+                    )}
+                    {groups.map((g) => (
+                      <div key={g.key} className={multiUnit ? "mt-4 first:mt-0" : undefined}>
+                        {multiUnit && (
+                          <div className="flex flex-wrap items-baseline gap-x-2 border-b px-1 pb-1">
+                            <span className="text-sm font-semibold">
+                              {unitLabel(
+                                g,
+                                g.unitName != null && (nameSeen.get(g.unitName) ?? 0) > 1
+                              )}
+                            </span>
+                            <span className="text-[11px] text-muted-foreground">
+                              {g.entries.length} người
+                              {g.scoringMode
+                                ? ` · cách xếp: ${SCORING_LABEL[g.scoringMode] ?? g.scoringMode}`
+                                : ""}
+                            </span>
+                          </div>
+                        )}
+                        <EntryList entries={g.entries} />
+                      </div>
+                    ))}
+                    {/* Nhãn chiều thang đặt SAU danh sách cho người KHÔNG có thẻ
                       "của bạn" (admin/manager): họ vẫn phải biết ít màu là rảnh,
                       nhưng thông tin đó không đáng chiếm đầu bảng. */}
-                  {!me && <AxisMeaning className="mt-2 px-1" />}
-                </>
-              );
-            })()}
-          </>
-        )}
-      </CardContent>
-    </Card>
+                    {!me && <AxisMeaning className="mt-2 px-1" />}
+                  </>
+                );
+              })()}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </OpenRowContext.Provider>
   );
 }


### PR DESCRIPTION
## Bối cảnh

Bảng "Vì sao bạn được chia lead" (PR #487, đã ở prod) — người dùng phản hồi khi thử thực tế: biểu đồ **không nói officer phải LÀM GÌ**; mở popover ra số **không mang màu của đoạn trên thanh** nên phải suy nghĩ để ánh xạ; và **không rê chuột xem được**.

3 commit, chỉ chạm 2 file FE (`OfficerDistributionPanel.tsx` + test). Không đụng backend, không migration.

## Thay đổi

**Vòng UX (`5d1f46c5`)**
- Backend **đã sinh sẵn** lời khuyên (`build_boost`) nhưng FE chôn ở đáy popover → nay đưa lên thẻ **"Việc của bạn"** đầu bảng, đọc được ngay không cần thao tác.
- Gom ngữ nghĩa màu về một nguồn (`SEG_META`): thanh + chấm cạnh số + legend cùng đọc; lặp lại thanh ở đầu popover; rê vào một dòng số thì đoạn tương ứng sáng lên.
- Thêm **rê-chuột mở popover** như lớp tăng tiến (chặn `(hover:hover) and (pointer:fine)` để cảm ứng không dính); **bấm = ghim** để đọc kỹ.
- Trục có nhãn hai đầu (điểm bận là thang **nghịch**); tiêu đề trung lập cho admin/manager (không xưng "bạn"); hiện dấu tràn khi giữ quá sức chứa.

**2 lỗi chỉ thấy khi smoke bằng mắt (`bc057a1e`)** — có sẵn từ #487:
- Nhãn trục `100%` đè `80%` ở bề ngang điện thoại → bỏ `100%`.
- Prod có 2 đơn vị **trùng tên** "Phòng Tuyển Sinh" → gắn `#id` khi trùng để phân biệt (admin nhìn toàn tổ chức).

**4 finding review 3-agent (`7433e09d`)**
- 🟠 Chặn `onCloseAutoFocus` — hover mở popover khi con trỏ ở nơi khác, đóng không được cướp focus.
- 🟡 Khôi phục mục legend "Ngưỡng tạm dừng 80%" (vạch đỏ vẫn vẽ nên phải có chú thích).
- 🟡 Trả lại dấu "🔒 chỉ bạn thấy" cho thẻ "Việc của bạn".
- 🔵 Điều phối "chỉ một popover mở" (`OpenRowContext`) — đúng ý đồ ghim-để-so-sánh.
- Vá 3 test "an toàn giả": fixture PEER tự nhất quán, mock `matchMedia` parse query thật, thêm test đường rê-mở→bấm-ghim + single-open.

## Kiểm chứng

- **Full gate toàn repo**: 1894/1894 vitest · lint 0 errors · type-check · prettier — tất cả pass.
- **Smoke Chrome** (stack worktree, dữ liệu dev thật): officer (đầy đủ tương tác) · admin (non-owner, gom 3 đơn vị) · light mode. Manager verify qua backend shape.
- ⚠️ **#1 (onCloseAutoFocus) chưa e2e**: jsdom không mô phỏng focus-scope của Radix (test kiểu đó xanh cả khi gỡ fix — đã bỏ để tránh test giả), MCP hover không dựng ổn cảnh cụ thể. Còn lại là fix đúng + đối xứng `onOpenAutoFocus`. Verify hành vi thật cần Playwright/thao tác tay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)