### PR TITLE
perf(admissions): tăng tốc trang danh sách hồ sơ — read-model + lean DTO + sweep

### DIFF
--- a/Backend_FastAPI/alembic/versions/admderivedcols20260721_add_admission_read_model_cols.py
+++ b/Backend_FastAPI/alembic/versions/admderivedcols20260721_add_admission_read_model_cols.py
@@ -1,0 +1,80 @@
+"""Add admission_profile read-model columns (perf/admissions-list).
+
+Trang danh sách hồ sơ (`/admissions`) chậm vì "compute-at-read-time":
+`/api/admissions/stats` tính `avg_completion` bằng fetch-all mọi hồ sơ + Python
+loop (~2.1s), và list serialize `AdmissionProfileResponse` nặng cho mỗi dòng
+(324KB/20 dòng). Ba cột read-model denormalized cho phép list + stats ĐỌC giá
+trị đã tính sẵn thay vì tính lại mỗi request.
+
+Cột (nullable — KHÔNG backfill trong migration):
+* ``cached_completion SMALLINT`` — completion_percent (0-100).
+* ``cached_readiness VARCHAR(20)`` — 'eligible'|'ineligible'.
+* ``cached_derived_at TIMESTAMPTZ`` — lần cuối refresh.
+
+⚠️ KHÔNG backfill ở đây: completion/readiness cần chạy validator Python
+(`_compute_completion_percent`/`_compute_readiness_status`), không SQL-able —
+đặc biệt multi-NV đọc live-config. Các cột khởi tạo NULL; **beat task
+`refresh_admission_derived_task` TỰ backfill lazily** (refresh mọi hàng
+`cached_derived_at IS NULL` + mọi hàng non-terminal mỗi chu kỳ). Stats
+`AVG(cached_completion)` bỏ qua NULL (COALESCE ở service cho cửa sổ đầu).
+
+Revision ID: admderivedcols20260721
+Revises: distpanelcasbin20260719
+Create Date: 2026-07-21
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "admderivedcols20260721"
+down_revision: Union[str, None] = "distpanelcasbin20260719"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "admission_profile"
+
+
+def upgrade() -> None:
+    op.add_column(
+        TABLE,
+        sa.Column(
+            "cached_completion",
+            sa.SmallInteger(),
+            nullable=True,
+            comment="Read-model: completion_percent (0-100). Ghi bởi refresh_derived_fields; đọc bởi list + AVG stats. Eventual-consistent.",
+        ),
+    )
+    op.add_column(
+        TABLE,
+        sa.Column(
+            "cached_readiness",
+            sa.String(length=20),
+            nullable=True,
+            comment="Read-model: 'eligible'|'ineligible'. Ghi bởi refresh_derived_fields; đọc bởi list. Eventual-consistent.",
+        ),
+    )
+    op.add_column(
+        TABLE,
+        sa.Column(
+            "cached_derived_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Lần cuối refresh_derived_fields ghi cached_completion/readiness (UTC).",
+        ),
+    )
+    # Partial index phục vụ sweep: quét nhanh hàng CHƯA tính (backfill lazy).
+    op.create_index(
+        "ix_admission_profile_derived_pending",
+        TABLE,
+        ["id"],
+        unique=False,
+        postgresql_where=sa.text("cached_derived_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_admission_profile_derived_pending", table_name=TABLE)
+    op.drop_column(TABLE, "cached_derived_at")
+    op.drop_column(TABLE, "cached_readiness")
+    op.drop_column(TABLE, "cached_completion")

--- a/Backend_FastAPI/alembic/versions/admderivedcols20260721_add_admission_read_model_cols.py
+++ b/Backend_FastAPI/alembic/versions/admderivedcols20260721_add_admission_read_model_cols.py
@@ -63,18 +63,21 @@ def upgrade() -> None:
             comment="Lần cuối refresh_derived_fields ghi cached_completion/readiness (UTC).",
         ),
     )
-    # Partial index phục vụ sweep: quét nhanh hàng CHƯA tính (backfill lazy).
+    # Index phục vụ sweep `refresh_admission_derived_task`, khớp CHÍNH XÁC thứ tự
+    # truy vấn: ORDER BY cached_derived_at ASC NULLS FIRST LIMIT N. NULLS FIRST
+    # trong index cho phép index-scan phục vụ CẢ (a) quét hàng CHƯA tính (NULL ở
+    # đầu = backfill lazy) LẪN (b) steady-state lấy N hàng cũ nhất — KHÔNG seq-scan
+    # + sort toàn bảng mỗi chu kỳ (khác partial-index-chỉ-NULL sẽ rỗng sau backfill).
     op.create_index(
-        "ix_admission_profile_derived_pending",
+        "ix_admission_profile_cached_derived_at",
         TABLE,
-        ["id"],
+        [sa.text("cached_derived_at ASC NULLS FIRST")],
         unique=False,
-        postgresql_where=sa.text("cached_derived_at IS NULL"),
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_admission_profile_derived_pending", table_name=TABLE)
+    op.drop_index("ix_admission_profile_cached_derived_at", table_name=TABLE)
     op.drop_column(TABLE, "cached_derived_at")
     op.drop_column(TABLE, "cached_readiness")
     op.drop_column(TABLE, "cached_completion")

--- a/Backend_FastAPI/alembic/versions/admderivedcols20260721_add_admission_read_model_cols.py
+++ b/Backend_FastAPI/alembic/versions/admderivedcols20260721_add_admission_read_model_cols.py
@@ -14,8 +14,9 @@ Cột (nullable — KHÔNG backfill trong migration):
 ⚠️ KHÔNG backfill ở đây: completion/readiness cần chạy validator Python
 (`_compute_completion_percent`/`_compute_readiness_status`), không SQL-able —
 đặc biệt multi-NV đọc live-config. Các cột khởi tạo NULL; **beat task
-`refresh_admission_derived_task` TỰ backfill lazily** (refresh mọi hàng
-`cached_derived_at IS NULL` + mọi hàng non-terminal mỗi chu kỳ). Stats
+`refresh_admission_derived_task` TỰ backfill lazily** (mỗi chu kỳ 5' refresh tối
+đa `_DERIVED_SWEEP_BATCH` hàng cũ nhất theo cached_derived_at NULLS FIRST — độ tươi
+thực = ceil(N_non_frozen/batch)×5', KHÔNG phải "mọi hàng mỗi chu kỳ"). Stats
 `AVG(cached_completion)` bỏ qua NULL (COALESCE ở service cho cửa sổ đầu).
 
 Revision ID: admderivedcols20260721

--- a/Backend_FastAPI/app/celery_app.py
+++ b/Backend_FastAPI/app/celery_app.py
@@ -243,6 +243,15 @@ celery_app.conf.beat_schedule = {
         "options": {"queue": "default"},
     },
 
+    # --- perf/admissions-list: read-model refresh sweep ---
+    # Làm tươi cached_completion/cached_readiness cho hồ sơ CHƯA tính (backfill
+    # lazy) + đang biến động. Backbone eventual-consistency của list/stats.
+    "refresh-admission-derived": {
+        "task": "refresh_admission_derived_task",
+        "schedule": 300,  # Every 5 minutes
+        "options": {"queue": "default"},
+    },
+
     # --- Phase C2: Stale delivery reconciliation ---
     "reconcile-stale-deliveries": {
         "task": "reconcile_stale_deliveries",

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -390,7 +390,9 @@ class AdmissionProfile(Base):
     # mà `_compute_frontend_fields` set: tránh collision khiến autoflush ghi cột
     # trên ĐƯỜNG ĐỌC (list gọi _compute_frontend_fields per-row rồi query batch →
     # autoflush sẽ flush cột dirty = write-on-GET). 3 cột này CHỈ được ghi TƯỜNG
-    # MINH bởi `refresh_derived_fields` (sweep nền + tại state-transition/update).
+    # MINH bởi `refresh_derived_fields` (HIỆN TẠI chỉ sweep nền
+    # `refresh_admission_derived_task`; chưa nối opportunistic-refresh tại
+    # state-transition/update → badge list trễ ≤ chu kỳ sweep).
     # completion/eligibility KHÔNG per-profile-pure (multi-NV đọc live-config +
     # doc-verify/choice-score không bump updated_at) ⇒ eventual-consistency: list
     # + stats đọc cột (trễ ≤ chu kỳ sweep); detail + cổng submit/approve vẫn LIVE.

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -384,6 +384,33 @@ class AdmissionProfile(Base):
     )
 
     # =========================================================================
+    # DERIVED READ-MODEL (denormalized snapshot — perf/admissions-list)
+    # =========================================================================
+    # ⚠️ CỐ Ý đặt tên KHÁC field transient `completion_percent`/`eligibility_status`
+    # mà `_compute_frontend_fields` set: tránh collision khiến autoflush ghi cột
+    # trên ĐƯỜNG ĐỌC (list gọi _compute_frontend_fields per-row rồi query batch →
+    # autoflush sẽ flush cột dirty = write-on-GET). 3 cột này CHỈ được ghi TƯỜNG
+    # MINH bởi `refresh_derived_fields` (sweep nền + tại state-transition/update).
+    # completion/eligibility KHÔNG per-profile-pure (multi-NV đọc live-config +
+    # doc-verify/choice-score không bump updated_at) ⇒ eventual-consistency: list
+    # + stats đọc cột (trễ ≤ chu kỳ sweep); detail + cổng submit/approve vẫn LIVE.
+    cached_completion: Mapped[Optional[int]] = mapped_column(
+        SmallInteger,
+        nullable=True,
+        comment="Read-model: completion_percent (0-100). Ghi bởi refresh_derived_fields; đọc bởi list + AVG stats. Eventual-consistent.",
+    )
+    cached_readiness: Mapped[Optional[str]] = mapped_column(
+        String(20),
+        nullable=True,
+        comment="Read-model: readiness/eligibility ('eligible'|'ineligible'). Ghi bởi refresh_derived_fields; đọc bởi list. Eventual-consistent.",
+    )
+    cached_derived_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Lần cuối refresh_derived_fields ghi cached_completion/readiness (UTC).",
+    )
+
+    # =========================================================================
     # ANALYTICS FIELDS (State Transition Tracking)
     # =========================================================================
 

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -44,6 +44,16 @@ class AdmissionProfile(Base):
     __table_args__ = (
         UniqueConstraint('citizen_id', 'academic_year', name='uq_citizen_academic_year'),
         Index('ix_admission_profile_citizen_year', 'citizen_id', 'academic_year'),
+        # perf/admissions-list read-model: index phục vụ sweep
+        # `refresh_admission_derived_task` (ORDER BY cached_derived_at ASC NULLS
+        # FIRST LIMIT N). PHẢI khai báo Ở ĐÂY, không chỉ trong migration
+        # `admderivedcols20260721` — Test DB (`Base.metadata.create_all()`) đọc
+        # declaration này + tránh `alembic autogenerate` sinh spurious DROP (mẫu
+        # lead.py). NULLS FIRST khớp migration (backfill NULL-đầu + steady-state).
+        Index(
+            'ix_admission_profile_cached_derived_at',
+            text('cached_derived_at ASC NULLS FIRST'),
+        ),
         # Wave 3-E (M-1-15a) replaces the legacy single-profile-per-lead
         # UNIQUE on ``lead_id`` with a composite ``(lead_id, academic_year)``
         # UNIQUE so a lead can apply for multiple academic years (one
@@ -392,10 +402,10 @@ class AdmissionProfile(Base):
     # autoflush sẽ flush cột dirty = write-on-GET). 3 cột này CHỈ được ghi TƯỜNG
     # MINH bởi `refresh_derived_fields` (HIỆN TẠI chỉ sweep nền
     # `refresh_admission_derived_task`; chưa nối opportunistic-refresh tại
-    # state-transition/update → badge list trễ ≤ chu kỳ sweep).
+    # state-transition/update → badge list trễ ≤ ceil(N_non_frozen/batch)×chu kỳ sweep).
     # completion/eligibility KHÔNG per-profile-pure (multi-NV đọc live-config +
     # doc-verify/choice-score không bump updated_at) ⇒ eventual-consistency: list
-    # + stats đọc cột (trễ ≤ chu kỳ sweep); detail + cổng submit/approve vẫn LIVE.
+    # + stats đọc cột (trễ ≤ ceil(N_non_frozen/batch)×chu kỳ sweep); detail + cổng submit/approve vẫn LIVE.
     cached_completion: Mapped[Optional[int]] = mapped_column(
         SmallInteger,
         nullable=True,

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -321,6 +321,7 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         unassigned: bool = False,
         today: Optional[date] = None,
         with_hk1: bool = False,
+        lean: bool = False,
         **filters
     ) -> Tuple[List[models.AdmissionProfile], int]:
         """
@@ -471,27 +472,34 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             ).join(
                 models.MajorProgram, models.ProgramOffering.program_id == models.MajorProgram.id
             )
-        data_query = (
-            data_query.options(
-                selectinload(models.AdmissionProfile.assigned_reviewer),
-                selectinload(models.AdmissionProfile.lead).options(
-                    selectinload(models.Lead.assigned_officer),
-                    selectinload(models.Lead.offering).options(
-                        selectinload(models.ProgramOffering.program),
-                        selectinload(models.ProgramOffering.academic_info_history)
-                        .selectinload(models.OfferingAcademicInfo.semester_tuitions),
-                    ),
+        # Eager NHẸ dùng chung: lead→officer + offering→program (program_name) +
+        # academic_info→semester_tuitions (HK1) + documents (doc-debt) + reviewer.
+        _eager_opts = [
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+            selectinload(models.AdmissionProfile.lead).options(
+                selectinload(models.Lead.assigned_officer),
+                selectinload(models.Lead.offering).options(
+                    selectinload(models.ProgramOffering.program),
+                    selectinload(models.ProgramOffering.academic_info_history)
+                    .selectinload(models.OfferingAcademicInfo.semester_tuitions),
                 ),
+            ),
+            selectinload(models.AdmissionProfile.documents).joinedload(ProfileDocument.document_type),
+        ]
+        if not lean:
+            # Graph NẶNG (student + subject_scores + choices 6-nhánh) CHỈ cần khi
+            # caller chạy `_compute_frontend_fields`/`_compute_completion_percent`
+            # per-row (list-đầy-đủ/export/stats-cũ). Đường LIST NHẸ (lean=True) đọc
+            # cached_completion/cached_readiness từ cột nên KHÔNG cần graph này →
+            # payload + thời gian giảm mạnh. (Multi-NV eligibility/completion read
+            # profile.choices → thiếu eager sẽ MissingGreenlet, nên chỉ bỏ khi lean.)
+            _eager_opts += [
                 selectinload(models.AdmissionProfile.student),
                 selectinload(models.AdmissionProfile.subject_scores).selectinload(ProfileSubjectScore.subject),
-                selectinload(models.AdmissionProfile.documents).joinedload(ProfileDocument.document_type),
-                # P0 hotfix multi-NV — list/export/stats call
-                # _compute_frontend_fields/_compute_completion_percent per row,
-                # which now read profile.choices (+ nested scores/group/criteria)
-                # for multi-NV eligibility/completion. Without this the per-row
-                # sync access lazy-loads → MissingGreenlet (N-row 500).
                 *_choices_eager_load_options(),
-            )
+            ]
+        data_query = (
+            data_query.options(*_eager_opts)
             # Stable secondary key: ties on the primary sort (esp. remaining_hk1 where
             # many profiles share a value, or no-HK1 rows all = 0) would otherwise
             # duplicate/skip across LIMIT/OFFSET pages (mirror Invoice.id tiebreaker

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -749,8 +749,6 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             conditions.append(models.AdmissionProfile.academic_year == academic_year)
 
         # Status counts in one query
-        # Note: completion_percent is computed at service layer (not a DB column),
-        # so we cannot use func.avg() here. avg_completion defaults to 0.
         query = (
             select(
                 models.AdmissionProfile.status,
@@ -764,6 +762,19 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
 
         result = await self.db.execute(query)
         rows = result.all()
+
+        # avg_completion — ĐỌC read-model `cached_completion` (perf/admissions-list)
+        # bằng AVG SQL, thay cho fetch-all mọi hồ sơ + Python loop (~2.1s → ~ms).
+        # AVG bỏ qua NULL (hồ sơ chưa được sweep tính); COALESCE 0 cho cửa sổ đầu
+        # khi mọi hàng còn NULL. Eventual-consistent với list (cùng cột).
+        avg_query = select(
+            func.coalesce(func.avg(models.AdmissionProfile.cached_completion), 0.0)
+        ).join(models.Lead)
+        if conditions:
+            avg_query = avg_query.where(and_(*conditions))
+        avg_completion = round(
+            float((await self.db.execute(avg_query)).scalar() or 0.0), 1
+        )
 
         status_counts = {}
         total = 0
@@ -798,7 +809,7 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             "withdrawn_count": withdrawn_count,
             "withdrawal_pending_count": withdrawal_pending_count,
             "conversion_rate": conversion_rate,
-            "avg_completion": 0.0,
+            "avg_completion": avg_completion,
         }
 
     async def get_distinct_academic_years(

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -473,15 +473,16 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
                 models.MajorProgram, models.ProgramOffering.program_id == models.MajorProgram.id
             )
         # Eager NHẸ dùng chung: lead→officer + offering→program (program_name) +
-        # academic_info→semester_tuitions (HK1) + documents (doc-debt) + reviewer.
+        # documents (doc-debt) + reviewer. HK1 money đến từ correlated subquery
+        # (with_hk1), KHÔNG từ offering.academic_info_history → đã BỎ eager nhánh đó
+        # (grep: không đường list/detail admission nào đọc semester_tuitions) để
+        # khỏi tải ~2 SELECT/trang rồi vứt — ngay trên endpoint đang tối ưu.
         _eager_opts = [
             selectinload(models.AdmissionProfile.assigned_reviewer),
             selectinload(models.AdmissionProfile.lead).options(
                 selectinload(models.Lead.assigned_officer),
                 selectinload(models.Lead.offering).options(
                     selectinload(models.ProgramOffering.program),
-                    selectinload(models.ProgramOffering.academic_info_history)
-                    .selectinload(models.OfferingAcademicInfo.semester_tuitions),
                 ),
             ),
             selectinload(models.AdmissionProfile.documents).joinedload(ProfileDocument.document_type),
@@ -497,6 +498,19 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
                 selectinload(models.AdmissionProfile.student),
                 selectinload(models.AdmissionProfile.subject_scores).selectinload(ProfileSubjectScore.subject),
                 *_choices_eager_load_options(),
+            ]
+        else:
+            # lean=True: student/subject_scores/fees khai báo lazy="selectin" ở MAPPER
+            # (models/admission.py) → BỎ khỏi .options() KHÔNG tắt được, vẫn nạp mặc
+            # định (+ subject_scores.subject KHÔNG nạp trên lean → chạm score.subject =
+            # MissingGreenlet ngầm). raiseload TẮT HẲN eager 3 quan hệ này (đường lean
+            # KHÔNG đọc chúng: chỉ cached cols + program_name/HK1(subquery)/tên phụ
+            # trách + documents) → giảm ~N query/trang THẬT + biến bẫy MissingGreenlet
+            # thành lỗi rõ nếu tương lai ai lỡ chạm.
+            _eager_opts += [
+                raiseload(models.AdmissionProfile.student),
+                raiseload(models.AdmissionProfile.subject_scores),
+                raiseload(models.AdmissionProfile.fees),
             ]
         data_query = (
             data_query.options(*_eager_opts)

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -118,7 +118,7 @@ from ..core.client_ip import get_client_ip  # noqa: E402
 @limiter.limit(RateLimits.DATA_READ)  # 1000/hour
 @router.get(
     "",
-    response_model=schemas.AdmissionsPage,
+    response_model=schemas.AdmissionsPageLite,
     summary="List admission profiles",
 )
 async def list_admission_profiles(
@@ -206,9 +206,10 @@ async def list_admission_profiles(
         unit_id=unit_id,
         reviewer_ids=reviewer_ids,
         unassigned=unassigned,
+        lean=True,  # perf/admissions-list: DTO nhẹ, đọc read-model cột (không graph)
     )
 
-    return schemas.AdmissionsPage(
+    return schemas.AdmissionsPageLite(
         total_count=total_count,
         page=page,
         page_size=page_size,

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -623,7 +623,10 @@ async def export_admissions_csv(
     _validate_payment_status(payment_status)
 
     # Export path: no page cap, lightweight hydration (only completion_percent).
-    # Same coordination filters as list so the CSV matches the on-screen rows.
+    # Same coordination filters as list so the CSV covers the same ROW SET as the
+    # on-screen list. ⚠️ Cột 'Tiến độ hoàn thiện' trong CSV tính LIVE (get_profiles_
+    # for_export, non-lean) nên có thể lệch badge trên BẢNG (đọc cached read-model,
+    # eventual) tới ≤1 chu kỳ sweep — khớp TẬP hàng, không nhất thiết khớp từng số.
     profiles = await admission_service.get_profiles_for_export(
         db=db,
         current_user=current_user,

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -162,6 +162,8 @@ from .admission import (
     AdmissionProfileUpdate,
     AdmissionProfileResponse,
     AdmissionsPage,
+    AdmissionProfileListItem,  # perf/admissions-list — DTO nhẹ cho bảng
+    AdmissionsPageLite,  # perf/admissions-list — paginated list nhẹ
     PendingDiplomaItem,  # PR #13.7 — nợ bằng reminder
     PendingDiplomaResponse,  # PR #13.7 — nợ bằng reminder
     AdmissionSubmitRequest,  # Fast-track C1 — submit-with-document-debt body

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1548,6 +1548,7 @@ class AdmissionProfileListItem(BaseModel):
     eligibility_status: Optional[str] = None
     tuition_paid_hk1: Optional[Decimal] = None
     tuition_remaining_hk1: Optional[Decimal] = None
+    tuition_overdue_hk1: bool = False
     tuition_hk1_status: Optional[str] = None
     assigned_officer_name: Optional[str] = None
     assigned_reviewer_name: Optional[str] = None

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1527,6 +1527,43 @@ class AdmissionsPage(BaseModel):
     profiles: List[AdmissionProfileResponse]
 
 
+class AdmissionProfileListItem(BaseModel):
+    """DTO NHẸ cho BẢNG danh sách `/admissions` (perf/admissions-list).
+
+    Chỉ ~15 field FE thật render — KHÔNG choices/documents_checklist/validation
+    summaries/priority cluster/executive_summary (tiết kiệm ~15KB/dòng, payload
+    324KB→~40KB). `completion_percent`/`eligibility_status` ĐỌC từ read-model
+    cột (`cached_completion`/`cached_readiness`, eventual-consistent qua sweep);
+    `available_actions` tính NHẸ (status+role+doc-debt), KHÔNG cần choices graph.
+    Detail vẫn dùng `AdmissionProfileResponse` (đầy đủ + LIVE).
+    """
+    id: int
+    lead_id: int
+    version: int
+    status: str
+    created_at: datetime
+    lead: Optional[LeadShallowForAdmission] = None
+    program_name: Optional[str] = None
+    completion_percent: int = 0
+    eligibility_status: Optional[str] = None
+    tuition_paid_hk1: Optional[Decimal] = None
+    tuition_remaining_hk1: Optional[Decimal] = None
+    tuition_hk1_status: Optional[str] = None
+    assigned_officer_name: Optional[str] = None
+    assigned_reviewer_name: Optional[str] = None
+    available_actions: List[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AdmissionsPageLite(BaseModel):
+    """Paginated list NHẸ — thay `AdmissionsPage` cho endpoint list `/admissions`."""
+    total_count: int
+    page: int
+    page_size: int
+    profiles: List[AdmissionProfileListItem]
+
+
 class PendingDiplomaItem(BaseModel):
     """PR #13.7 — một hồ sơ còn "nợ bằng" (Giấy CN tốt nghiệp tạm thời)."""
     profile_id: int

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1425,9 +1425,55 @@ def _validate_personal_info(
     return missing_personal, validation_errors
 
 
+def _run_profile_validators(
+    profile: models.AdmissionProfile,
+    documents: list,
+    applied_rules: dict,
+) -> dict:
+    """Chạy 3 validator (scores/documents/personal) MỘT LẦN và trả MỌI output.
+
+    `_compute_completion_percent` + `_compute_readiness_status` mỗi hàm vốn tự
+    chạy đủ 3 validator; khi tính cả hai cho cùng một hồ sơ (read-model refresh),
+    truyền kết quả hàm này vào để KHỎI duyệt lại — phần nặng nhất là
+    `_validate_scores`→`validate_choice_scores_complete` (multi-NV duyệt LIVE
+    criteria/subject-group).
+    """
+    gpa_error, score_ve, gpa_errors = _validate_scores(profile, applied_rules)
+    doc_errors, doc_ve, uploaded_doc_codes, upload_required_docs, unverified_doc_codes = (
+        _validate_documents(profile, documents, applied_rules)
+    )
+    missing_personal, personal_ve = _validate_personal_info(profile)
+    return {
+        "gpa_error": gpa_error,
+        "score_ve": score_ve,
+        "gpa_errors": gpa_errors,
+        "doc_errors": doc_errors,
+        "doc_ve": doc_ve,
+        "uploaded_doc_codes": uploaded_doc_codes,
+        "upload_required_docs": upload_required_docs,
+        "unverified_doc_codes": unverified_doc_codes,
+        "missing_personal": missing_personal,
+        "personal_ve": personal_ve,
+    }
+
+
+def _eligibility_from_errors(validation_errors: list, status: str) -> str:
+    """Quy tắc DUY NHẤT map validation_errors → eligibility ('eligible'|
+    'ineligible'). NGUỒN SỰ THẬT dùng chung bởi `_compute_frontend_fields`
+    (detail) và `_compute_readiness_status` (read-model list) ⇒ badge list KHỚP
+    detail, không drift khi ai sửa luật eligibility."""
+    if len(validation_errors) == 0:
+        return "eligible"
+    if status in ("approved", "enrolled"):
+        return "eligible"
+    return "ineligible"
+
+
 def _compute_completion_percent(
     profile: models.AdmissionProfile,
     documents: list = None,
+    *,
+    _validators: dict = None,
 ) -> int:
     """
     Compute completion_percent for a profile from step status weights.
@@ -1438,14 +1484,19 @@ def _compute_completion_percent(
     Args:
         profile: AdmissionProfile with subject_scores and lead loaded
         documents: Optional list of ProfileDocument
+        _validators: Optional pre-run `_run_profile_validators` result — truyền
+            khi caller đã chạy validator (tránh duyệt lại; xem refresh_derived_fields).
 
     Returns:
         Completion percentage (0-100)
     """
     applied_rules = profile.applied_rules or {}
-    gpa_error, _, _ = _validate_scores(profile, applied_rules)
-    doc_errors, _, _, _, _ = _validate_documents(profile, documents, applied_rules)
-    missing_personal, _ = _validate_personal_info(profile)
+    _v = _validators if _validators is not None else _run_profile_validators(
+        profile, documents, applied_rules
+    )
+    gpa_error = _v["gpa_error"]
+    doc_errors = _v["doc_errors"]
+    missing_personal = _v["missing_personal"]
 
     # Eligibility (simplified — mirrors _compute_frontend_fields logic)
     has_any_validation_error = gpa_error or len(doc_errors) > 0 or len(missing_personal) > 0
@@ -1533,27 +1584,29 @@ def _compute_completion_percent(
 def _compute_readiness_status(
     profile: models.AdmissionProfile,
     documents: list = None,
+    *,
+    _validators: dict = None,
 ) -> str:
     """Readiness/eligibility ('eligible'|'ineligible') — THUẦN (không cần
-    current_user). MIRROR chính xác khối "eligibility_status" của
-    `_compute_frontend_fields` (validation_errors == 0 ⇒ eligible; approved/
-    enrolled ⇒ eligible). Dùng cho read-model `cached_readiness`.
+    current_user). Dùng CHUNG luật `_eligibility_from_errors` với
+    `_compute_frontend_fields` (detail) nên KHỚP y hệt. Dùng cho read-model
+    `cached_readiness`.
 
     ⚠️ Multi-NV: `_validate_scores`→`validate_choice_scores_complete` đọc LIVE
     `admission_path.criteria` + `subject_group.subject_mappings` ⇒ KHÔNG
     per-profile-pure. Caller PHẢI eager-load choices graph (nếu không →
     MissingGreenlet trong async session).
+
+    `_validators`: truyền `_run_profile_validators` đã chạy sẵn để khỏi duyệt lại.
     """
-    if profile.status in ("approved", "enrolled"):
+    if _validators is None and profile.status in ("approved", "enrolled"):
         return "eligible"
     applied_rules = profile.applied_rules or {}
-    _gpa_error, score_ve, _gpa_errors = _validate_scores(profile, applied_rules)
-    _doc_errors, doc_ve, _u1, _u2, _u3 = _validate_documents(
+    _v = _validators if _validators is not None else _run_profile_validators(
         profile, documents, applied_rules
     )
-    _missing_personal, personal_ve = _validate_personal_info(profile)
-    validation_errors = score_ve + doc_ve + personal_ve
-    return "eligible" if len(validation_errors) == 0 else "ineligible"
+    validation_errors = _v["score_ve"] + _v["doc_ve"] + _v["personal_ve"]
+    return _eligibility_from_errors(validation_errors, profile.status)
 
 
 def refresh_derived_fields(
@@ -1561,26 +1614,67 @@ def refresh_derived_fields(
     documents: list = None,
 ) -> tuple[int, str]:
     """Tính + GHI read-model (`cached_completion`/`cached_readiness`/
-    `cached_derived_at`) cho một profile. Backbone của eventual-consistency:
-    gọi bởi sweep nền + tại state-transition + `update_profile` (mọi caller PHẢI
-    commit sau đó).
+    `cached_derived_at`) cho một profile. Backbone của eventual-consistency.
 
-    Tái dùng `_calculate_and_update_totals` → `_compute_completion_percent` →
-    `_compute_readiness_status` (đúng THỨ TỰ như đường list/detail: tính
-    total/average trước để `_validate_scores` single-NV đọc đúng). Giá trị KHỚP
-    y hệt live mà detail trả.
+    Caller HIỆN TẠI: CHỈ `refresh_admission_derived_task` (sweep nền ~5'). Chưa
+    nối opportunistic-refresh tại state-transition/update_profile ⇒ badge list +
+    AVG stats trễ ≤ chu kỳ sweep; detail + cổng submit/approve luôn LIVE. Mọi
+    caller PHẢI commit sau đó.
+
+    Chạy `_run_profile_validators` MỘT lần rồi truyền cho cả
+    `_compute_completion_percent` + `_compute_readiness_status` (khỏi duyệt
+    choice-graph 2×). Gọi `_calculate_and_update_totals` TRƯỚC (total/average để
+    `_validate_scores` single-NV đọc đúng). Giá trị KHỚP y hệt live mà detail trả.
 
     ⚠️ PHẢI gọi với choices/documents/scores ĐÃ eager-load (multi-NV cần graph).
     """
     if documents is None:
         documents = profile.__dict__.get("documents")
     _calculate_and_update_totals(profile)
-    completion = _compute_completion_percent(profile, documents)
-    readiness = _compute_readiness_status(profile, documents)
+    _v = _run_profile_validators(profile, documents, profile.applied_rules or {})
+    completion = _compute_completion_percent(profile, documents, _validators=_v)
+    readiness = _compute_readiness_status(profile, documents, _validators=_v)
     profile.cached_completion = completion
     profile.cached_readiness = readiness
     profile.cached_derived_at = datetime.now(timezone.utc)
     return completion, readiness
+
+
+def _list_action_flags(
+    profile: models.AdmissionProfile,
+    current_user: models.User,
+    *,
+    is_manager: bool,
+    is_admin: bool,
+    outstanding_debt_codes: list,
+) -> dict:
+    """Cổng boolean cho 5 hành động MÀ CẢ detail LẪN list bày: approve / reject /
+    claim / unclaim / assign_officer.
+
+    NGUỒN SỰ THẬT DUY NHẤT — `_compute_frontend_fields` (permissions dict, detail)
+    và `_compute_list_actions` (hàng list) CÙNG gọi hàm này ⇒ KHÔNG drift (đây là
+    gốc lỗi assign_officer bị bỏ sót ở bản list đầu). Chỉ đọc status +
+    assigned_reviewer_id + lead.unit_id (mapped / eager-safe), KHÔNG cần choices
+    graph. Cổng THẬT (fee/doc-debt/quota) vẫn re-check LIVE ở mutation.
+    """
+    status = profile.status
+    can_review = status in ("submitted", "resubmitted") and (is_manager or is_admin)
+    return {
+        "approve": can_review and not outstanding_debt_codes,
+        "reject": can_review,
+        "claim": can_review and not profile.assigned_reviewer_id,
+        "unclaim": bool(profile.assigned_reviewer_id)
+        and (profile.assigned_reviewer_id == current_user.id or is_admin),
+        # Officer-to-lead assignment (POST /admissions/bulk/assign): admin luôn,
+        # manager khi lead cùng unit. KHÔNG gate theo status (route cập nhật
+        # lead.assigned_officer_id bất kể admission state).
+        "assign_officer": is_admin or (
+            is_manager
+            and profile.lead is not None
+            and profile.lead.unit_id is not None
+            and profile.lead.unit_id == current_user.unit_id
+        ),
+    }
 
 
 @dataclass
@@ -2142,6 +2236,14 @@ def _compute_frontend_fields(
     # service-side gate in ``approve_profile``; assigned to the profile lower
     # down (single source of truth for the FE badge + parity with GET).
     _outstanding_debt_codes = _compute_outstanding_debt_codes(profile, documents)
+    # Cổng 5 hành động (approve/reject/claim/unclaim/assign_officer) dùng CHUNG
+    # với hàng list (`_compute_list_actions`) qua `_list_action_flags` — nguồn sự
+    # thật duy nhất, chống drift (từng để sót assign_officer ở bản list đầu).
+    _la = _list_action_flags(
+        profile, current_user,
+        is_manager=is_manager, is_admin=is_admin,
+        outstanding_debt_codes=_outstanding_debt_codes,
+    )
     permissions = {
         "edit": status in ["draft", "rejected", "revision_requested"] and (is_owner or is_manager or is_admin),
         "save": status in ["draft", "rejected", "revision_requested"] and (is_owner or is_manager or is_admin),
@@ -2150,12 +2252,8 @@ def _compute_frontend_fields(
         # FE hides/disables the button and the service raises BusinessRuleViolation
         # if it is attempted anyway. ``_outstanding_debt_codes`` is [] for every
         # profile without a debt snapshot → no behaviour change there.
-        "approve": (
-            status in ["submitted", "resubmitted"]
-            and (is_manager or is_admin)
-            and not _outstanding_debt_codes
-        ),
-        "reject": status in ["submitted", "resubmitted"] and (is_manager or is_admin),
+        "approve": _la["approve"],
+        "reject": _la["reject"],
         # Phase 3 multi-NV simplified flow 2026-05-15: manager/admin click
         # "Công bố kết quả" trực tiếp từ submitted/reviewing → engine cascade
         # auto-transition submitted→reviewing→result_published→admitted/rejected.
@@ -2262,20 +2360,9 @@ def _compute_frontend_fields(
         # was rejected (so the profile is not stuck awaiting a refund).
         "cancel_withdrawal": is_admin and status == "withdrawal_pending",
         "drop": status == "enrolled" and not _is_dropped and (is_manager or is_admin),
-        "claim": (status in ["submitted", "resubmitted"] and (is_manager or is_admin)
-                  and not profile.assigned_reviewer_id),
-        "unclaim": (bool(profile.assigned_reviewer_id)
-                    and (profile.assigned_reviewer_id == current_user.id or is_admin)),
-        # Officer-to-lead assignment via POST /admissions/bulk/assign. Mirrors
-        # the route: admin always, manager when the lead's unit matches theirs.
-        # Not gated by profile status (route updates lead.assigned_officer_id
-        # regardless of admission state).
-        "assign_officer": is_admin or (
-            is_manager
-            and profile.lead is not None
-            and profile.lead.unit_id is not None
-            and profile.lead.unit_id == current_user.unit_id
-        ),
+        "claim": _la["claim"],
+        "unclaim": _la["unclaim"],
+        "assign_officer": _la["assign_officer"],
         # PR #7 — official fee/invoice creation via POST /api/fees/calculate.
         # Mirrors _fee_calc_authorized in routers/fees.py: admin + accountant
         # always (central finance roles, Casbin grants accountant /fees/calculate
@@ -2454,13 +2541,10 @@ def _compute_frontend_fields(
     # Track CCCD error for backward compatibility with step_status logic
     cccd_error = not profile.citizen_id
     
-    # Determine eligibility status
-    if len(validation_errors) == 0:
-        profile.eligibility_status = "eligible"
-    elif status in ["approved", "enrolled"]:
-        profile.eligibility_status = "eligible"
-    else:
-        profile.eligibility_status = "ineligible"
+    # Determine eligibility status — luật dùng CHUNG với read-model list
+    # (`_compute_readiness_status` gọi cùng `_eligibility_from_errors`) nên badge
+    # list KHỚP detail.
+    profile.eligibility_status = _eligibility_from_errors(validation_errors, status)
     
     # Ticket #2: Compute is_qualified
     profile.is_qualified = not gpa_error
@@ -4736,31 +4820,31 @@ def _compute_list_actions(
     current_user: Optional[models.User],
     documents: list = None,
 ) -> list:
-    """Tập hành động NHẸ cho hàng LIST — {approve, reject, claim, unclaim} tính
-    THUẦN từ status + role + assigned_reviewer + doc-debt, KHÔNG cần choices
-    graph. Mirror ĐÚNG nhánh permissions của `_compute_frontend_fields` cho 4
-    key này (approve gate `not _compute_outstanding_debt_codes`). Cổng THẬT
-    (fee/doc-debt/quota) re-check LIVE ở mutation nên eventual-lệch vô hại.
-    `available_actions_v2` KHÔNG set ở list ⇒ FE `hasAction` fallback về đây.
+    """Tập hành động NHẸ cho hàng LIST — tính THUẦN từ status + role +
+    assigned_reviewer + lead.unit_id + doc-debt, KHÔNG cần choices graph.
+
+    Dùng CHUNG `_list_action_flags` với `_compute_frontend_fields` (detail) ⇒ cổng
+    KHỚP y hệt, không drift. Chỉ TRẢ các action mà UI list thật tiêu thụ:
+    approve/reject/claim (RowActionsMenu) + assign_officer (bulk bar). `unclaim`
+    tính trong flags nhưng KHÔNG có component list nào đọc → bỏ khỏi output (tránh
+    payload chết + lệch với detail-collapse). `available_actions_v2` KHÔNG set ở
+    list ⇒ FE `hasAction` fallback về `available_actions` đây.
     """
     if current_user is None:
+        return []
+    # Ghế đã thôi học (is_dropped=True; status vẫn 'enrolled') là side-channel
+    # terminal — detail collapse mọi action về `view`; list cũng KHÔNG bày action.
+    if getattr(profile, "is_dropped", False):
         return []
     role = current_user.role
     is_manager = role == UserRole.MANAGER
     is_admin = role == UserRole.ADMIN
-    status = profile.status
-    actions: list = []
-    if status in ("submitted", "resubmitted") and (is_manager or is_admin):
-        if not _compute_outstanding_debt_codes(profile, documents):
-            actions.append("approve")
-        actions.append("reject")
-        if not profile.assigned_reviewer_id:
-            actions.append("claim")
-    if profile.assigned_reviewer_id and (
-        profile.assigned_reviewer_id == current_user.id or is_admin
-    ):
-        actions.append("unclaim")
-    return actions
+    flags = _list_action_flags(
+        profile, current_user,
+        is_manager=is_manager, is_admin=is_admin,
+        outstanding_debt_codes=_compute_outstanding_debt_codes(profile, documents),
+    )
+    return [a for a in ("approve", "reject", "claim", "assign_officer") if flags[a]]
 
 
 async def get_profiles(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1530,6 +1530,59 @@ def _compute_completion_percent(
     return min(100, completion)
 
 
+def _compute_readiness_status(
+    profile: models.AdmissionProfile,
+    documents: list = None,
+) -> str:
+    """Readiness/eligibility ('eligible'|'ineligible') — THUẦN (không cần
+    current_user). MIRROR chính xác khối "eligibility_status" của
+    `_compute_frontend_fields` (validation_errors == 0 ⇒ eligible; approved/
+    enrolled ⇒ eligible). Dùng cho read-model `cached_readiness`.
+
+    ⚠️ Multi-NV: `_validate_scores`→`validate_choice_scores_complete` đọc LIVE
+    `admission_path.criteria` + `subject_group.subject_mappings` ⇒ KHÔNG
+    per-profile-pure. Caller PHẢI eager-load choices graph (nếu không →
+    MissingGreenlet trong async session).
+    """
+    if profile.status in ("approved", "enrolled"):
+        return "eligible"
+    applied_rules = profile.applied_rules or {}
+    _gpa_error, score_ve, _gpa_errors = _validate_scores(profile, applied_rules)
+    _doc_errors, doc_ve, _u1, _u2, _u3 = _validate_documents(
+        profile, documents, applied_rules
+    )
+    _missing_personal, personal_ve = _validate_personal_info(profile)
+    validation_errors = score_ve + doc_ve + personal_ve
+    return "eligible" if len(validation_errors) == 0 else "ineligible"
+
+
+def refresh_derived_fields(
+    profile: models.AdmissionProfile,
+    documents: list = None,
+) -> tuple[int, str]:
+    """Tính + GHI read-model (`cached_completion`/`cached_readiness`/
+    `cached_derived_at`) cho một profile. Backbone của eventual-consistency:
+    gọi bởi sweep nền + tại state-transition + `update_profile` (mọi caller PHẢI
+    commit sau đó).
+
+    Tái dùng `_calculate_and_update_totals` → `_compute_completion_percent` →
+    `_compute_readiness_status` (đúng THỨ TỰ như đường list/detail: tính
+    total/average trước để `_validate_scores` single-NV đọc đúng). Giá trị KHỚP
+    y hệt live mà detail trả.
+
+    ⚠️ PHẢI gọi với choices/documents/scores ĐÃ eager-load (multi-NV cần graph).
+    """
+    if documents is None:
+        documents = profile.__dict__.get("documents")
+    _calculate_and_update_totals(profile)
+    completion = _compute_completion_percent(profile, documents)
+    readiness = _compute_readiness_status(profile, documents)
+    profile.cached_completion = completion
+    profile.cached_readiness = readiness
+    profile.cached_derived_at = datetime.now(timezone.utc)
+    return completion, readiness
+
+
 @dataclass
 class LeadAdmissionEligibility:
     """Result of lead-level admission eligibility check.
@@ -4917,36 +4970,15 @@ async def get_admission_stats(
 
     unit_filter, officer_filter = _resolve_idor_filters(current_user)
 
-    stats = await admission_repo.get_aggregate_stats(
+    # avg_completion đã được `get_aggregate_stats` tính bằng AVG(cached_completion)
+    # SQL (perf/admissions-list). VÒNG FETCH-ALL cũ (load mọi hồ sơ + Python loop,
+    # ~2.1s) ĐÃ BỎ — read-model do `refresh_admission_derived_task` làm tươi nền,
+    # eventual-consistent. Detail vẫn hiển thị completion tính LIVE.
+    return await admission_repo.get_aggregate_stats(
         unit_id=unit_filter,
         assigned_officer_id=officer_filter,
         academic_year=academic_year,
     )
-
-    # Compute avg_completion over ALL profiles in scope (no sampling)
-    total = stats.get("total_profiles", 0)
-    if total > 0:
-        completion_sum = 0
-        fetched = 0
-        batch_size = 500
-        while fetched < total:
-            batch, _ = await admission_repo.get_filtered_with_count(
-                skip=fetched,
-                limit=batch_size,
-                unit_id=unit_filter,
-                assigned_officer_id=officer_filter,
-                academic_year=academic_year,
-            )
-            if not batch:
-                break
-            for p in batch:
-                _calculate_and_update_totals(p)
-                docs = p.documents if hasattr(p, "documents") else None
-                completion_sum += _compute_completion_percent(p, docs)
-            fetched += len(batch)
-        stats["avg_completion"] = round(completion_sum / fetched, 1) if fetched > 0 else 0.0
-
-    return stats
 
 
 async def get_academic_years(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4731,6 +4731,38 @@ async def create_profile(
 
 
 
+def _compute_list_actions(
+    profile: models.AdmissionProfile,
+    current_user: Optional[models.User],
+    documents: list = None,
+) -> list:
+    """Tập hành động NHẸ cho hàng LIST — {approve, reject, claim, unclaim} tính
+    THUẦN từ status + role + assigned_reviewer + doc-debt, KHÔNG cần choices
+    graph. Mirror ĐÚNG nhánh permissions của `_compute_frontend_fields` cho 4
+    key này (approve gate `not _compute_outstanding_debt_codes`). Cổng THẬT
+    (fee/doc-debt/quota) re-check LIVE ở mutation nên eventual-lệch vô hại.
+    `available_actions_v2` KHÔNG set ở list ⇒ FE `hasAction` fallback về đây.
+    """
+    if current_user is None:
+        return []
+    role = current_user.role
+    is_manager = role == UserRole.MANAGER
+    is_admin = role == UserRole.ADMIN
+    status = profile.status
+    actions: list = []
+    if status in ("submitted", "resubmitted") and (is_manager or is_admin):
+        if not _compute_outstanding_debt_codes(profile, documents):
+            actions.append("approve")
+        actions.append("reject")
+        if not profile.assigned_reviewer_id:
+            actions.append("claim")
+    if profile.assigned_reviewer_id and (
+        profile.assigned_reviewer_id == current_user.id or is_admin
+    ):
+        actions.append("unclaim")
+    return actions
+
+
 async def get_profiles(
     db: AsyncSession,
     skip: int,
@@ -4750,6 +4782,7 @@ async def get_profiles(
     officer_ids: Optional[List[int]] = None,
     reviewer_ids: Optional[List[int]] = None,
     unassigned: bool = False,
+    lean: bool = False,
 ) -> Tuple[List[models.AdmissionProfile], int]:
     """
     Get filtered list of admission profiles with total count.
@@ -4802,8 +4835,34 @@ async def get_profiles(
         order=order,
         today=today,
         with_hk1=True,  # list path needs HK1 money columns + remaining_hk1 sort
+        lean=lean,
         **coord,
     )
+
+    if lean:
+        # ── Đường LIST NHẸ (perf/admissions-list) ────────────────────────────
+        # KHÔNG chạy `_compute_frontend_fields`/`_calculate_and_update_totals`
+        # per-row (nặng + cần choices graph), KHÔNG batch verifier-names/minor-
+        # correction. Chỉ đọc read-model cột + tính action nhẹ. program_name +
+        # HK1 money đã do repo set (object.__setattr__). Trả `AdmissionProfile
+        # ListItem` (~15 field) → payload ~40KB thay 324KB.
+        for profile in profiles:
+            profile.completion_percent = (
+                profile.cached_completion if profile.cached_completion is not None else 0
+            )
+            profile.eligibility_status = profile.cached_readiness or "pending"
+            # Tên hiển thị (mirror _compute_frontend_fields:2371-2377) — dùng
+            # __dict__.get để KHÔNG lazy-load (MissingGreenlet trong sync).
+            _reviewer = profile.__dict__.get("assigned_reviewer")
+            profile.assigned_reviewer_name = _reviewer.full_name if _reviewer else None
+            _lead = profile.__dict__.get("lead")
+            _officer = _lead.__dict__.get("assigned_officer") if _lead else None
+            profile.assigned_officer_name = _officer.full_name if _officer else None
+            _docs = profile.__dict__.get("documents")
+            profile.available_actions = _compute_list_actions(
+                profile, current_user, _docs
+            )
+        return profiles, total_count
 
     # ADM-031 round 10: pre-resolve verifier names ACROSS all profiles in
     # one SELECT so the listing endpoint stays free of N+1 even when many

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1612,13 +1612,16 @@ def _compute_readiness_status(
 def refresh_derived_fields(
     profile: models.AdmissionProfile,
     documents: list = None,
+    *,
+    preserve_updated_at: bool = True,
 ) -> tuple[int, str]:
     """Tính + GHI read-model (`cached_completion`/`cached_readiness`/
     `cached_derived_at`) cho một profile. Backbone của eventual-consistency.
 
     Caller HIỆN TẠI: CHỈ `refresh_admission_derived_task` (sweep nền ~5'). Chưa
     nối opportunistic-refresh tại state-transition/update_profile ⇒ badge list +
-    AVG stats trễ ≤ chu kỳ sweep; detail + cổng submit/approve luôn LIVE. Mọi
+    AVG stats trễ ≤ ceil(N_non_frozen/batch)×chu kỳ sweep; detail + cổng
+    submit/approve luôn LIVE. Mọi
     caller PHẢI commit sau đó.
 
     Chạy `_run_profile_validators` MỘT lần rồi truyền cho cả
@@ -1627,6 +1630,9 @@ def refresh_derived_fields(
     `_validate_scores` single-NV đọc đúng). Giá trị KHỚP y hệt live mà detail trả.
 
     ⚠️ PHẢI gọi với choices/documents/scores ĐÃ eager-load (multi-NV cần graph).
+    ⚠️ `preserve_updated_at=True` (mặc định) GIỮ `updated_at`. Nếu nối vào mutation
+    nghiệp vụ CÙNG transaction → truyền `preserve_updated_at=False` để mutation vẫn
+    bump updated_at (xem comment dưới).
     """
     if documents is None:
         documents = profile.__dict__.get("documents")
@@ -1637,7 +1643,37 @@ def refresh_derived_fields(
     profile.cached_completion = completion
     profile.cached_readiness = readiness
     profile.cached_derived_at = datetime.now(timezone.utc)
+    # ⚠️ preserve_updated_at (mặc định True, cho SWEEP nền): KHÔNG để làm-tươi
+    # read-model bump `updated_at` — đây là refresh view nội bộ, KHÔNG phải sửa
+    # nghiệp vụ. Ghi cached_* làm row dirty → UPDATE; Python onupdate của
+    # `updated_at` recompute NẾU updated_at không trong SET → sweep 5' ghi đè 'sửa
+    # lần cuối' của MỌI hồ sơ non-terminal (hỏng sort_by=updated_at, cột CSV, magic-
+    # link consumed_at). flag_modified đưa updated_at (GIÁ TRỊ CŨ) vào SET → onupdate
+    # bỏ qua → giữ mốc.
+    # 🔴 KHI nối opportunistic-refresh vào mutation nghiệp vụ (approve/enroll/
+    # update_profile) trong CÙNG transaction: PHẢI gọi preserve_updated_at=False,
+    # nếu không flag_modified sẽ ghi đè mốc cũ → mutation THẬT mất bump updated_at.
+    if preserve_updated_at:
+        flag_modified(profile, "updated_at")
     return completion, readiness
+
+
+def mark_derived_failed(profile: models.AdmissionProfile) -> None:
+    """Sentinel khi `refresh_derived_fields` RAISE (sweep gọi trong except).
+
+    - Đóng dấu `cached_derived_at = now()` → đẩy hồ sơ lỗi KHỎI đầu ORDER BY
+      cached_derived_at NULLS FIRST (chống poison head-of-line + log ERROR mỗi
+      chu kỳ); chỉ thử lại khi lại là cũ nhất.
+    - INVALIDATE `cached_completion`/`cached_readiness` về NULL — KHÔNG giữ giá
+      trị cũ (có thể đã sai vì input đổi) → list hiện 0%/'pending' TRUNG THỰC +
+      hàng nằm NGOÀI AVG stats, thay vì trông y hệt hàng khoẻ (silent lie).
+    - GIỮ `updated_at` (flag_modified) như `refresh_derived_fields` — sentinel
+      cũng là ghi read-model, KHÔNG phải sửa nghiệp vụ.
+    """
+    profile.cached_completion = None
+    profile.cached_readiness = None
+    profile.cached_derived_at = datetime.now(timezone.utc)
+    flag_modified(profile, "updated_at")
 
 
 def _list_action_flags(
@@ -2537,7 +2573,21 @@ def _compute_frontend_fields(
     
     # Aggregate validation errors
     validation_errors = score_ve + doc_ve + personal_ve
-    
+
+    # perf: gói kết quả 3 validator (VỪA chạy ở trên) để `_compute_completion_
+    # percent` (dưới) KHỎI duyệt LẠI — nặng nhất là `_validate_scores`→
+    # `validate_choice_scores_complete` (multi-NV duyệt LIVE choice-graph). Đây là
+    # caller NÓNG nhất (mọi detail GET + mọi mutation response qua
+    # `_populate_response_fields`), nên bỏ double-validation ở đây đáng giá.
+    _fe_validators = {
+        "gpa_error": gpa_error, "score_ve": score_ve, "gpa_errors": gpa_errors,
+        "doc_errors": doc_errors, "doc_ve": doc_ve,
+        "uploaded_doc_codes": uploaded_doc_codes,
+        "upload_required_docs": upload_required_docs,
+        "unverified_doc_codes": unverified_doc_codes,
+        "missing_personal": missing_personal, "personal_ve": personal_ve,
+    }
+
     # Track CCCD error for backward compatibility with step_status logic
     cccd_error = not profile.citizen_id
     
@@ -2840,7 +2890,9 @@ def _compute_frontend_fields(
     # =========================================================================
     # 6. COMPLETION PERCENT (delegates to shared pure helper)
     # =========================================================================
-    profile.completion_percent = _compute_completion_percent(profile, documents)
+    profile.completion_percent = _compute_completion_percent(
+        profile, documents, _validators=_fe_validators
+    )
     
     # =========================================================================
     # 7. DOCUMENTS CHECKLIST (for frontend display)
@@ -5015,9 +5067,11 @@ async def get_profiles_for_export(
     Skips full _compute_frontend_fields (permissions, actions, step_status, etc.).
 
     Honors the SAME coordination filters as the list (officer/unit/reviewer/
-    unassigned) so the exported set matches the on-screen filtered rows.
-    with_hk1=False (default): export doesn't render HK1 money columns, so skip the
-    aggregate subqueries.
+    unassigned) so the exported ROW SET matches the on-screen filtered rows.
+    ⚠️ completion_percent ở đây tính LIVE (`_compute_completion_percent` per-row) —
+    KHÁC đường list (đọc cached read-model, eventual): cùng TẬP hàng nhưng cột tiến
+    độ có thể lệch badge bảng tới ≤1 chu kỳ sweep. with_hk1=False (default): export
+    doesn't render HK1 money columns, so skip the aggregate subqueries.
     """
     from app.repositories import AdmissionRepository
     admission_repo = AdmissionRepository(db)
@@ -13022,6 +13076,14 @@ async def bulk_approve(
     per_profile_callbacks: List[Optional[Callable]] = []
     bundle_persist_results: List[str] = []
 
+    # Khoá FOR UPDATE theo profile_id TĂNG dần (thứ tự canonical) để tránh deadlock
+    # ABBA: sweep read-model (`refresh_admission_derived_task`) UPDATE cached_* theo
+    # PK tăng dần, còn payload FE theo thứ tự bảng (created_at desc ≈ id giảm) — khoá
+    # ngược chiều nhau + giữ tới lần commit duy nhất ở router = vòng khoá đảo chiều.
+    # Sort KHÔNG đổi ngữ nghĩa (kết quả keyed theo profile_id, callback per-profile);
+    # cũng đồng bộ thứ tự khoá giữa các bulk song song.
+    items = sorted(items, key=lambda it: it["profile_id"])
+
     for item in items:
         profile_id = item["profile_id"]
         expected_version = item["version"]
@@ -13284,6 +13346,14 @@ async def bulk_reject(
     errors: Dict[int, str] = {}
     per_profile_callbacks: List[Optional[Callable]] = []
     bundle_persist_results: List[str] = []
+
+    # Khoá FOR UPDATE theo profile_id TĂNG dần (thứ tự canonical) để tránh deadlock
+    # ABBA: sweep read-model (`refresh_admission_derived_task`) UPDATE cached_* theo
+    # PK tăng dần, còn payload FE theo thứ tự bảng (created_at desc ≈ id giảm) — khoá
+    # ngược chiều nhau + giữ tới lần commit duy nhất ở router = vòng khoá đảo chiều.
+    # Sort KHÔNG đổi ngữ nghĩa (kết quả keyed theo profile_id, callback per-profile);
+    # cũng đồng bộ thứ tự khoá giữa các bulk song song.
+    items = sorted(items, key=lambda it: it["profile_id"])
 
     for item in items:
         profile_id = item["profile_id"]

--- a/Backend_FastAPI/app/tasks/__init__.py
+++ b/Backend_FastAPI/app/tasks/__init__.py
@@ -42,6 +42,7 @@ from .collaborator_tasks import (
 from .admission_tasks import (
     check_admission_surveys_due_task,
     check_admission_confirmation_reminders_task,
+    refresh_admission_derived_task,
 )
 from .notification_outbox_tasks import (
     dispatch_pending_outbox,  # T0-4a skeleton; T0-4b will replace body
@@ -79,6 +80,7 @@ __all__ = [
     "send_ctv_weekly_summary_task",
     # Admission tasks
     "check_admission_surveys_due_task",
+    "refresh_admission_derived_task",
     "check_admission_confirmation_reminders_task",
     # T0-4a admission outbox skeleton (cold cutover prerequisite)
     "dispatch_pending_outbox",

--- a/Backend_FastAPI/app/tasks/admission_tasks.py
+++ b/Backend_FastAPI/app/tasks/admission_tasks.py
@@ -604,19 +604,27 @@ def refresh_admission_derived_task(self):
     task_log = logging.getLogger(task_name)
 
     async def _run() -> dict:
+        from sqlalchemy.orm import joinedload
+        from ..models import ProfileDocument, ProfileSubjectScore
         from ..models.admission import AdmissionProfile
-        from ..models.profile_data import ProfileSubjectScore
         from ..repositories.admission_repository import _choices_eager_load_options
         from ..services.admission_service import refresh_derived_fields
 
         result = {"scanned": 0, "refreshed": 0, "failed": 0}
 
         async with task_db_session() as session:
+            # Eager PHẢI phủ mọi quan hệ refresh_derived_fields chạm (sync, không
+            # được lazy-load): lead (gpa_only) + subject_scores→subject +
+            # documents→document_type (validator đọc doc.document_type.code) +
+            # choices graph (multi-NV criteria/subject-group live).
             stmt = (
                 select(AdmissionProfile)
                 .options(
                     *_choices_eager_load_options(),
-                    selectinload(AdmissionProfile.documents),
+                    selectinload(AdmissionProfile.lead),
+                    selectinload(AdmissionProfile.documents).joinedload(
+                        ProfileDocument.document_type
+                    ),
                     selectinload(AdmissionProfile.subject_scores).selectinload(
                         ProfileSubjectScore.subject
                     ),

--- a/Backend_FastAPI/app/tasks/admission_tasks.py
+++ b/Backend_FastAPI/app/tasks/admission_tasks.py
@@ -40,8 +40,11 @@ from .utils import run_async_task, task_db_session
 # phải giá trị status hợp lệ — đã bỏ khỏi tuple: entry chết.)
 _DERIVED_FROZEN_STATUSES = ("enrolled", "withdrawn")
 # Trần mỗi lần chạy — sweep round-robin theo cached_derived_at cũ nhất (NULLS
-# FIRST = backfill trước). Đủ cho vài nghìn hồ sơ active với chu kỳ 5'.
-_DERIVED_SWEEP_BATCH = 400
+# FIRST = backfill trước). ⚠️ Độ tươi THỰC của read-model = ceil(N_non_frozen /
+# batch) × 5' — KHÔNG phải "≤ 1 chu kỳ" (mỗi cycle chỉ chạm tối đa `batch` hàng).
+# Prod hiện ~478 non-frozen → 1000 phủ hết trong 1 cycle. Khi N_non_frozen vượt
+# batch (mùa cao điểm) độ trễ tăng tuyến tính → cân nhắc tăng batch hoặc rút chu kỳ.
+_DERIVED_SWEEP_BATCH = 1000
 
 
 @celery_app.task(
@@ -609,11 +612,11 @@ def refresh_admission_derived_task(self):
     task_log = logging.getLogger(task_name)
 
     async def _run() -> dict:
-        from sqlalchemy.orm import joinedload
+        from sqlalchemy.orm import joinedload, raiseload
         from ..models import ProfileDocument, ProfileSubjectScore
         from ..models.admission import AdmissionProfile
         from ..repositories.admission_repository import _choices_eager_load_options
-        from ..services.admission_service import refresh_derived_fields
+        from ..services.admission_service import refresh_derived_fields, mark_derived_failed
 
         result = {"scanned": 0, "refreshed": 0, "failed": 0}
 
@@ -622,9 +625,16 @@ def refresh_admission_derived_task(self):
             # được lazy-load): lead (gpa_only) + subject_scores→subject +
             # documents→document_type (validator đọc doc.document_type.code) +
             # choices graph (multi-NV criteria/subject-group live).
+            # raiseload student + fees (fees→invoices→payments→transactions là cây
+            # SÂU) — 2 quan hệ lazy="selectin" ở mapper NẶNG nhất mà refresh KHÔNG
+            # đọc → khỏi nạp cho tối đa _DERIVED_SWEEP_BATCH hồ sơ mỗi 5'. (7 quan hệ
+            # audit User còn eager theo mapper — nhẹ hơn; nâng lên raiseload("*") sau
+            # khi chạy sweep xác nhận refresh không chạm quan hệ nào ngoài 4 cái dưới.)
             stmt = (
                 select(AdmissionProfile)
                 .options(
+                    raiseload(AdmissionProfile.student),
+                    raiseload(AdmissionProfile.fees),
                     *_choices_eager_load_options(),
                     selectinload(AdmissionProfile.lead),
                     selectinload(AdmissionProfile.documents).joinedload(
@@ -637,7 +647,27 @@ def refresh_admission_derived_task(self):
                 .where(
                     or_(
                         AdmissionProfile.cached_derived_at.is_(None),
+                        # Chưa tính XONG (chưa từng tính HOẶC sweep-fail → mark_derived_
+                        # failed set NULL + stamp cached_derived_at) → retry. KHÔNG có
+                        # vế này, hồ sơ ĐÃ FROZEN mà fail đúng 1 lần sẽ kẹt 0%/'pending'
+                        # vĩnh viễn (cached_derived_at>updated_at + status frozen → rớt).
+                        AdmissionProfile.cached_completion.is_(None),
                         AdmissionProfile.status.notin_(_DERIVED_FROZEN_STATUSES),
+                        # Hồ sơ ĐÃ đóng băng NHƯNG có sửa nghiệp vụ (updated_at) SAU
+                        # lần cache gần nhất → tính LẠI 1 lần. `status` là INPUT của
+                        # completion/eligibility (approved→enrolled: _eligibility_from
+                        # _errors trả 'eligible' + step-8 lock→success +12đ), nên hồ
+                        # sơ cache lúc còn 'approved' rồi mới enroll sẽ HIỆN SAI nếu
+                        # không tính lại. Nhờ sweep GIỮ updated_at (flag_modified),
+                        # sau lần bắt kịp cached_derived_at > updated_at → tự đóng băng
+                        # lại (không lặp vô hạn).
+                        # ⚠️ HỞ CÒN LẠI (đã thu hẹp, chấp nhận được): thay đổi KHÔNG
+                        # bump updated_at trên hồ sơ ĐÃ frozen — doc-verify (policy CHO
+                        # withdrawn) hoặc admin sửa admission_path.criteria (live-config
+                        # multi-NV) — sẽ KHÔNG kích vế này ⇒ cached lệch tới khi có
+                        # transition/edit khác. Hiếm (enrolled/withdrawn ít bị đụng);
+                        # nếu cần kín tuyệt đối phải bỏ freeze hoặc thêm cột cached_status.
+                        AdmissionProfile.cached_derived_at < AdmissionProfile.updated_at,
                     )
                 )
                 .order_by(AdmissionProfile.cached_derived_at.asc().nulls_first())
@@ -656,12 +686,10 @@ def refresh_admission_derived_task(self):
                     result["refreshed"] += 1
                 except Exception:
                     result["failed"] += 1
-                    # Sentinel: đóng dấu cached_derived_at (GIỮ completion/readiness
-                    # NULL) để hồ sơ lỗi KHÔNG kẹt đầu ORDER BY ... NULLS FIRST và
-                    # bị chọn lại → log ERROR MỖI chu kỳ (poison head-of-line). Nay
-                    # nó lùi về cuối, chỉ thử lại khi lại là cũ nhất; completion NULL
-                    # nên vẫn ngoài AVG stats (không bơm số sai).
-                    profile.cached_derived_at = datetime.now(timezone.utc)
+                    # Sentinel: đẩy hồ sơ lỗi khỏi đầu NULLS-FIRST (chống poison
+                    # head-of-line) + INVALIDATE cached về NULL (0%/'pending' trung
+                    # thực, ngoài AVG) + GIỮ updated_at. Xem docstring helper.
+                    mark_derived_failed(profile)
                     task_log.exception(
                         "refresh_derived failed", extra={"profile_id": profile.id}
                     )

--- a/Backend_FastAPI/app/tasks/admission_tasks.py
+++ b/Backend_FastAPI/app/tasks/admission_tasks.py
@@ -29,11 +29,16 @@ from sqlalchemy.orm import selectinload
 from ..celery_app import celery_app
 from .utils import run_async_task, task_db_session
 
-# Trạng thái ĐÓNG BĂNG read-model (completion/readiness không còn đổi) — sweep
-# tính 1 lần (khi cached_derived_at NULL) rồi thôi. Mọi trạng thái KHÁC được coi
-# là "đang biến động" và refresh mỗi chu kỳ (an toàn: thà refresh thừa còn hơn
-# để badge lệch — completion KHÔNG per-profile-pure nên không suy được từ 1 cột).
-_DERIVED_FROZEN_STATUSES = ("enrolled", "dropped", "withdrawn")
+# Trạng thái ĐÓNG BĂNG read-model (completion/readiness KHÔNG còn đổi) — sweep
+# tính 1 lần (khi cached_derived_at NULL) rồi thôi. Mọi trạng thái KHÁC coi là
+# "đang biến động" và refresh mỗi chu kỳ (an toàn: thà refresh thừa còn hơn để
+# badge lệch — completion KHÔNG per-profile-pure nên không suy được từ 1 cột).
+# CHỈ gồm state THỰC-SỰ-XONG + KHÔNG editable: 'enrolled' (đã nhập học; ghế
+# thôi-học is_dropped VẪN status 'enrolled' nên đã phủ) + 'withdrawn'. KHÔNG
+# đóng băng 'rejected'/'revision_requested' vì chúng CÒN editable (edit gate
+# admission_service.py) → completion đổi tại chỗ, phải re-sweep. ('dropped' KHÔNG
+# phải giá trị status hợp lệ — đã bỏ khỏi tuple: entry chết.)
+_DERIVED_FROZEN_STATUSES = ("enrolled", "withdrawn")
 # Trần mỗi lần chạy — sweep round-robin theo cached_derived_at cũ nhất (NULLS
 # FIRST = backfill trước). Đủ cho vài nghìn hồ sơ active với chu kỳ 5'.
 _DERIVED_SWEEP_BATCH = 400
@@ -643,12 +648,20 @@ def refresh_admission_derived_task(self):
 
             for profile in profiles:
                 try:
-                    # Savepoint per-hồ-sơ: 1 hồ sơ lỗi compute không chặn cả batch.
-                    async with session.begin_nested():
-                        refresh_derived_fields(profile, profile.documents)
+                    # `refresh_derived_fields` thuần Python (không SQL trong block)
+                    # → try/except đã đủ cô lập 1 hồ sơ lỗi khỏi cả batch; KHÔNG
+                    # cần SAVEPOINT (bỏ ~2×N round-trip begin_nested/release mỗi
+                    # chu kỳ). Ghi cached_* chỉ pending trong session tới commit.
+                    refresh_derived_fields(profile, profile.documents)
                     result["refreshed"] += 1
                 except Exception:
                     result["failed"] += 1
+                    # Sentinel: đóng dấu cached_derived_at (GIỮ completion/readiness
+                    # NULL) để hồ sơ lỗi KHÔNG kẹt đầu ORDER BY ... NULLS FIRST và
+                    # bị chọn lại → log ERROR MỖI chu kỳ (poison head-of-line). Nay
+                    # nó lùi về cuối, chỉ thử lại khi lại là cũ nhất; completion NULL
+                    # nên vẫn ngoài AVG stats (không bơm số sai).
+                    profile.cached_derived_at = datetime.now(timezone.utc)
                     task_log.exception(
                         "refresh_derived failed", extra={"profile_id": profile.id}
                     )

--- a/Backend_FastAPI/app/tasks/admission_tasks.py
+++ b/Backend_FastAPI/app/tasks/admission_tasks.py
@@ -23,11 +23,20 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from sqlalchemy import and_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import selectinload
 
 from ..celery_app import celery_app
 from .utils import run_async_task, task_db_session
+
+# Trạng thái ĐÓNG BĂNG read-model (completion/readiness không còn đổi) — sweep
+# tính 1 lần (khi cached_derived_at NULL) rồi thôi. Mọi trạng thái KHÁC được coi
+# là "đang biến động" và refresh mỗi chu kỳ (an toàn: thà refresh thừa còn hơn
+# để badge lệch — completion KHÔNG per-profile-pure nên không suy được từ 1 cột).
+_DERIVED_FROZEN_STATUSES = ("enrolled", "dropped", "withdrawn")
+# Trần mỗi lần chạy — sweep round-robin theo cached_derived_at cũ nhất (NULLS
+# FIRST = backfill trước). Đủ cho vài nghìn hồ sơ active với chu kỳ 5'.
+_DERIVED_SWEEP_BATCH = 400
 
 
 @celery_app.task(
@@ -565,5 +574,89 @@ def check_admission_confirmation_reminders_task(self):
             "outcome": outcome,
             **result,
         },
+    )
+    return result
+
+
+@celery_app.task(
+    name="refresh_admission_derived_task",
+    bind=True,
+    autoretry_for=(Exception,),
+    max_retries=2,
+    default_retry_delay=120,
+)
+def refresh_admission_derived_task(self):
+    """Beat (~5'): làm tươi read-model `cached_completion`/`cached_readiness`/
+    `cached_derived_at` cho hồ sơ CHƯA tính (backfill lazy) hoặc đang biến động.
+
+    Backbone của eventual-consistency (perf/admissions-list): list + stats đọc
+    cột thay vì tính-lại-mỗi-request. Sweep phủ MỌI nguyên nhân đổi completion
+    (kể cả sửa live-config multi-NV + doc-verify/choice-score không bump
+    updated_at) nên KHÔNG cần rải recompute vào từng mutation-site.
+
+    - Chọn: `cached_derived_at IS NULL` (chưa tính) HOẶC status NOT IN frozen.
+    - Order: cached_derived_at ASC NULLS FIRST → backfill trước, rồi cũ-nhất
+      trước (round-robin), LIMIT batch → bounded mỗi lần.
+    - Eager: choices graph (multi-NV đọc live criteria/subject-group) + documents
+      + subject_scores → refresh_derived_fields chạy thuần, không MissingGreenlet.
+    """
+    task_name = "refresh_admission_derived_task"
+    task_log = logging.getLogger(task_name)
+
+    async def _run() -> dict:
+        from ..models.admission import AdmissionProfile
+        from ..models.profile_data import ProfileSubjectScore
+        from ..repositories.admission_repository import _choices_eager_load_options
+        from ..services.admission_service import refresh_derived_fields
+
+        result = {"scanned": 0, "refreshed": 0, "failed": 0}
+
+        async with task_db_session() as session:
+            stmt = (
+                select(AdmissionProfile)
+                .options(
+                    *_choices_eager_load_options(),
+                    selectinload(AdmissionProfile.documents),
+                    selectinload(AdmissionProfile.subject_scores).selectinload(
+                        ProfileSubjectScore.subject
+                    ),
+                )
+                .where(
+                    or_(
+                        AdmissionProfile.cached_derived_at.is_(None),
+                        AdmissionProfile.status.notin_(_DERIVED_FROZEN_STATUSES),
+                    )
+                )
+                .order_by(AdmissionProfile.cached_derived_at.asc().nulls_first())
+                .limit(_DERIVED_SWEEP_BATCH)
+            )
+            profiles = (await session.execute(stmt)).scalars().unique().all()
+            result["scanned"] = len(profiles)
+
+            for profile in profiles:
+                try:
+                    # Savepoint per-hồ-sơ: 1 hồ sơ lỗi compute không chặn cả batch.
+                    async with session.begin_nested():
+                        refresh_derived_fields(profile, profile.documents)
+                    result["refreshed"] += 1
+                except Exception:
+                    result["failed"] += 1
+                    task_log.exception(
+                        "refresh_derived failed", extra={"profile_id": profile.id}
+                    )
+
+            await session.commit()
+
+        return result
+
+    result = run_async_task(
+        async_func=_run,
+        task_name=task_name,
+        task_log=task_log,
+        validate_keys=["scanned", "refreshed", "failed"],
+    )
+    task_log.info(
+        "refresh_admission_derived heartbeat: end",
+        extra={"event": "refresh_admission_derived_heartbeat", "phase": "end", **result},
     )
     return result

--- a/Backend_FastAPI/tests/api/test_admission_readmodel.py
+++ b/Backend_FastAPI/tests/api/test_admission_readmodel.py
@@ -6,7 +6,7 @@ conftest truncate mọi bảng mỗi test → mỗi test tự kiểm soát datas
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select, update
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload, selectinload
 
 from app import models
 from app.database import AsyncSessionLocal
@@ -72,7 +72,13 @@ class TestAdmissionReadModel:
                 .where(models.AdmissionProfile.id == pid)
                 .options(
                     selectinload(models.AdmissionProfile.lead),
-                    selectinload(models.AdmissionProfile.documents),
+                    # joinedload(document_type) KHỚP eager của sweep task — validator
+                    # đọc doc.document_type.code; thiếu nó + hồ sơ có giấy = Missing
+                    # Greenlet. Test giữ đúng graph sweep để không cho cảm giác an
+                    # toàn giả (dù fixture hiện không có ProfileDocument).
+                    selectinload(models.AdmissionProfile.documents).joinedload(
+                        models.ProfileDocument.document_type
+                    ),
                     selectinload(models.AdmissionProfile.subject_scores),
                     *_choices_eager_load_options(),
                 )
@@ -131,7 +137,8 @@ class TestAdmissionReadModel:
     ):
         """_compute_list_actions: submitted + admin + chưa claim → reject+claim;
         approve chỉ khi không nợ giấy (hồ sơ này không có debt snapshot → approve
-        có mặt)."""
+        có mặt); admin luôn có assign_officer (bulk-assign bar). unclaim KHÔNG lọt
+        vào output list (không UI list nào đọc)."""
         unit_id = seed_lead_dependencies["unit_id"]
         pid = await _make_profile(unit_id)
         await _set_cached(pid, 50, "ineligible")
@@ -141,3 +148,25 @@ class TestAdmissionReadModel:
         assert "reject" in acts
         assert "claim" in acts  # chưa có reviewer
         assert "approve" in acts  # no document_debt snapshot → không gate
+        # Regression guard: bulk "Phân công hàng loạt" cần assign_officer trên MỌI
+        # hàng (FE canAssign = every('assign_officer')). Admin → luôn có.
+        assert "assign_officer" in acts
+        assert "unclaim" not in acts  # dead-data đã bỏ khỏi output list
+
+    async def test_lean_list_actions_dropped_seat_collapses(
+        self, client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        """Ghế thôi học (is_dropped=True, status vẫn 'enrolled') → list KHÔNG bày
+        action nào (mirror detail-collapse), kể cả assign_officer."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        pid = await _make_profile(unit_id, status="enrolled")
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                await session.execute(
+                    update(models.AdmissionProfile)
+                    .where(models.AdmissionProfile.id == pid)
+                    .values(is_dropped=True, cached_completion=100, cached_readiness="eligible")
+                )
+        resp = await client.get("/api/admissions", headers=admin_token_headers)
+        row = _find(resp.json(), pid)
+        assert row["available_actions"] == []

--- a/Backend_FastAPI/tests/api/test_admission_readmodel.py
+++ b/Backend_FastAPI/tests/api/test_admission_readmodel.py
@@ -1,0 +1,143 @@
+"""Read-model (perf/admissions-list) — cached_completion/readiness đúng, lean
+list đọc cột (không graph), stats AVG(cached_completion).
+
+conftest truncate mọi bảng mỗi test → mỗi test tự kiểm soát dataset.
+"""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, update
+from sqlalchemy.orm import selectinload
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.repositories.admission_repository import _choices_eager_load_options
+from app.services import admission_service
+
+pytestmark = pytest.mark.asyncio
+
+_SEQ = iter(range(30000, 90000))
+
+
+async def _make_profile(unit_id, *, status="submitted", reviewer_id=None) -> int:
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            n = next(_SEQ)
+            lead = models.Lead(
+                full_name="ReadModel Test Lead",
+                phone="0901112233",
+                email=f"rm_{n}@test.com",
+                source="website",
+                unit_id=unit_id,
+            )
+            session.add(lead)
+            await session.flush()
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                status=status,
+                citizen_id=f"0791{n:08d}",
+                academic_year=2026,
+                version=1,
+                applied_rules={"min_gpa": 0, "mandatory_docs": []},
+                assigned_reviewer_id=reviewer_id,
+            )
+            session.add(profile)
+            await session.flush()
+            return profile.id
+
+
+async def _set_cached(pid: int, completion: int, readiness: str = "ineligible"):
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            await session.execute(
+                update(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == pid)
+                .values(cached_completion=completion, cached_readiness=readiness)
+            )
+
+
+def _find(payload, pid):
+    return next(r for r in payload["profiles"] if r["id"] == pid)
+
+
+class TestAdmissionReadModel:
+    async def test_refresh_matches_live_and_persists(self, seed_lead_dependencies):
+        """refresh_derived_fields ghi cột == đúng giá trị live (_compute_*).
+        Đây là bất biến eventual-consistency: cached khớp detail-live cùng data.
+        """
+        unit_id = seed_lead_dependencies["unit_id"]
+        pid = await _make_profile(unit_id)
+        async with AsyncSessionLocal() as session:
+            stmt = (
+                select(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == pid)
+                .options(
+                    selectinload(models.AdmissionProfile.lead),
+                    selectinload(models.AdmissionProfile.documents),
+                    selectinload(models.AdmissionProfile.subject_scores),
+                    *_choices_eager_load_options(),
+                )
+            )
+            p = (await session.execute(stmt)).scalars().first()
+            # _compute_completion_percent → _validate_scores (single-NV) đọc
+            # profile.average_score (transient) nên PHẢI _calculate_and_update_
+            # totals trước — đúng thứ tự mọi đường thật + refresh_derived_fields.
+            admission_service._calculate_and_update_totals(p)
+            live_c = admission_service._compute_completion_percent(p, p.documents)
+            live_r = admission_service._compute_readiness_status(p, p.documents)
+            comp, ready = admission_service.refresh_derived_fields(p, p.documents)
+            assert comp == live_c
+            assert ready == live_r
+            assert p.cached_completion == live_c
+            assert p.cached_readiness == live_r
+            assert p.cached_derived_at is not None
+            await session.commit()
+
+    async def test_lean_list_reads_cached_no_graph(
+        self, client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        """List NHẸ đọc completion/eligibility TỪ cột cached; KHÔNG serialize
+        choices/documents_checklist; available_actions là list."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        pid = await _make_profile(unit_id)
+        await _set_cached(pid, 73, "eligible")
+
+        resp = await client.get("/api/admissions", headers=admin_token_headers)
+        assert resp.status_code == 200, resp.text
+        row = _find(resp.json(), pid)
+        assert row["completion_percent"] == 73
+        assert row["eligibility_status"] == "eligible"
+        assert "choices" not in row
+        assert "documents_checklist" not in row
+        assert isinstance(row["available_actions"], list)
+
+    async def test_stats_avg_from_cached_column(
+        self, client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        """stats.avg_completion = AVG(cached_completion) SQL (không fetch-all)."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        p1 = await _make_profile(unit_id)
+        p2 = await _make_profile(unit_id)
+        await _set_cached(p1, 40)
+        await _set_cached(p2, 60)
+
+        resp = await client.get(
+            "/api/admissions/stats?academic_year=2026", headers=admin_token_headers
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["avg_completion"] == 50.0
+
+    async def test_lean_list_actions_reject_claim_for_submitted(
+        self, client: AsyncClient, admin_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        """_compute_list_actions: submitted + admin + chưa claim → reject+claim;
+        approve chỉ khi không nợ giấy (hồ sơ này không có debt snapshot → approve
+        có mặt)."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        pid = await _make_profile(unit_id)
+        await _set_cached(pid, 50, "ineligible")
+        resp = await client.get("/api/admissions", headers=admin_token_headers)
+        row = _find(resp.json(), pid)
+        acts = set(row["available_actions"])
+        assert "reject" in acts
+        assert "claim" in acts  # chưa có reviewer
+        assert "approve" in acts  # no document_debt snapshot → không gate

--- a/Backend_FastAPI/tests/api/test_admission_readmodel.py
+++ b/Backend_FastAPI/tests/api/test_admission_readmodel.py
@@ -170,3 +170,50 @@ class TestAdmissionReadModel:
         resp = await client.get("/api/admissions", headers=admin_token_headers)
         row = _find(resp.json(), pid)
         assert row["available_actions"] == []
+
+    async def test_refresh_preserves_updated_at(self, seed_lead_dependencies):
+        """refresh_derived_fields ghi cached_* NHƯNG KHÔNG bump `updated_at`
+        (flag_modified) — sweep 5' không được giả làm 'sửa lần cuối' của mọi hồ sơ
+        non-terminal (hỏng sort_by=updated_at / cột CSV / magic-link consumed_at)."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        pid = await _make_profile(unit_id)
+        async with AsyncSessionLocal() as session:
+            p0 = await session.get(models.AdmissionProfile, pid)
+            orig_updated = p0.updated_at
+        async with AsyncSessionLocal() as session:
+            stmt = (
+                select(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == pid)
+                .options(
+                    selectinload(models.AdmissionProfile.lead),
+                    selectinload(models.AdmissionProfile.documents).joinedload(
+                        models.ProfileDocument.document_type
+                    ),
+                    selectinload(models.AdmissionProfile.subject_scores),
+                    *_choices_eager_load_options(),
+                )
+            )
+            p = (await session.execute(stmt)).scalars().first()
+            admission_service.refresh_derived_fields(p, p.documents)
+            assert p.cached_derived_at is not None
+            await session.commit()
+        async with AsyncSessionLocal() as session:
+            p2 = await session.get(models.AdmissionProfile, pid)
+            assert p2.cached_completion is not None  # cached ĐÃ ghi (row có UPDATE)
+            assert p2.updated_at == orig_updated, (
+                "refresh_derived_fields KHÔNG được bump updated_at "
+                f"(gốc {orig_updated} → sau refresh {p2.updated_at})"
+            )
+
+    async def test_lean_list_actions_manager_same_unit(
+        self, client: AsyncClient, manager_token_headers: dict, seed_lead_dependencies: dict
+    ):
+        """Manager CÙNG unit → hàng list có assign_officer (nhánh is_manager của
+        `_list_action_flags` — bổ sung test admin vốn phủ nhánh is_admin)."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        pid = await _make_profile(unit_id)  # lead trong unit của manager
+        await _set_cached(pid, 50, "ineligible")
+        resp = await client.get("/api/admissions", headers=manager_token_headers)
+        assert resp.status_code == 200, resp.text
+        row = _find(resp.json(), pid)
+        assert "assign_officer" in set(row["available_actions"])

--- a/Backend_FastAPI/tests/integration/test_admission_state_transitions.py
+++ b/Backend_FastAPI/tests/integration/test_admission_state_transitions.py
@@ -1351,9 +1351,14 @@ class TestTokenBasedConfirmation:
 
 
 class TestAdmissionListNullJsonbFields:
-    """BUG-2 regression guard: GET /admissions must tolerate rows with NULL
-    JSONB list columns (family_info, academic_history). Pre-fix this crashed
-    the whole page with pydantic `list_type` validation error.
+    """BUG-2 regression guard: endpoint admission phải tolerate hàng có NULL
+    JSONB list columns (family_info, academic_history). Pre-fix crash cả trang
+    với pydantic `list_type` error.
+
+    Sau perf/admissions-list: LIST trả lean DTO (không còn 2 field này) nên chỉ
+    cần list 200 + không rớt hàng; coercion NULL→[] được kiểm ở đường DETAIL
+    (`AdmissionProfileResponse._coerce_null_list_jsonb_to_empty`) — nơi vẫn
+    serialize chúng.
     """
 
     async def test_list_tolerates_profile_with_null_list_fields(
@@ -1395,8 +1400,9 @@ class TestAdmissionListNullJsonbFields:
             f"fields. Got {response.status_code}: {response.text[:300]}"
         )
 
-        # Find the poisoned row in the response; its list fields must have
-        # been coerced to `[]`.
+        # Lean list DTO (perf/admissions-list) KHÔNG còn serialize family_info/
+        # academic_history (field nặng, đã bỏ khỏi bảng) → list KHÔNG THỂ dính
+        # BUG-2 `list_type` cho 2 field này nữa; chỉ cần list 200 + không rớt hàng.
         body = response.json()
         rows = body.get("profiles") or body.get("items") or []
         poison = next((p for p in rows if p["id"] == profile_id), None)
@@ -1404,8 +1410,23 @@ class TestAdmissionListNullJsonbFields:
             f"Poisoned profile {profile_id} missing from response; list "
             f"may have silently dropped it."
         )
-        assert poison["family_info"] == []
-        assert poison["academic_history"] == []
+        assert "family_info" not in poison and "academic_history" not in poison, (
+            "Lean list DTO không nên chứa family_info/academic_history (đã chuyển "
+            "khỏi list — nếu xuất hiện lại nghĩa là DTO bị phình ngược)."
+        )
+
+        # BUG-2 coercion guard THỰC ở đường DETAIL — nơi AdmissionProfileResponse
+        # VẪN serialize 2 field JSONB này; `_coerce_null_list_jsonb_to_empty`
+        # (schemas/admission.py mode='before') biến NULL→[] TRƯỚC type-check nên
+        # detail không 500 + trả [].
+        detail = await client.get(f"/api/admissions/{profile_id}", headers=headers)
+        assert detail.status_code == 200, (
+            f"Detail endpoint must not 500 on NULL list JSONB fields. "
+            f"Got {detail.status_code}: {detail.text[:300]}"
+        )
+        dbody = detail.json()
+        assert dbody["family_info"] == []
+        assert dbody["academic_history"] == []
 
 
 # ==============================================================================

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -348,7 +348,11 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
   const handleExport = useCallback(() => {
     exportCsv.mutate({
       status: state.statusFilters.length > 0 ? state.statusFilters.join(",") : undefined,
-      search: state.search || undefined,
+      // debounced (apiFilters.search) — KHÔNG state.search thô: bảng + đếm tab dùng
+      // debouncedSearch, nếu export đọc thô thì khi user XOÁ ô search rồi bấm 'Xuất
+      // CSV' trong 300ms → CSV gửi search=undefined → tải TOÀN BỘ thay vì tập đang
+      // thấy (comment gốc hứa 'CSV matches the on-screen list').
+      search: apiFilters.search,
       major_id: state.majorFilter || undefined,
       academic_year: state.academicYear || undefined,
       degree_level: state.degreeLevelFilter || undefined,
@@ -364,7 +368,7 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
         unassigned: state.unassigned,
       }),
     })
-  }, [exportCsv, state])
+  }, [exportCsv, state, apiFilters])
 
   const isAnyLoading = bulkApprove.isPending || bulkReject.isPending || bulkAssign.isPending || exportCsv.isPending
 

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -59,7 +59,7 @@ import {
 } from "@/hooks/admissions/filterDefaults"
 import { admissionsApi } from "@/lib/api/admissions"
 import { handleApiError, type ApiErrorResponse } from "@/lib/error-handler"
-import type { AdmissionListParams, AdmissionProfileResponse, AdmissionsPage } from "@/lib/zod/admissions"
+import type { AdmissionListParams, AdmissionListItem, AdmissionsPageLite } from "@/lib/zod/admissions"
 
 import { getColumns } from "./columns"
 import { AdmissionsBulkActionsBar } from "./AdmissionsBulkActionsBar"
@@ -90,7 +90,7 @@ function activateRow(e: React.KeyboardEvent, fn: () => void) {
 // =============================================================================
 
 interface AdmissionsClientProps {
-  initialData?: AdmissionsPage
+  initialData?: AdmissionsPageLite
   initialQueryParams?: AdmissionListParams
 }
 
@@ -105,7 +105,7 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
   const [rejectDialogOpen, setRejectDialogOpen] = useState(false)
   const [assignDialogOpen, setAssignDialogOpen] = useState(false)
-  const [rowRejectTarget, setRowRejectTarget] = useState<AdmissionProfileResponse | null>(null)
+  const [rowRejectTarget, setRowRejectTarget] = useState<AdmissionListItem | null>(null)
 
   // Density: default 'comfortable' (SSR-safe), đọc localStorage SAU mount
   // để tránh hydration mismatch.
@@ -189,7 +189,7 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
 
   // ── Claim handler ─────────────────────────────────────────────────────
   const handleClaimFromList = useCallback(
-    async (profile: AdmissionProfileResponse) => {
+    async (profile: AdmissionListItem) => {
       if (profile.version == null) return
       try {
         await admissionsApi.claimAdmissionProfile(profile.id, { version: profile.version })
@@ -209,7 +209,7 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
 
   // ── Single-row approve/reject (row menu) — gated by hasAction ──────────
   const handleRowApprove = useCallback(
-    async (profile: AdmissionProfileResponse) => {
+    async (profile: AdmissionListItem) => {
       try {
         await bulkApprove.mutateAsync({
           items: [{ profile_id: profile.id, version: profile.version ?? 1 }],
@@ -223,7 +223,7 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
   )
 
   // Reject cần lý do → mở dialog cho đúng 1 hồ sơ.
-  const requestRowReject = useCallback((profile: AdmissionProfileResponse) => {
+  const requestRowReject = useCallback((profile: AdmissionListItem) => {
     setRowRejectTarget(profile)
   }, [])
 
@@ -671,12 +671,12 @@ function LoadingState() {
 // =============================================================================
 
 interface AdmissionCardProps {
-  profile: AdmissionProfileResponse
+  profile: AdmissionListItem
   isSelected: boolean
   onSelect: (checked: boolean) => void
-  onClaim: (profile: AdmissionProfileResponse) => void
-  onApprove: (profile: AdmissionProfileResponse) => void
-  onReject: (profile: AdmissionProfileResponse) => void
+  onClaim: (profile: AdmissionListItem) => void
+  onApprove: (profile: AdmissionListItem) => void
+  onReject: (profile: AdmissionListItem) => void
   onOpen: () => void
 }
 

--- a/frontend/src/app/(dashboard)/admissions/_components/columns.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/columns.tsx
@@ -15,7 +15,7 @@ import { ArrowDown, ArrowUp, ArrowUpDown, ChevronRight } from "lucide-react"
 import Link from "next/link"
 
 import { Checkbox } from "@/components/ui/checkbox"
-import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+import type { AdmissionListItem } from "@/lib/zod/admissions"
 import { formatDate } from "@/lib/utils/admission-helpers"
 import {
   Assignees,
@@ -29,12 +29,12 @@ import {
 
 type Density = "comfortable" | "compact"
 
-const columnHelper = createColumnHelper<AdmissionProfileResponse>()
+const columnHelper = createColumnHelper<AdmissionListItem>()
 
 interface ColumnOptions {
-  onClaim?: (profile: AdmissionProfileResponse) => void
-  onApprove?: (profile: AdmissionProfileResponse) => void
-  onReject?: (profile: AdmissionProfileResponse) => void
+  onClaim?: (profile: AdmissionListItem) => void
+  onApprove?: (profile: AdmissionListItem) => void
+  onReject?: (profile: AdmissionListItem) => void
   density?: Density
 }
 
@@ -43,7 +43,7 @@ function SortableHeader<TValue>({
   column,
   label,
 }: {
-  column: Column<AdmissionProfileResponse, TValue>
+  column: Column<AdmissionListItem, TValue>
   label: string
 }) {
   const sorted = column.getIsSorted()
@@ -60,7 +60,7 @@ function SortableHeader<TValue>({
   )
 }
 
-export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileResponse, unknown>[] {
+export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionListItem, unknown>[] {
   const compact = options?.density === "compact"
 
   return [
@@ -88,7 +88,7 @@ export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileR
       enableSorting: false,
       enableHiding: false,
       size: 40,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+    }) as ColumnDef<AdmissionListItem, unknown>,
 
     // Identity (sortable by name)
     columnHelper.accessor((row) => row.lead?.full_name ?? `Lead #${row.lead_id}`, {
@@ -120,7 +120,7 @@ export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileR
         )
       },
       size: 240,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+    }) as ColumnDef<AdmissionListItem, unknown>,
 
     // Status
     columnHelper.accessor("status", {
@@ -128,7 +128,7 @@ export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileR
       cell: ({ getValue }) => <StatusDot status={getValue()} />,
       enableSorting: false,
       size: 130,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+    }) as ColumnDef<AdmissionListItem, unknown>,
 
     // Progress
     columnHelper.accessor("completion_percent", {
@@ -136,7 +136,7 @@ export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileR
       cell: ({ getValue }) => <ProgressBar value={getValue()} className="min-w-[120px]" />,
       enableSorting: false,
       size: 150,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+    }) as ColumnDef<AdmissionListItem, unknown>,
 
     // Eligibility
     columnHelper.accessor("eligibility_status", {
@@ -144,7 +144,7 @@ export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileR
       cell: ({ getValue }) => <EligibilityToken status={getValue()} />,
       enableSorting: false,
       size: 120,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+    }) as ColumnDef<AdmissionListItem, unknown>,
 
     // Học phí HK1 (Admission List v2) — sortable theo "Còn lại". id="remaining_hk1"
     // khớp state.sortBy → BE sort end-to-end; accessor là number (normalize ở
@@ -160,7 +160,7 @@ export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileR
         />
       ),
       size: 170,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+    }) as ColumnDef<AdmissionListItem, unknown>,
 
     // Assignees (officer + reviewer — luôn hiện cả hai, mọi density)
     columnHelper.accessor("assigned_officer_name", {
@@ -174,7 +174,7 @@ export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileR
       ),
       enableSorting: false,
       size: 110,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+    }) as ColumnDef<AdmissionListItem, unknown>,
 
     // Created date (sortable)
     columnHelper.accessor("created_at", {
@@ -185,7 +185,7 @@ export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileR
         </span>
       ),
       size: 110,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+    }) as ColumnDef<AdmissionListItem, unknown>,
 
     // Actions (chevron hover + menu)
     columnHelper.display({
@@ -204,6 +204,6 @@ export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileR
       ),
       enableSorting: false,
       size: 64,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+    }) as ColumnDef<AdmissionListItem, unknown>,
   ]
 }

--- a/frontend/src/app/(dashboard)/admissions/_components/roster-parts.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/roster-parts.tsx
@@ -22,7 +22,7 @@ import { cn } from "@/lib/utils"
 import { ADMISSION_STATUS_CONFIG, getStatusDotColor } from "@/lib/status-config"
 import { hasAction } from "@/lib/admission/permissions"
 import { formatVND } from "@/lib/zod/finance"
-import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+import type { AdmissionListItem } from "@/lib/zod/admissions"
 
 export function getInitials(name: string): string {
   const parts = name.trim().split(/\s+/).filter(Boolean)
@@ -158,10 +158,10 @@ export function RowActionsMenu({
   onApprove,
   onReject,
 }: {
-  profile: AdmissionProfileResponse
-  onClaim?: (profile: AdmissionProfileResponse) => void
-  onApprove?: (profile: AdmissionProfileResponse) => void
-  onReject?: (profile: AdmissionProfileResponse) => void
+  profile: AdmissionListItem
+  onClaim?: (profile: AdmissionListItem) => void
+  onApprove?: (profile: AdmissionListItem) => void
+  onReject?: (profile: AdmissionListItem) => void
 }) {
   // Quyền hành động do BE quyết (available_actions) — thin client, không gate
   // bằng status string ở FE.

--- a/frontend/src/hooks/admissions/useAdmissions.ts
+++ b/frontend/src/hooks/admissions/useAdmissions.ts
@@ -21,7 +21,7 @@ import type {
   AdmissionProfileResponse,
   AdmissionProfileUpdate,
   AdmissionListParams,
-  AdmissionsPage,
+  AdmissionsPageLite,
   AdmissionStatusCounts,
   AdmissionStats,
   BulkApproveRequest,
@@ -54,7 +54,7 @@ export const admissionsKeys = {
 
 export function useListAdmissions(
   filters?: AdmissionListParams,
-  options?: { initialData?: AdmissionsPage }
+  options?: { initialData?: AdmissionsPageLite }
 ) {
   return useQuery({
     queryKey: admissionsKeys.list(filters as Record<string, unknown> | undefined),

--- a/frontend/src/hooks/admissions/useAdmissionsFilter.ts
+++ b/frontend/src/hooks/admissions/useAdmissionsFilter.ts
@@ -241,6 +241,17 @@ export function useAdmissionsFilter(
   const [page, setPage] = useState(initialValues.page)
   const [pageSize] = useState(defaultPageSize)
   const [search, setSearch] = useState(initialValues.search)
+  // perf/admissions-list: debounce search TRƯỚC khi vào apiFilters (query params)
+  // — ô search hiển thị `search` tức thì (gõ mượt), nhưng API `/api/admissions`
+  // CHỈ fire sau khi ngưng gõ 300ms. Trước đây `apiFilters` đọc `search` thô →
+  // fire GET mỗi phím (mỗi lần lại là 1 query key + fan-out BE). URL-debounce
+  // (100ms, effect riêng) không đụng tới đây. Các filter khác đổi 1-phát nên
+  // không cần debounce.
+  const [debouncedSearch, setDebouncedSearch] = useState(initialValues.search)
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 300)
+    return () => clearTimeout(t)
+  }, [search])
   const [statusFilters, setStatusFilters] = useState<string[]>(initialValues.statusFilters)
   const [majorFilter, setMajorFilter] = useState(initialValues.majorFilter)
   const [academicYear, setAcademicYear] = useState<number | undefined>(initialValues.academicYear)
@@ -543,7 +554,7 @@ export function useAdmissionsFilter(
       order: sortOrder,
     }
 
-    if (search) params.search = search
+    if (debouncedSearch) params.search = debouncedSearch
     if (statusFilters.length > 0) params.status = statusFilters.join(",")
     if (majorFilter) params.major_id = majorFilter
     if (academicYear !== undefined) params.academic_year = academicYear
@@ -557,7 +568,7 @@ export function useAdmissionsFilter(
 
     return params
   }, [
-    page, pageSize, search, statusFilters, majorFilter, academicYear,
+    page, pageSize, debouncedSearch, statusFilters, majorFilter, academicYear,
     degreeLevelFilter, paymentStatusFilter, dateFrom, dateTo, sortBy, sortOrder,
     officerFilters, unitId, reviewerFilters, unassigned,
   ])

--- a/frontend/src/hooks/admissions/useAdmissionsFilter.ts
+++ b/frontend/src/hooks/admissions/useAdmissionsFilter.ts
@@ -577,7 +577,11 @@ export function useAdmissionsFilter(
   const countFilters: Record<string, unknown> = useMemo(() => {
     const params: Record<string, unknown> = {}
 
-    if (search) params.search = search
+    // debouncedSearch (KHÔNG phải `search` thô) để: (a) status-counts KHÔNG fire
+    // mỗi phím gõ, (b) số đếm tab KHỚP hàng danh sách (apiFilters cũng dùng
+    // debouncedSearch) — nếu dùng `search` thô, đếm theo 'abc' còn rows theo 'ab'
+    // lệch tới 300ms.
+    if (debouncedSearch) params.search = debouncedSearch
     if (majorFilter) params.major_id = majorFilter
     if (academicYear !== undefined) params.academic_year = academicYear
     if (degreeLevelFilter) params.degree_level = degreeLevelFilter
@@ -589,7 +593,7 @@ export function useAdmissionsFilter(
 
     return params
   }, [
-    search, majorFilter, academicYear, degreeLevelFilter, paymentStatusFilter,
+    debouncedSearch, majorFilter, academicYear, degreeLevelFilter, paymentStatusFilter,
     dateFrom, dateTo, officerFilters, unitId, reviewerFilters, unassigned,
   ])
 

--- a/frontend/src/lib/api/admissions.ts
+++ b/frontend/src/lib/api/admissions.ts
@@ -11,7 +11,7 @@ import type {
   AdmissionProfileUpdate,
   AdmissionSubmitResponse,
   EnrollStudentResponse,
-  AdmissionsPage,
+  AdmissionsPageLite,
   AdmissionListParams,
   AdmissionStatusCounts,
   AdmissionStats,
@@ -40,8 +40,8 @@ function toNum(v: unknown): number | null {
  */
 export async function listAdmissions(
   params?: AdmissionListParams
-): Promise<AdmissionsPage> {
-  const response = await api.get<AdmissionsPage>('/api/admissions', { params })
+): Promise<AdmissionsPageLite> {
+  const response = await api.get<AdmissionsPageLite>('/api/admissions', { params })
   const page = response.data
   return {
     ...page,

--- a/frontend/src/lib/api/server.ts
+++ b/frontend/src/lib/api/server.ts
@@ -66,7 +66,7 @@ import type {
   EventGroupPreferencesResponse,
   UserSessionListResponse,
 } from '@/types/api.types';
-import type { AdmissionListParams, AdmissionProfileResponse, AdmissionsPage } from '@/lib/zod/admissions';
+import type { AdmissionListParams, AdmissionProfileResponse, AdmissionsPageLite } from '@/lib/zod/admissions';
 import type { EnhancedOfficerStats } from '@/hooks/useDashboardStats';
 import type { CollaboratorsPage } from '@/types/collaborator.types';
 import type {
@@ -582,8 +582,8 @@ const admissions = {
   /**
    * List admission profiles (Server-Side)
    */
-  async listProfiles(params?: AdmissionListParams): Promise<AdmissionsPage> {
-    return serverFetch<AdmissionsPage>('/api/admissions', {
+  async listProfiles(params?: AdmissionListParams): Promise<AdmissionsPageLite> {
+    return serverFetch<AdmissionsPageLite>('/api/admissions', {
       params: params as Record<string, unknown> | undefined,
     });
   },

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -1279,6 +1279,42 @@ export const admissionsPageSchema = z.object({
 export type AdmissionsPage = z.infer<typeof admissionsPageSchema>
 
 /**
+ * DTO NHẸ cho BẢNG danh sách /admissions (perf/admissions-list).
+ * `.pick` từ response đầy đủ ⇒ subset TƯƠNG THÍCH: đọc field nằm trong đây OK,
+ * đọc field nặng đã bỏ (choices/documents_checklist/validation...) → TS chặn.
+ * BE trả đúng bộ này (schemas.AdmissionProfileListItem); detail vẫn full.
+ */
+export const admissionListItemSchema = admissionProfileResponseSchema.pick({
+  id: true,
+  lead_id: true,
+  version: true,
+  status: true,
+  created_at: true,
+  lead: true,
+  program_name: true,
+  completion_percent: true,
+  eligibility_status: true,
+  tuition_paid_hk1: true,
+  tuition_remaining_hk1: true,
+  tuition_overdue_hk1: true,
+  tuition_hk1_status: true,
+  assigned_officer_name: true,
+  assigned_reviewer_name: true,
+  available_actions: true,
+})
+
+export type AdmissionListItem = z.infer<typeof admissionListItemSchema>
+
+export const admissionsPageLiteSchema = z.object({
+  total_count: z.number(),
+  page: z.number(),
+  page_size: z.number(),
+  profiles: z.array(admissionListItemSchema),
+})
+
+export type AdmissionsPageLite = z.infer<typeof admissionsPageLiteSchema>
+
+/**
  * Submit Response Schema
  * Used for POST /api/admissions/{id}/submit response
  * 


### PR DESCRIPTION
## Vấn đề

Trang danh sách hồ sơ tuyển sinh (`/admissions`) chậm khi load & filter (đo thật, Chrome MCP + Performance API, admin, 473 hồ sơ prod):

| Endpoint | Trước | Payload |
|---|---|---|
| `GET /api/admissions/stats` | **~2.1s** 🔴 | — |
| `GET /api/admissions` (list) | ~410ms | **324KB / 20 dòng** ⚠️ |

**Gốc = compute-at-read-time:** `stats.avg_completion` fetch-all mọi hồ sơ + Python loop; list serialize `AdmissionProfileResponse` nặng (choices graph 6 nhánh + validation summaries + …) mỗi dòng.

## Giải pháp

**Read-model denormalized + eventual-consistency** (completion/eligibility KHÔNG per-profile-pure — multi-NV đọc live-config + doc-verify/choice-score không bump `updated_at` → không thể recompute-tại-site đủ, phải sweep nền):

- **3 cột read-model** `cached_completion`/`cached_readiness`/`cached_derived_at` (tên KHÁC field transient để tránh autoflush ghi-trên-đọc).
- **Beat sweep** `refresh_admission_derived_task` (5') làm tươi cột — backbone eventual-consistency; đóng băng terminal + bắt kịp khi status đổi (`cached_derived_at < updated_at`); KHÔNG bump `updated_at` (flag_modified).
- **stats** = `AVG(cached_completion)` SQL thay fetch-all.
- **Lean list DTO** `AdmissionProfileListItem` (~15 field FE thật render) — đọc cột cached, `available_actions` tính nhẹ (không choices graph). Detail giữ `AdmissionProfileResponse` LIVE đầy đủ.
- **Anti-drift:** tách `_list_action_flags` + `_eligibility_from_errors` dùng CHUNG detail ↔ list (nguồn sự thật duy nhất).
- **FE:** type-narrowing sang `AdmissionListItem` (TS chặn đọc field nặng) + debounce search 300ms.

## Đo lường (sau, đo thật)

| | Trước | Sau |
|---|---|---|
| stats | ~2.1s | **~30ms** |
| list payload | 324KB/20 dòng | **10.1KB** (~32×) |

## Rà soát (3 vòng sâu)

1. **7-finder + adversarial verify** — 0 lỗi crash; phát hiện + vá regression `assign_officer` (nút "Phân công hàng loạt" chết).
2. **Phase-3 (15 finding)** — vá 13: `updated_at` bị sweep bump (~115k UPDATE/ngày), frozen-stale (enrolled hiện giá trị pre-transition), lean raiseload thật, ABBA deadlock bulk_approve↔sweep, +test; 2 note by-design.
3. **Follow-up bậc-2 (A–D)** — `preserve_updated_at` param, sweep raiseload(student,fees), sentinel invalidate, frozen-fail retry.

## Kiểm chứng

- **Backend pytest 132 pass** (read-model + HK1 lean + assign_officer + workflow + doc-parity + IDOR + null-jsonb).
- **Sweep runtime thật** qlts_dev 304/304 0-fail · **A: 310/310 hồ sơ `updated_at < cached_derived_at`** (không bị bump).
- **FE type-check 0 · lint 0 error · vitest 32 pass.**
- **Smoke thực thi nghiệp vụ** (session admin thật): claim/unclaim (reversible) · bulk-approve 2-item (sort fix + state transition) · bulk-assign (revived) · filter/search-debounce — read-model + counts + filter phản ánh đúng mutation. Detail response `_compute_frontend_fields` refactor **byte-identical**.

## ⚠️ Lưu ý deploy

1. **Image mới PHẢI tới CẢ backend + celery-worker + celery-beat** — nếu chỉ backend, sweep không chạy → badge/stats trống.
2. **Backfill sau deploy:** `celery -A app.celery_app call refresh_admission_derived_task` chạy **2×** (478 > batch 1000... chạy 1× là đủ với batch=1000; nếu N_non_frozen > batch thì chạy tới khi hết NULL) hoặc chờ ≤ ceil(N/1000)×5'.
3. **Migration** `admderivedcols20260721` (3 cột nullable + index) — apply tự động qua entrypoint; index trivial ở quy mô ~478 dòng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
