### PR TITLE
fix(sms): 3 lỗi vận hành từ chiến dịch thật #6 — bàn giao ẩn nút, import header tiếng Việt, CTR bị máy quét thổi phồng

### DIFF
--- a/Backend_FastAPI/app/models/sms/click_event.py
+++ b/Backend_FastAPI/app/models/sms/click_event.py
@@ -8,6 +8,10 @@ tổng recipient handed_off. Không lưu IP thô → ip_hash HMAC.
 `sms_campaign_recipient` (report đã JOIN sẵn). KHÔNG denormalize campaign_id/
 contact_id ở đây vì 3 FK độc lập cho phép gắn sai campaign/contact → hỏng CTR.
 Xem `Documents/SMS_MARKETING_MODULE_DESIGN.md` §4.10.
+
+`bot_reason` (cột comment liệt kê 3 giá trị đầu, giữ nguyên để không sinh
+migration comment-only): known_scanner_ua · prefetch_head · no_user_agent ·
+non_mobile_ua (chỉ kênh SMS) · instant_after_send. Nguồn: `utils/sms_bot.py`.
 """
 from datetime import datetime
 from typing import Optional

--- a/Backend_FastAPI/app/repositories/sms_tracking_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_tracking_repository.py
@@ -104,6 +104,45 @@ class SmsTrackingRepository:
             .values(**values)
         )
 
+    async def count_recent_same_ua_recipients(
+        self,
+        *,
+        user_agent: Optional[str],
+        campaign_id: int,
+        since: datetime,
+        exclude_recipient_id: int,
+    ) -> int:
+        """Đếm người nhận KHÁC **của cùng campaign** mà cùng UA này vừa mở
+        link từ `since`.
+
+        Vân tay máy quét nhà mạng = MỘT user-agent mở link của hàng loạt người
+        nhận trong vài giây (campaign #6: 10 người/28 giây). Người thật dùng
+        máy tính/iPad thì lẻ tẻ nên đếm ra 0 → không bị gắn nhãn bot.
+
+        ⚠️ Bắt buộc giới hạn theo campaign: chuỗi UA của Chrome desktop đã bị
+        đóng băng từ bản 120 nên hàng triệu máy gửi y hệt nhau — đếm trên toàn
+        bảng thì vài người thật ở các campaign khác nhau cùng bấm trong 60
+        giây là đủ để người thứ ba bị gán nhãn oan.
+        Cửa sổ nhỏ + index `clicked_at` → chỉ quét vài dòng cuối bảng.
+        """
+        if not user_agent:
+            return 0
+        res = await self.db.execute(
+            select(func.count(func.distinct(SmsClickEvent.recipient_id)))
+            .select_from(SmsClickEvent)
+            .join(
+                SmsCampaignRecipient,
+                SmsCampaignRecipient.id == SmsClickEvent.recipient_id,
+            )
+            .where(
+                SmsClickEvent.user_agent == user_agent[:512],
+                SmsClickEvent.clicked_at >= since,
+                SmsClickEvent.recipient_id != exclude_recipient_id,
+                SmsCampaignRecipient.campaign_id == campaign_id,
+            )
+        )
+        return int(res.scalar() or 0)
+
     # ---------------------------------------------------------------
     # Click event + denorm counter (atomic — chống lost update khi click //)
     # ---------------------------------------------------------------

--- a/Backend_FastAPI/app/routers/sms_export.py
+++ b/Backend_FastAPI/app/routers/sms_export.py
@@ -46,7 +46,10 @@ async def export_campaign(
     await db.commit()
     if callback is not None:
         await callback()
-    return await service.get_export_result(campaign_id)
+    # callback None = không batch nào cần sinh lại → nói đúng điều đó.
+    return await service.get_export_result(
+        campaign_id, regenerated=callback is not None
+    )
 
 
 @router.get(

--- a/Backend_FastAPI/app/schemas/sms.py
+++ b/Backend_FastAPI/app/schemas/sms.py
@@ -429,6 +429,10 @@ class SmsCampaignOut(BaseModel):
     # Computed (service điền)
     has_link: Optional[bool] = None
     group_count: Optional[int] = None
+    # Gate TRẠNG THÁI export/re-export (status + đã build). KHÔNG gồm
+    # attestation/preflight — FE hiển thị riêng phần "còn thiếu gì".
+    # 'handed_off' VẪN true: re-export để retry batch nhà mạng lỗi (§8.4).
+    can_export: Optional[bool] = None
 
 
 class SmsCampaignList(BaseModel):

--- a/Backend_FastAPI/app/schemas/sms.py
+++ b/Backend_FastAPI/app/schemas/sms.py
@@ -432,7 +432,11 @@ class SmsCampaignOut(BaseModel):
     # Gate TRẠNG THÁI export/re-export (status + đã build). KHÔNG gồm
     # attestation/preflight — FE hiển thị riêng phần "còn thiếu gì".
     # 'handed_off' VẪN true: re-export để retry batch nhà mạng lỗi (§8.4).
-    can_export: Optional[bool] = None
+    # KHÔNG đặt default: đây là cờ gate, path nào quên `_with_computed` phải
+    # vỡ ngay lúc serialize chứ không im lặng phát ra false rồi ẩn mất nút
+    # bàn giao — đúng lớp sự cố #6. Cả 6 endpoint trả SmsCampaignOut hiện đều
+    # đi qua `_with_computed`.
+    can_export: bool
 
 
 class SmsCampaignList(BaseModel):

--- a/Backend_FastAPI/app/services/sms_campaign_service.py
+++ b/Backend_FastAPI/app/services/sms_campaign_service.py
@@ -24,6 +24,7 @@ from app.models.sms import SmsCampaign, SmsContactGroup
 from app.repositories.sms_campaign_repository import SmsCampaignRepository
 from app.repositories.sms_contact_repository import SmsContactRepository
 from app.schemas import sms as sms_schemas
+from app.services.sms_export_service import EXPORTABLE_CAMPAIGN_STATUS
 from app.utils.exceptions import (
     BusinessRuleViolation,
     ConflictError,
@@ -134,10 +135,16 @@ class SmsCampaignService:
     def _with_computed(
         self, campaign: SmsCampaign, group_count: Optional[int] = None
     ) -> SmsCampaign:
-        # Luôn set cả 2 transient attr (kể cả None) để Pydantic from_attributes
+        # Luôn set cả 3 transient attr (kể cả None) để Pydantic from_attributes
         # không thiếu thuộc tính khi serialize SmsCampaignOut ở list.
         campaign.has_link = has_link(campaign.sms_template)
         campaign.group_count = group_count
+        # Nguồn sự thật DUY NHẤT của gate trạng thái export = hằng bên
+        # export_service → FE không tự suy diễn từ status (đọc cờ này).
+        campaign.can_export = (
+            campaign.status in EXPORTABLE_CAMPAIGN_STATUS
+            and campaign.build_revision >= 1
+        )
         return campaign
 
     # ===============================================================

--- a/Backend_FastAPI/app/services/sms_campaign_service.py
+++ b/Backend_FastAPI/app/services/sms_campaign_service.py
@@ -10,7 +10,6 @@ Tuân thủ kiến trúc QLTS: KHÔNG import fastapi; raise domain exception; ch
 SMS_MARKETING_MODULE_DESIGN.md §3/§6/§7/§8.
 """
 import re
-import unicodedata
 from datetime import datetime, timezone
 
 from app.utils.tz import ensure_aware
@@ -24,7 +23,7 @@ from app.models.sms import SmsCampaign, SmsContactGroup
 from app.repositories.sms_campaign_repository import SmsCampaignRepository
 from app.repositories.sms_contact_repository import SmsContactRepository
 from app.schemas import sms as sms_schemas
-from app.services.sms_export_service import EXPORTABLE_CAMPAIGN_STATUS
+from app.services.sms_export_service import campaign_state_allows_export
 from app.utils.exceptions import (
     BusinessRuleViolation,
     ConflictError,
@@ -49,6 +48,7 @@ from app.utils.sms_token import (
     generate_short_code,
 )
 from app.utils.sms_url import host_in_allowlist
+from app.utils.text_helpers import strip_diacritics
 
 # Status cho phép build lại (chưa bàn giao/đóng).
 _REBUILDABLE = {"draft", "ready", "exported"}
@@ -56,9 +56,9 @@ _TOKEN_RETRY = 5  # số lần auto-retry khi token_hash collision (§6.1)
 
 
 def _slugify(name: str) -> str:
-    s = unicodedata.normalize("NFD", name or "")
-    s = "".join(c for c in s if unicodedata.category(c) != "Mn")
-    s = s.replace("đ", "d").replace("Đ", "D").lower().strip()
+    """Slug ASCII cho campaign code — dùng chung helper bỏ dấu (đừng chép lại
+    vòng NFD; bản ở `sms_contact_service` đã gom về `text_helpers`)."""
+    s = strip_diacritics(name).lower().strip()
     s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
     return s[:50] or "campaign"
 
@@ -139,12 +139,9 @@ class SmsCampaignService:
         # không thiếu thuộc tính khi serialize SmsCampaignOut ở list.
         campaign.has_link = has_link(campaign.sms_template)
         campaign.group_count = group_count
-        # Nguồn sự thật DUY NHẤT của gate trạng thái export = hằng bên
-        # export_service → FE không tự suy diễn từ status (đọc cờ này).
-        campaign.can_export = (
-            campaign.status in EXPORTABLE_CAMPAIGN_STATUS
-            and campaign.build_revision >= 1
-        )
+        # Gọi thẳng vị từ của export_service → FE không tự suy diễn từ status,
+        # và cờ hiển thị không thể lệch khỏi gate thật.
+        campaign.can_export = campaign_state_allows_export(campaign)
         return campaign
 
     # ===============================================================

--- a/Backend_FastAPI/app/services/sms_contact_service.py
+++ b/Backend_FastAPI/app/services/sms_contact_service.py
@@ -46,30 +46,59 @@ from app.utils.phone_helpers import (
 MAX_IMPORT_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 MAX_IMPORT_ROWS = 50000
 
-# Alias header tiếng Việt → tên cột chuẩn
+# Alias header tiếng Việt → tên cột chuẩn. So khớp SAU khi bỏ dấu
+# (`_normalize_header`) nên chỉ cần liệt kê dạng ASCII: "Họ và tên" →
+# "ho_va_ten", "SĐT" → "sdt".
 _COL_ALIASES = {
-    "full_name": {"full_name", "fullname", "ho_ten", "hoten", "ten", "name"},
+    "full_name": {
+        "full_name", "fullname", "ho_ten", "hoten", "ten", "name",
+        "ho_va_ten", "hovaten", "ho_ten_hoc_sinh", "ten_hoc_sinh",
+        "hoc_sinh", "ho_ten_thi_sinh", "ten_thi_sinh",
+    },
     "phone": {
         "phone", "so_dien_thoai", "sodienthoai", "sdt", "dien_thoai",
-        "phone_number", "phonenumber",
+        "phone_number", "phonenumber", "so_dt", "dt", "so_may",
+        "dien_thoai_lien_he", "sdt_lien_he", "so_dien_thoai_lien_he",
+        "mobile", "so_dien_thoai_hoc_sinh",
     },
-    "note": {"note", "ghi_chu", "ghichu", "notes"},
+    "note": {"note", "ghi_chu", "ghichu", "notes", "chu_thich"},
 }
+
+
+def _strip_diacritics(text: str) -> str:
+    """Bỏ dấu tiếng Việt → ASCII (đ/Đ không phải dấu tổ hợp nên thay tay)."""
+    s = unicodedata.normalize("NFD", text or "")
+    s = "".join(c for c in s if unicodedata.category(c) != "Mn")
+    return s.replace("đ", "d").replace("Đ", "D")
 
 
 def _slugify(name: str) -> str:
     """Sinh slug ASCII (bỏ dấu tiếng Việt) cho group code."""
-    s = unicodedata.normalize("NFD", name or "")
-    s = "".join(c for c in s if unicodedata.category(c) != "Mn")
-    s = s.replace("đ", "d").replace("Đ", "D").lower().strip()
+    s = _strip_diacritics(name).lower().strip()
     s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
     return s[:50] or "group"
+
+
+def _normalize_header(col: str) -> str:
+    """Chuẩn hóa 1 header về khóa so-alias: bỏ dấu + lower + gộp mọi ký tự
+    không phải chữ/số thành '_'.
+
+    ⚠ Bước bỏ dấu là BẮT BUỘC: thiếu nó thì alias viết cho tiếng Việt không
+    bao giờ khớp header thật ("Họ tên" → "họ_tên" ≠ "ho_ten"), khiến file
+    hợp lệ bị từ chối 400 "thiếu cột bắt buộc".
+    """
+    s = _strip_diacritics(str(col or "")).lower().strip()
+    return re.sub(r"[^a-z0-9]+", "_", s).strip("_")
 
 
 def _resolve_columns(columns: List[str]) -> dict:
     """Map tên cột thực (đã chuẩn hóa) → cột chuẩn. Trả {chuẩn: thực}."""
     found = {}
-    norm = {c.lower().strip().replace(" ", "_"): c for c in columns}
+    # setdefault: 2 header khác nhau có thể chuẩn hóa về CÙNG khóa (vd "Họ tên"
+    # và "Ho ten") → giữ cột xuất hiện TRƯỚC thay vì để cột sau ghi đè.
+    norm: dict = {}
+    for c in columns:
+        norm.setdefault(_normalize_header(c), c)
     for canonical, aliases in _COL_ALIASES.items():
         for key, original in norm.items():
             if key in aliases:

--- a/Backend_FastAPI/app/services/sms_contact_service.py
+++ b/Backend_FastAPI/app/services/sms_contact_service.py
@@ -10,9 +10,9 @@ Tuân thủ kiến trúc QLTS: KHÔNG import fastapi; raise domain exception (kh
 HTTPException); chỉ `flush` (router `commit`). SMS marketing KHÔNG qua
 dispatch() (§11.8) nên service trả thẳng result, không (result, callback).
 """
+import asyncio
 import io
 import re
-import unicodedata
 from datetime import datetime
 from typing import List, Optional, Tuple
 
@@ -41,70 +41,168 @@ from app.utils.phone_helpers import (
     normalize_vn_mobile,
     to_zalo_phone,
 )
+from app.utils.text_helpers import strip_diacritics
 
 # Import giới hạn an toàn
 MAX_IMPORT_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 MAX_IMPORT_ROWS = 50000
 
-# Alias header tiếng Việt → tên cột chuẩn. So khớp SAU khi bỏ dấu
-# (`_normalize_header`) nên chỉ cần liệt kê dạng ASCII: "Họ và tên" →
-# "ho_va_ten", "SĐT" → "sdt".
-_COL_ALIASES = {
-    "full_name": {
-        "full_name", "fullname", "ho_ten", "hoten", "ten", "name",
-        "ho_va_ten", "hovaten", "ho_ten_hoc_sinh", "ten_hoc_sinh",
-        "hoc_sinh", "ho_ten_thi_sinh", "ten_thi_sinh",
-    },
-    "phone": {
-        "phone", "so_dien_thoai", "sodienthoai", "sdt", "dien_thoai",
-        "phone_number", "phonenumber", "so_dt", "dt", "so_may",
-        "dien_thoai_lien_he", "sdt_lien_he", "so_dien_thoai_lien_he",
-        "mobile", "so_dien_thoai_hoc_sinh",
-    },
-    "note": {"note", "ghi_chu", "ghichu", "notes", "chu_thich"},
-}
-
-
-def _strip_diacritics(text: str) -> str:
-    """Bỏ dấu tiếng Việt → ASCII (đ/Đ không phải dấu tổ hợp nên thay tay)."""
-    s = unicodedata.normalize("NFD", text or "")
-    s = "".join(c for c in s if unicodedata.category(c) != "Mn")
-    return s.replace("đ", "d").replace("Đ", "D")
+# Nhận diện cột theo CỤM CON trên header đã bỏ dấu + gộp "_"
+# (`_normalize_header`), KHÔNG so bằng danh sách chuỗi cố định: header thật
+# luôn có đuôi ("Họ và tên học sinh", "SĐT phụ huynh", "Số điện thoại (Zalo)")
+# nên liệt kê tổ hợp là trò đuổi bắt không hồi kết.
+#
+# ⚠️ TUYỆT ĐỐI KHÔNG thêm "dt": trong danh sách trường "DT" gần như luôn là
+# **Dân tộc**, và sau bước bỏ dấu thì "ĐT" (điện thoại) cũng thành "dt" —
+# không phân biệt được. Nhận nhầm còn tệ hơn báo thiếu cột: cả file import
+# im lặng 0 dòng vì "Kinh"/"Tày" không phải số di động.
+_NAME_PHRASES = ("full_name", "fullname", "ho_va_ten", "hovaten", "ho_ten", "hoten")
+_PHONE_PHRASES = (
+    "so_dien_thoai", "sodienthoai", "dien_thoai", "sdt", "so_dt",
+    "phone", "mobile", "so_may",
+)
+_NOTE_PHRASES = ("ghi_chu", "ghichu", "note", "chu_thich")
+# Chỉ khớp CHÍNH XÁC (không phải cụm con) — "ten" là cụm con của "ten_truong",
+# "ten_lop", "ten_nganh"… nên dùng làm cụm con sẽ gán bừa.
+_NAME_EXACT_FALLBACK = {"ten", "name"}
+# Cột "họ" đứng riêng ⇒ file tách họ/tên, ghép sai sẽ mất họ đệm (xem
+# `_resolve_columns`).
+_SURNAME_EXACT = {"ho", "ho_dem", "hodem", "ho_va_dem"}
 
 
 def _slugify(name: str) -> str:
     """Sinh slug ASCII (bỏ dấu tiếng Việt) cho group code."""
-    s = _strip_diacritics(name).lower().strip()
+    s = strip_diacritics(name).lower().strip()
     s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
     return s[:50] or "group"
 
 
 def _normalize_header(col: str) -> str:
-    """Chuẩn hóa 1 header về khóa so-alias: bỏ dấu + lower + gộp mọi ký tự
-    không phải chữ/số thành '_'.
+    """Chuẩn hóa 1 header về khóa so khớp: bỏ dấu + lower + gộp mọi ký tự
+    không phải chữ/số thành '_' (nuốt luôn BOM nếu file CSV có).
 
-    ⚠ Bước bỏ dấu là BẮT BUỘC: thiếu nó thì alias viết cho tiếng Việt không
+    ⚠ Bước bỏ dấu là BẮT BUỘC: thiếu nó thì cụm viết cho tiếng Việt không
     bao giờ khớp header thật ("Họ tên" → "họ_tên" ≠ "ho_ten"), khiến file
     hợp lệ bị từ chối 400 "thiếu cột bắt buộc".
     """
-    s = _strip_diacritics(str(col or "")).lower().strip()
+    s = strip_diacritics(str(col or "")).lower().strip()
     return re.sub(r"[^a-z0-9]+", "_", s).strip("_")
 
 
 def _resolve_columns(columns: List[str]) -> dict:
-    """Map tên cột thực (đã chuẩn hóa) → cột chuẩn. Trả {chuẩn: thực}."""
-    found = {}
+    """Map cột thực → cột chuẩn. Trả {chuẩn: thực}.
+
+    Nhiều cột cùng khớp (vd "SĐT học sinh" + "SĐT phụ huynh") → lấy cột đứng
+    TRƯỚC trong file, theo quy ước cột chính nằm bên trái.
+    """
+    found: dict = {}
     # setdefault: 2 header khác nhau có thể chuẩn hóa về CÙNG khóa (vd "Họ tên"
     # và "Ho ten") → giữ cột xuất hiện TRƯỚC thay vì để cột sau ghi đè.
     norm: dict = {}
     for c in columns:
-        norm.setdefault(_normalize_header(c), c)
-    for canonical, aliases in _COL_ALIASES.items():
+        key = _normalize_header(c)
+        if key:
+            norm.setdefault(key, c)
+
+    for canonical, phrases in (
+        ("full_name", _NAME_PHRASES),
+        ("phone", _PHONE_PHRASES),
+        ("note", _NOTE_PHRASES),
+    ):
         for key, original in norm.items():
-            if key in aliases:
+            if any(p in key for p in phrases):
                 found[canonical] = original
                 break
+
+    if "full_name" not in found:
+        weak = next(
+            (o for k, o in norm.items() if k in _NAME_EXACT_FALLBACK), None
+        )
+        if weak is not None:
+            surname = next(
+                (o for k, o in norm.items() if k in _SURNAME_EXACT), None
+            )
+            # File tách "Họ đệm" + "Tên": nhận cột "Tên" làm full_name sẽ lưu
+            # tên cụt ("An", "Bình") mà KHÔNG báo lỗi gì — hỏng dữ liệu âm thầm
+            # rồi đem cá nhân hoá nội dung SMS. Thà chặn to tiếng.
+            if surname is not None:
+                raise ValidationError(
+                    detail=(
+                        f"File tách cột họ ('{surname}') và tên ('{weak}') — "
+                        "gộp thành MỘT cột họ tên đầy đủ (vd 'Họ và tên') "
+                        "rồi import lại."
+                    )
+                )
+            found["full_name"] = weak
     return found
+
+
+def _read_csv_bytes(content: bytes):
+    """Đọc CSV chịu được thực tế Excel tiếng Việt.
+
+    Hai cái bẫy khiến file "đúng" vẫn 400:
+    - **Dấu phân cách**: Excel bản vi-VN dùng dấu chấm phẩy làm list separator
+      nên "CSV (Comma delimited)" lại ghi ra `full_name;phone;note`. Mặc định
+      `read_csv` tách bằng dấu phẩy → cả dòng thành MỘT cột → "thiếu cột".
+      `sep=None` + engine python để pandas tự dò.
+    - **Bảng mã**: Excel có thể ghi ANSI (cp1258) hoặc "Unicode Text" (UTF-16)
+      thay vì UTF-8.
+    """
+    import pandas as pd
+
+    # UTF-16 phải thử TRƯỚC: `latin1` giải mã được mọi chuỗi byte nên nó sẽ
+    # nuốt file UTF-16 thành mojibake, rồi báo "thiếu cột" — sai nguyên nhân,
+    # người dùng không đời nào đoán ra là do bảng mã.
+    encodings = ("utf-8-sig", "cp1258", "latin1")
+    if content[:2] in (b"\xff\xfe", b"\xfe\xff"):
+        encodings = ("utf-16",) + encodings
+
+    last_error: Exception = ValidationError(detail="File CSV không đọc được")
+    for encoding in encodings:
+        try:
+            return pd.read_csv(
+                io.BytesIO(content),
+                dtype=str,
+                sep=None,
+                engine="python",
+                encoding=encoding,
+            )
+        except UnicodeDecodeError as exc:
+            last_error = exc
+            continue
+        except pd.errors.ParserError as exc:
+            # Sniffer bó tay (thường là file đúng 1 cột) → ép dấu phẩy.
+            last_error = exc
+            try:
+                return pd.read_csv(
+                    io.BytesIO(content), dtype=str, encoding=encoding
+                )
+            except UnicodeDecodeError:
+                continue
+    raise last_error
+
+
+def _clean_phone_cell(phone: str) -> str:
+    """Dọn 2 biến dạng do Excel gây ra trước khi validate số.
+
+    1. Lớp bọc chống-ép-kiểu `="0912345678"` (file mẫu của ta dùng đúng cách
+       này; Excel hiển thị thành chữ nhưng nếu upload thẳng thì tới đây vẫn
+       là chuỗi thô).
+    2. Số 0 đầu bị ăn mất khi Excel ép cột SĐT thành số ("0912345678" →
+       "912345678") — không vá thì TOÀN BỘ file bị loại "không phải di động
+       VN". Chỉ đụng đúng ca 9 chữ số mở đầu bằng đầu số di động VN (3/5/7/
+       8/9); số 10 chữ số hay dạng +84 không bị ảnh hưởng.
+
+    Cố ý làm ở tầng import, KHÔNG nới `normalize_vn_mobile` (helper dùng chung
+    toàn hệ thống — nới ở đó thì nhập tay/API cũng nhận bừa số thiếu số 0).
+    """
+    cleaned = phone.strip()
+    m = re.fullmatch(r'="?([^"]*)"?', cleaned)
+    if m:
+        cleaned = m.group(1).strip()
+    if re.fullmatch(r"[35789]\d{8}", cleaned):
+        return "0" + cleaned
+    return cleaned
 
 
 def _reject_null(patch: dict, fields) -> None:
@@ -439,7 +537,7 @@ class SmsContactService:
         ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
         try:
             if ext == "csv":
-                df = pd.read_csv(io.BytesIO(file_content), dtype=str)
+                df = _read_csv_bytes(file_content)
             elif ext == "xlsx":
                 df = pd.read_excel(
                     io.BytesIO(file_content), engine="openpyxl", dtype=str
@@ -469,7 +567,9 @@ class SmsContactService:
                     "full_name": str(
                         row.get(colmap["full_name"]) or ""
                     ).strip(),
-                    "phone": str(row.get(colmap["phone"]) or "").strip(),
+                    "phone": _clean_phone_cell(
+                        str(row.get(colmap["phone"]) or "")
+                    ),
                     "note": (
                         str(row.get(colmap["note"]) or "").strip()
                         if "note" in colmap
@@ -512,7 +612,13 @@ class SmsContactService:
             consent_proof_ref,
             consent_obtained_at,
         )
-        rows = self._parse_rows(file_content, filename or "")
+        # `_parse_rows` là CPU-bound thuần sync (pandas đọc tới 50.000 dòng,
+        # engine="python" để dò dấu phân cách lại chậm hơn engine C khoảng một
+        # bậc) → chạy thẳng trong coroutine sẽ treo event loop của worker vài
+        # giây, mọi request khác trên worker đó đứng theo.
+        rows = await asyncio.to_thread(
+            self._parse_rows, file_content, filename or ""
+        )
 
         # --- Phân loại từng dòng (mỗi dòng vào ĐÚNG 1 bucket) ---
         errors: List[sms_schemas.SmsImportRowError] = []

--- a/Backend_FastAPI/app/services/sms_export_service.py
+++ b/Backend_FastAPI/app/services/sms_export_service.py
@@ -38,12 +38,10 @@ from app.utils.sms_render import has_link
 
 log = logging.getLogger(__name__)
 
-# Campaign đã build, được phép export (lần đầu 'ready'; re-export idempotent
-# khi 'exported'). 'draft' = chưa build/stale; 'handed_off'/'closed' = khoá.
 # Campaign được phép export: 'ready' (lần đầu), 'exported' (re-export), và
 # 'handed_off' (re-export để RETRY batch failed của nhà mạng khác mà không
-# kẹt — xem mark_handed_off). 'draft' = chưa build/stale; 'closed' = đã bàn
-# giao hết → khoá.
+# kẹt — xem mark_handed_off). 'draft' = chưa build hoặc build đã stale;
+# 'closed' = đã bàn giao hết → khoá.
 # Public: campaign_service đọc để điền cờ `can_export` cho FE (thin-client)
 # → chỉ MỘT định nghĩa gate, không drift giữa gate thật và cờ hiển thị.
 EXPORTABLE_CAMPAIGN_STATUS = {"ready", "exported", "handed_off"}
@@ -52,6 +50,21 @@ _REGENERATE_BATCH_STATUS = {"pending", "failed", "purged", "invalidated"}
 
 
 _aware = ensure_aware  # alias tới helper tz chung (bỏ bản sao logic)
+
+
+def campaign_state_allows_export(campaign: SmsCampaign) -> bool:
+    """Campaign có ở TRẠNG THÁI cho phép export/re-export không.
+
+    MỘT nguồn sự thật cho hai chỗ: gate thật (`_assert_exportable`) và cờ
+    `can_export` mà `sms_campaign_service` gửi cho FE — thêm điều kiện mới
+    thì cả hai cùng đổi, không còn cảnh FE bật nút rồi ăn 400.
+    KHÔNG bao gồm attestation/preflight: những thứ đó FE hiển thị riêng dưới
+    dạng "còn thiếu gì" nên không được nuốt vào một cờ boolean.
+    """
+    return (
+        campaign.status in EXPORTABLE_CAMPAIGN_STATUS
+        and campaign.build_revision >= 1
+    )
 
 
 def _carrier_label(carrier_bucket: str) -> str:
@@ -105,6 +118,12 @@ class SmsExportService:
             and b.purged_at is None
             and not is_expired
         )
+        # KHÔNG cần thêm điều kiện `b.build_revision == campaign.build_revision`
+        # (gate thứ 5 của `mark_handed_off`): batch revision cũ vừa bị
+        # `invalidate_export_batches_before` đặt 'invalidated' khi build lại,
+        # vừa bị `list_batches(campaign_id, build_revision)` lọc khỏi response.
+        # ⚠️ Cờ này giờ là gate DUY NHẤT của nút "Đã bàn giao" ở FE — nếu sau
+        # này list trả cả batch revision cũ thì PHẢI thêm điều kiện đó vào đây.
         out.can_mark_handed_off = bool(
             b.status == "generated"
             and b.invalidated_at is None
@@ -123,19 +142,21 @@ class SmsExportService:
     # Gate fail-closed (§8.4)
     # ===============================================================
     def _assert_exportable(self, campaign: SmsCampaign) -> None:
+        # Phần trạng thái dùng CHUNG `campaign_state_allows_export` với cờ
+        # `can_export` gửi cho FE; chỉ các thông điệp lỗi là riêng ở đây.
         if campaign.status == "draft":
             raise BusinessRuleViolation(
                 detail="Campaign chưa Build (hoặc đã đổi nhóm/nội dung sau "
                 "Build) — Build lại trước khi export."
             )
-        if campaign.status not in EXPORTABLE_CAMPAIGN_STATUS:
-            raise BusinessRuleViolation(
-                detail="Campaign đã bàn giao/đóng — không export lại; tạo "
-                "campaign mới."
-            )
-        rev = campaign.build_revision
-        if rev < 1:
+        if not campaign_state_allows_export(campaign):
+            if campaign.status not in EXPORTABLE_CAMPAIGN_STATUS:
+                raise BusinessRuleViolation(
+                    detail="Campaign đã bàn giao/đóng — không export lại; tạo "
+                    "campaign mới."
+                )
             raise BusinessRuleViolation(detail="Campaign chưa Build.")
+        rev = campaign.build_revision
         # 3 attestation phải khớp build_revision hiện tại + có reference thật.
         missing: List[str] = []
         if campaign.consent_checked_build_revision != rev or not (
@@ -383,7 +404,7 @@ class SmsExportService:
     # Read: kết quả export + danh sách batch (GET)
     # ===============================================================
     async def get_export_result(
-        self, campaign_id: int
+        self, campaign_id: int, *, regenerated: bool = True
     ) -> sms_schemas.SmsExportResult:
         # File sinh ở session callback KHÁC → expire instance cũ trong session
         # này để list_batches đọc trạng thái mới nhất (pending→generated).
@@ -400,6 +421,15 @@ class SmsExportService:
             build_revision=campaign.build_revision,
             total_exportable=sum(b.recipient_count for b in batches),
             batches=[self._batch_out(b, now) for b in batches],
+            # Export là idempotent: mọi batch còn hạn + còn file thì KHÔNG sinh
+            # lại. Nói thẳng ra, đừng để FE báo "Đã tạo file export" cho một
+            # thao tác không tạo gì (hay gặp ở campaign 'handed_off' đang retry
+            # một nhà mạng lỗi).
+            message=(
+                None
+                if regenerated
+                else "Các file export hiện có vẫn dùng được — không sinh lại."
+            ),
         )
 
     async def list_export_batches(

--- a/Backend_FastAPI/app/services/sms_export_service.py
+++ b/Backend_FastAPI/app/services/sms_export_service.py
@@ -44,7 +44,9 @@ log = logging.getLogger(__name__)
 # 'handed_off' (re-export để RETRY batch failed của nhà mạng khác mà không
 # kẹt — xem mark_handed_off). 'draft' = chưa build/stale; 'closed' = đã bàn
 # giao hết → khoá.
-_EXPORTABLE_CAMPAIGN_STATUS = {"ready", "exported", "handed_off"}
+# Public: campaign_service đọc để điền cờ `can_export` cho FE (thin-client)
+# → chỉ MỘT định nghĩa gate, không drift giữa gate thật và cờ hiển thị.
+EXPORTABLE_CAMPAIGN_STATUS = {"ready", "exported", "handed_off"}
 # Batch ở các trạng thái này = CHƯA có file dùng được → (re)generate.
 _REGENERATE_BATCH_STATUS = {"pending", "failed", "purged", "invalidated"}
 
@@ -126,7 +128,7 @@ class SmsExportService:
                 detail="Campaign chưa Build (hoặc đã đổi nhóm/nội dung sau "
                 "Build) — Build lại trước khi export."
             )
-        if campaign.status not in _EXPORTABLE_CAMPAIGN_STATUS:
+        if campaign.status not in EXPORTABLE_CAMPAIGN_STATUS:
             raise BusinessRuleViolation(
                 detail="Campaign đã bàn giao/đóng — không export lại; tạo "
                 "campaign mới."

--- a/Backend_FastAPI/app/services/sms_tracking_service.py
+++ b/Backend_FastAPI/app/services/sms_tracking_service.py
@@ -9,7 +9,7 @@ KHÔNG import fastapi; raise domain exception; service flush (router commit).
 Xem SMS_MARKETING_MODULE_DESIGN.md §6.
 """
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Mapping, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.repositories.sms_tracking_repository import SmsTrackingRepository
 from app.services.sms_resolve import GENERIC_404, resolve_code
 from app.utils.exceptions import ResourceNotFoundError
-from app.utils.sms_bot import detect_bot
+from app.utils.sms_bot import BURST_WINDOW_SECONDS, detect_bot
 from app.utils.sms_token import compute_ip_hash
 from app.utils.sms_url import host_in_allowlist
 
@@ -58,15 +58,22 @@ class SmsTrackingService:
                     raise ResourceNotFoundError(detail=GENERIC_404)
             else:
                 target = f"/lp/{code}"
-            # mobile_channel=True: lượt này đến TỪ TIN SMS → chỉ mở được trên
-            # điện thoại. UA desktop = máy quét chống spam của nhà mạng, vốn
-            # lọt hết 3 dấu hiệu cũ và thổi phồng CTR (xem sms_bot).
+            # Lượt này đến TỪ TIN SMS → bật dấu hiệu chùm quét nhà mạng: cùng
+            # một UA không-di-động mở link của nhiều người nhận khác trong ít
+            # giây (xem sms_bot). Đếm TRƯỚC khi ghi click hiện tại.
+            same_ua_recipients = await self.repo.count_recent_same_ua_recipients(
+                user_agent=user_agent,
+                campaign_id=resolved.recipient.campaign_id,
+                since=now - timedelta(seconds=BURST_WINDOW_SECONDS),
+                exclude_recipient_id=resolved.recipient.id,
+            )
             is_bot, reason = detect_bot(
                 user_agent=user_agent,
                 headers=headers,
                 handed_off_at=resolved.recipient.handed_off_at,
                 now=now,
                 mobile_channel=True,
+                same_ua_recipients=same_ua_recipients,
             )
             await self.repo.record_click(
                 recipient_id=resolved.recipient.id,

--- a/Backend_FastAPI/app/services/sms_tracking_service.py
+++ b/Backend_FastAPI/app/services/sms_tracking_service.py
@@ -58,11 +58,15 @@ class SmsTrackingService:
                     raise ResourceNotFoundError(detail=GENERIC_404)
             else:
                 target = f"/lp/{code}"
+            # mobile_channel=True: lượt này đến TỪ TIN SMS → chỉ mở được trên
+            # điện thoại. UA desktop = máy quét chống spam của nhà mạng, vốn
+            # lọt hết 3 dấu hiệu cũ và thổi phồng CTR (xem sms_bot).
             is_bot, reason = detect_bot(
                 user_agent=user_agent,
                 headers=headers,
                 handed_off_at=resolved.recipient.handed_off_at,
                 now=now,
+                mobile_channel=True,
             )
             await self.repo.record_click(
                 recipient_id=resolved.recipient.id,

--- a/Backend_FastAPI/app/utils/sms_bot.py
+++ b/Backend_FastAPI/app/utils/sms_bot.py
@@ -4,13 +4,31 @@ SMS click bot heuristic (PR-5): phân loại 1 lượt /r/{code} có phải bot/
 preview KHÔNG, để KHÔNG tính vào CTR "người thật". Best-effort, fail-OPEN cho
 phía người (chỉ flag khi có dấu hiệu rõ) — CTR thà thiếu hơn thừa.
 
-3 dấu hiệu (khớp click_event.bot_reason §4.10):
+4 dấu hiệu (khớp click_event.bot_reason §4.10):
 - known_scanner_ua: User-Agent của crawler/link-preview (Facebook, Zalo,
   Telegram, WhatsApp, Slack, Google, bot/crawler/spider, curl/wget/python…).
 - prefetch_head: request mang header prefetch/preview (Purpose/X-Purpose) hoặc
   Sec-Purpose=prefetch.
+- non_mobile_ua: CHỈ kênh SMS (`mobile_channel=True`) — UA không có dấu hiệu
+  di động. Tin SMS chỉ mở được trên điện thoại, nên UA desktop = máy quét
+  chống spam của nhà mạng (xem bên dưới).
 - instant_after_send: click trong vài giây ngay sau bàn giao (preview server
   fetch tức thì khi tin vừa gửi) — đo `now - recipient.handed_off_at`.
+
+⚠ Vì sao cần `non_mobile_ua` (bằng chứng chiến dịch #6, 13-07): 23 lượt vào
+`/r/` thì 20 lượt cùng UA `Mozilla/5.0 (X11; Linux x86_64) …Chrome` trong
+chùm 28 giây (10 người nhận × 2 lượt, 11 IP khác nhau) + 1 lượt
+`antispam/1.0.0` — đều là máy quét của nhà mạng fetch mọi URL khi tin vừa
+gửi. Cả hai lọt hết 3 dấu hiệu cũ: UA trông như trình duyệt thật (không chứa
+token scanner nào), còn `instant_after_send` vô hiệu vì operator bấm "Đã bàn
+giao" 10 phút SAU khi nhà mạng đã gửi → lúc quét `handed_off_at` còn NULL.
+Hệ quả: báo cáo ghi 22 "người thật" trong khi chỉ ~1 người thật.
+
+⚠ Đánh đổi CÓ CHỦ Ý: người thật mở link SMS trên máy tính (thường là chính
+mình test) cũng bị đếm là bot. Chấp nhận được vì (a) học sinh nhận SMS gần
+như luôn bấm trên điện thoại, (b) tín hiệu engagement "quan tâm ngành"
+(session + dwell, cần JS) KHÔNG áp dấu hiệu này nên vẫn ghi nhận đầy đủ —
+xem `mobile_channel` chỉ được bật ở nhánh recipient của `resolve_click`.
 """
 from datetime import datetime, timedelta, timezone
 
@@ -28,8 +46,22 @@ _SCANNER_UA_TOKENS = (
 )
 _INSTANT_SECONDS = 8  # click ≤8s sau handoff → nghi preview server
 
+# Dấu hiệu trình duyệt DI ĐỘNG. Thiếu TẤT CẢ ở kênh SMS = không phải người
+# nhận thật (điện thoại luôn gửi ít nhất một trong các token này).
+_MOBILE_UA_TOKENS = (
+    "mobile", "android", "iphone", "ipad", "ipod", "windows phone",
+    "iemobile", "blackberry", "opera mini", "opera mobi", "silk",
+    "kaios", "harmonyos", "webos",
+)
+
 
 _aware = ensure_aware  # alias tới helper tz chung (bỏ bản sao logic)
+
+
+def is_mobile_ua(user_agent: Optional[str]) -> bool:
+    """UA có dấu hiệu trình duyệt di động không (lower-case substring)."""
+    ua = (user_agent or "").lower()
+    return any(tok in ua for tok in _MOBILE_UA_TOKENS)
 
 
 def detect_bot(
@@ -38,8 +70,15 @@ def detect_bot(
     headers: Optional[Mapping[str, str]] = None,
     handed_off_at: Optional[datetime] = None,
     now: Optional[datetime] = None,
+    mobile_channel: bool = False,
 ) -> Tuple[bool, Optional[str]]:
-    """Trả (is_bot, reason|None). Ưu tiên reason: UA > prefetch > instant."""
+    """Trả (is_bot, reason|None). Ưu tiên reason: UA > prefetch > non-mobile >
+    instant.
+
+    `mobile_channel=True` CHỈ cho lượt đến từ tin SMS thật (recipient) — bật
+    dấu hiệu `non_mobile_ua`. Mặc định False để link tư vấn officer / phiên
+    landing mở trên máy tính KHÔNG bị đếm nhầm là bot.
+    """
     ua = (user_agent or "").lower()
     if ua:
         for tok in _SCANNER_UA_TOKENS:
@@ -61,6 +100,9 @@ def detect_bot(
             return True, "prefetch_head"
         if (headers.get("x-moz") or "").lower() == "prefetch":
             return True, "prefetch_head"
+
+    if mobile_channel and not is_mobile_ua(ua):
+        return True, "non_mobile_ua"
 
     if handed_off_at is not None:
         ref = now or datetime.now(timezone.utc)

--- a/Backend_FastAPI/app/utils/sms_bot.py
+++ b/Backend_FastAPI/app/utils/sms_bot.py
@@ -9,14 +9,14 @@ phía người (chỉ flag khi có dấu hiệu rõ) — CTR thà thiếu hơn t
   Telegram, WhatsApp, Slack, Google, bot/crawler/spider, curl/wget/python…).
 - prefetch_head: request mang header prefetch/preview (Purpose/X-Purpose) hoặc
   Sec-Purpose=prefetch.
-- non_mobile_ua: CHỈ kênh SMS (`mobile_channel=True`) — UA không có dấu hiệu
-  di động. Tin SMS chỉ mở được trên điện thoại, nên UA desktop = máy quét
-  chống spam của nhà mạng (xem bên dưới).
+- carrier_scan_burst: CHỈ kênh SMS (`mobile_channel=True`) — UA không phải
+  trình duyệt di động VÀ cùng UA đó vừa mở link của nhiều người nhận KHÁC
+  trong ít giây (xem bên dưới).
 - instant_after_send: click trong vài giây ngay sau bàn giao (preview server
   fetch tức thì khi tin vừa gửi) — đo `now - recipient.handed_off_at`.
 
-⚠ Vì sao cần `non_mobile_ua` (bằng chứng chiến dịch #6, 13-07): 23 lượt vào
-`/r/` thì 20 lượt cùng UA `Mozilla/5.0 (X11; Linux x86_64) …Chrome` trong
+⚠ Vì sao cần `carrier_scan_burst` (bằng chứng chiến dịch #6, 13-07): 23 lượt
+vào `/r/` thì 20 lượt cùng UA `Mozilla/5.0 (X11; Linux x86_64) …Chrome` trong
 chùm 28 giây (10 người nhận × 2 lượt, 11 IP khác nhau) + 1 lượt
 `antispam/1.0.0` — đều là máy quét của nhà mạng fetch mọi URL khi tin vừa
 gửi. Cả hai lọt hết 3 dấu hiệu cũ: UA trông như trình duyệt thật (không chứa
@@ -24,16 +24,21 @@ token scanner nào), còn `instant_after_send` vô hiệu vì operator bấm "Đ
 giao" 10 phút SAU khi nhà mạng đã gửi → lúc quét `handed_off_at` còn NULL.
 Hệ quả: báo cáo ghi 22 "người thật" trong khi chỉ ~1 người thật.
 
-⚠ Đánh đổi CÓ CHỦ Ý: người thật mở link SMS trên máy tính (thường là chính
-mình test) cũng bị đếm là bot. Chấp nhận được vì (a) học sinh nhận SMS gần
-như luôn bấm trên điện thoại, (b) tín hiệu engagement "quan tâm ngành"
-(session + dwell, cần JS) KHÔNG áp dấu hiệu này nên vẫn ghi nhận đầy đủ —
-xem `mobile_channel` chỉ được bật ở nhánh recipient của `resolve_click`.
+⚠ Vì sao KHÔNG chỉ dựa "UA không phải di động": iPadOS 13+ Safari gửi UA
+Macintosh, Android bật "Yêu cầu trang máy tính" gửi đúng `X11; Linux x86_64`
+như máy quét. Nhãn bot ghi CỨNG lúc ghi click (không tính lại được) và người
+bị gắn nhãn sẽ rơi khỏi CẢ CTR lẫn danh sách "đã click" để officer gọi lại
+— hỏng nghiệp vụ, không chỉ hỏng số liệu. Vân tay thật của máy quét là
+**một UA mở link của NHIỀU người nhận khác nhau trong vài giây**; người thật
+dùng máy tính thì lẻ tẻ nên không dính.
 """
 from datetime import datetime, timedelta, timezone
 
-from app.utils.tz import ensure_aware
 from typing import Mapping, Optional, Tuple
+
+from user_agents import parse as parse_user_agent
+
+from app.utils.tz import ensure_aware
 
 # Token UA hay gặp ở crawler/link-preview/HTTP client (so khớp lower-case).
 _SCANNER_UA_TOKENS = (
@@ -46,12 +51,18 @@ _SCANNER_UA_TOKENS = (
 )
 _INSTANT_SECONDS = 8  # click ≤8s sau handoff → nghi preview server
 
-# Dấu hiệu trình duyệt DI ĐỘNG. Thiếu TẤT CẢ ở kênh SMS = không phải người
-# nhận thật (điện thoại luôn gửi ít nhất một trong các token này).
+# Cửa sổ + số người nhận KHÁC tối thiểu (trong CÙNG campaign) để coi là chùm
+# quét — tính cả lượt đang xét là ≥4 người trong 60 giây. Chùm thật của nhà
+# mạng dày hơn nhiều (campaign #6: 10 người/28 giây) nên vẫn còn rất nhiều
+# biên; ngưỡng cao giữ cho người thật dùng máy tính không bị gán nhãn oan.
+BURST_WINDOW_SECONDS = 60
+BURST_MIN_OTHER_RECIPIENTS = 3
+
+# Fallback khi `user_agents` không parse được (UA rỗng/kỳ dị). Danh sách ngắn
+# vì đường chính là thư viện — đừng nuôi thêm token ở đây.
 _MOBILE_UA_TOKENS = (
     "mobile", "android", "iphone", "ipad", "ipod", "windows phone",
     "iemobile", "blackberry", "opera mini", "opera mobi", "silk",
-    "kaios", "harmonyos", "webos",
 )
 
 
@@ -59,9 +70,22 @@ _aware = ensure_aware  # alias tới helper tz chung (bỏ bản sao logic)
 
 
 def is_mobile_ua(user_agent: Optional[str]) -> bool:
-    """UA có dấu hiệu trình duyệt di động không (lower-case substring)."""
-    ua = (user_agent or "").lower()
-    return any(tok in ua for tok in _MOBILE_UA_TOKENS)
+    """UA là trình duyệt di động (gồm cả tablet) hay không.
+
+    Dùng thư viện `user-agents` (đã là dependency production, cùng thư viện
+    `session_service`/`login_history_service` dùng để phân loại thiết bị) →
+    một cách hiểu UA duy nhất trong hệ thống, và bắt được cả những dòng máy
+    mà danh sách token tự chế bỏ sót (Symbian/Nokia, UCWEB, Fennec…).
+    """
+    ua = (user_agent or "").strip()
+    if not ua:
+        return False
+    try:
+        parsed = parse_user_agent(ua)
+        return bool(parsed.is_mobile or parsed.is_tablet)
+    except Exception:  # noqa: BLE001 — UA rác không được làm sập /r/
+        lowered = ua.lower()
+        return any(tok in lowered for tok in _MOBILE_UA_TOKENS)
 
 
 def detect_bot(
@@ -71,13 +95,16 @@ def detect_bot(
     handed_off_at: Optional[datetime] = None,
     now: Optional[datetime] = None,
     mobile_channel: bool = False,
+    same_ua_recipients: int = 0,
 ) -> Tuple[bool, Optional[str]]:
-    """Trả (is_bot, reason|None). Ưu tiên reason: UA > prefetch > non-mobile >
+    """Trả (is_bot, reason|None). Ưu tiên reason: UA > prefetch > chùm quét >
     instant.
 
     `mobile_channel=True` CHỈ cho lượt đến từ tin SMS thật (recipient) — bật
-    dấu hiệu `non_mobile_ua`. Mặc định False để link tư vấn officer / phiên
-    landing mở trên máy tính KHÔNG bị đếm nhầm là bot.
+    dấu hiệu `carrier_scan_burst`. Mặc định False để link tư vấn officer /
+    phiên landing KHÔNG bị đếm nhầm.
+    `same_ua_recipients` = số người nhận KHÁC mà cùng UA này vừa mở link
+    trong `BURST_WINDOW_SECONDS` giây (0 = không tra, coi như không có chùm).
     """
     ua = (user_agent or "").lower()
     if ua:
@@ -101,8 +128,12 @@ def detect_bot(
         if (headers.get("x-moz") or "").lower() == "prefetch":
             return True, "prefetch_head"
 
-    if mobile_channel and not is_mobile_ua(ua):
-        return True, "non_mobile_ua"
+    if (
+        mobile_channel
+        and same_ua_recipients >= BURST_MIN_OTHER_RECIPIENTS
+        and not is_mobile_ua(user_agent)
+    ):
+        return True, "carrier_scan_burst"
 
     if handed_off_at is not None:
         ref = now or datetime.now(timezone.utc)

--- a/Backend_FastAPI/app/utils/text_helpers.py
+++ b/Backend_FastAPI/app/utils/text_helpers.py
@@ -10,6 +10,22 @@ import unicodedata
 from typing import Optional
 
 
+def strip_diacritics(raw: Optional[str]) -> str:
+    """Bỏ dấu tiếng Việt, GIỮ nguyên mọi ký tự khác (khoảng trắng, dấu câu).
+
+    Dùng chung cho mọi chỗ cần so khớp không-dấu (slug nhóm/campaign, nhận
+    diện header import…) — đừng chép lại vòng NFD ở service mới.
+    """
+    if not raw:
+        return ""
+    # NFD decomposition splits accented chars into base + combining mark;
+    # dropping Mn (Mark, nonspacing) removes the accent while keeping the letter.
+    normalized = unicodedata.normalize("NFD", raw)
+    ascii_str = "".join(c for c in normalized if unicodedata.category(c) != "Mn")
+    # Replace đ/Đ separately — NFD doesn't decompose them (Latin Extended).
+    return ascii_str.replace("đ", "d").replace("Đ", "D")
+
+
 def to_bank_transfer_note(raw: Optional[str], max_len: int = 90) -> str:
     """Strip Vietnamese diacritics and non-alphanumeric characters.
 
@@ -19,12 +35,7 @@ def to_bank_transfer_note(raw: Optional[str], max_len: int = 90) -> str:
     """
     if not raw:
         return ""
-    # NFD decomposition splits accented chars into base + combining mark;
-    # dropping Mn (Mark, nonspacing) removes the accent while keeping the letter.
-    normalized = unicodedata.normalize("NFD", raw)
-    ascii_str = "".join(c for c in normalized if unicodedata.category(c) != "Mn")
-    # Replace đ/Đ separately — NFD doesn't decompose them (Latin Extended).
-    ascii_str = ascii_str.replace("đ", "d").replace("Đ", "D")
+    ascii_str = strip_diacritics(raw)
     # Collapse any non-[a-zA-Z0-9] run into a single space, then trim.
     ascii_str = re.sub(r"[^a-zA-Z0-9 ]+", " ", ascii_str)
     ascii_str = re.sub(r"\s+", " ", ascii_str).strip()

--- a/Backend_FastAPI/tests/unit/test_sms_bot_carrier_scanner.py
+++ b/Backend_FastAPI/tests/unit/test_sms_bot_carrier_scanner.py
@@ -36,17 +36,19 @@ _UA_DESKTOP_WINDOWS = (
 
 @pytest.mark.unit
 @pytest.mark.parametrize("ua", [_UA_CARRIER_SCANNER, _UA_ANTISPAM])
-def test_carrier_scanner_flagged_on_sms_channel(ua):
-    """Regression sự cố CTR #6: 2 UA này lọt HẾT 3 dấu hiệu cũ."""
+def test_carrier_scanner_flagged_when_burst(ua):
+    """Regression sự cố CTR #6: 2 UA này lọt HẾT 3 dấu hiệu cũ; chỉ lộ ra khi
+    nhìn thấy cùng UA quét link của nhiều người nhận khác trong ít giây."""
     from app.utils.sms_bot import detect_bot
 
-    # Không bật kênh SMS → vẫn lọt (chứng minh dấu hiệu cũ không đủ).
-    is_bot_old, _ = detect_bot(user_agent=ua)
-    assert is_bot_old is False
+    # Dấu hiệu cũ (không có ngữ cảnh chùm) → vẫn lọt.
+    assert detect_bot(user_agent=ua)[0] is False
 
-    is_bot, reason = detect_bot(user_agent=ua, mobile_channel=True)
+    is_bot, reason = detect_bot(
+        user_agent=ua, mobile_channel=True, same_ua_recipients=9
+    )
     assert is_bot is True
-    assert reason == "non_mobile_ua"
+    assert reason == "carrier_scan_burst"
 
 
 @pytest.mark.unit
@@ -54,29 +56,68 @@ def test_carrier_scanner_flagged_on_sms_channel(ua):
 def test_real_mobile_click_still_human(ua):
     from app.utils.sms_bot import detect_bot
 
-    is_bot, reason = detect_bot(user_agent=ua, mobile_channel=True)
+    is_bot, reason = detect_bot(
+        user_agent=ua, mobile_channel=True, same_ua_recipients=9
+    )
     assert is_bot is False
     assert reason is None
 
 
 @pytest.mark.unit
-def test_desktop_not_flagged_outside_sms_channel():
-    """Link tư vấn officer / phiên landing mở trên máy tính là HỢP LỆ —
-    mobile_channel mặc định False nên không đụng tới các luồng đó."""
+@pytest.mark.parametrize(
+    "ua",
+    [
+        _UA_DESKTOP_WINDOWS,
+        # iPadOS 13+ Safari tự giới thiệu là Macintosh; Android bật "Yêu cầu
+        # trang máy tính" gửi đúng X11/Linux như máy quét. Người thật dùng máy
+        # tính KHÔNG được biến thành bot chỉ vì UA — họ sẽ rơi khỏi cả CTR lẫn
+        # danh sách officer gọi lại.
+        (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 "
+            "Safari/605.1.15"
+        ),
+        _UA_CARRIER_SCANNER,
+    ],
+)
+def test_lone_desktop_click_is_not_a_bot(ua):
+    """Không có chùm → không gắn nhãn, dù UA là desktop.
+
+    Ngưỡng đếm theo NGƯỜI NHẬN KHÁC trong CÙNG campaign: vài người thật dùng
+    Windows (chuỗi UA Chrome desktop đã đóng băng từ bản 120 nên giống hệt
+    nhau) bấm trong cùng phút vẫn phải là người thật.
+    """
     from app.utils.sms_bot import detect_bot
 
-    is_bot, reason = detect_bot(user_agent=_UA_DESKTOP_WINDOWS)
+    for peers in (0, 1, 2):
+        is_bot, reason = detect_bot(
+            user_agent=ua, mobile_channel=True, same_ua_recipients=peers
+        )
+        assert is_bot is False, f"{peers} người khác chưa phải chùm"
+        assert reason is None
+
+
+@pytest.mark.unit
+def test_burst_ignored_outside_sms_channel():
+    """Link tư vấn officer không bật `mobile_channel` → chùm không áp dụng."""
+    from app.utils.sms_bot import detect_bot
+
+    is_bot, reason = detect_bot(
+        user_agent=_UA_CARRIER_SCANNER, same_ua_recipients=9
+    )
     assert is_bot is False
     assert reason is None
 
 
 @pytest.mark.unit
 def test_known_scanner_ua_takes_priority():
-    """UA crawler quen mặt vẫn giữ nhãn cũ (không bị non_mobile_ua nuốt)."""
+    """UA crawler quen mặt vẫn giữ nhãn cũ (không bị nhãn chùm nuốt)."""
     from app.utils.sms_bot import detect_bot
 
     is_bot, reason = detect_bot(
-        user_agent="facebookexternalhit/1.1", mobile_channel=True
+        user_agent="facebookexternalhit/1.1",
+        mobile_channel=True,
+        same_ua_recipients=9,
     )
     assert is_bot is True
     assert reason == "known_scanner_ua"
@@ -92,13 +133,14 @@ def test_missing_ua_keeps_own_reason():
 
 
 @pytest.mark.unit
-def test_prefetch_header_takes_priority_over_non_mobile():
+def test_prefetch_header_takes_priority_over_burst():
     from app.utils.sms_bot import detect_bot
 
     is_bot, reason = detect_bot(
         user_agent=_UA_CARRIER_SCANNER,
         headers={"sec-purpose": "prefetch;prerender"},
         mobile_channel=True,
+        same_ua_recipients=9,
     )
     assert is_bot is True
     assert reason == "prefetch_head"
@@ -122,9 +164,42 @@ def test_instant_after_send_still_works_for_mobile_ua():
 
 
 @pytest.mark.unit
-def test_is_mobile_ua_helper():
+def test_burst_threshold_boundary():
+    """Ngưỡng = số người nhận KHÁC; 1 người khác vẫn chưa đủ thành chùm."""
+    from app.utils.sms_bot import BURST_MIN_OTHER_RECIPIENTS, detect_bot
+
+    assert BURST_MIN_OTHER_RECIPIENTS == 3
+    below = detect_bot(
+        user_agent=_UA_CARRIER_SCANNER,
+        mobile_channel=True,
+        same_ua_recipients=BURST_MIN_OTHER_RECIPIENTS - 1,
+    )
+    at = detect_bot(
+        user_agent=_UA_CARRIER_SCANNER,
+        mobile_channel=True,
+        same_ua_recipients=BURST_MIN_OTHER_RECIPIENTS,
+    )
+    assert below == (False, None)
+    assert at == (True, "carrier_scan_burst")
+
+
+@pytest.mark.unit
+def test_is_mobile_ua_uses_shared_library():
+    """Dùng `user-agents` (thư viện đã dùng ở session/login_history) nên bắt
+    được cả những dòng máy mà danh sách token tự chế bỏ sót."""
     from app.utils.sms_bot import is_mobile_ua
 
     assert is_mobile_ua(_UA_ANDROID) is True
+    assert is_mobile_ua(_UA_IPHONE) is True
     assert is_mobile_ua(_UA_CARRIER_SCANNER) is False
     assert is_mobile_ua(None) is False
+    # Máy cũ / trình duyệt hiếm — token list trước đây bỏ sót.
+    assert is_mobile_ua(
+        "Mozilla/5.0 (SymbianOS/9.4; Series60/5.0 NokiaN97-1/12.0.024) "
+        "AppleWebKit/525 (KHTML, like Gecko) BrowserNG/7.1.12344"
+    ) is True
+    # Tablet cũng là người thật mở tin.
+    assert is_mobile_ua(
+        "Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) AppleWebKit/605.1.15 "
+        "(KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1"
+    ) is True

--- a/Backend_FastAPI/tests/unit/test_sms_bot_carrier_scanner.py
+++ b/Backend_FastAPI/tests/unit/test_sms_bot_carrier_scanner.py
@@ -1,0 +1,130 @@
+# tests/unit/test_sms_bot_carrier_scanner.py
+"""
+Unit test dấu hiệu `non_mobile_ua` — chặn máy quét chống spam của nhà mạng.
+
+Bối cảnh (log prod chiến dịch #6, 13-07): 23 lượt vào /r/ thì 20 lượt cùng UA
+`X11; Linux x86_64 …Chrome` trong chùm 28 giây (10 người nhận × 2 lượt, 11 IP)
++ 1 lượt `antispam/1.0.0`. Cả hai lọt hết 3 dấu hiệu cũ → báo cáo ghi 22
+"người thật" trong khi chỉ ~1 người thật.
+
+Thuần logic, không chạm DB/HTTP.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+# UA THẬT lấy từ log prod campaign #6.
+_UA_CARRIER_SCANNER = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+_UA_ANTISPAM = "antispam/1.0.0"
+_UA_IPHONE = (
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) "
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 "
+    "Safari/604.1"
+)
+_UA_ANDROID = (
+    "Mozilla/5.0 (Linux; Android 13; SM-A536E) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36"
+)
+_UA_DESKTOP_WINDOWS = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("ua", [_UA_CARRIER_SCANNER, _UA_ANTISPAM])
+def test_carrier_scanner_flagged_on_sms_channel(ua):
+    """Regression sự cố CTR #6: 2 UA này lọt HẾT 3 dấu hiệu cũ."""
+    from app.utils.sms_bot import detect_bot
+
+    # Không bật kênh SMS → vẫn lọt (chứng minh dấu hiệu cũ không đủ).
+    is_bot_old, _ = detect_bot(user_agent=ua)
+    assert is_bot_old is False
+
+    is_bot, reason = detect_bot(user_agent=ua, mobile_channel=True)
+    assert is_bot is True
+    assert reason == "non_mobile_ua"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("ua", [_UA_IPHONE, _UA_ANDROID])
+def test_real_mobile_click_still_human(ua):
+    from app.utils.sms_bot import detect_bot
+
+    is_bot, reason = detect_bot(user_agent=ua, mobile_channel=True)
+    assert is_bot is False
+    assert reason is None
+
+
+@pytest.mark.unit
+def test_desktop_not_flagged_outside_sms_channel():
+    """Link tư vấn officer / phiên landing mở trên máy tính là HỢP LỆ —
+    mobile_channel mặc định False nên không đụng tới các luồng đó."""
+    from app.utils.sms_bot import detect_bot
+
+    is_bot, reason = detect_bot(user_agent=_UA_DESKTOP_WINDOWS)
+    assert is_bot is False
+    assert reason is None
+
+
+@pytest.mark.unit
+def test_known_scanner_ua_takes_priority():
+    """UA crawler quen mặt vẫn giữ nhãn cũ (không bị non_mobile_ua nuốt)."""
+    from app.utils.sms_bot import detect_bot
+
+    is_bot, reason = detect_bot(
+        user_agent="facebookexternalhit/1.1", mobile_channel=True
+    )
+    assert is_bot is True
+    assert reason == "known_scanner_ua"
+
+
+@pytest.mark.unit
+def test_missing_ua_keeps_own_reason():
+    from app.utils.sms_bot import detect_bot
+
+    is_bot, reason = detect_bot(user_agent=None, mobile_channel=True)
+    assert is_bot is True
+    assert reason == "no_user_agent"
+
+
+@pytest.mark.unit
+def test_prefetch_header_takes_priority_over_non_mobile():
+    from app.utils.sms_bot import detect_bot
+
+    is_bot, reason = detect_bot(
+        user_agent=_UA_CARRIER_SCANNER,
+        headers={"sec-purpose": "prefetch;prerender"},
+        mobile_channel=True,
+    )
+    assert is_bot is True
+    assert reason == "prefetch_head"
+
+
+@pytest.mark.unit
+def test_instant_after_send_still_works_for_mobile_ua():
+    """Dấu hiệu cũ không bị regression: UA mobile nhưng click tức thì sau
+    handoff vẫn bị nghi (preview server)."""
+    from app.utils.sms_bot import detect_bot
+
+    now = datetime(2026, 7, 13, 7, 39, tzinfo=timezone.utc)
+    is_bot, reason = detect_bot(
+        user_agent=_UA_IPHONE,
+        handed_off_at=now - timedelta(seconds=3),
+        now=now,
+        mobile_channel=True,
+    )
+    assert is_bot is True
+    assert reason == "instant_after_send"
+
+
+@pytest.mark.unit
+def test_is_mobile_ua_helper():
+    from app.utils.sms_bot import is_mobile_ua
+
+    assert is_mobile_ua(_UA_ANDROID) is True
+    assert is_mobile_ua(_UA_CARRIER_SCANNER) is False
+    assert is_mobile_ua(None) is False

--- a/Backend_FastAPI/tests/unit/test_sms_export_gate_flag.py
+++ b/Backend_FastAPI/tests/unit/test_sms_export_gate_flag.py
@@ -1,0 +1,51 @@
+# tests/unit/test_sms_export_gate_flag.py
+"""
+Unit test cờ `can_export` (gate trạng thái khu Export/bàn giao).
+
+Bối cảnh: FE trước đây tự suy diễn từ `campaign.status` với
+CLOSED_STATUSES={handed_off, closed}. Bàn giao batch ĐẦU đẩy campaign sang
+'handed_off' → FE ẩn luôn nút bàn giao của các nhà mạng còn lại, operator
+tưởng đã xong. Sự cố thật chiến dịch #6 (13-07): 338/380 người nhận kẹt ở
+'generated', báo cáo giấu 46 lượt click người thật.
+
+Thuần logic, không chạm DB/HTTP.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "status,build_revision,expected",
+    [
+        ("draft", 0, False),      # chưa build
+        ("draft", 2, False),      # đổi nhóm sau build → phải build lại
+        ("ready", 1, True),       # build xong, chưa export
+        ("exported", 1, True),    # re-export
+        # Bàn giao batch ĐẦU đẩy campaign sang 'handed_off' nhưng vẫn phải
+        # export/bàn giao được cho các nhà mạng còn lại — ca gây sự cố #6.
+        ("handed_off", 3, True),
+        ("closed", 3, False),     # đã bàn giao hết → khoá
+    ],
+)
+def test_can_export_flag(status, build_revision, expected):
+    from app.services.sms_campaign_service import SmsCampaignService
+
+    service = SmsCampaignService(db=None)
+    campaign = SimpleNamespace(
+        status=status,
+        build_revision=build_revision,
+        sms_template="[QC] Test {link}",
+    )
+    service._with_computed(campaign, group_count=1)
+    assert campaign.can_export is expected
+
+
+@pytest.mark.unit
+def test_can_export_uses_single_source_of_truth():
+    """Cờ hiển thị phải đọc CÙNG hằng với gate thật của export service —
+    tránh drift kiểu 'FE nghĩ export được, BE trả 400' (và ngược lại)."""
+    from app.services.sms_export_service import EXPORTABLE_CAMPAIGN_STATUS
+
+    assert EXPORTABLE_CAMPAIGN_STATUS == {"ready", "exported", "handed_off"}

--- a/Backend_FastAPI/tests/unit/test_sms_import_headers.py
+++ b/Backend_FastAPI/tests/unit/test_sms_import_headers.py
@@ -11,6 +11,8 @@ Thuần logic, không chạm DB/HTTP.
 """
 import pytest
 
+from app.utils.exceptions import ValidationError
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
@@ -23,6 +25,11 @@ import pytest
         ["Họ tên học sinh", "Số điện thoại"],      # biến thể hay gặp
         ["  Họ tên  ", " SĐT "],                   # thừa khoảng trắng
         ["Ho ten", "So dien thoai"],               # gõ không dấu
+        # Header thật luôn có đuôi → phải khớp theo CỤM CON, không so cả chuỗi
+        ["Họ và tên học sinh", "SĐT học sinh"],
+        ["Họ tên thí sinh", "Số điện thoại phụ huynh"],
+        ["Họ và tên", "Số điện thoại (Zalo)"],
+        ["﻿Họ và tên", "SĐT"],                # BOM do Excel ghi CSV
     ],
 )
 def test_resolve_columns_accepts_vietnamese_headers(headers):
@@ -31,6 +38,54 @@ def test_resolve_columns_accepts_vietnamese_headers(headers):
     found = _resolve_columns(headers)
     assert "full_name" in found, f"không nhận cột tên trong {headers}"
     assert "phone" in found, f"không nhận cột sđt trong {headers}"
+
+
+@pytest.mark.unit
+def test_dt_column_is_never_read_as_phone():
+    """"DT" trong danh sách trường = Dân tộc, và sau khi bỏ dấu thì "ĐT"
+    (điện thoại) cũng ra "dt" → không phân biệt được. Nhận nhầm sẽ khiến cả
+    file import 0 dòng trong im lặng, tệ hơn hẳn báo thiếu cột."""
+    from app.services.sms_contact_service import _resolve_columns
+
+    found = _resolve_columns(["STT", "Họ và tên", "DT", "Lớp", "SĐT"])
+    assert found["phone"] == "SĐT"
+    assert found["full_name"] == "Họ và tên"
+
+
+@pytest.mark.unit
+def test_split_surname_given_name_rejected_loudly():
+    """File tách "Họ đệm" + "Tên": nhận cột "Tên" làm họ tên sẽ lưu tên cụt
+    mà không báo gì — chặn to tiếng thay vì hỏng dữ liệu âm thầm."""
+    from app.services.sms_contact_service import _resolve_columns
+
+    with pytest.raises(ValidationError) as exc:
+        _resolve_columns(["Họ đệm", "Tên", "SĐT"])
+    assert "gộp" in str(exc.value.detail).lower()
+
+
+@pytest.mark.unit
+def test_ten_alone_still_accepted():
+    """Chỉ có 1 cột tên (không tách họ) thì vẫn nhận như trước."""
+    from app.services.sms_contact_service import _resolve_columns
+
+    found = _resolve_columns(["Tên", "SĐT"])
+    assert found["full_name"] == "Tên"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "headers",
+    [
+        ["Tên trường", "SĐT"],      # "ten" là cụm con → không được gán bừa
+        ["Tên lớp", "SĐT"],
+        ["Tên ngành", "SĐT"],
+    ],
+)
+def test_weak_name_alias_is_exact_match_only(headers):
+    from app.services.sms_contact_service import _resolve_columns
+
+    found = _resolve_columns(headers)
+    assert "full_name" not in found
 
 
 @pytest.mark.unit
@@ -69,3 +124,27 @@ def test_slugify_still_ascii_after_refactor():
 
     assert _slugify("Trường THPT Số 1 Đông Hòa") == "truong-thpt-so-1-dong-hoa"
     assert _slugify("") == "group"
+
+
+# ===================================================================
+# Ô số điện thoại sau khi qua tay Excel
+# ===================================================================
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("0912345678", "0912345678"),        # bình thường
+        ("912345678", "0912345678"),         # Excel ép số → mất số 0 đầu
+        ('="0912345678"', "0912345678"),     # lớp bọc chống-ép-kiểu ở file mẫu
+        ('="912345678"', "0912345678"),      # bọc + đã mất số 0
+        (" 0912345678 ", "0912345678"),      # thừa khoảng trắng
+        ("+84912345678", "+84912345678"),    # dạng quốc tế: không đụng
+        ("02363822655", "02363822655"),      # số cố định: không đụng
+        ("123456789", "123456789"),          # 9 số nhưng sai đầu số → giữ nguyên
+        ("", ""),
+    ],
+)
+def test_clean_phone_cell(raw, expected):
+    from app.services.sms_contact_service import _clean_phone_cell
+
+    assert _clean_phone_cell(raw) == expected

--- a/Backend_FastAPI/tests/unit/test_sms_import_headers.py
+++ b/Backend_FastAPI/tests/unit/test_sms_import_headers.py
@@ -1,0 +1,71 @@
+# tests/unit/test_sms_import_headers.py
+"""
+Unit test nhận diện header file import liên hệ SMS.
+
+Bối cảnh: `_resolve_columns` chuẩn hóa header chỉ bằng lower/strip/thay dấu
+cách nên alias viết cho tiếng Việt KHÔNG BAO GIỜ khớp header có dấu
+("Họ tên" → "họ_tên" ≠ "ho_ten") → file hợp lệ bị từ chối 400 "thiếu cột bắt
+buộc" (log prod 13-07, group_id=2). Nay bỏ dấu trước khi so alias.
+
+Thuần logic, không chạm DB/HTTP.
+"""
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "headers",
+    [
+        ["full_name", "phone"],                    # tên chuẩn ASCII
+        ["Họ tên", "Số điện thoại"],               # có dấu
+        ["Họ và tên", "SĐT"],                      # đ + viết tắt
+        ["HỌ VÀ TÊN", "Số Điện Thoại"],            # in hoa có dấu
+        ["Họ tên học sinh", "Số điện thoại"],      # biến thể hay gặp
+        ["  Họ tên  ", " SĐT "],                   # thừa khoảng trắng
+        ["Ho ten", "So dien thoai"],               # gõ không dấu
+    ],
+)
+def test_resolve_columns_accepts_vietnamese_headers(headers):
+    from app.services.sms_contact_service import _resolve_columns
+
+    found = _resolve_columns(headers)
+    assert "full_name" in found, f"không nhận cột tên trong {headers}"
+    assert "phone" in found, f"không nhận cột sđt trong {headers}"
+
+
+@pytest.mark.unit
+def test_resolve_columns_maps_back_to_original_header():
+    """Trả về TÊN CỘT THẬT (chưa chuẩn hóa) để đọc DataFrame."""
+    from app.services.sms_contact_service import _resolve_columns
+
+    found = _resolve_columns(["Họ và tên", "SĐT", "Ghi chú"])
+    assert found["full_name"] == "Họ và tên"
+    assert found["phone"] == "SĐT"
+    assert found["note"] == "Ghi chú"
+
+
+@pytest.mark.unit
+def test_resolve_columns_missing_required():
+    from app.services.sms_contact_service import _resolve_columns
+
+    found = _resolve_columns(["Mã học sinh", "Lớp"])
+    assert "full_name" not in found
+    assert "phone" not in found
+
+
+@pytest.mark.unit
+def test_resolve_columns_keeps_first_on_collision():
+    """2 header chuẩn hóa về cùng khóa → giữ cột xuất hiện TRƯỚC."""
+    from app.services.sms_contact_service import _resolve_columns
+
+    found = _resolve_columns(["Họ tên", "Ho ten"])
+    assert found["full_name"] == "Họ tên"
+
+
+@pytest.mark.unit
+def test_slugify_still_ascii_after_refactor():
+    """`_slugify` dùng chung helper bỏ dấu — không đổi hành vi group code."""
+    from app.services.sms_contact_service import _slugify
+
+    assert _slugify("Trường THPT Số 1 Đông Hòa") == "truong-thpt-so-1-dong-hoa"
+    assert _slugify("") == "group"

--- a/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsCampaignWorkspace.tsx
@@ -131,7 +131,10 @@ export function SmsCampaignWorkspace({ campaignId }: { campaignId: number }) {
             campaign={campaign}
             editable={audienceEditable}
           />
-          <SmsExportSection campaign={campaign} editable={audienceEditable} />
+          {/* Khu Export tự đọc cờ BE (`can_export` + `can_mark_handed_off`
+              từng batch) — KHÔNG dùng chung cờ audience, vì bàn giao/re-export
+              vẫn hợp lệ sau khi campaign chuyển 'handed_off'. */}
+          <SmsExportSection campaign={campaign} />
         </>
       )}
 

--- a/frontend/src/components/sms/admin/campaigns/SmsExportSection.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsExportSection.tsx
@@ -40,8 +40,6 @@ const REQUIRED = SMS_ATTESTATION_KINDS.length
 
 interface Props {
   campaign: SmsCampaign
-  /** Export/handoff được khi chưa bàn giao/đóng. Chỉ mount khi đã build. */
-  editable: boolean
 }
 
 function formatBytes(n: number | null | undefined): string {
@@ -51,7 +49,12 @@ function formatBytes(n: number | null | undefined): string {
   return `${(n / (1024 * 1024)).toFixed(1)} MB`
 }
 
-export function SmsExportSection({ campaign, editable }: Props) {
+export function SmsExportSection({ campaign }: Props) {
+  // Cờ BE. Bàn giao là chuyện TỪNG batch (`b.can_mark_handed_off`) — KHÔNG gắn
+  // với vòng đời campaign: bàn giao batch đầu đẩy campaign sang 'handed_off',
+  // nếu khoá cả khu theo status thì các nhà mạng còn lại mất nút bàn giao và
+  // operator tưởng đã xong (sự cố chiến dịch #6: 338/380 người kẹt).
+  const canExport = campaign.can_export === true
   const [handoffTarget, setHandoffTarget] = useState<{
     id: number
     carrier: string
@@ -92,7 +95,7 @@ export function SmsExportSection({ campaign, editable }: Props) {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0">
         <CardTitle className="text-base">Export &amp; bàn giao</CardTitle>
-        {editable && (
+        {canExport && (
           <Button
             size="sm"
             onClick={() => exportMut.mutate()}
@@ -108,7 +111,7 @@ export function SmsExportSection({ campaign, editable }: Props) {
         )}
       </CardHeader>
       <CardContent className="space-y-3">
-        {editable && !ready && (
+        {canExport && !ready && (
           <div className="rounded border border-amber-300 bg-amber-50 p-2.5">
             <p className="flex items-center gap-1.5 text-xs font-medium text-amber-800">
               <AlertTriangle className="h-3.5 w-3.5" />
@@ -175,7 +178,7 @@ export function SmsExportSection({ campaign, editable }: Props) {
                       <Download className="mr-1.5 h-3.5 w-3.5" /> Tải
                     </Button>
                   )}
-                  {editable && b.can_mark_handed_off && (
+                  {b.can_mark_handed_off && (
                     <Button
                       size="sm"
                       onClick={() =>

--- a/frontend/src/components/sms/admin/campaigns/SmsExportSection.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsExportSection.tsx
@@ -138,7 +138,11 @@ export function SmsExportSection({ campaign }: Props) {
           <Skeleton className="h-16 w-full" />
         ) : batches.length === 0 ? (
           <p className="text-muted-foreground py-3 text-center text-sm">
-            Chưa có file export. Bấm “Export Excel” để sinh 1 file / nhà mạng.
+            {/* Đừng bảo người ta bấm một nút không tồn tại: khi trạng thái
+                không cho export thì nút "Export Excel" đã bị ẩn. */}
+            {canExport
+              ? "Chưa có file export. Bấm “Export Excel” để sinh 1 file / nhà mạng."
+              : "Chưa có file export cho bản dựng hiện tại."}
           </p>
         ) : (
           <div className="divide-y">

--- a/frontend/src/components/sms/admin/campaigns/SmsExportSection.tsx
+++ b/frontend/src/components/sms/admin/campaigns/SmsExportSection.tsx
@@ -54,7 +54,7 @@ export function SmsExportSection({ campaign }: Props) {
   // với vòng đời campaign: bàn giao batch đầu đẩy campaign sang 'handed_off',
   // nếu khoá cả khu theo status thì các nhà mạng còn lại mất nút bàn giao và
   // operator tưởng đã xong (sự cố chiến dịch #6: 338/380 người kẹt).
-  const canExport = campaign.can_export === true
+  const canExport = campaign.can_export
   const [handoffTarget, setHandoffTarget] = useState<{
     id: number
     carrier: string
@@ -116,6 +116,20 @@ export function SmsExportSection({ campaign }: Props) {
             <p className="flex items-center gap-1.5 text-xs font-medium text-amber-800">
               <AlertTriangle className="h-3.5 w-3.5" />
               Chưa export được: {reasons.join(" · ")}.
+            </p>
+          </div>
+        )}
+
+        {/* Không export được vì TRẠNG THÁI (đổi nhóm sau build → 'draft', hoặc
+            đã đóng): phải nói ra, nếu không thẻ chỉ còn dòng "Bấm Export
+            Excel…" trong khi chẳng có nút nào để bấm. */}
+        {!canExport && (
+          <div className="rounded border bg-muted/40 p-2.5">
+            <p className="text-muted-foreground flex items-center gap-1.5 text-xs">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              {campaign.status === "closed"
+                ? "Chiến dịch đã đóng — mọi nhà mạng đã bàn giao xong."
+                : "Nhóm hoặc nội dung đã đổi sau lần dựng gần nhất — Build lại để export bản mới."}
             </p>
           </div>
         )}

--- a/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
@@ -30,6 +30,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { useUploadContacts } from "@/hooks/useSmsContacts"
+import { downloadBlob } from "@/lib/utils/download-blob"
 import type { SmsImportResult } from "@/lib/zod/sms"
 
 import {
@@ -42,23 +43,20 @@ const NONE = "none"
 
 // Header mẫu = đúng tên cột chuẩn BE. BE cũng chấp nhận biến thể tiếng Việt
 // có dấu ("Họ và tên", "SĐT"), nhưng file mẫu dùng tên chuẩn cho chắc chắn.
+// SĐT bọc ="…" — mở bằng Excel thì cột giữ nguyên dạng chữ, không bị ép thành
+// số làm mất số 0 đầu (0912… → 912…). Backend vẫn tự gỡ lớp bọc này.
 const SAMPLE_CSV = [
   "full_name,phone,note",
-  "Nguyen Van A,0912345678,Lop 12A1",
-  "Tran Thi B,0987654321,",
+  'Nguyen Van A,="0912345678",Lop 12A1',
+  'Tran Thi B,="0987654321",',
 ].join("\r\n")
 
 function downloadSampleCsv() {
   // BOM để Excel nhận UTF-8 (tên có dấu không thành ký tự lạ).
-  const blob = new Blob(["﻿" + SAMPLE_CSV], {
-    type: "text/csv;charset=utf-8",
-  })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement("a")
-  a.href = url
-  a.download = "mau-danh-sach-lien-he.csv"
-  a.click()
-  URL.revokeObjectURL(url)
+  downloadBlob(
+    new Blob(["﻿" + SAMPLE_CSV], { type: "text/csv;charset=utf-8" }),
+    "mau-danh-sach-lien-he.csv",
+  )
 }
 
 interface Props {
@@ -170,9 +168,13 @@ export function SmsImportDialog({
               <div className="text-muted-foreground space-y-1 rounded border bg-muted/40 p-2 text-xs">
                 <p>
                   Bắt buộc 2 cột: <code className="font-mono">full_name</code>{" "}
-                  và <code className="font-mono">phone</code> (chấp nhận tên
-                  tiếng Việt: “Họ và tên”, “Số điện thoại”, “SĐT”). Cột{" "}
-                  <code className="font-mono">note</code> tùy chọn.
+                  và <code className="font-mono">phone</code> — chấp nhận tên
+                  tiếng Việt (“Họ và tên”, “SĐT học sinh”, “Số điện thoại phụ
+                  huynh”). Cột <code className="font-mono">note</code> tùy chọn.
+                </p>
+                <p>
+                  Họ và tên phải nằm CHUNG một cột (file tách “Họ đệm” + “Tên”
+                  sẽ bị từ chối để tránh lưu thiếu họ).
                 </p>
                 <Button
                   type="button"

--- a/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
+++ b/frontend/src/components/sms/admin/contacts/SmsImportDialog.tsx
@@ -2,7 +2,13 @@
 "use client"
 
 import { useState } from "react"
-import { AlertTriangle, CheckCircle2, Loader2, Upload } from "lucide-react"
+import {
+  AlertTriangle,
+  CheckCircle2,
+  FileDown,
+  Loader2,
+  Upload,
+} from "lucide-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -33,6 +39,27 @@ import {
 } from "../labels"
 
 const NONE = "none"
+
+// Header mẫu = đúng tên cột chuẩn BE. BE cũng chấp nhận biến thể tiếng Việt
+// có dấu ("Họ và tên", "SĐT"), nhưng file mẫu dùng tên chuẩn cho chắc chắn.
+const SAMPLE_CSV = [
+  "full_name,phone,note",
+  "Nguyen Van A,0912345678,Lop 12A1",
+  "Tran Thi B,0987654321,",
+].join("\r\n")
+
+function downloadSampleCsv() {
+  // BOM để Excel nhận UTF-8 (tên có dấu không thành ký tự lạ).
+  const blob = new Blob(["﻿" + SAMPLE_CSV], {
+    type: "text/csv;charset=utf-8",
+  })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = "mau-danh-sach-lien-he.csv"
+  a.click()
+  URL.revokeObjectURL(url)
+}
 
 interface Props {
   open: boolean
@@ -122,8 +149,8 @@ export function SmsImportDialog({
         <DialogHeader>
           <DialogTitle>Import liên hệ vào «{groupName}»</DialogTitle>
           <DialogDescription>
-            File .csv hoặc .xlsx (cột số điện thoại + họ tên). Số cố định / không
-            hợp lệ sẽ bị bỏ qua và liệt kê ở kết quả.
+            File .csv hoặc .xlsx. Số cố định / không hợp lệ sẽ bị bỏ qua và liệt
+            kê ở kết quả.
           </DialogDescription>
         </DialogHeader>
 
@@ -140,6 +167,23 @@ export function SmsImportDialog({
                 disabled={mutation.isPending}
                 onChange={(e) => setFile(e.target.files?.[0] ?? null)}
               />
+              <div className="text-muted-foreground space-y-1 rounded border bg-muted/40 p-2 text-xs">
+                <p>
+                  Bắt buộc 2 cột: <code className="font-mono">full_name</code>{" "}
+                  và <code className="font-mono">phone</code> (chấp nhận tên
+                  tiếng Việt: “Họ và tên”, “Số điện thoại”, “SĐT”). Cột{" "}
+                  <code className="font-mono">note</code> tùy chọn.
+                </p>
+                <Button
+                  type="button"
+                  variant="link"
+                  size="sm"
+                  className="h-auto p-0 text-xs"
+                  onClick={downloadSampleCsv}
+                >
+                  <FileDown className="mr-1 h-3.5 w-3.5" /> Tải file mẫu (.csv)
+                </Button>
+              </div>
             </div>
 
             <div className="space-y-1.5">

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -591,8 +591,10 @@ export const smsCampaignSchema = z.object({
   has_link: z.boolean().nullable().optional(),
   group_count: z.number().nullable().optional(),
   /** Gate trạng thái export/re-export do BE tính (còn true khi handed_off để
-   *  retry batch nhà mạng lỗi). KHÔNG suy diễn lại từ `status` ở FE. */
-  can_export: z.boolean().nullable().optional(),
+   *  retry batch nhà mạng lỗi). KHÔNG suy diễn lại từ `status` ở FE.
+   *  BẮT BUỘC như can_download/can_mark_handed_off: thiếu cờ = lỗi hợp đồng,
+   *  phải để Zod chặn chứ không mặc định false rồi ẩn nút trong im lặng. */
+  can_export: z.boolean(),
 })
 export type SmsCampaign = z.infer<typeof smsCampaignSchema>
 

--- a/frontend/src/lib/zod/sms.ts
+++ b/frontend/src/lib/zod/sms.ts
@@ -590,6 +590,9 @@ export const smsCampaignSchema = z.object({
   handed_off_marked_at: z.string().nullable().optional(),
   has_link: z.boolean().nullable().optional(),
   group_count: z.number().nullable().optional(),
+  /** Gate trạng thái export/re-export do BE tính (còn true khi handed_off để
+   *  retry batch nhà mạng lỗi). KHÔNG suy diễn lại từ `status` ở FE. */
+  can_export: z.boolean().nullable().optional(),
 })
 export type SmsCampaign = z.infer<typeof smsCampaignSchema>
 


### PR DESCRIPTION
Ba lỗi vận hành SMS phát hiện qua chiến dịch thật #6 (THPT Số 1 Nguyễn Công Trứ, 13-07). Dữ liệu prod của campaign đó đã vá tay 14-07 nhưng **code thì chưa** — chiến dịch kế tiếp sẽ dính lại y hệt.

Không migration. Deploy = restart backend (đổi service/schema) + rebuild FE.

## 1. Bàn giao 1 nhà mạng làm ẩn nút của các nhà mạng còn lại

Bàn giao batch đầu đẩy campaign sang `handed_off`; FE lấy `CLOSED_STATUSES = {handed_off, closed}` làm cờ chung cho cả khu Export nên nút "Đã bàn giao" của 3 nhà mạng còn lại biến mất — operator tưởng đã xong. Hậu quả thật: **338/380 người nhận kẹt** ở `generated`, báo cáo giấu 46 lượt click người thật.

Backend vốn đã đúng (`mark_handed_off` chỉ neo 1 batch, `can_mark_handed_off` tính per-batch độc lập với `campaign.status`). Lớp suy diễn ở FE mới là gốc lỗi.

- `EXPORTABLE_CAMPAIGN_STATUS` thành hằng public + vị từ `campaign_state_allows_export()` dùng chung cho gate thật lẫn cờ hiển thị
- Campaign trả thêm cờ **bắt buộc** `can_export` (không default: path nào quên `_with_computed` phải vỡ lúc serialize chứ không im lặng ẩn nút)
- `SmsExportSection` bỏ hẳn prop `editable`; nút bàn giao chỉ theo cờ BE per-batch. `audienceEditable` giữ nguyên cho nhóm/build/attestation
- Thêm khối giải thích khi không export được vì trạng thái (trước đó thẻ chỉ còn dòng "Bấm Export Excel…" mà không có nút nào)

## 2. Import liên hệ từ chối file có header tiếng Việt

`_resolve_columns` không bỏ dấu nên alias viết cho tiếng Việt không bao giờ khớp: `"Họ tên"` → `họ_tên` ≠ `ho_ten`. File hợp lệ bị 400 "thiếu cột bắt buộc" (log prod 13-07).

- Bỏ dấu trước khi so khớp, và so theo **cụm con** thay danh sách chuỗi cố định → phủ "Họ và tên học sinh", "SĐT phụ huynh", "Số điện thoại (Zalo)"
- ⚠️ **Không** thêm alias `dt`: trong danh sách trường "DT" gần như luôn là *Dân tộc*, mà bỏ dấu xong "ĐT" cũng ra `dt` — gán nhầm khiến cả file import 0 dòng trong im lặng, tệ hơn báo thiếu cột
- `ten`/`name` chỉ khớp chính xác; file tách `Họ đệm | Tên` bị **chặn to tiếng** thay vì lưu tên cụt không báo gì
- `read_csv` tự dò dấu phân cách (Excel vi-VN ghi `;`) + nhận diện BOM UTF-16 trước `latin1`
- Khôi phục số 0 đầu bị Excel ăn mất (`912…` → `0912…`) + gỡ lớp bọc `="…"`, chỉ ở tầng import
- `_parse_rows` chạy qua `asyncio.to_thread` (50k dòng + engine python treo cả event loop worker)
- Dialog import ghi rõ cột bắt buộc + nút tải file mẫu

## 3. CTR bị máy quét nhà mạng thổi phồng

Log campaign #6: 23 lượt vào `/r/` thì 20 lượt cùng UA `X11; Linux x86_64 …Chrome` trong chùm 28 giây (10 người nhận, 11 IP) + 1 lượt `antispam/1.0.0`. Cả hai lọt hết 3 dấu hiệu cũ; `instant_after_send` vô hiệu vì operator bấm "Đã bàn giao" 10 phút **sau** khi nhà mạng đã gửi. Báo cáo ghi 22 "người thật" trong khi chỉ ~1.

- Dấu hiệu mới `carrier_scan_burst`: chỉ gắn nhãn khi UA không phải di động **và** cùng UA đó vừa mở link của ≥3 người nhận khác **trong cùng campaign** trong 60 giây
- Cố ý **không** chỉ dựa "UA không di động": iPadOS 13+ Safari gửi UA Macintosh, Android "Yêu cầu trang máy tính" gửi đúng `X11/Linux` như máy quét. Nhãn bot ghi cứng lúc ghi click nên người thật sẽ rơi khỏi **cả CTR lẫn danh sách officer gọi lại**
- Scope theo campaign là bắt buộc: chuỗi UA Chrome desktop đóng băng từ bản 120 nên "cùng UA" vô nghĩa nếu thiếu ngữ cảnh
- `is_mobile_ua` dùng thư viện `user-agents` đã là dependency production (cùng thư viện `session_service` dùng)
- Chấp nhận: 2-3 lượt đầu mỗi chùm vẫn lọt (#6 sẽ từ 22 giả-người-thật xuống ~2). Siết thêm là quay lại false positive vừa gỡ

## Kiểm chứng

- **185 test SMS pass** (7 file integration + 51 unit mới), chạy trong container throwaway
- flake8 sạch · FE type-check sạch · lint 0 error
- **Chrome smoke trên dev**: 6/6 đường parse campaign (list/tạo/chi tiết/sửa/gắn nhóm/attestation) không lỗi zod · ca gỡ-nhóm-sau-build hiện đúng khối giải thích · 3 file import (header có dấu vào được / tách họ-tên bị chặn đúng thông điệp / số 0 đầu + `="…"` khôi phục đủ 2 dòng) · nút tải mẫu. Dữ liệu test dọn sạch, 0 orphan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
