### PR TITLE
fix(admission): rút hồ sơ 500 MissingGreenlet khi còn học phí HK1 chưa thu

### DIFF
--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -3310,6 +3310,157 @@ async def _populate_priority_evidence_projections(
         profile.priority_evidence_documents = []
 
 
+_CHOICE_EAGER_PATHS_CACHE: Optional[tuple[tuple[str, ...], ...]] = None
+
+
+def _choice_eager_paths() -> tuple[tuple[str, ...], ...]:
+    """The relationship legs the guard must verify, DERIVED from the canonical
+    loader rather than hand-copied.
+
+    Each leg is a path of relationship keys rooted at an
+    ``AdmissionProfileChoice`` (the leading ``choices`` hop is dropped). It is
+    read straight out of ``admission_repository._choices_eager_load_options()``
+    — the same options every GET path and ``reload_profile_with_lead`` splat —
+    so the guard and that loader CANNOT drift: there is one source, not a
+    literal table to keep in sync by hand. Today this yields:
+        admission_path → academic_info → offering → program
+        admission_path → admission_method
+        admission_path → admission_round
+        admission_path → criteria
+        path_subject_group_config → subject_group → subject_mappings → subject
+        scores → subject
+
+    ``AdmissionProfileChoiceResponse._compute_display_fields`` getattr-walks
+    the same relations at serialization, so an incomplete graph 500s there too
+    — this is the graph that keeps that safe.
+
+    The reload path uses ``list_by_profile(eager=True)`` (a DIFFERENT loader);
+    it must remain a superset of this contract or a repaired profile would
+    still trip the guard. ``test_guard_matches_repository_eager_contract``
+    pins that agreement. Cached module-side (loader options are static);
+    imported lazily to avoid a repository→service import cycle at module load.
+    """
+    global _CHOICE_EAGER_PATHS_CACHE
+    if _CHOICE_EAGER_PATHS_CACHE is None:
+        from sqlalchemy.orm import RelationshipProperty
+
+        from app.repositories.admission_repository import (
+            _choices_eager_load_options,
+        )
+        legs: list[tuple[str, ...]] = []
+        for opt in _choices_eager_load_options():
+            keys = tuple(
+                p.key for p in opt.path
+                if isinstance(p, RelationshipProperty)
+            )
+            # keys[0] is the leading ``AdmissionProfile.choices`` hop.
+            if len(keys) > 1:
+                legs.append(keys[1:])
+        if not legs:
+            # Deriving nothing would make the guard a no-op (reports every
+            # graph complete → the MissingGreenlet 500 returns silently). A
+            # loader that loads no nested legs is a wiring break, not a valid
+            # empty contract — fail loudly at first use rather than ship a
+            # dead guard.
+            raise RuntimeError(
+                "_choices_eager_load_options() yielded no nested choice "
+                "relationship legs — the eager-graph guard would be a no-op. "
+                "Check the loader options in admission_repository."
+            )
+        _CHOICE_EAGER_PATHS_CACHE = tuple(legs)
+    return _CHOICE_EAGER_PATHS_CACHE
+
+
+def _relation_path_incomplete(obj: Any, path: tuple[str, ...]) -> bool:
+    """True when any hop of ``path`` starting at ``obj`` is not loaded.
+
+    Never touches a lazy attribute: each hop consults ``inspect(obj).unloaded``
+    and descends through ``__dict__`` only. Collections are walked element-wise
+    (an ``InstrumentedList`` is a ``list``). A relationship that is
+    loaded-and-None (nullable FK) is COMPLETE — stop descending, do not reload.
+    """
+    import sqlalchemy as _sa
+
+    if obj is None or not path:
+        return False
+    if isinstance(obj, (list, tuple)):
+        return any(_relation_path_incomplete(o, path) for o in obj)
+
+    state = _sa.inspect(obj, raiseerr=False)
+    # ``state is None`` → plain object; a mapped CLASS yields a ``Mapper``,
+    # which has no ``.unloaded``. Neither can lazy-load, so treat as complete
+    # rather than letting ``NoInspectionAvailable``/``AttributeError`` turn
+    # this guard — whose job is to PREVENT 500s — into one.
+    if state is None or not hasattr(state, "unloaded"):
+        return False
+
+    attr, rest = path[0], path[1:]
+    if attr in state.unloaded:
+        return True
+    if attr not in obj.__dict__:
+        # Reported "loaded" (not in ``unloaded``) yet physically ABSENT from
+        # ``__dict__``. ``unloaded`` is ``set(manager) - committed_state -
+        # dict``, so a key parked in ``committed_state`` alone lands here —
+        # e.g. a backref append onto an unloaded collection
+        # (``choice.profile = profile``) fires ``_modified_event`` and stores
+        # the item in ``state._pending_mutations`` without materialising the
+        # collection. Reading ``__dict__.get()`` would yield None and the walk
+        # would call the leg COMPLETE, disarming the guard. Fail CLOSED.
+        return True
+    return _relation_path_incomplete(obj.__dict__[attr], rest)
+
+
+def _choices_eager_graph_incomplete(profile: models.AdmissionProfile) -> bool:
+    """True when ``profile.choices`` is missing ANY leg of
+    ``_choice_eager_paths()``.
+
+    Why not just ``"choices" in inspect(profile).unloaded``: a caller may have
+    already loaded ``choices`` SHALLOW, which marks the top-level relationship
+    as loaded and makes that check pass while the nested graph the sync
+    response code walks is still lazy. Live example — withdraw STEP 2 cancels
+    an unpaid HK1 tuition fee, ``fee_calculation_service.cancel_fee`` →
+    ``_get_profile`` does a bare ``selectinload(AdmissionProfile.choices)``
+    (fee_calculation_service.py:1519), the profile lands in the identity map
+    with shallow choices, and ``_resolve_allowed_subjects`` →
+    ``group.subject_mappings`` then fires IO from sync code → MissingGreenlet
+    (500, whole withdraw rolled back).
+
+    Scope note: "complete" here means "safe for the consumers that read the
+    repository contract" — NOT "every relationship any consumer might want".
+    ``program.degree_level_ref`` and ``offering.offering_type_config`` are
+    deliberately outside it (the eligibility gate loads its own richer chain).
+
+    Deliberately does NOT special-case expired/detached instances. An earlier
+    draft returned True for them; both cases were wrong:
+      * expired — redundant: an expired instance already reports ``choices``
+        in ``unloaded``, so the check below handles it.
+      * ``session is None`` (transient/detached) — harmful: returning True
+        sends the caller INTO the reload, and a transient profile has
+        ``id is None``, so ``list_by_profile(None)`` matches nothing and
+        ``set_committed_value`` then overwrites a perfectly good in-memory
+        collection with ``[]``. The overwrite is the consequence of reloading,
+        so the fix is to not force the reload here — fall through instead.
+    """
+    import sqlalchemy as _sa
+
+    _state = _sa.inspect(profile, raiseerr=False)
+    if _state is None or not hasattr(_state, "unloaded"):
+        return False
+    if "choices" in _state.unloaded or "choices" not in profile.__dict__:
+        # Second clause: same committed_state-without-__dict__ hole as in
+        # _relation_path_incomplete — an append through the ``profile``
+        # backref makes ``choices`` look loaded while it is physically absent.
+        return True
+
+    _choices = profile.__dict__["choices"] or []
+    _paths = _choice_eager_paths()
+    return any(
+        _relation_path_incomplete(_choice, _path)
+        for _choice in _choices
+        for _path in _paths
+    )
+
+
 async def _populate_response_fields(
     db: AsyncSession,
     profile: models.AdmissionProfile,
@@ -3361,16 +3512,32 @@ async def _populate_response_fields(
     # raises MissingGreenlet. Inject the eager-loaded list as a *committed*
     # value (does NOT mark the instance dirty, does NOT re-lazy) so EVERY
     # mutation response (approve/reject/override/submit/v2 helpers) is covered
-    # without touching each dependency. Skip when already loaded (GET paths
-    # eager-load via _choices_eager_load_options).
+    # without touching each dependency. Skip when the FULL graph is already
+    # loaded (GET paths eager-load via _choices_eager_load_options).
+    #
+    # 2026-07-20 — the guard used to test only ``"choices" in unloaded``, which
+    # a SHALLOW pre-load silently satisfied while the nested graph stayed lazy
+    # (withdraw + cancel_fee on unpaid HK1 tuition → MissingGreenlet 500).
+    # _choices_eager_graph_incomplete walks the whole repository contract, so
+    # any present or future shallow loader is repaired here instead of blowing
+    # up in sync response code or at schema serialization.
     if getattr(profile, "uses_choice_engine", False):
-        import sqlalchemy as _sa
         from sqlalchemy.orm.attributes import set_committed_value
 
-        if "choices" in _sa.inspect(profile).unloaded:
+        if _choices_eager_graph_incomplete(profile):
             from app.repositories.admission_profile_choice_repository import (
                 AdmissionProfileChoiceRepository,
             )
+            # ⚠️ CONTRACT: this helper must be called AFTER db.flush() (see the
+            # "Mutation response contract" in Backend_FastAPI/CLAUDE.md). The
+            # session is autoflush=False (database.py), so list_by_profile
+            # reads only what has been flushed, and set_committed_value then
+            # REPLACES the in-memory collection wholesale. If a future caller
+            # adds/removes a choice and reaches this chokepoint WITHOUT
+            # flushing, that choice is dropped from the response object (the
+            # row is still in session.new and the DB stays correct, but the
+            # returned NV list is short). Every caller flushes today; keep it
+            # that way, or flush here before reloading.
             _fresh_choices = await AdmissionProfileChoiceRepository(
                 db
             ).list_by_profile(profile.id)

--- a/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
+++ b/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
@@ -841,6 +841,26 @@ async def _fees_of(profile_id: int) -> list[models.Fee]:
         return list(rows.scalars().all())
 
 
+async def _tuition_invoice_id_of(profile_id: int) -> int:
+    """Invoice id of the profile's tuition fee — lets a test collect a SECOND
+    instalment on the same invoice (multi-payment refund coverage)."""
+    async with AsyncSessionLocal() as session:
+        row = await session.execute(
+            select(models.Invoice.id)
+            .join(models.Fee, models.Fee.id == models.Invoice.fee_id)
+            .where(
+                models.Fee.admission_profile_id == profile_id,
+                models.Fee.fee_type == "tuition",
+            )
+            .order_by(models.Invoice.id)
+        )
+        invoice_id = row.scalars().first()
+        assert invoice_id is not None, (
+            f"profile {profile_id} has no tuition invoice"
+        )
+        return invoice_id
+
+
 async def _invoice_statuses_of(profile_id: int) -> list[str]:
     """Statuses of every invoice hanging off a profile's fees."""
     async with AsyncSessionLocal() as session:
@@ -1376,3 +1396,197 @@ class TestWithdrawalPendingFlow:
             json={"reason": "Rút lần hai", "version": body2["version"]},
         )
         assert r2.status_code == 400, r2.text
+
+    async def test_two_collected_payments_need_both_refunds_to_settle(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """A student who paid tuition in TWO instalments gets TWO refund
+        requests — refunds are per-PAYMENT, never merged.
+
+        The dangerous property this pins: processing only the FIRST refund
+        leaves the profile silently parked in ``withdrawal_pending`` with NO
+        error anywhere — the operator's only signal that work remains is that
+        the status did not flip. If a future change let the profile settle on
+        a non-final refund, money would stay unreturned on a ``withdrawn``
+        profile; if it never settled on the last one, the profile would be
+        stuck forever. Both directions are asserted below.
+
+        Verified against real data shapes during the 2026-07-20 dry run (two
+        live profiles carry exactly this 2-payment shape).
+        """
+        unit_id = seed_lead_dependencies["unit_id"]
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+        await _ensure_consultation_status(
+            "sts08", "Tu choi tu van", "stg07", "#CC0000"
+        )
+
+        pid = await _submit_and_prepay(
+            client, officer, manager, accountant, unit_id,
+            officer_user_in_db["id"],
+        )
+
+        # SECOND instalment on the same tuition invoice.
+        second = Decimal("500000")
+        invoice_id = await _tuition_invoice_id_of(pid)
+        await _record_and_verify_payment(
+            client, accountant, manager, invoice_id, second
+        )
+
+        body = await _get(client, officer, pid)
+        res = await client.post(
+            f"{ADMISSIONS}/{pid}/withdraw",
+            headers=officer,
+            json={"reason": "Rút hồ sơ, đã đóng 2 lần", "version": body["version"]},
+        )
+        assert res.status_code == 200, res.text
+        assert res.json()["status"] == "withdrawal_pending", res.json()
+
+        pending = await client.get(
+            "/api/refunds", params={"status": "pending"}, headers=manager
+        )
+        assert pending.status_code == 200, pending.text
+        mine = [
+            r for r in pending.json()["items"]
+            if f"#{pid}" in (r.get("reason") or "")
+        ]
+        assert len(mine) == 2, (
+            f"one refund per collected payment expected, got {len(mine)}: {mine}"
+        )
+        assert {Decimal(r["amount"]) for r in mine} == {PREPAY, second}, mine
+
+        for r in mine:
+            appr = await client.post(
+                f"/api/refunds/{r['id']}/approve", headers=manager
+            )
+            assert appr.status_code == 200, appr.text
+
+        # --- Process ONLY the first refund -------------------------------
+        first_id = mine[0]["id"]
+        proc1 = await client.post(
+            f"/api/refunds/{first_id}/process",
+            json={"refund_id": first_id, "refund_reference": "BANK-REF-1of2"},
+            headers=accountant,
+        )
+        assert proc1.status_code == 200, proc1.text
+
+        midway = await _get(client, manager, pid)
+        assert midway["status"] == "withdrawal_pending", (
+            "profile MUST stay parked while a refund is still outstanding — "
+            f"settling here would strand unreturned money; got {midway['status']}"
+        )
+        assert await _lead_status_of(pid) != "sts08", (
+            "lead must not advance to sts08 before the final refund"
+        )
+
+        # --- Process the LAST refund → self-settle ------------------------
+        last_id = mine[1]["id"]
+        proc2 = await client.post(
+            f"/api/refunds/{last_id}/process",
+            json={"refund_id": last_id, "refund_reference": "BANK-REF-2of2"},
+            headers=accountant,
+        )
+        assert proc2.status_code == 200, proc2.text
+
+        after = await _get(client, manager, pid)
+        assert after["status"] == "withdrawn", (
+            f"last refund must trigger the finalize hook; got {after['status']} "
+            "— a profile stuck in withdrawal_pending with everything refunded "
+            "is the silent-failure mode this test exists for"
+        )
+        assert after["has_unrefunded_payment"] is False, after
+        assert await _lead_status_of(pid) == "sts08"
+
+        leftover = [
+            (f.id, f.fee_type, f.status)
+            for f in await _fees_of(pid)
+            if f.fee_type != "application" and f.status != "cancelled"
+        ]
+        assert not leftover, f"non-application fee left payable: {leftover}"
+
+    async def test_cannot_reject_single_refund_while_withdrawal_pending(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """Rejecting ONE withdrawal-sourced refund of a profile parked in
+        ``withdrawal_pending`` must be refused (400).
+
+        Allowing it would strand the profile forever: the finalize gate waits
+        for the unrefunded balance to reach zero, and a rejected strand never
+        contributes. The supported escape is cancel-withdrawal, which rejects
+        every withdrawal refund atomically and reverts to draft — asserted
+        here as the working alternative so the guard cannot be "fixed" by
+        simply removing it.
+        """
+        unit_id = seed_lead_dependencies["unit_id"]
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+        admin = await _auth(client, admin_user_in_db)
+        await _ensure_consultation_status(
+            "sts08", "Tu choi tu van", "stg07", "#CC0000"
+        )
+
+        pid = await _submit_and_prepay(
+            client, officer, manager, accountant, unit_id,
+            officer_user_in_db["id"],
+        )
+
+        body = await _get(client, officer, pid)
+        res = await client.post(
+            f"{ADMISSIONS}/{pid}/withdraw",
+            headers=officer,
+            json={"reason": "Rút hồ sơ để thử từ chối lẻ", "version": body["version"]},
+        )
+        assert res.status_code == 200, res.text
+        assert res.json()["status"] == "withdrawal_pending", res.json()
+
+        pending = await client.get(
+            "/api/refunds", params={"status": "pending"}, headers=manager
+        )
+        mine = [
+            r for r in pending.json()["items"]
+            if f"#{pid}" in (r.get("reason") or "")
+        ]
+        assert len(mine) == 1, mine
+        refund_id = mine[0]["id"]
+
+        rej = await client.post(
+            f"/api/refunds/{refund_id}/reject",
+            json={"rejection_reason": "Quản lý không đồng ý hoàn"},
+            headers=manager,
+        )
+        assert rej.status_code == 400, (
+            f"single-reject on a withdrawal_pending profile must be blocked; "
+            f"got {rej.status_code}: {rej.text}"
+        )
+
+        still = await _get(client, manager, pid)
+        assert still["status"] == "withdrawal_pending", still
+        refund_row = await _refund_by_id(refund_id)
+        assert refund_row.status == RefundStatusEnum.pending.value, (
+            "a blocked reject must not have mutated the refund"
+        )
+
+        # The supported way out: cancel-withdrawal (admin) rejects the whole
+        # bundle and reverts to draft — money stays with the school.
+        cancel = await client.post(
+            f"{ADMISSIONS}/{pid}/cancel-withdrawal",
+            json={"reason": "Thí sinh đổi ý, hủy quy trình rút"},
+            headers=admin,
+        )
+        assert cancel.status_code == 200, cancel.text
+        assert cancel.json()["status"] == "draft", cancel.json()
+        refund_row = await _refund_by_id(refund_id)
+        assert refund_row.status == RefundStatusEnum.rejected.value, refund_row

--- a/Backend_FastAPI/tests/services/test_withdraw_choices_eager_graph.py
+++ b/Backend_FastAPI/tests/services/test_withdraw_choices_eager_graph.py
@@ -1,0 +1,776 @@
+"""Regression suite — withdraw must survive a SHALLOW-loaded ``choices``
+relation (fix/admission-choices-eager-graph, 2026-07-20).
+
+Background — production bug found while rehearsing a bulk withdrawal:
+
+    Withdrawing a profile that still has an UNPAID HK1 tuition fee returned
+    HTTP 500. ``withdraw_profile`` STEP 2 cancels every unpaid fee;
+    ``cancel_fee`` reverts the HK1-tuition lead projection and for that calls
+    ``fee_calculation_service._get_profile``, which eager-loads only
+    ``selectinload(AdmissionProfile.choices)`` — SHALLOW. The profile lands in
+    the identity map with ``choices`` marked loaded but the nested graph still
+    lazy. ``_populate_response_fields`` then asked only
+    ``"choices" in inspect(profile).unloaded`` → False → skipped its defensive
+    reload → ``_resolve_allowed_subjects`` touched ``group.subject_mappings``
+    from sync code → ``MissingGreenlet`` → 500 and the whole withdrawal rolled
+    back. Several live profiles were left unwithdrawable through the UI.
+
+The fix is ONE layer, deliberately: ``_choices_eager_graph_incomplete``
+validates the whole ``_choice_eager_paths()`` contract at the response
+chokepoint and reloads when any hop is unloaded.
+
+    A second "belt" layer — making ``_resolve_allowed_subjects`` degrade to
+    ``[]`` on an unloaded graph — was written, reviewed, and REMOVED. ``[]``
+    is fail-closed only from the submit gate's point of view; the T6 publish
+    cascade reads the same helper and treats an empty allowed-set as "cannot
+    score", skipping straight to a persisted ``decision='rejected'`` with an
+    EMPTY reason list. It turned a loud, rolled-back 500 into a silent,
+    permanent, unexplainable rejection of a qualified candidate. Do not
+    reintroduce it: a graph that is not loaded must stop the caller, never
+    produce a decision.
+
+Non-tautological: every test asserts concrete DB state / status codes /
+message text that a regression cannot satisfy by accident.
+"""
+from __future__ import annotations
+
+import random
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app import models
+from app.database import AsyncSessionLocal
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ==============================================================================
+# FIXTURES / HELPERS
+# ==============================================================================
+
+
+@pytest_asyncio.fixture(scope="function")
+async def seed_sts08(seed_lead_dependencies: dict):
+    """``lead_admission_sync`` moves a withdrawn profile's lead to sts08."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            existing = await session.get(models.ConsultationStatus, "sts08")
+            if existing is None:
+                session.add(
+                    models.ConsultationStatus(
+                        id="sts08",
+                        name="Khong tiep tuc ho so",
+                        color_code="#FF0000",
+                        # stg07 = "Khong di hoc" (is_final_stage). stage_id MUST
+                        # match
+                        # test_tuition_prepay_flow::_ensure_consultation_status
+                        # — both are get-or-create against a shared qlts_test, so a
+                        # mismatch makes the winner collection-order dependent.
+                        stage_id="stg07",
+                    )
+                )
+    return seed_lead_dependencies
+
+
+async def _seed_multi_nv_profile(
+    seed_lead_dependencies: dict,
+    *,
+    status: str = "submitted",
+) -> dict:
+    """Seed a multi-NV profile whose single choice carries the full
+    subject-group graph (path → config → group → mapping → subject).
+
+    Mirrors the anchor seeding in
+    ``tests/api/test_admission_response_choices_serialization.py`` so both
+    suites exercise the same shape.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    unit_id = seed_lead_dependencies["unit_id"]
+    program_id = seed_lead_dependencies["major_program_id"]
+
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            offering_type = models.ConfigOfferingType(
+                code=f"eg_ot_{suffix}", name=f"EG OT {suffix}", is_active=True,
+            )
+            s.add(offering_type)
+            await s.flush()
+
+            offering = models.ProgramOffering(
+                offering_type=f"eg_ot_{suffix}",
+                program_id=program_id,
+                offering_type_id=offering_type.id,
+            )
+            s.add(offering)
+            await s.flush()
+
+            academic_info = models.OfferingAcademicInfo(
+                offering_id=offering.id, academic_year=2026, is_published=True,
+            )
+            s.add(academic_info)
+            await s.flush()
+
+            method = models.AdmissionMethod(
+                code=f"eg_m_{suffix}", name="EG method", is_active=True,
+            )
+            s.add(method)
+            await s.flush()
+
+            criteria = models.AdmissionCriteria(
+                method_id=method.id,
+                code=f"eg_c_{suffix}",
+                name="EG criteria",
+                min_gpa=0,
+                is_active=True,
+            )
+            s.add(criteria)
+            await s.flush()
+
+            round_obj = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"EG_R_{suffix}",
+                round_name=f"EG round {suffix}",
+                is_active=True,
+                allow_multi_nv=True,
+            )
+            s.add(round_obj)
+            await s.flush()
+
+            path = models.AdmissionPath(
+                academic_info_id=academic_info.id,
+                admission_method_id=method.id,
+                admission_round_id=round_obj.id,
+                criteria_id=criteria.id,
+                status="active",
+            )
+            s.add(path)
+            await s.flush()
+
+            # SubjectGroup.code is VARCHAR(10).
+            subject_group = models.SubjectGroup(
+                code=f"eg{suffix[:6]}", name=f"Tổ hợp {suffix}", is_active=True,
+            )
+            s.add(subject_group)
+            await s.flush()
+
+            subject = models.Subject(
+                code=f"S{suffix[:4]}",
+                name_vi=f"Môn {suffix}",
+                is_active=True,
+            )
+            s.add(subject)
+            await s.flush()
+
+            s.add(
+                models.SubjectGroupSubject(
+                    subject_group_id=subject_group.id,
+                    subject_id=subject.id,
+                    position=1,
+                )
+            )
+            await s.flush()
+
+            sg_config = models.PathSubjectGroupConfig(
+                admission_path_id=path.id, subject_group_id=subject_group.id,
+            )
+            s.add(sg_config)
+            await s.flush()
+
+            lead = models.Lead(
+                full_name=f"Eager graph {suffix}",
+                phone=f"097{random.randint(1000000, 9999999)}",
+                email=f"eager_{suffix}@test.com",
+                source="walkin",
+                unit_id=unit_id,
+                pipeline_stage_id=seed_lead_dependencies["stage_id"],
+                consultation_status_id="sts06",
+            )
+            s.add(lead)
+            await s.flush()
+
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                citizen_id=uuid.uuid4().hex[:12],
+                status=status,
+                applied_rules={},
+                academic_year=2026,
+                version=1,
+                uses_choice_engine=True,
+            )
+            s.add(profile)
+            await s.flush()
+
+            choice = models.AdmissionProfileChoice(
+                admission_profile_id=profile.id,
+                admission_path_id=path.id,
+                path_subject_group_config_id=sg_config.id,
+                display_order=1,
+                decision="pending",
+            )
+            s.add(choice)
+            await s.flush()
+
+            # One score row so the ("scores", "subject") leg is actually
+            # walked. With zero scores the collection is empty and BOTH
+            # directions of the parity assertion pass vacuously — the leg
+            # could be dropped from the repository and nothing would fail.
+            s.add(
+                models.ProfileChoiceScore(
+                    admission_profile_choice_id=choice.id,
+                    subject_id=subject.id,
+                    score=Decimal("8.0"),
+                    max_score_snapshot=Decimal("10.0"),
+                    weight_snapshot=Decimal("1.0"),
+                )
+            )
+            await s.flush()
+
+            return {
+                "profile_id": profile.id,
+                "lead_id": lead.id,
+                "subject_code": subject.code,
+                "suffix": suffix,
+            }
+
+
+async def _add_fee(
+    session,
+    profile_id: int,
+    *,
+    fee_type: str,
+    semester_no: int | None,
+    final_amount: Decimal,
+    paid_amount: Decimal,
+    status: str,
+    with_invoice: bool = False,
+) -> models.Fee:
+    fee = models.Fee(
+        admission_profile_id=profile_id,
+        fee_type=fee_type,
+        semester_no=semester_no,
+        academic_year=2026,
+        base_amount=final_amount,
+        total_discount=Decimal("0"),
+        final_amount=final_amount,
+        paid_amount=paid_amount,
+        waived_amount=Decimal("0"),
+        status=status,
+        calculated_at=datetime.now(timezone.utc),
+        version=1,
+    )
+    session.add(fee)
+    await session.flush()
+
+    if with_invoice:
+        session.add(
+            models.Invoice(
+                fee_id=fee.id,
+                invoice_number=f"INV-T-{uuid.uuid4().hex[:10]}",
+                installment_no=1,
+                amount=final_amount,
+                paid_amount=Decimal("0"),
+                penalty_amount=Decimal("0"),
+                status="issued",
+                due_date=date.today() + timedelta(days=30),
+            )
+        )
+        await session.flush()
+    return fee
+
+
+# ==============================================================================
+# T1 — the identity-map repro, at the guard level
+# ==============================================================================
+
+
+class TestChoicesEagerGraphGuard:
+    async def test_shallow_loaded_choices_is_reported_incomplete(
+        self, seed_lead_dependencies: dict,
+    ) -> None:
+        """A profile loaded with a bare ``selectinload(choices)`` — exactly
+        what ``fee_calculation_service._get_profile`` does — must be reported
+        INCOMPLETE, otherwise the chokepoint skips its reload and the sync
+        response code lazy-loads (MissingGreenlet).
+
+        The pre-fix guard (``"choices" in inspect(profile).unloaded``) returns
+        False here, so this test fails on a revert.
+        """
+        from app.services.admission_service import (
+            _choices_eager_graph_incomplete,
+        )
+
+        seeded = await _seed_multi_nv_profile(seed_lead_dependencies)
+
+        async with AsyncSessionLocal() as s:
+            profile = (
+                await s.execute(
+                    select(models.AdmissionProfile)
+                    .where(
+                        models.AdmissionProfile.id == seeded["profile_id"]
+                    )
+                    .options(selectinload(models.AdmissionProfile.choices))
+                )
+            ).scalar_one()
+
+            # Top-level relation IS loaded — the old guard was satisfied here.
+            assert "choices" not in sa.inspect(profile).unloaded, (
+                "precondition: shallow selectinload must mark choices loaded"
+            )
+            assert _choices_eager_graph_incomplete(profile) is True, (
+                "shallow-loaded choices must be reported incomplete — the "
+                "nested subject-group graph is still lazy"
+            )
+
+    async def test_repository_eager_load_is_reported_complete(
+        self, seed_lead_dependencies: dict,
+    ) -> None:
+        """The list the chokepoint injects must satisfy its own guard —
+        otherwise the reload would loop or fire on every mutation."""
+        from sqlalchemy.orm.attributes import set_committed_value
+
+        from app.repositories.admission_profile_choice_repository import (
+            AdmissionProfileChoiceRepository,
+        )
+        from app.services.admission_service import (
+            _choices_eager_graph_incomplete,
+        )
+
+        seeded = await _seed_multi_nv_profile(seed_lead_dependencies)
+
+        async with AsyncSessionLocal() as s:
+            profile = await s.get(
+                models.AdmissionProfile, seeded["profile_id"]
+            )
+            fresh = await AdmissionProfileChoiceRepository(s).list_by_profile(
+                profile.id
+            )
+            set_committed_value(profile, "choices", fresh)
+
+            assert _choices_eager_graph_incomplete(profile) is False, (
+                "list_by_profile(eager=True) output must satisfy the guard; "
+                "if this fails the guard checks a relation the repository "
+                "does not load — they must stay in sync"
+            )
+
+    async def test_guard_pinpoints_the_deep_subject_mappings_hop(
+        self, seed_lead_dependencies: dict,
+    ) -> None:
+        """Pin WHICH hop is actually lazy, so a future model change that flips
+        ``lazy=`` is caught here rather than in production.
+
+        ``AdmissionProfileChoice.admission_path`` /
+        ``path_subject_group_config`` / ``scores`` are declared
+        ``lazy="selectin"`` (admission_profile_choice.py:193-205), so a bare
+        ``selectinload(AdmissionProfile.choices)`` already drags those in —
+        which is exactly why the old top-level guard looked satisfied. The
+        genuinely unloaded hop is ``SubjectGroup.subject_mappings``, the one
+        that raised MissingGreenlet in production.
+        """
+        from app.services.admission_service import (
+            _choices_eager_graph_incomplete,
+        )
+
+        seeded = await _seed_multi_nv_profile(seed_lead_dependencies)
+
+        async with AsyncSessionLocal() as s:
+            profile = (
+                await s.execute(
+                    select(models.AdmissionProfile)
+                    .where(
+                        models.AdmissionProfile.id == seeded["profile_id"]
+                    )
+                    .options(selectinload(models.AdmissionProfile.choices))
+                )
+            ).scalar_one()
+
+            choice = profile.__dict__["choices"][0]
+            config = choice.__dict__.get("path_subject_group_config")
+            assert config is not None, (
+                "lazy='selectin' should have auto-loaded the config"
+            )
+            group = config.__dict__.get("subject_group")
+            assert group is not None, (
+                "lazy='selectin' should have auto-loaded the subject_group"
+            )
+            assert "subject_mappings" in sa.inspect(group).unloaded, (
+                "subject_mappings is THE lazy hop that crashed production; if "
+                "this fails the model changed and the guard needs revisiting"
+            )
+
+            # Assert the SUBJECT-GROUP leg ALONE is reported incomplete.
+            # Asserting the whole guard here would pass through an unrelated
+            # leg: AdmissionPath.admission_method/criteria/academic_info/
+            # admission_round are all default-lazy too, so the guard trips on
+            # the FIRST of them and never reaches the hop this test names.
+            # NOTE this pins the WALKER's descent, not the contents of
+            # the guard's leg set (the leg is passed as a literal). Removing
+            # that leg from the table is caught by
+            # test_guard_matches_repository_eager_contract, not here.
+            from app.services.admission_service import (
+                _relation_path_incomplete,
+            )
+            sg_leg = ("path_subject_group_config", "subject_group",
+                      "subject_mappings", "subject")
+            assert _relation_path_incomplete(choice, sg_leg) is True, (
+                "the subject-group leg must be reported incomplete on its own"
+            )
+            assert _choices_eager_graph_incomplete(profile) is True
+
+    async def test_guard_matches_repository_eager_contract(
+        self, seed_lead_dependencies: dict,
+    ) -> None:
+        """PARITY, in the direction that actually breaks: every relationship
+        the repository eager-loads must be covered by the guard's leg set
+        (``_choice_eager_paths()``, now derived from
+        ``_choices_eager_load_options()`` — this test is what pins that that
+        loader stays a subset of what ``list_by_profile`` actually loads).
+
+        The dangerous drift is the repository growing a leg the guard does not
+        know about — the guard then reports "complete", the reload is skipped,
+        and the MissingGreenlet 500 returns with the fix still in place. A test
+        that merely asserts ``incomplete is False`` on a fully-loaded profile
+        cannot catch that: a guard checking NOTHING satisfies it too.
+
+        So: load via the repository, walk the graph it actually populated, and
+        require each loaded relationship path to be a prefix of a declared leg.
+        """
+        from app.repositories.admission_profile_choice_repository import (
+            AdmissionProfileChoiceRepository,
+        )
+        from app.services.admission_service import (
+            _choice_eager_paths,
+            _relation_path_incomplete,
+        )
+
+        declared = set(_choice_eager_paths())
+
+        seeded = await _seed_multi_nv_profile(seed_lead_dependencies)
+
+        max_depth = max(len(leg) for leg in declared)
+
+        def _loaded_paths(obj: Any, prefix: tuple = ()) -> set:
+            """Relationship paths actually populated on ``obj``.
+
+            Depth cap is derived from the declared legs (+1) so a repository
+            chain DEEPER than anything declared is still observed — a fixed
+            cap equal to the longest leg would make such drift invisible.
+            """
+            found: set = set()
+            if obj is None or len(prefix) > max_depth:
+                return found
+            if isinstance(obj, (list, tuple)):
+                for item in obj:
+                    found |= _loaded_paths(item, prefix)
+                return found
+            state = sa.inspect(obj, raiseerr=False)
+            if state is None or not hasattr(state, "mapper"):
+                return found
+            for rel in state.mapper.relationships.keys():
+                if rel not in obj.__dict__:
+                    continue  # not loaded — nothing to cover
+                path = prefix + (rel,)
+                found.add(path)
+                found |= _loaded_paths(obj.__dict__[rel], path)
+            return found
+
+        async with AsyncSessionLocal() as s:
+            choices = await AdmissionProfileChoiceRepository(
+                s
+            ).list_by_profile(seeded["profile_id"])
+            assert choices, (
+                "seed must produce at least one choice — an empty list makes "
+                "every assertion below vacuously true"
+            )
+            loaded = set()
+            for choice in choices:
+                loaded |= _loaded_paths(choice)
+        assert loaded, "walk found no loaded relationships — test is vacuous"
+
+        def _covered(path: tuple) -> bool:
+            # A loaded path is covered when it is a prefix of a declared leg
+            # (the guard walks the full leg, so it inspects every prefix).
+            return any(leg[:len(path)] == path for leg in declared)
+
+        # Exclude the ``profile`` back-reference: list_by_profile never loads
+        # AdmissionProfile, so it does not appear in ``loaded`` today — this is
+        # a defensive filter against a future explicit backref eager-load,
+        # narrow on purpose (``p[0]``, not a blanket set) so it cannot mask a
+        # genuine uncovered leg.
+        uncovered = {
+            p for p in loaded if not _covered(p) and p[0] != "profile"
+        }
+        assert not uncovered, (
+            f"the repository eager-loads relationship path(s) the guard does "
+            f"not check: {sorted(uncovered)}. Add them to "
+            f"the loader/guard contract in admission_service.py, or the "
+            f"reload will "
+            f"be skipped on a graph that is actually incomplete."
+        )
+
+        # And the reverse: nothing declared may be missing from a repository
+        # load, else the guard would demand a reload on every single request.
+        for leg in declared:
+            for choice in choices:
+                assert not _relation_path_incomplete(choice, leg), (
+                    f"guard declares leg {leg} that list_by_profile does not "
+                    f"load — every mutation would fire a redundant reload"
+                )
+
+
+# ==============================================================================
+# T2/T3 — the live withdraw scenarios
+# ==============================================================================
+
+
+class TestWithdrawWithUnpaidHK1Tuition:
+    async def test_unpaid_hk1_tuition_withdraws_and_cancels_fee(
+        self,
+        seed_lead_dependencies: dict,
+        seed_sts08: dict,
+        admin_user_in_db: dict,
+    ) -> None:
+        """THE production repro shape.
+
+        submitted + application fee paid + HK1 tuition ``invoiced``/unpaid.
+        STEP 2 cancels the tuition fee → ``cancel_fee`` shallow-loads choices
+        → pre-fix this raised MissingGreenlet and rolled the whole withdrawal
+        back. Must now settle to ``withdrawn`` with the tuition fee AND its
+        invoice cancelled, while the non-refundable application fee is kept.
+        """
+        from app.services import admission_service
+
+        seeded = await _seed_multi_nv_profile(seed_lead_dependencies)
+        profile_id = seeded["profile_id"]
+
+        async with AsyncSessionLocal() as s:
+            async with s.begin():
+                await _add_fee(
+                    s, profile_id,
+                    fee_type="application", semester_no=None,
+                    final_amount=Decimal("70000"),
+                    paid_amount=Decimal("70000"),
+                    status="paid",
+                )
+                await _add_fee(
+                    s, profile_id,
+                    fee_type="tuition", semester_no=1,
+                    final_amount=Decimal("9200000"),
+                    paid_amount=Decimal("0"),
+                    status="invoiced",
+                    with_invoice=True,
+                )
+
+        async with AsyncSessionLocal() as s:
+            actor = await s.get(models.User, admin_user_in_db["id"])
+            assert actor is not None, "admin_user_in_db fixture must seed one"
+
+            profile = (
+                await s.execute(
+                    select(models.AdmissionProfile)
+                    .where(models.AdmissionProfile.id == profile_id)
+                    .options(selectinload(models.AdmissionProfile.lead))
+                )
+            ).scalar_one()
+
+            result, callback = await admission_service.withdraw_profile(
+                db=s,
+                profile_id=profile_id,
+                actor=actor,
+                data={
+                    "reason": "Rút hồ sơ — repro HK1 chưa thu",
+                    "version": profile.version,
+                },
+            )
+            await s.commit()
+            if callback:
+                await callback()
+
+            assert result.status == "withdrawn", (
+                f"no refundable money collected → must settle straight to "
+                f"withdrawn; got {result.status!r}"
+            )
+
+        async with AsyncSessionLocal() as s:
+            fees = (
+                await s.execute(
+                    select(models.Fee).where(
+                        models.Fee.admission_profile_id == profile_id
+                    )
+                )
+            ).scalars().all()
+            by_type = {f.fee_type: f for f in fees}
+
+            assert by_type["tuition"].status == "cancelled", (
+                "unpaid HK1 tuition must be cancelled by STEP 2 — this is "
+                "what closes the 'still collectable after withdrawal' hole"
+            )
+            assert by_type["application"].status == "paid", (
+                "lệ phí xét tuyển is non-refundable and must be left intact"
+            )
+
+            invoice_statuses = (
+                await s.execute(
+                    select(models.Invoice.status)
+                    .join(models.Fee, models.Fee.id == models.Invoice.fee_id)
+                    .where(models.Fee.admission_profile_id == profile_id)
+                )
+            ).scalars().all()
+            assert invoice_statuses == ["cancelled"], (
+                f"cancel_fee must cascade to the one tuition invoice; got "
+                f"{invoice_statuses} (a bare all() would pass on an empty list)"
+            )
+
+            lead_status = (
+                await s.execute(
+                    select(models.Lead.consultation_status_id).where(
+                        models.Lead.id == seeded["lead_id"]
+                    )
+                )
+            ).scalar_one()
+            assert lead_status == "sts08", (
+                f"withdrawn profile must push lead to sts08; got {lead_status}"
+            )
+
+    async def test_unpaid_hk1_plus_collected_fee_goes_withdrawal_pending(
+        self,
+        seed_lead_dependencies: dict,
+        seed_sts08: dict,
+        admin_user_in_db: dict,
+    ) -> None:
+        """The rarer branch the reviewer asked to cover: an unpaid HK1 tuition
+        (→ triggers the shallow load) PLUS refundable money already collected
+        (→ routes to ``withdrawal_pending`` instead of ``_finalize_withdrawn``).
+
+        Both branches call ``_populate_response_fields``, so this pins the
+        second entry point against the same crash.
+
+        ``paid_amount`` is set on the fee directly: STEP 3 computes the
+        refundable balance in-memory from the fee rows, so this reaches the
+        withdrawal_pending branch without seeding payment-method scaffolding.
+        """
+        from app.services import admission_service
+
+        seeded = await _seed_multi_nv_profile(seed_lead_dependencies)
+        profile_id = seeded["profile_id"]
+
+        async with AsyncSessionLocal() as s:
+            async with s.begin():
+                await _add_fee(
+                    s, profile_id,
+                    fee_type="tuition", semester_no=1,
+                    final_amount=Decimal("9200000"),
+                    paid_amount=Decimal("0"),
+                    status="invoiced",
+                    with_invoice=True,
+                )
+                await _add_fee(
+                    s, profile_id,
+                    fee_type="tuition", semester_no=2,
+                    final_amount=Decimal("5000000"),
+                    paid_amount=Decimal("2570000"),
+                    status="partial",
+                )
+
+        async with AsyncSessionLocal() as s:
+            actor = await s.get(models.User, admin_user_in_db["id"])
+            profile = (
+                await s.execute(
+                    select(models.AdmissionProfile)
+                    .where(models.AdmissionProfile.id == profile_id)
+                    .options(selectinload(models.AdmissionProfile.lead))
+                )
+            ).scalar_one()
+
+            result, callback = await admission_service.withdraw_profile(
+                db=s,
+                profile_id=profile_id,
+                actor=actor,
+                data={
+                    "reason": "Rút hồ sơ — còn tiền phải hoàn",
+                    "version": profile.version,
+                },
+            )
+            await s.commit()
+            if callback:
+                await callback()
+
+            assert result.status == "withdrawal_pending", (
+                f"refundable money still held → must wait in "
+                f"withdrawal_pending; got {result.status!r}"
+            )
+
+        async with AsyncSessionLocal() as s:
+            lead_status = (
+                await s.execute(
+                    select(models.Lead.consultation_status_id).where(
+                        models.Lead.id == seeded["lead_id"]
+                    )
+                )
+            ).scalar_one()
+            assert lead_status == "sts06", (
+                f"lead must be HELD at its pre-withdraw status until the "
+                f"refund completes (a '!= sts08' assertion would also accept "
+                f"a wrong terminal status); got {lead_status}"
+            )
+
+
+# ==============================================================================
+# T4 — response serialization must not lazy-load either
+# ==============================================================================
+
+
+class TestResponseSerializationAfterShallowLoad:
+    async def test_admission_response_serializes_after_shallow_choices_load(
+        self, seed_lead_dependencies: dict, admin_user_in_db: dict,
+    ) -> None:
+        """``AdmissionProfileChoiceResponse`` getattr-walks admission_path,
+        academic_info/offering/program, method/round, subject-group config and
+        scores.subject (schemas/admission_profile_choice.py:156). So a shallow
+        graph 500s at SERIALIZATION even when no validation code runs.
+
+        After ``_populate_response_fields`` repairs the graph, model_validate
+        must succeed AND the display fields must be populated — proving the
+        reload injected real data rather than an empty placeholder.
+        """
+        from app.schemas.admission import AdmissionProfileResponse
+        from app.services.admission_service import _populate_response_fields
+
+        seeded = await _seed_multi_nv_profile(seed_lead_dependencies)
+
+        async with AsyncSessionLocal() as s:
+            actor = await s.get(models.User, admin_user_in_db["id"])
+
+            profile = (
+                await s.execute(
+                    select(models.AdmissionProfile)
+                    .where(
+                        models.AdmissionProfile.id == seeded["profile_id"]
+                    )
+                    .options(
+                        selectinload(models.AdmissionProfile.lead),
+                        # SHALLOW — mirrors fee_calculation_service._get_profile
+                        selectinload(models.AdmissionProfile.choices),
+                    )
+                )
+            ).scalar_one()
+
+            await _populate_response_fields(s, profile, actor)
+
+            payload = AdmissionProfileResponse.model_validate(profile)
+
+        assert len(payload.choices) == 1, (
+            f"seeded choice must serialize; got {len(payload.choices)}"
+        )
+        assert payload.choices[0].display_subject_group_name, (
+            "display_subject_group_name comes from the nested subject_group; "
+            "empty means the repaired graph did not reach it"
+        )


### PR DESCRIPTION
## Vấn đề

Rút hồ sơ **multi-NV** có khoản **học phí HK1 chưa thu** (hoá đơn đã phát hành, `paid_amount=0`) trả **HTTP 500 và rollback toàn bộ** → không rút được bằng bất kỳ cách nào qua giao diện. Không hỏng dữ liệu (rollback sạch), nhưng luồng rút bế tắc; số hồ sơ dính tăng theo số hoá đơn học phí phát hành.

## Nguyên nhân

`withdraw` STEP 2 huỷ khoản phí chưa thu → `cancel_fee` revert lead projection HK1 nên gọi `fee_calculation_service._get_profile`, hàm này chỉ `selectinload(AdmissionProfile.choices)` **NÔNG**. Profile vào identity map với `choices` "đã nạp" nhưng đồ thị lồng còn lazy. `_populate_response_fields` khi đó chỉ hỏi `"choices" in inspect(profile).unloaded` → False → bỏ qua nạp phòng thủ → sync code chạm `group.subject_mappings` → **MissingGreenlet** trong async context.

## Sửa

Chốt chặn `_choices_eager_graph_incomplete` kiểm **đủ đồ thị eager** (6 nhánh: `admission_path` + `academic_info/offering/program` + `method/round/criteria`, `path_subject_group_config → subject_group → subject_mappings → subject`, `scores → subject`) thay vì mỗi quan hệ tầng đầu; thiếu hop nào thì nạp lại qua `list_by_profile` + `set_committed_value`. Duyệt hoàn toàn in-memory qua `inspect().unloaded` + `__dict__`, không chạm lazy. Phủ cả rủi ro serialization (schema getattr-walk cùng các quan hệ này).

Danh sách nhánh **không chép tay**: `_choice_eager_paths()` **suy ra** từ chính `admission_repository._choices_eager_load_options()` (introspect loader options, cache) — một nguồn duy nhất, xoá mặt drift.

**Cứng hoá** (từ 2 vòng /code-review max):
- fail-CLOSED khi tên hop sai hoặc `committed_state`-không-`__dict__` (backref append làm `choices` "trông đã nạp" mà thực chất vắng → tránh vô hiệu hoá guard)
- `inspect(raiseerr=False)` + chặn Mapper (object không phải ORM không được biến guard chống-500 thành 500)

**Không** làm lớp đệm thứ hai: bản nháp đầu có "belt" cho `_resolve_allowed_subjects` (trả `[]` khi chưa nạp), review cho thấy nguy hiểm và đã gỡ hoàn toàn — `[]` chỉ fail-closed dưới góc submit, còn cascade publish T6 hiểu là "không chấm được" → ghi `decision='rejected'` reason rỗng (trượt oan). `admission_choice_engine_service.py` giữ nguyên `origin/main`.

## Test

- 7 test mới (`test_withdraw_choices_eager_graph.py`): repro identity-map nạp nông; PARITY guard↔loader (xác minh bằng mutation); repro rút hồ sơ còn HK1 chưa thu → `withdrawn` + phí/hoá đơn cancelled; nhánh `withdrawal_pending`; serialization sau nạp nông. **Xác minh 7/7 FAIL khi gỡ bản vá.**
- 2 test bổ sung (`TestWithdrawalPendingFlow`) lấp lỗ hổng luồng hoàn tiền: hai lần đóng → hai phiếu hoàn (chi 1/2 vẫn kẹt, chi nốt mới chốt); từ chối lẻ phiếu khi chờ hoàn → 400.
- Hồi quy 62 test pass. flake8 net-zero.

Không migration, không đổi frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)